### PR TITLE
cant-exit-midworkout

### DIFF
--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -2555,6 +2555,171 @@ body.gym-tracker #footer {
     white-space: pre-wrap;
 }
 
+/* Paused Workout Banner */
+.paused-workout-banner {
+    background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-card) 100%);
+    border: 2px solid var(--accent-warning);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-lg);
+    margin-bottom: var(--spacing-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+}
+
+@media (min-width: 768px) {
+    .paused-workout-banner {
+        flex-direction: row;
+        align-items: center;
+    }
+}
+
+.paused-workout-icon {
+    font-size: 2.5rem;
+    color: var(--accent-warning);
+    text-align: center;
+}
+
+@media (min-width: 768px) {
+    .paused-workout-icon {
+        margin-right: var(--spacing-md);
+    }
+}
+
+.paused-workout-info {
+    flex: 1;
+    text-align: center;
+}
+
+@media (min-width: 768px) {
+    .paused-workout-info {
+        text-align: left;
+    }
+}
+
+.paused-workout-info h3 {
+    margin: 0 0 var(--spacing-xs) 0;
+    color: var(--accent-warning);
+    font-size: 1.1rem;
+}
+
+.paused-workout-info p {
+    margin: 0;
+    color: var(--text-primary);
+}
+
+.paused-workout-meta {
+    display: flex;
+    gap: var(--spacing-md);
+    justify-content: center;
+    margin-top: var(--spacing-xs);
+    color: var(--text-secondary) !important;
+    font-size: 0.85rem;
+}
+
+@media (min-width: 768px) {
+    .paused-workout-meta {
+        justify-content: flex-start;
+    }
+}
+
+.paused-workout-meta i {
+    margin-right: var(--spacing-xs);
+}
+
+.paused-workout-actions {
+    display: flex;
+    gap: var(--spacing-sm);
+    justify-content: center;
+}
+
+@media (min-width: 768px) {
+    .paused-workout-actions {
+        flex-direction: column;
+    }
+}
+
+.paused-workout-actions .btn {
+    min-width: 100px;
+}
+
+.btn-danger-outline {
+    background: transparent;
+    border: 1px solid var(--accent-error);
+    color: var(--accent-error);
+}
+
+.btn-danger-outline:hover {
+    background: rgba(255, 82, 82, 0.1);
+}
+
+/* Paused program item in quick programs */
+.quick-program-item.paused {
+    border-color: var(--accent-warning);
+    background: rgba(255, 165, 0, 0.1);
+}
+
+.quick-program-item.paused .paused-label {
+    color: var(--accent-warning);
+    font-weight: 500;
+}
+
+.quick-program-item.paused .paused-label i {
+    margin-right: 4px;
+}
+
+.quick-program-item.paused .fa-play-circle {
+    color: var(--accent-warning);
+}
+
+/* Exercise History Set Badges */
+.sets-cell {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.set-badge {
+    display: inline-block;
+    background: var(--bg-tertiary);
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    white-space: nowrap;
+}
+
+.set-badge.set-improved {
+    color: var(--accent-success);
+}
+
+.set-badge.set-worse {
+    color: var(--accent-error);
+}
+
+/* Exercise History Count Badge */
+.exercise-db-card {
+    position: relative;
+}
+
+.history-count-badge {
+    position: absolute;
+    top: -8px;
+    right: -8px;
+    background: var(--accent-primary);
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 600;
+    min-width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 4px;
+    box-shadow: var(--shadow-md);
+}
+
 /* Print Styles */
 @media print {
     .bottom-nav,

--- a/apps/gym-tracker/js/models/WorkoutSession.js
+++ b/apps/gym-tracker/js/models/WorkoutSession.js
@@ -25,6 +25,11 @@ export class WorkoutSession {
         this.maxHeartRate = data.maxHeartRate || null;
         this.caloriesBurned = data.caloriesBurned || null;
 
+        // Pause/Resume state
+        this.paused = data.paused || false;
+        this.pausedAt = data.pausedAt || null;
+        this.elapsedBeforePause = data.elapsedBeforePause || 0; // Seconds elapsed before pause
+
         // Metadata
         this.timestamp = data.timestamp || new Date().toISOString();
     }
@@ -55,6 +60,18 @@ export class WorkoutSession {
         this.completed = true;
     }
 
+    pauseWorkout(elapsedSeconds) {
+        this.paused = true;
+        this.pausedAt = new Date().toISOString();
+        this.elapsedBeforePause = elapsedSeconds;
+    }
+
+    resumeWorkout() {
+        this.paused = false;
+        this.pausedAt = null;
+        // elapsedBeforePause is kept to restore timer state
+    }
+
     toJSON() {
         return {
             id: this.id,
@@ -70,6 +87,9 @@ export class WorkoutSession {
             avgHeartRate: this.avgHeartRate,
             maxHeartRate: this.maxHeartRate,
             caloriesBurned: this.caloriesBurned,
+            paused: this.paused,
+            pausedAt: this.pausedAt,
+            elapsedBeforePause: this.elapsedBeforePause,
             timestamp: this.timestamp
         };
     }

--- a/apps/gym-tracker/js/services/StorageService.js
+++ b/apps/gym-tracker/js/services/StorageService.js
@@ -10,7 +10,8 @@ export class StorageService {
             SETTINGS: 'gymTrackerSettings',
             ACHIEVEMENTS: 'gymTrackerAchievements',
             ACTIVE_PROGRAM: 'gymTrackerActiveProgram',
-            CUSTOM_EXERCISES: 'gymTrackerCustomExercises'
+            CUSTOM_EXERCISES: 'gymTrackerCustomExercises',
+            ACTIVE_WORKOUT: 'gymTrackerActiveWorkout'
         };
     }
 
@@ -175,6 +176,23 @@ export class StorageService {
         const exercises = this.getCustomExercises();
         const filtered = exercises.filter(e => e.id !== id);
         return this.saveCustomExercises(filtered);
+    }
+
+    // Active Workout (in-progress workout that can be resumed)
+    getActiveWorkout() {
+        return this.get(this.keys.ACTIVE_WORKOUT, null);
+    }
+
+    saveActiveWorkout(workoutData) {
+        return this.set(this.keys.ACTIVE_WORKOUT, workoutData);
+    }
+
+    clearActiveWorkout() {
+        return this.remove(this.keys.ACTIVE_WORKOUT);
+    }
+
+    hasActiveWorkout() {
+        return this.getActiveWorkout() !== null;
     }
 
     // Data Management

--- a/apps/gym-tracker/js/services/TimerService.js
+++ b/apps/gym-tracker/js/services/TimerService.js
@@ -61,13 +61,14 @@ export class TimerService {
     }
 
     // Workout Timer
-    startWorkoutTimer(onTick) {
+    startWorkoutTimer(onTick, initialElapsed = 0) {
         if (this.workoutTimer) {
             this.stopWorkoutTimer();
         }
 
-        const startTime = Date.now();
-        let elapsed = 0;
+        // Adjust startTime to account for any previously elapsed time
+        const startTime = Date.now() - (initialElapsed * 1000);
+        let elapsed = initialElapsed;
 
         const interval = setInterval(() => {
             elapsed = Math.floor((Date.now() - startTime) / 1000);
@@ -81,6 +82,11 @@ export class TimerService {
             startTime,
             elapsed
         };
+
+        // Immediately call onTick to show correct time
+        if (onTick && initialElapsed > 0) {
+            onTick(initialElapsed);
+        }
 
         return startTime;
     }

--- a/apps/gym-tracker/js/views/history-view.js
+++ b/apps/gym-tracker/js/views/history-view.js
@@ -127,7 +127,7 @@ class HistoryView {
                     <div class="workout-card-stats">
                         <div class="stat">
                             <i class="fas fa-weight"></i>
-                            ${Math.round(session.totalVolume)}${unit}
+                            ${Math.round(session.totalVolume).toLocaleString()}${unit}
                         </div>
                         <div class="stat">
                             <i class="fas fa-list"></i>
@@ -194,7 +194,7 @@ class HistoryView {
                     </div>
                     <div class="detail-stat">
                         <span class="label">Total Volume</span>
-                        <span class="value">${Math.round(session.totalVolume)}${unit}</span>
+                        <span class="value">${Math.round(session.totalVolume).toLocaleString()}${unit}</span>
                     </div>
                     <div class="detail-stat">
                         <span class="label">Total Sets</span>
@@ -255,9 +255,9 @@ class HistoryView {
                         html += `<td>${mins}:${secs.toString().padStart(2, '0')}</td>`;
                     } else {
                         html += `
-                            <td>${set.weight}${unit}</td>
+                            <td>${set.weight.toLocaleString()}${unit}</td>
                             <td>${set.reps}</td>
-                            <td>${Math.round(set.volume)}${unit}</td>
+                            <td>${Math.round(set.volume).toLocaleString()}${unit}</td>
                         `;
                     }
 
@@ -323,7 +323,7 @@ class HistoryView {
         const session = this.app.workoutSessions.find(s => s.id === sessionId);
         if (!session) return;
 
-        const message = `Are you sure you want to delete this workout?<br><br><strong>${session.workoutDayName}</strong><br>${formatDate(session.date)}<br><br>This workout included ${session.exercises.length} exercise${session.exercises.length !== 1 ? 's' : ''} and ${Math.round(session.totalVolume)}${this.app.settings.weightUnit} total volume.<br><br><strong>This action cannot be undone.</strong>`;
+        const message = `Are you sure you want to delete this workout?<br><br><strong>${session.workoutDayName}</strong><br>${formatDate(session.date)}<br><br>This workout included ${session.exercises.length} exercise${session.exercises.length !== 1 ? 's' : ''} and ${Math.round(session.totalVolume).toLocaleString()}${this.app.settings.weightUnit} total volume.<br><br><strong>This action cannot be undone.</strong>`;
 
         const confirmed = await showConfirmModal({
             title: 'Delete Workout',

--- a/apps/gym-tracker/js/views/home-view.js
+++ b/apps/gym-tracker/js/views/home-view.js
@@ -3,6 +3,7 @@
  * Dashboard and overview
  */
 import { app } from '../app.js';
+import { storageService } from '../services/StorageService.js';
 import { formatDate, formatWeight } from '../utils/helpers.js';
 
 class HomeView {
@@ -16,14 +17,95 @@ class HomeView {
     }
 
     render() {
+        this.renderPausedWorkoutBanner();
         this.renderActiveProgram();
         this.renderRecentWorkouts();
         this.renderRecentAchievements();
     }
 
+    renderPausedWorkoutBanner() {
+        const container = document.getElementById('active-program-card');
+        const pausedWorkout = storageService.getActiveWorkout();
+
+        // Remove any existing banner first
+        const existingBanner = document.querySelector('.paused-workout-banner');
+        if (existingBanner) {
+            existingBanner.remove();
+        }
+
+        if (!pausedWorkout || !pausedWorkout.paused) {
+            return;
+        }
+
+        const pausedAt = new Date(pausedWorkout.pausedAt);
+        const elapsed = pausedWorkout.elapsedBeforePause;
+        const minutes = Math.floor(elapsed / 60);
+        const seconds = elapsed % 60;
+
+        // Count total sets saved
+        const totalSets = pausedWorkout.exercises.reduce((sum, ex) =>
+            sum + (ex.sets ? ex.sets.length : 0), 0
+        );
+
+        const bannerHTML = `
+            <div class="paused-workout-banner">
+                <div class="paused-workout-icon">
+                    <i class="fas fa-pause-circle"></i>
+                </div>
+                <div class="paused-workout-info">
+                    <h3>Paused Workout</h3>
+                    <p><strong>${pausedWorkout.workoutDayName}</strong></p>
+                    <p class="paused-workout-meta">
+                        <span><i class="fas fa-clock"></i> ${minutes}:${String(seconds).padStart(2, '0')} elapsed</span>
+                        <span><i class="fas fa-dumbbell"></i> ${totalSets} set${totalSets !== 1 ? 's' : ''}</span>
+                    </p>
+                </div>
+                <div class="paused-workout-actions">
+                    <button class="btn btn-primary" onclick="window.gymApp.viewControllers.home.resumeWorkout()">
+                        <i class="fas fa-play"></i> Resume
+                    </button>
+                    <button class="btn btn-outline btn-danger-outline" onclick="window.gymApp.viewControllers.home.discardPausedWorkout()">
+                        <i class="fas fa-trash"></i> Discard
+                    </button>
+                </div>
+            </div>
+        `;
+
+        // Insert banner before the container
+        container.insertAdjacentHTML('beforebegin', bannerHTML);
+    }
+
+    resumeWorkout() {
+        this.app.showView('workout');
+        setTimeout(() => {
+            if (this.app.viewControllers.workout) {
+                this.app.viewControllers.workout.resumeWorkout();
+            }
+        }, 100);
+    }
+
+    async discardPausedWorkout() {
+        const { showConfirmModal } = await import('../utils/helpers.js');
+        const confirmed = await showConfirmModal({
+            title: 'Discard Paused Workout',
+            message: 'Are you sure you want to discard this paused workout?<br><br><strong>All progress will be lost.</strong>',
+            confirmText: 'Discard',
+            cancelText: 'Keep',
+            isDangerous: true
+        });
+
+        if (confirmed) {
+            storageService.clearActiveWorkout();
+            this.render();
+            const { showToast } = await import('../utils/helpers.js');
+            showToast('Paused workout discarded', 'info');
+        }
+    }
+
     renderActiveProgram() {
         const container = document.getElementById('active-program-card');
         const programs = this.app.programs;
+        const pausedWorkout = storageService.getActiveWorkout();
 
         if (programs.length === 0) {
             container.innerHTML = `
@@ -40,15 +122,42 @@ class HomeView {
             <div class="program-summary">
                 <h3>Your Programs</h3>
                 <div class="quick-programs">
-                    ${programs.map(program => `
-                        <div class="quick-program-item" ${program.exercises.length > 0 ? `onclick="window.gymApp.viewControllers.home.startWorkoutWithProgram(${program.id})"` : ''}>
-                            <div class="program-info">
-                                <strong>${program.name}</strong>
-                                <span>${program.exercises.length} exercises</span>
-                            </div>
-                            ${program.exercises.length > 0 ? '<i class="fas fa-play-circle"></i>' : '<i class="fas fa-edit" onclick="event.stopPropagation(); window.gymApp.viewControllers.programs.editProgram(' + program.id + ')"></i>'}
-                        </div>
-                    `).join('')}
+                    ${programs.map(program => {
+                        const isPaused = pausedWorkout && pausedWorkout.paused && pausedWorkout.programId === program.id;
+                        const hasExercises = program.exercises.length > 0;
+
+                        if (isPaused) {
+                            return `
+                                <div class="quick-program-item paused" onclick="window.gymApp.viewControllers.home.resumeWorkout()">
+                                    <div class="program-info">
+                                        <strong>${program.name}</strong>
+                                        <span class="paused-label"><i class="fas fa-pause"></i> Paused</span>
+                                    </div>
+                                    <i class="fas fa-play-circle"></i>
+                                </div>
+                            `;
+                        } else if (hasExercises) {
+                            return `
+                                <div class="quick-program-item" onclick="window.gymApp.viewControllers.home.startWorkoutWithProgram(${program.id})">
+                                    <div class="program-info">
+                                        <strong>${program.name}</strong>
+                                        <span>${program.exercises.length} exercises</span>
+                                    </div>
+                                    <i class="fas fa-play-circle"></i>
+                                </div>
+                            `;
+                        } else {
+                            return `
+                                <div class="quick-program-item">
+                                    <div class="program-info">
+                                        <strong>${program.name}</strong>
+                                        <span>${program.exercises.length} exercises</span>
+                                    </div>
+                                    <i class="fas fa-edit" onclick="event.stopPropagation(); window.gymApp.viewControllers.programs.editProgram(${program.id})"></i>
+                                </div>
+                            `;
+                        }
+                    }).join('')}
                 </div>
             </div>
         `;
@@ -81,7 +190,7 @@ class HomeView {
                 <div class="workout-card-stats">
                     <div class="stat">
                         <i class="fas fa-weight"></i>
-                        ${Math.round(session.totalVolume)}${unit}
+                        ${Math.round(session.totalVolume).toLocaleString()}${unit}
                     </div>
                     <div class="stat">
                         <i class="fas fa-list"></i>
@@ -138,7 +247,28 @@ class HomeView {
         `).join('');
     }
 
-    startWorkoutWithProgram(programId) {
+    async startWorkoutWithProgram(programId) {
+        const pausedWorkout = storageService.getActiveWorkout();
+
+        // Check if there's a paused workout
+        if (pausedWorkout && pausedWorkout.paused) {
+            const { showConfirmModal } = await import('../utils/helpers.js');
+            const confirmed = await showConfirmModal({
+                title: 'Workout In Progress',
+                message: `You have a paused workout "<strong>${pausedWorkout.workoutDayName}</strong>" with saved progress.<br><br>Starting a new workout will <strong>discard</strong> your paused workout.<br><br>Do you want to continue?`,
+                confirmText: 'Start New Workout',
+                cancelText: 'Cancel',
+                isDangerous: true
+            });
+
+            if (!confirmed) {
+                return;
+            }
+
+            // Clear the paused workout
+            storageService.clearActiveWorkout();
+        }
+
         // Navigate to workout view and start the workout
         this.app.showView('workout');
         // Small delay to ensure view is rendered

--- a/apps/gym-tracker/js/views/programs-view.js
+++ b/apps/gym-tracker/js/views/programs-view.js
@@ -85,14 +85,12 @@ class ProgramsView {
                     </div>
                 </div>
                 <div class="program-actions">
-                    ${program.exercises.length > 0
-                        ? `<button class="btn btn-primary" onclick="window.gymApp.viewControllers.programs.startWorkout(${program.id})">
-                            <i class="fas fa-play"></i> Start
-                        </button>`
-                        : '<button class="btn btn-secondary" disabled title="Add exercises first">No Exercises</button>'
-                    }
-                    <button class="btn btn-secondary" onclick="window.gymApp.viewControllers.programs.editProgram(${program.id})">Edit</button>
-                    <button class="btn btn-danger" onclick="window.gymApp.viewControllers.programs.deleteProgram(${program.id})">Delete</button>
+                    <button class="btn btn-secondary" onclick="window.gymApp.viewControllers.programs.editProgram(${program.id})">
+                        <i class="fas fa-edit"></i> Edit
+                    </button>
+                    <button class="btn btn-danger" onclick="window.gymApp.viewControllers.programs.deleteProgram(${program.id})">
+                        <i class="fas fa-trash"></i> Delete
+                    </button>
                 </div>
             </div>
         `).join('');


### PR DESCRIPTION
Workout Pause/Resume Feature:
  - Added ability to pause and resume workouts mid-session
  - Workout progress is automatically saved when navigating away, switching tabs, or closing the browser
  - Added confirmation modal when leaving an active workout with options to: Pause & Save, Discard, or Continue
  - Modal only appears if user has added at least one set
  - Added paused workout banner on Home page with Resume/Discard buttons
  - Added paused workout indicator on program cards in Home page quick start section
  - Added warning when starting a new workout while one is paused

  Storage & Models:
  - Added gymTrackerActiveWorkout localStorage key for storing paused workouts
  - Added getActiveWorkout(), saveActiveWorkout(), clearActiveWorkout(), hasActiveWorkout() methods to StorageService
  - Added paused, pausedAt, elapsedBeforePause properties to WorkoutSession model
  - Added pauseWorkout() and resumeWorkout() methods to WorkoutSession model
  - Updated TimerService to support resuming from a specific elapsed time

  Programs Page:
  - Removed Start button from program cards (users now start workouts only from Home page)
  - Kept Edit and Delete buttons

  Exercise Database History:
  - Grouped sets by date in the history table (all sets from same workout shown in one row)
  - Added color coding for progress comparison vs previous workout:
    - Green: improved (higher weight, or same weight with more reps)
    - Red: worse (lower weight, or same weight with fewer reps)
    - White: same or no previous data
  - Added history count badge (purple circle) on exercise tiles showing number of workout sessions

  Number Formatting:
  - Added comma formatting to all numbers throughout the app (e.g., 1,640lb instead of 1640lb)
