### PR TITLE
Gym tracker: UX overhaul + mid-workout polish

### DIFF
--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -54,6 +54,9 @@
     --transition-fast: 150ms ease;
     --transition-base: 200ms ease;
     --transition-slow: 300ms ease;
+
+    /* Layout */
+    --bottom-nav-height: 64px;  /* Used by FAB + rest timer bar to clear the mobile nav */
 }
 
 /* Base Styles */
@@ -208,6 +211,102 @@ body.gym-tracker #footer {
 
 .bottom-nav .nav-item.workout-btn {
     color: var(--text-muted);
+}
+
+/* Center "Workout" item: raised pill, always readable so the primary
+   action is visually obvious even when inactive. */
+.bottom-nav .nav-item.nav-item-primary {
+    color: #ffffff !important;
+    background: linear-gradient(135deg, rgba(108, 99, 255, 0.9), rgba(139, 92, 246, 0.95));
+    box-shadow: 0 4px 14px rgba(108, 99, 255, 0.45);
+    margin: -0.4rem 0.25rem 0;
+    padding: 0.55rem 0.5rem;
+    border-radius: 999px;
+}
+
+.bottom-nav .nav-item.nav-item-primary i,
+.bottom-nav .nav-item.nav-item-primary span {
+    color: #ffffff !important;
+}
+
+.bottom-nav .nav-item.nav-item-primary.active {
+    background: linear-gradient(135deg, #7c6cff, #9a6cff);
+    box-shadow: 0 6px 18px rgba(108, 99, 255, 0.6);
+}
+
+/* Floating action button — one-tap Start/Resume workout on Home. */
+.workout-fab {
+    position: fixed;
+    right: 1rem;
+    bottom: calc(76px + env(safe-area-inset-bottom, 0px));
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.85rem 1.25rem;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(135deg, var(--accent-primary), #8b5cf6);
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+    box-shadow: 0 12px 26px rgba(108, 99, 255, 0.45);
+    cursor: pointer;
+    z-index: 950;
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-base);
+    animation: fab-in 260ms ease-out;
+}
+
+.workout-fab i {
+    font-size: 1.05rem;
+    color: #ffffff;
+}
+
+.workout-fab:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 30px rgba(108, 99, 255, 0.6);
+}
+
+.workout-fab:active { transform: scale(0.97); }
+
+.workout-fab:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px rgba(108, 99, 255, 0.45), 0 12px 26px rgba(108, 99, 255, 0.45);
+}
+
+.workout-fab[hidden] { display: none; }
+
+.workout-fab--resume {
+    background: linear-gradient(135deg, #22c55e, #16a34a);
+    box-shadow: 0 12px 26px rgba(34, 197, 94, 0.45);
+}
+
+.workout-fab--resume:hover {
+    box-shadow: 0 16px 30px rgba(34, 197, 94, 0.6);
+}
+
+.workout-fab--resume:focus-visible {
+    box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.45), 0 12px 26px rgba(34, 197, 94, 0.45);
+}
+
+@keyframes fab-in {
+    from { opacity: 0; transform: translateY(16px) scale(0.92); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@media (min-width: 768px) {
+    .workout-fab { bottom: 1.5rem; right: 1.5rem; }
+}
+
+@media (max-width: 360px) {
+    .workout-fab .workout-fab-label { display: none; }
+    .workout-fab {
+        width: 56px;
+        height: 56px;
+        padding: 0;
+        justify-content: center;
+    }
+    .workout-fab i { font-size: 1.25rem; }
 }
 
 @media (min-width: 768px) {
@@ -1411,13 +1510,15 @@ body.gym-tracker #footer {
 .workout-header-actions {
     display: flex;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.6rem;
 }
 
-/* Unified sizing for every header control — creates one visual system */
+/* Unified sizing for every header control — creates one visual system.
+   Minimum 44px tap target (WCAG 2.2 AA) so sweaty mid-workout fingers
+   can't accidentally trigger Discard instead of Pause/Finish. */
 .workout-header .btn-icon {
-    width: 38px !important;
-    height: 38px !important;
+    width: 44px !important;
+    height: 44px !important;
     padding: 0 !important;
     border-radius: var(--radius-md);
     font-size: 0.95rem !important;
@@ -1510,13 +1611,14 @@ body.gym-tracker #footer {
     }
 
     .workout-header .btn-icon {
-        width: 36px !important;
-        height: 36px !important;
-        font-size: 0.9rem !important;
+        /* Keep 44px even on small phones — accessibility minimum */
+        width: 44px !important;
+        height: 44px !important;
+        font-size: 0.95rem !important;
     }
 
     .workout-header-actions {
-        gap: 0.3rem;
+        gap: 0.55rem;
     }
 
     .workout-info h2 {
@@ -1577,6 +1679,218 @@ body.gym-tracker #footer {
     }
 }
 
+/* Rest timer — persistent floating pill above the bottom nav.
+   Sits well clear of the nav (20px gap + drop shadow) so it always reads
+   as an elevated, separate layer. Uses a contained palette that matches
+   the app's purple/green language without overwhelming the workout content. */
+.rest-timer-bar {
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 20px);
+    width: calc(100% - 1rem);
+    max-width: 520px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0) 40%),
+        linear-gradient(135deg, rgba(40, 32, 95, 0.92) 0%, rgba(30, 24, 75, 0.92) 100%);
+    border: 1px solid rgba(108, 99, 255, 0.45);
+    border-radius: 18px;
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%);
+    box-shadow:
+        0 1px 0 rgba(255, 255, 255, 0.08) inset,
+        0 12px 32px rgba(0, 0, 0, 0.55),
+        0 0 0 1px rgba(108, 99, 255, 0.08);
+    z-index: 90;
+    animation: rest-bar-in 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    overflow: hidden;
+}
+
+.rest-timer-bar[hidden] { display: none; }
+
+@keyframes rest-bar-in {
+    from { opacity: 0; transform: translate(-50%, 16px) scale(0.97); }
+    to   { opacity: 1; transform: translate(-50%, 0) scale(1); }
+}
+
+.rest-timer-bar.rest-timer-done {
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0) 40%),
+        linear-gradient(135deg, rgba(20, 83, 45, 0.92) 0%, rgba(15, 60, 35, 0.92) 100%);
+    border-color: rgba(34, 197, 94, 0.6);
+    box-shadow:
+        0 1px 0 rgba(255, 255, 255, 0.08) inset,
+        0 12px 32px rgba(0, 0, 0, 0.55),
+        0 0 0 1px rgba(34, 197, 94, 0.18),
+        0 0 24px rgba(34, 197, 94, 0.25);
+}
+
+.rest-timer-bar-inner {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 0.7rem 0.9rem 0.85rem;
+}
+
+.rest-timer-info {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: var(--text-primary);
+    font-weight: 600;
+    font-size: 0.92rem;
+    min-width: 0;
+}
+
+.rest-timer-info i {
+    color: var(--accent-primary);
+    font-size: 0.95rem;
+    width: 22px;
+    height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(108, 99, 255, 0.18);
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.rest-timer-bar.rest-timer-done .rest-timer-info i {
+    color: #4ade80;
+    background: rgba(34, 197, 94, 0.22);
+}
+
+.rest-timer-label {
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.64rem;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.rest-timer-value {
+    font-variant-numeric: tabular-nums;
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: #ffffff;
+    letter-spacing: -0.02em;
+    line-height: 1;
+    margin-left: auto;
+    padding-left: 0.3rem;
+}
+
+.rest-timer-bar.rest-timer-done .rest-timer-value {
+    color: #4ade80;
+}
+
+.rest-timer-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+}
+
+/* Uniform 38px pills. +30s uses an accent tint to hint "add time," while
+   Skip stays quiet so "end rest early" doesn't feel like the primary CTA.
+   !important on `color` is required because assets/css/main.css applies
+   `button { color: #555555 !important; }` globally with higher priority. */
+.rest-timer-action-btn {
+    background: rgba(255, 255, 255, 0.08);
+    color: #ffffff !important;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 999px;
+    padding: 0 0.95rem;
+    font-weight: 700;
+    font-size: 0.82rem;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    height: 38px;
+    min-width: 52px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: inherit;
+    font-variant-numeric: tabular-nums;
+    transition: background var(--transition-fast), border-color var(--transition-fast),
+                transform var(--transition-fast), color var(--transition-fast);
+    -webkit-tap-highlight-color: transparent;
+}
+
+.rest-timer-action-btn:hover {
+    background: rgba(108, 99, 255, 0.3);
+    border-color: rgba(108, 99, 255, 0.6);
+    color: #ffffff !important;
+}
+
+.rest-timer-action-btn:active { transform: scale(0.96); }
+
+.rest-timer-action-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.45);
+}
+
+.rest-timer-action-btn.rest-timer-skip {
+    background: transparent;
+    color: #e5e7eb !important;
+    border-color: rgba(255, 255, 255, 0.18);
+}
+
+.rest-timer-action-btn.rest-timer-skip:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: #ffffff !important;
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.rest-timer-bar.rest-timer-done .rest-timer-action-btn {
+    border-color: rgba(34, 197, 94, 0.35);
+}
+
+.rest-timer-bar.rest-timer-done .rest-timer-action-btn:hover {
+    background: rgba(34, 197, 94, 0.25);
+    border-color: rgba(34, 197, 94, 0.65);
+}
+
+/* Thicker, unbroken progress line anchored to the bar's bottom edge so it
+   reads as part of the pill itself — not a floating extra element. */
+.rest-timer-progress {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 4px;
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+}
+
+.rest-timer-progress-fill {
+    display: block;
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(90deg, var(--accent-primary) 0%, #a78bfa 70%, #c4b5fd 100%);
+    transform-origin: left center;
+    transition: transform 1s linear;
+    box-shadow: 0 0 12px rgba(167, 139, 250, 0.55);
+}
+
+.rest-timer-bar.rest-timer-done .rest-timer-progress-fill {
+    background: linear-gradient(90deg, #22c55e 0%, #4ade80 100%);
+    box-shadow: 0 0 12px rgba(74, 222, 128, 0.6);
+}
+
+@media (min-width: 768px) {
+    .rest-timer-bar {
+        bottom: 20px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .rest-timer-bar { animation: none; }
+    .rest-timer-progress-fill { transition: none; }
+}
+
 .workout-day-list {
     display: grid;
     grid-template-columns: 1fr;
@@ -1620,29 +1934,34 @@ body.gym-tracker #footer {
 .exercise-entry {
     background: var(--bg-card);
     border-radius: var(--radius-lg);
-    padding: 0.9rem 0.95rem;
-    margin-bottom: 0.75rem;
+    padding: 0.95rem 0.95rem 0.85rem;
+    margin-bottom: 0.85rem;
     border: 1px solid var(--border-color);
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset, var(--shadow-sm);
+    transition: border-color var(--transition-base), box-shadow var(--transition-base);
 }
 
 .exercise-entry-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.7rem;
+    align-items: flex-start;
+    gap: 0.6rem;
+    margin-bottom: 0.6rem;
 }
 
 .exercise-entry-header h3 {
     margin: 0;
-    font-size: 1.08rem;
+    font-size: 1.05rem;
     color: var(--text-primary);
     font-weight: 700;
     letter-spacing: -0.015em;
     display: inline-flex;
     flex-wrap: wrap;
     align-items: baseline;
-    gap: 0.4rem;
+    gap: 0.45rem;
     line-height: 1.25;
+    min-width: 0;
+    flex: 1;
 }
 
 .exercise-name-main {
@@ -1652,35 +1971,55 @@ body.gym-tracker #footer {
 
 .exercise-name-sub {
     color: var(--text-muted);
-    font-size: 0.76rem;
+    font-size: 0.74rem;
     font-weight: 500;
     white-space: nowrap;
-    opacity: 0.75;
+    opacity: 0.7;
+    letter-spacing: 0.005em;
 }
 
 /* Last-time reference section — deferential styling so the active inputs
-   remain the focal point. */
+   remain the focal point. Rendered as a contained rail with a muted label
+   so the chips read as quiet reference material, not part of the active UI. */
 .previous-data {
-    background: transparent;
-    padding: 0.4rem 0;
-    border-radius: 0;
-    margin-bottom: 0.65rem;
-    opacity: 0.88;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 0.55rem 0.7rem;
+    margin-bottom: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    flex-wrap: wrap;
 }
 
 .previous-sets-label {
-    font-size: 0.68rem;
+    font-size: 0.64rem;
     color: var(--text-muted);
-    margin-bottom: 0.35rem;
+    margin: 0;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
+    flex-shrink: 0;
+}
+
+.previous-sets-label span {
+    color: var(--text-muted);
+    opacity: 0.7;
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 500;
+    font-size: 0.74rem;
+    margin-left: 0.3rem;
 }
 
 .previous-sets-row {
     display: flex;
     flex-wrap: wrap;
+    /* Matching horizontal + vertical gap so multi-line wrapping stays even. */
     gap: 0.35rem;
+    flex: 1;
+    min-width: 0;
 }
 
 .previous-set-badge {
@@ -2177,6 +2516,571 @@ body.gym-tracker #footer {
     }
 }
 
+/* --- Planned set rows ---
+   Each exercise renders an <ol> of rows where `i < sets.length` is a
+   committed set (locked, edit/delete) and later rows are planned inputs
+   with a tap-to-complete button. */
+.exercise-progress {
+    flex-shrink: 0;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    padding: 0.25rem 0.7rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    line-height: 1;
+    transition: background var(--transition-base), border-color var(--transition-base),
+                color var(--transition-base);
+}
+
+.exercise-progress.is-complete {
+    background: rgba(34, 197, 94, 0.16);
+    border-color: rgba(34, 197, 94, 0.5);
+    color: #4ade80;
+}
+
+.exercise-progress.is-complete i {
+    font-size: 0.68rem;
+}
+
+.exercise-entry.exercise-complete {
+    border-color: rgba(34, 197, 94, 0.38);
+    box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.2) inset,
+                0 6px 16px rgba(34, 197, 94, 0.1);
+}
+
+.set-row-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/* Horizontal three-zone layout: [ num ] [ content ] [ actions + check ].
+   Flex with align-items:center gives bulletproof vertical centering so the
+   set number, the "55lb × 8" text, and the right-side icons always share
+   the same baseline — no matter how tall the row grows. */
+.set-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.7rem 0.6rem 0.7rem 0.6rem;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    min-height: 60px;
+    transition: background var(--transition-fast), border-color var(--transition-fast),
+                box-shadow var(--transition-fast);
+}
+
+.set-row-planned {
+    background: rgba(255, 255, 255, 0.02);
+    border-style: dashed;
+    border-color: rgba(74, 74, 117, 0.7);
+}
+
+.set-row-planned:focus-within {
+    background: var(--bg-card);
+    border-style: solid;
+    border-color: rgba(108, 99, 255, 0.5);
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.12);
+}
+
+.set-row-complete {
+    background: rgba(34, 197, 94, 0.08);
+    border-color: rgba(34, 197, 94, 0.3);
+    border-left: 3px solid rgba(34, 197, 94, 0.7);
+    /* Border-left adds 2px — compensate so text alignment with planned rows stays flush. */
+    padding-left: calc(0.6rem - 2px);
+}
+
+.set-row-editing {
+    background: var(--bg-card);
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 0 2px rgba(108, 99, 255, 0.2);
+}
+
+.set-row-num {
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: rgba(108, 99, 255, 0.12);
+    border: 1px solid rgba(108, 99, 255, 0.28);
+    color: var(--accent-primary);
+    font-weight: 700;
+    font-size: 0.76rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.01em;
+    transition: background var(--transition-base), border-color var(--transition-base),
+                color var(--transition-base);
+}
+
+.set-row-planned .set-row-num {
+    background: transparent;
+    border-color: var(--border-color);
+    color: var(--text-muted);
+}
+
+.set-row-complete .set-row-num {
+    background: rgba(34, 197, 94, 0.2);
+    border-color: rgba(34, 197, 94, 0.55);
+    color: #4ade80;
+}
+
+.set-row-inputs {
+    flex: 1;
+    min-width: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}
+
+.set-row-inputs input {
+    width: 76px;
+    padding: 0.5rem 0.55rem;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-size: 1rem;
+    font-weight: 700;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.01em;
+    transition: border-color var(--transition-fast), background var(--transition-fast),
+                box-shadow var(--transition-fast);
+}
+
+.set-row-inputs input::placeholder {
+    color: var(--text-muted);
+    opacity: 0.5;
+    font-weight: 500;
+}
+
+.set-row-inputs input:hover { border-color: var(--border-light); }
+
+.set-row-inputs input:focus {
+    outline: none;
+    border-color: var(--accent-primary);
+    background: var(--bg-hover);
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.16);
+}
+
+.set-row-x,
+.set-row-inputs .duration-separator {
+    color: var(--text-muted);
+    font-weight: 700;
+    font-size: 0.9rem;
+    opacity: 0.8;
+}
+
+.set-row-details {
+    flex: 1;
+    min-width: 0;
+    color: var(--text-primary);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+}
+
+/* ===== Pill toggle — the sole "mark set complete" control =====
+   iOS/premium-fitness-app feel: horizontal pill track + circular knob that
+   slides from left (incomplete) to right (completed). The knob's checkmark
+   fades in as it lands, and a soft green glow confirms the ON state.
+   Driven purely by `aria-pressed` so the DOM stays identical between states. */
+.set-toggle {
+    --toggle-width: 54px;
+    --toggle-height: 30px;
+    --toggle-pad: 3px;
+    --toggle-knob: calc(var(--toggle-height) - (var(--toggle-pad) * 2));
+    --toggle-travel: calc(var(--toggle-width) - var(--toggle-knob) - (var(--toggle-pad) * 2));
+
+    flex-shrink: 0;
+    position: relative;
+    width: var(--toggle-width);
+    height: var(--toggle-height);
+    padding: 0;
+    border-radius: 999px;
+    border: 1px solid var(--border-light);
+    background: var(--bg-tertiary);
+    cursor: pointer;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
+    transition: background 220ms cubic-bezier(0.2, 0.8, 0.2, 1),
+                border-color 220ms ease,
+                box-shadow 220ms ease;
+    -webkit-tap-highlight-color: transparent;
+    font-family: inherit;
+}
+
+.set-toggle-knob {
+    position: absolute;
+    top: var(--toggle-pad);
+    left: var(--toggle-pad);
+    width: var(--toggle-knob);
+    height: var(--toggle-knob);
+    border-radius: 50%;
+    background: linear-gradient(180deg, #c7c7d8 0%, #8a8aa6 100%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.45),
+                0 0 0 1px rgba(0, 0, 0, 0.1);
+    transition: transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+                background 200ms ease;
+    will-change: transform;
+}
+
+.set-toggle-knob i {
+    color: #ffffff !important;
+    font-size: 0.62rem;
+    font-weight: 900;
+    opacity: 0;
+    transform: scale(0.7);
+    transition: opacity 150ms ease 40ms, transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1) 40ms;
+    line-height: 1;
+}
+
+/* ---- ON state: completed ---- */
+.set-toggle[aria-pressed="true"] {
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    border-color: rgba(34, 197, 94, 0.85);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18),
+                0 0 0 1px rgba(34, 197, 94, 0.3),
+                0 2px 10px rgba(34, 197, 94, 0.35);
+}
+
+.set-toggle[aria-pressed="true"] .set-toggle-knob {
+    transform: translateX(var(--toggle-travel));
+    background: linear-gradient(180deg, #ffffff 0%, #e8eae7 100%);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35),
+                0 0 0 1px rgba(0, 0, 0, 0.08);
+}
+
+.set-toggle[aria-pressed="true"] .set-toggle-knob i {
+    /* Dark green check reads cleanly on the white knob. */
+    color: #15803d !important;
+    opacity: 1;
+    transform: scale(1);
+}
+
+/* ---- Affordances on pointer devices ---- */
+@media (hover: hover) {
+    .set-toggle:hover {
+        border-color: var(--text-muted);
+    }
+    .set-toggle[aria-pressed="true"]:hover {
+        filter: brightness(1.06);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2),
+                    0 0 0 1px rgba(34, 197, 94, 0.4),
+                    0 4px 14px rgba(34, 197, 94, 0.5);
+    }
+}
+
+.set-toggle:active .set-toggle-knob {
+    /* Subtle squish on press — communicates tactile feedback. */
+    transform: translateX(0) scale(0.92);
+}
+
+.set-toggle[aria-pressed="true"]:active .set-toggle-knob {
+    transform: translateX(var(--toggle-travel)) scale(0.92);
+}
+
+.set-toggle:focus-visible {
+    outline: none;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35),
+                0 0 0 3px rgba(108, 99, 255, 0.45);
+}
+
+.set-toggle[aria-pressed="true"]:focus-visible {
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18),
+                0 0 0 3px rgba(34, 197, 94, 0.45),
+                0 2px 10px rgba(34, 197, 94, 0.35);
+}
+
+/* Highlight the toggle when the user is entering weight/reps — subtle hint
+   about what to do next, without switching state. */
+.set-row-planned:focus-within .set-toggle:not([aria-pressed="true"]) {
+    border-color: rgba(34, 197, 94, 0.55);
+    background: rgba(34, 197, 94, 0.1);
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25),
+                0 0 0 3px rgba(34, 197, 94, 0.12);
+}
+
+.set-row-planned:focus-within .set-toggle:not([aria-pressed="true"]) .set-toggle-knob {
+    background: linear-gradient(180deg, #e5e7eb 0%, #9ca3af 100%);
+}
+
+/* Celebratory pulse when a row transitions to the completed state. Triggers
+   whenever the exercise re-renders with a new committed set — short, subtle,
+   and skipped entirely for users who prefer reduced motion. */
+@keyframes set-row-complete-pop {
+    0%   { background: rgba(34, 197, 94, 0.3);
+           box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2); }
+    60%  { background: rgba(34, 197, 94, 0.15); }
+    100% { background: rgba(34, 197, 94, 0.08);
+           box-shadow: none; }
+}
+
+/* Knob entrance — CSS transitions don't fire on freshly-mounted elements,
+   so play the slide explicitly when a completed row is first rendered. */
+@keyframes set-toggle-knob-in {
+    0%   { transform: translateX(0) scale(0.85); }
+    60%  { transform: translateX(var(--toggle-travel)) scale(1.05); }
+    100% { transform: translateX(var(--toggle-travel)) scale(1); }
+}
+
+@keyframes set-toggle-check-in {
+    0%   { opacity: 0; transform: scale(0.5); }
+    100% { opacity: 1; transform: scale(1); }
+}
+
+.set-row-complete {
+    animation: set-row-complete-pop 480ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.set-row-complete .set-toggle[aria-pressed="true"] .set-toggle-knob {
+    animation: set-toggle-knob-in 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.set-row-complete .set-toggle[aria-pressed="true"] .set-toggle-knob i {
+    animation: set-toggle-check-in 200ms ease-out 100ms both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .set-row-complete,
+    .set-row-complete .set-toggle[aria-pressed="true"] .set-toggle-knob,
+    .set-row-complete .set-toggle[aria-pressed="true"] .set-toggle-knob i {
+        animation: none;
+    }
+    .set-toggle, .set-toggle-knob, .set-toggle-knob i {
+        transition: none;
+    }
+}
+
+/* Group edit/delete so they share the right-side zone with the check mark.
+   Consistent gap between all three icons = even rhythm. */
+.set-row-actions {
+    flex-shrink: 0;
+    display: inline-flex;
+    gap: 0.35rem;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+/* Edit/delete icons on completed set rows: always at least readable on
+   touch screens (where :hover never fires), slightly bigger tap target. */
+.set-row .btn-set-action {
+    width: 34px !important;
+    height: 34px !important;
+    opacity: 0.85;
+}
+
+.set-row-complete .btn-set-action {
+    color: rgba(74, 222, 128, 0.75) !important;
+}
+
+.set-row-complete .btn-set-delete {
+    color: rgba(239, 68, 68, 0.7) !important;
+}
+
+.set-row .btn-set-action:hover,
+.set-row .btn-set-action:focus-visible {
+    opacity: 1;
+}
+
+/* Row of add/remove controls under the set list. Remove is a compact square
+   icon button that only renders when there's an uncommitted row to drop. */
+.set-row-footer {
+    margin-top: 0.6rem;
+    display: flex;
+    align-items: stretch;
+    gap: 0.5rem;
+}
+
+.set-row-footer .btn-add-set--extra {
+    margin-top: 0;
+    flex: 1;
+}
+
+.btn-remove-set {
+    flex: 0 0 auto;
+    width: 44px;
+    min-height: 44px;
+    padding: 0;
+    background: rgba(239, 68, 68, 0.07);
+    border: 1px dashed rgba(239, 68, 68, 0.4);
+    border-radius: var(--radius-md);
+    color: #fca5a5 !important;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 700;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background var(--transition-fast), color var(--transition-fast),
+                border-color var(--transition-fast), transform var(--transition-fast),
+                box-shadow var(--transition-fast);
+    -webkit-tap-highlight-color: transparent;
+}
+
+.btn-remove-set i {
+    color: inherit !important;
+    font-size: 0.85rem;
+}
+
+.btn-remove-set:hover {
+    background: rgba(239, 68, 68, 0.18);
+    color: #ffffff !important;
+    border-color: rgba(239, 68, 68, 0.7);
+    border-style: solid;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.12);
+}
+
+.btn-remove-set:active {
+    transform: translateY(1px);
+    background: rgba(239, 68, 68, 0.28);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.btn-remove-set:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.4);
+}
+
+/* Secondary CTA — reads as clearly clickable at rest (primary-text color,
+   visible tinted surface). Hover ramps brightness + border solidifies so the
+   affordance upgrade feels tactile.
+   !important on `color` is required because assets/css/main.css applies
+   `button { color: #555555 !important; }` globally with higher cascade
+   priority than our variable reference. */
+.btn-add-set--extra {
+    margin-top: 0.6rem;
+    width: 100%;
+    min-height: 44px;
+    padding: 0.7rem 1rem;
+    background: rgba(108, 99, 255, 0.12);
+    border: 1px dashed rgba(108, 99, 255, 0.55);
+    border-radius: var(--radius-md);
+    color: #ffffff !important;
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    transition: background var(--transition-fast), color var(--transition-fast),
+                border-color var(--transition-fast), transform var(--transition-fast),
+                box-shadow var(--transition-fast);
+    -webkit-tap-highlight-color: transparent;
+}
+
+.btn-add-set--extra i {
+    font-size: 0.8rem;
+    color: var(--accent-primary) !important;
+    transition: transform var(--transition-fast), color var(--transition-fast);
+}
+
+.btn-add-set--extra:hover {
+    background: rgba(108, 99, 255, 0.22);
+    color: #ffffff !important;
+    border-color: var(--accent-primary);
+    border-style: solid;
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.15), 0 4px 12px rgba(108, 99, 255, 0.2);
+}
+
+.btn-add-set--extra:hover i {
+    transform: scale(1.15);
+    color: #ffffff !important;
+}
+
+.btn-add-set--extra:active {
+    transform: translateY(1px);
+    background: rgba(108, 99, 255, 0.3);
+    color: #ffffff !important;
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.btn-add-set--extra:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.45);
+}
+
+@media (max-width: 480px) {
+    .set-row {
+        gap: 0.5rem;
+        padding: 0.7rem 0.5rem 0.7rem 0.55rem;
+    }
+    .set-row-complete {
+        padding-left: calc(0.55rem - 2px);
+    }
+    /* Slightly smaller input width so the planned-row [weight × reps] line
+       doesn't wrap on narrow phones. */
+    .set-row-inputs input { width: 70px; }
+    /* Tighter action spacing on phones to keep the right cluster compact. */
+    .set-row-actions { gap: 0.25rem; }
+}
+
+/* Last-time chips — self-contained compact pills so wrapping always looks
+   clean (each chip keeps its own padding/background; no cross-chip dividers
+   that would snap awkwardly when the row breaks). Fixed height guarantees
+   uniform visual weight regardless of content length (e.g. `72.5lb × 15`
+   sits at the same height as `60lb × 8`). */
+.previous-sets-row .prev-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    height: 22px;
+    padding: 0 0.45rem 0 0.3rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+    letter-spacing: -0.005em;
+    white-space: nowrap;
+}
+
+.previous-sets-row .prev-chip b {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 15px;
+    height: 15px;
+    padding: 0 0.22rem;
+    background: rgba(108, 99, 255, 0.18);
+    border-radius: 999px;
+    color: var(--accent-primary);
+    font-weight: 700;
+    font-size: 0.6rem;
+    letter-spacing: 0;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+}
+
 /* Toast Notifications */
 .toast {
     position: fixed;
@@ -2210,6 +3114,35 @@ body.gym-tracker #footer {
 
 .toast.toast-warning {
     border-left-color: var(--accent-warning);
+}
+
+.toast.toast-has-action {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+}
+
+.toast .toast-action {
+    flex-shrink: 0;
+    background: transparent;
+    color: var(--accent-primary);
+    border: 1px solid var(--accent-primary);
+    padding: 0.3rem 0.75rem;
+    border-radius: var(--radius-md);
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background var(--transition-base), color var(--transition-base);
+}
+
+.toast .toast-action:hover {
+    background: var(--accent-primary);
+    color: #fff;
+}
+
+.toast .toast-action:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.35);
 }
 
 /* History Grid */
@@ -3156,6 +4089,143 @@ body.gym-tracker #footer {
     font-weight: 500;
 }
 
+/* Picked state for multi-select — card stays visible so the user can unselect. */
+.exercise-picker-card.is-picked {
+    border-color: var(--accent-primary);
+    background: linear-gradient(135deg, rgba(108, 99, 255, 0.18), rgba(139, 92, 246, 0.22));
+    box-shadow: 0 0 0 1px rgba(108, 99, 255, 0.45) inset;
+}
+
+.exercise-picker-card.is-picked::before { opacity: 1; }
+
+.exercise-picker-check {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.65rem;
+    font-size: 1.1rem;
+    color: var(--text-muted);
+    opacity: 0.65;
+    transition: color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.exercise-picker-card.is-picked .exercise-picker-check {
+    color: #22c55e;
+    opacity: 1;
+}
+
+/* Sticky tray pinned to the bottom of the picker modal body. */
+.exercise-picker-tray {
+    position: sticky;
+    bottom: 0;
+    margin-top: var(--spacing-lg);
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-lg);
+    padding: 0.7rem 0.9rem;
+    box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.35);
+    z-index: 2;
+}
+
+.exercise-picker-tray[hidden] { display: none; }
+
+.exercise-picker-tray-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.55rem;
+}
+
+.exercise-picker-tray-count {
+    font-weight: 700;
+    color: var(--text-primary);
+    font-size: 0.88rem;
+    letter-spacing: 0.02em;
+}
+
+.exercise-picker-tray-list {
+    list-style: none;
+    margin: 0 0 0.65rem 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    max-height: 240px;
+    overflow-y: auto;
+}
+
+.exercise-picker-tray-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    gap: 0.55rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 0.45rem 0.6rem;
+}
+
+.exercise-picker-tray-row .tray-name {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 0.92rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.exercise-picker-tray-row .tray-steppers {
+    display: inline-flex;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.exercise-picker-tray-row .tray-remove {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    transition: background var(--transition-fast), color var(--transition-fast),
+                border-color var(--transition-fast);
+}
+
+.exercise-picker-tray-row .tray-remove:hover {
+    background: rgba(239, 68, 68, 0.18);
+    border-color: rgba(239, 68, 68, 0.5);
+    color: #ef4444;
+}
+
+.exercise-picker-tray-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+@media (max-width: 600px) {
+    .exercise-picker-tray-row {
+        grid-template-columns: 1fr auto;
+        grid-template-areas:
+            "name remove"
+            "steppers remove";
+    }
+    .exercise-picker-tray-row .tray-name { grid-area: name; }
+    .exercise-picker-tray-row .tray-steppers {
+        grid-area: steppers;
+        justify-content: flex-start;
+    }
+    .exercise-picker-tray-row .tray-remove {
+        grid-area: remove;
+        align-self: center;
+    }
+}
+
 .exercise-picker-list {
     display: grid;
     grid-template-columns: 1fr;
@@ -3332,18 +4402,206 @@ body.gym-tracker #footer {
     line-height: 1.4;
 }
 
+/* Two-row layout at every breakpoint so exercise identity never competes with
+   the numeric controls. The drag handle + index badge span both rows so the
+   whole card reads as a single draggable unit; identity + delete occupy the
+   top row; the Sets/Reps/Rest cluster sits below as a secondary control row. */
 .program-exercise-row {
     display: grid;
     grid-template-columns: auto auto 1fr auto;
+    grid-template-areas:
+        "handle position name   delete"
+        "handle position targets targets";
     align-items: center;
     column-gap: 0.55rem;
-    padding: 0.45rem 0.6rem;
+    row-gap: 0.45rem;
+    padding: 0.55rem 0.7rem;
     background: var(--bg-card);
     border: 1px solid var(--border-color);
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-sm);
     transition: transform var(--transition-fast), background var(--transition-fast),
                 border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.program-exercise-row .pex-drag-handle { grid-area: handle; align-self: center; }
+.program-exercise-row .pex-position    { grid-area: position; align-self: center; }
+.program-exercise-row .pex-name        { grid-area: name; align-self: center; }
+.program-exercise-row .pex-delete      { grid-area: delete; align-self: center; justify-self: end; }
+
+.pex-targets {
+    grid-area: targets;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+}
+
+/* Desktop refinement — left-aligned card, tighter title/control connection,
+   and a structured CSS Grid for Sets / Reps / Rest. Each stepper lives
+   inside a bounded grid cell so siblings can NEVER overlap.
+   Mobile keeps its existing flex-wrap layout via the media query boundary. */
+@media (min-width: 641px) {
+    /* Wider program modal so there's real horizontal space for three
+       stepper cells + padding without crowding. */
+    #program-modal .modal-content { max-width: 760px; }
+
+    /* Left-aligned, full-width: the list fills the modal body instead of
+       centering a narrow column. */
+    #program-exercises-list {
+        max-width: none;
+        margin-inline: 0;
+    }
+
+    .program-exercise-row {
+        padding: 0.75rem 1rem;
+        column-gap: 0.75rem;
+        /* Tight row-gap + dashed divider = "title and controls are one unit." */
+        row-gap: 0.4rem;
+        border-radius: var(--radius-lg);
+    }
+
+    .program-exercise-row .pex-name-main { font-size: 1.05rem; }
+
+    .program-exercise-row .pex-name-sub {
+        font-size: 0.78rem;
+        opacity: 0.75;
+    }
+
+    /* CSS Grid with auto-fit: three 170px-floor cells fit on one row at
+       normal desktop widths. If the container gets too narrow (narrow window,
+       user-shrunk modal), cells automatically wrap to the next row instead of
+       overlapping. Grid bounds each stepper so they CANNOT spill into one
+       another the way `flex: 1; min-width: 0` allowed. */
+    .pex-targets {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+        gap: 0.55rem;
+        padding-top: 0.45rem;
+        margin-top: 0;
+        border-top: 1px dashed var(--border-color);
+    }
+
+    /* Stepper fills its grid cell. No flex:1 or min-width:0 overrides —
+       the grid container owns the sizing, and the stepper's natural content
+       width (~150px) fits comfortably inside the 170px cell floor. */
+    .program-exercise-row .pex-stepper {
+        padding: 0.3rem 0.6rem 0.3rem 0.75rem;
+        min-height: 34px;
+        gap: 0.6rem;
+    }
+
+    /* Slightly larger value floor so "2:15"/"10:30" sit cleanly without
+       crowding the +/- buttons. Tabular numerals keep widths stable. */
+    .program-exercise-row .pex-stepper-value {
+        min-width: 3ch;
+        font-size: 0.9rem;
+    }
+
+    .program-exercise-row .pex-stepper-controls {
+        gap: 0.4rem;
+    }
+
+    .program-exercise-row .pex-stepper-btn {
+        width: 26px;
+        height: 26px;
+        font-size: 0.75rem;
+    }
+
+    /* Drag handle + index badge — more presence on the taller card. */
+    .program-exercise-row .pex-drag-handle {
+        height: 28px;
+        font-size: 0.9rem;
+    }
+    .program-exercise-row .pex-position {
+        width: 24px;
+        height: 24px;
+        font-size: 0.7rem;
+    }
+
+    /* Delete stays tertiary at rest; aligned to the identity row's right edge. */
+    .program-exercise-row .pex-delete {
+        width: 28px !important;
+        height: 28px !important;
+        font-size: 0.82rem !important;
+    }
+}
+
+/* Stepper — two zones separated by space-between:
+     [ LABEL ]                   [ - value + ]
+   The inner .pex-stepper-controls owns its own fixed inter-element gap so
+   the spacing between minus, value, and plus is ALWAYS identical, no matter
+   how long the value string is ("3", "10", "1:30", "2:15", "10:30"). */
+.pex-stepper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 0.15rem 0.35rem;
+    font-size: 0.78rem;
+}
+
+.pex-stepper-label {
+    flex-shrink: 0;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.65rem;
+}
+
+/* Right-side group: [-] value [+]. Fixed gap guarantees visual rhythm. */
+.pex-stepper-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    flex-shrink: 0;
+}
+
+.pex-stepper-value {
+    min-width: 2.6ch;
+    padding: 0 0.1rem;
+    text-align: center;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    letter-spacing: -0.005em;
+    white-space: nowrap;
+}
+
+.pex-stepper-btn {
+    flex-shrink: 0;
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    width: 22px;
+    height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    font-size: 0.7rem;
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.pex-stepper-btn:hover:not(:disabled) {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+
+.pex-stepper-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.pex-stepper-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(108, 99, 255, 0.45);
 }
 
 /* Tighter gap specifically between the number badge and the exercise name,

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -39,6 +39,10 @@
                 <i class="fas fa-list"></i>
                 <span>Programs</span>
             </button>
+            <button class="nav-item nav-item-primary" data-view="workout" aria-label="Start or resume workout">
+                <i class="fas fa-dumbbell"></i>
+                <span>Workout</span>
+            </button>
             <button class="nav-item" data-view="history">
                 <i class="fas fa-chart-line"></i>
                 <span>History</span>
@@ -94,6 +98,11 @@
                     <h1>Dashboard</h1>
                     <p class="subtitle">Track your fitness journey</p>
                 </div>
+
+                <button type="button" id="home-workout-fab" class="workout-fab" hidden aria-label="Start workout">
+                    <i class="fas fa-play" aria-hidden="true"></i>
+                    <span class="workout-fab-label">Start workout</span>
+                </button>
 
                 <!-- Active Program -->
                 <section class="section">
@@ -205,7 +214,7 @@
                 <div id="exercise-picker-modal" class="modal">
                     <div class="modal-content large">
                         <div class="modal-header">
-                            <h2>Select Exercise</h2>
+                            <h2>Select Exercises</h2>
                             <button class="modal-close">&times;</button>
                         </div>
                         <div class="modal-body">
@@ -260,6 +269,24 @@
                             <div id="exercise-picker-list" class="exercise-grid">
                                 <!-- Will be populated by JS -->
                             </div>
+
+                            <!-- Sticky tray of picked exercises; appears once at least one is selected -->
+                            <div id="exercise-picker-tray" class="exercise-picker-tray" hidden>
+                                <div class="exercise-picker-tray-header">
+                                    <span class="exercise-picker-tray-count" id="exercise-picker-tray-count">Added 0</span>
+                                    <button type="button" class="btn btn-ghost btn-sm" id="exercise-picker-tray-clear">
+                                        <i class="fas fa-rotate-left"></i> Clear
+                                    </button>
+                                </div>
+                                <ul id="exercise-picker-tray-list" class="exercise-picker-tray-list">
+                                    <!-- populated by JS -->
+                                </ul>
+                                <div class="exercise-picker-tray-actions">
+                                    <button type="button" class="btn btn-primary" id="exercise-picker-commit">
+                                        <i class="fas fa-check"></i> Add to program
+                                    </button>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -281,8 +308,8 @@
                 <!-- Active Workout Screen -->
                 <div id="active-workout" class="workout-screen">
                     <div class="workout-header">
-                        <button class="btn-icon btn-icon-end" id="end-workout-btn" title="Discard Workout">
-                            <i class="fas fa-times"></i>
+                        <button class="btn-icon btn-icon-end" id="end-workout-btn" title="Discard Workout" aria-label="Discard workout without saving">
+                            <i class="fas fa-trash-can"></i>
                         </button>
                         <div class="workout-info">
                             <h2 id="workout-title">Workout</h2>
@@ -292,10 +319,10 @@
                             </div>
                         </div>
                         <div class="workout-header-actions">
-                            <button class="btn-icon btn-icon-pause" id="pause-workout-btn" title="Pause Workout">
+                            <button class="btn-icon btn-icon-pause" id="pause-workout-btn" title="Pause Workout" aria-label="Pause workout and save progress">
                                 <i class="fas fa-pause"></i>
                             </button>
-                            <button class="btn-icon btn-icon-finish" id="finish-workout-btn" title="Finish Workout">
+                            <button class="btn-icon btn-icon-finish" id="finish-workout-btn" title="Finish Workout" aria-label="Finish workout and save">
                                 <i class="fas fa-check"></i>
                             </button>
                         </div>
@@ -307,19 +334,24 @@
                         </div>
                     </div>
 
-                    <!-- Rest Timer Modal -->
-                    <div id="rest-timer-modal" class="modal">
-                        <div class="modal-content small">
-                            <div class="rest-timer-content">
-                                <h3>Rest Timer</h3>
-                                <div class="rest-timer-display">
-                                    <div id="rest-timer-value">90</div>
-                                    <div class="rest-timer-label">seconds</div>
-                                </div>
-                                <div class="rest-timer-actions">
-                                    <button class="btn btn-secondary" id="skip-rest-btn">Skip</button>
-                                    <button class="btn btn-primary" id="add-time-btn">+30s</button>
-                                </div>
+                    <!-- Rest Timer Bar (persistent; appears after a set is logged) -->
+                    <div id="rest-timer-bar" class="rest-timer-bar" role="status" aria-live="polite" hidden>
+                        <div class="rest-timer-bar-inner">
+                            <div class="rest-timer-info">
+                                <i class="fas fa-hourglass-half" aria-hidden="true"></i>
+                                <span class="rest-timer-label">Rest</span>
+                                <span id="rest-timer-value" class="rest-timer-value">0:00</span>
+                            </div>
+                            <div class="rest-timer-progress" aria-hidden="true">
+                                <span id="rest-timer-progress-fill" class="rest-timer-progress-fill"></span>
+                            </div>
+                            <div class="rest-timer-actions">
+                                <button type="button" class="rest-timer-action-btn" id="rest-add-btn" aria-label="Add 30 seconds">
+                                    +30s
+                                </button>
+                                <button type="button" class="rest-timer-action-btn rest-timer-skip" id="rest-skip-btn" aria-label="Skip rest">
+                                    Skip
+                                </button>
                             </div>
                         </div>
                     </div>

--- a/apps/gym-tracker/js/app.js
+++ b/apps/gym-tracker/js/app.js
@@ -329,32 +329,30 @@ class GymTrackerApp {
     }
 
     /**
-     * Clear all data
+     * Clear all data. Caller is responsible for confirming with the user first.
      */
     clearAllData() {
-        if (confirm('Are you sure you want to delete ALL data? This cannot be undone!')) {
-            storageService.clearAllData();
-            this.programs = [];
-            this.workoutSessions = [];
-            this.achievements = AchievementService.getDefaultAchievements();
-            this.customExercises = [];
-            this.settings = Settings.getDefault();
-            this.currentWorkoutSession = null;
+        storageService.clearAllData();
+        this.programs = [];
+        this.workoutSessions = [];
+        this.achievements = AchievementService.getDefaultAchievements();
+        this.customExercises = [];
+        this.settings = Settings.getDefault();
+        this.currentWorkoutSession = null;
 
-            this.savePrograms();
-            this.saveWorkoutSessions();
-            this.saveAchievements();
-            this.saveCustomExercises();
-            this.saveSettings();
+        this.savePrograms();
+        this.saveWorkoutSessions();
+        this.saveAchievements();
+        this.saveCustomExercises();
+        this.saveSettings();
 
-            showToast('All data cleared', 'info');
-            this.showView('home');
+        showToast('All data cleared', 'info');
+        this.showView('home');
 
-            // Reload to ensure clean state
-            setTimeout(() => {
-                location.reload();
-            }, 1000);
-        }
+        // Reload to ensure clean state
+        setTimeout(() => {
+            location.reload();
+        }, 1000);
     }
 
     /**

--- a/apps/gym-tracker/js/models/Program.js
+++ b/apps/gym-tracker/js/models/Program.js
@@ -7,20 +7,31 @@ export class Program {
         this.id = data.id || Date.now();
         this.name = data.name || '';
         this.description = data.description || '';
-        this.exercises = data.exercises || []; // Array of { exerciseId, exerciseName, targetSets, targetReps, notes, order }
+        // Array of { exerciseId, exerciseName, targetSets, targetReps, restSeconds, notes, order }
+        this.exercises = (data.exercises || []).map(normalizeExercise);
         this.createdAt = data.createdAt || new Date().toISOString();
         this.updatedAt = data.updatedAt || new Date().toISOString();
     }
 
-    addExercise(exerciseId, exerciseName, targetSets = 3, targetReps = 10, notes = '') {
+    addExercise(exerciseId, exerciseName, targetSets = 3, targetReps = 10, notes = '', restSeconds = null) {
         const order = this.exercises.length;
-        this.exercises.push({
+        this.exercises.push(normalizeExercise({
             exerciseId,
             exerciseName,
             targetSets,
             targetReps,
+            restSeconds,
             notes,
-            order
+            order,
+        }));
+        this.updatedAt = new Date().toISOString();
+    }
+
+    updateExercise(index, patch = {}) {
+        if (index < 0 || index >= this.exercises.length) return;
+        this.exercises[index] = normalizeExercise({
+            ...this.exercises[index],
+            ...patch,
         });
         this.updatedAt = new Date().toISOString();
     }
@@ -59,4 +70,56 @@ export class Program {
     static fromJSON(json) {
         return new Program(json);
     }
+}
+
+/**
+ * Default rest (seconds) by equipment type. Heavy compound movements need
+ * more rest; accessory/bodyweight work needs less. Callers pass `null` to
+ * let us choose the default for the exercise's equipment.
+ */
+const REST_DEFAULTS_BY_EQUIPMENT = {
+    barbell: 180,
+    'trap-bar': 180,
+    dumbbell: 90,
+    kettlebell: 90,
+    cable: 75,
+    machine: 75,
+    'resistance-band': 60,
+    bodyweight: 60,
+    plate: 90,
+    'medicine-ball': 60,
+    'battle-ropes': 60,
+    'ab-wheel': 60,
+    sled: 120,
+    tire: 120,
+    gripper: 45,
+    towel: 60,
+    various: 90,
+};
+
+export function defaultRestForEquipment(equipment) {
+    return REST_DEFAULTS_BY_EQUIPMENT[equipment] ?? 90;
+}
+
+/**
+ * Coerce a raw exercise entry into the canonical program-exercise shape.
+ * Guarantees every row has targetSets/targetReps/restSeconds so the UI
+ * can render steppers without null-checks on older saved data.
+ */
+function normalizeExercise(ex) {
+    return {
+        exerciseId: ex.exerciseId,
+        exerciseName: ex.exerciseName,
+        targetSets: clampInt(ex.targetSets, 1, 20, 3),
+        targetReps: clampInt(ex.targetReps, 1, 100, 10),
+        restSeconds: clampInt(ex.restSeconds, 0, 900, 90),
+        notes: ex.notes || '',
+        order: Number.isFinite(ex.order) ? ex.order : 0,
+    };
+}
+
+function clampInt(value, min, max, fallback) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    return Math.max(min, Math.min(max, Math.round(n)));
 }

--- a/apps/gym-tracker/js/models/WorkoutExercise.js
+++ b/apps/gym-tracker/js/models/WorkoutExercise.js
@@ -10,9 +10,15 @@ export class WorkoutExercise {
         this.exerciseName = data.exerciseName || '';
         this.sets = (data.sets || []).map(s => s instanceof Set ? s : new Set(s));
         this.targetSets = data.targetSets || 3;
+        this.targetReps = data.targetReps || 10;
+        this.restSeconds = Number.isFinite(data.restSeconds) ? data.restSeconds : 90;
         this.notes = data.notes || '';
         this.order = data.order || 0;
         this.completed = data.completed || false;
+        // stickyValues: per-slot defaults for planned rows, populated when a
+        // user unchecks a previously-completed set. Keys are slot indices,
+        // values are {weight, reps, duration} — same shape as a prior-set entry.
+        this.stickyValues = data.stickyValues || {};
     }
 
     get totalVolume() {
@@ -39,9 +45,12 @@ export class WorkoutExercise {
             exerciseName: this.exerciseName,
             sets: this.sets.map(s => s.toJSON()),
             targetSets: this.targetSets,
+            targetReps: this.targetReps,
+            restSeconds: this.restSeconds,
             notes: this.notes,
             order: this.order,
-            completed: this.completed
+            completed: this.completed,
+            stickyValues: this.stickyValues,
         };
     }
 

--- a/apps/gym-tracker/js/models/WorkoutSession.js
+++ b/apps/gym-tracker/js/models/WorkoutSession.js
@@ -43,6 +43,21 @@ export class WorkoutSession {
         return 0;
     }
 
+    /**
+     * Canonical chronological key for sorting/comparison. Uses the most
+     * precise timestamp available so two workouts on the same calendar day
+     * order correctly by time-of-day, not by insertion order.
+     *
+     * Priority:
+     *   endTime (actual completion)
+     *     → startTime (session began)
+     *     → timestamp (created-at)
+     *     → date (last-resort midnight-local)
+     */
+    get sortTimestamp() {
+        return this.endTime || this.startTime || this.timestamp || this.date;
+    }
+
     get totalVolume() {
         return this.exercises.reduce((sum, ex) => sum + ex.totalVolume, 0);
     }

--- a/apps/gym-tracker/js/utils/helpers.js
+++ b/apps/gym-tracker/js/utils/helpers.js
@@ -132,6 +132,27 @@ export function formatWeight(weight, unit = 'kg') {
 }
 
 /**
+ * Format a workout session's date + time-of-day for display.
+ * Returns e.g. "Apr 20, 2026 • 6:42 PM". Falls back to just the date when
+ * no precise timestamp is available (very old data).
+ */
+export function formatSessionDateTime(session) {
+    if (!session) return '';
+    const datePart = formatDate(session.date);
+    // Prefer endTime; fall back through startTime then timestamp.
+    const timeSrc = session.endTime || session.startTime || session.timestamp;
+    if (!timeSrc) return datePart;
+    const d = new Date(timeSrc);
+    if (Number.isNaN(d.getTime())) return datePart;
+    const time = d.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+    });
+    return `${datePart} • ${time}`;
+}
+
+/**
  * Convert weight between units
  */
 export function convertWeight(weight, fromUnit, toUnit) {
@@ -246,12 +267,39 @@ export function downloadJSON(data, filename) {
 }
 
 /**
- * Show toast notification
+ * Show toast notification.
+ *
+ * Accepts either `showToast(message, type, duration)` or
+ * `showToast(message, type, duration, { action: { label, onClick } })`.
+ * When `action` is provided, the toast renders an inline button. Clicking
+ * the button invokes `onClick` and dismisses the toast.
  */
-export function showToast(message, type = 'info', duration = 3000) {
+export function showToast(message, type = 'info', duration = 3000, opts = {}) {
     const toast = document.createElement('div');
     toast.className = `toast toast-${type}`;
-    toast.textContent = message;
+
+    const msg = document.createElement('span');
+    msg.className = 'toast-message';
+    msg.textContent = message;
+    toast.appendChild(msg);
+
+    let dismiss;
+
+    if (opts.action && opts.action.label) {
+        toast.classList.add('toast-has-action');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'toast-action';
+        btn.textContent = opts.action.label;
+        btn.addEventListener('click', () => {
+            try {
+                if (typeof opts.action.onClick === 'function') opts.action.onClick();
+            } finally {
+                dismiss && dismiss();
+            }
+        });
+        toast.appendChild(btn);
+    }
 
     document.body.appendChild(toast);
 
@@ -264,18 +312,21 @@ export function showToast(message, type = 'info', duration = 3000) {
     });
     toast.style.top = `${offset}px`;
 
-    setTimeout(() => {
-        toast.classList.add('show');
-    }, 10);
+    setTimeout(() => { toast.classList.add('show'); }, 10);
 
-    setTimeout(() => {
+    let removed = false;
+    dismiss = () => {
+        if (removed) return;
+        removed = true;
         toast.classList.remove('show');
         setTimeout(() => {
-            if (toast.parentNode) {
-                document.body.removeChild(toast);
-            }
+            if (toast.parentNode) toast.parentNode.removeChild(toast);
         }, 300);
-    }, duration);
+    };
+
+    setTimeout(dismiss, duration);
+
+    return { dismiss };
 }
 
 /**

--- a/apps/gym-tracker/js/views/calendar-view.js
+++ b/apps/gym-tracker/js/views/calendar-view.js
@@ -227,7 +227,11 @@ class CalendarView {
         if (!container) return;
 
         const sessions = this.app.workoutSessions || [];
-        const daySessions = sessions.filter(s => s.date === this.selectedDate);
+        // Sort same-day sessions by time-of-day, latest first, so an evening
+        // workout shows above a morning one on the same calendar day.
+        const daySessions = sessions
+            .filter(s => s.date === this.selectedDate)
+            .sort((a, b) => new Date(b.sortTimestamp) - new Date(a.sortTimestamp));
         const dateObj = new Date(this.selectedDate);
         const headerLabel = dateObj.toLocaleDateString(undefined, {
             weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',

--- a/apps/gym-tracker/js/views/exercises-view.js
+++ b/apps/gym-tracker/js/views/exercises-view.js
@@ -261,6 +261,7 @@ class ExercisesView {
                     if (set.completed) {
                         history.push({
                             date: session.date,
+                            sortKey: session.sortTimestamp,
                             weight: set.weight,
                             reps: set.reps,
                             duration: set.duration || 0,
@@ -271,40 +272,40 @@ class ExercisesView {
             }
         });
 
-        // Sort by date (most recent first) using local date parsing
-        return history.sort((a, b) => parseLocalDate(b.date) - parseLocalDate(a.date));
+        // Sort by full session timestamp (most recent first) so multiple
+        // sessions on the same day order by time-of-day.
+        return history.sort((a, b) => new Date(b.sortKey) - new Date(a.sortKey));
     }
 
+    /**
+     * Group by session (not by calendar date) so two workouts on the same day
+     * remain distinct in the exercise-history table. Sorted newest-first by
+     * full timestamp.
+     */
     getExerciseHistoryGroupedByDate(exerciseId) {
-        const groupedHistory = {};
+        const groups = [];
 
         this.app.workoutSessions.forEach(session => {
             const exercise = session.exercises.find(ex => ex.exerciseId === exerciseId);
             if (exercise && exercise.sets && exercise.sets.length > 0) {
                 const completedSets = exercise.sets.filter(set => set.completed);
                 if (completedSets.length > 0) {
-                    if (!groupedHistory[session.date]) {
-                        groupedHistory[session.date] = {
-                            date: session.date,
-                            sets: []
-                        };
-                    }
-                    completedSets.forEach(set => {
-                        groupedHistory[session.date].sets.push({
+                    groups.push({
+                        date: session.date,
+                        sortKey: session.sortTimestamp,
+                        sessionId: session.id,
+                        sets: completedSets.map(set => ({
                             weight: set.weight,
                             reps: set.reps,
                             duration: set.duration || 0,
-                            volume: set.volume
-                        });
+                            volume: set.volume,
+                        })),
                     });
                 }
             }
         });
 
-        // Convert to array and sort by date (most recent first)
-        return Object.values(groupedHistory).sort((a, b) =>
-            parseLocalDate(b.date) - parseLocalDate(a.date)
-        );
+        return groups.sort((a, b) => new Date(b.sortKey) - new Date(a.sortKey));
     }
 
     openCustomExerciseModal() {
@@ -433,6 +434,17 @@ class ExercisesView {
             year: 'numeric', month: 'short', day: 'numeric',
         });
 
+        // "6:42 PM" from an ISO timestamp. Used to disambiguate two sessions
+        // on the same calendar day.
+        const fmtTime = (iso) => {
+            if (!iso) return '';
+            const d = new Date(iso);
+            if (Number.isNaN(d.getTime())) return '';
+            return d.toLocaleTimeString(undefined, {
+                hour: 'numeric', minute: '2-digit', hour12: true,
+            });
+        };
+
         // Caption that explains what makes the best set "best"
         const bestCaption = isDuration ? 'Longest duration' : 'Highest volume (weight × reps)';
 
@@ -470,11 +482,23 @@ class ExercisesView {
             <span class="set-badge ${stateClass || ''}"${title ? ` title="${title}"` : ''}>${label}</span>
         `;
 
+        // Which calendar dates have more than one session? When they do, we
+        // add the time-of-day to the row label so multiple same-day sessions
+        // remain distinguishable at a glance.
+        const sessionsPerDate = groupedHistory.reduce((acc, r) => {
+            acc[r.date] = (acc[r.date] || 0) + 1;
+            return acc;
+        }, {});
+
         // groupedHistory is sorted newest-first, so the previous session for
         // each row is at the next index.
         const tableBodyHTML = groupedHistory.map((record, recordIdx) => {
-            const isBestRow = record.date === bestSet.date;
+            // Match the "best" session uniquely by timestamp — `date` alone
+            // would flag every session on the best-performance day.
+            const isBestRow = record.sortKey === bestSet.sortKey;
             const previousRecord = groupedHistory[recordIdx + 1];
+            const showTime = sessionsPerDate[record.date] > 1;
+            const timeLabel = showTime ? fmtTime(record.sortKey) : '';
 
             const setsDisplay = record.sets.map((set, idx) => {
                 const prevSet = previousRecord?.sets?.[idx];
@@ -527,7 +551,7 @@ class ExercisesView {
             return `
                 <tr class="${isBestRow ? 'is-best-row' : ''}">
                     <td class="col-date">
-                        <span class="history-date">${fmtDate(record.date)}</span>
+                        <span class="history-date">${fmtDate(record.date)}${timeLabel ? ` · ${timeLabel}` : ''}</span>
                         ${isBestRow ? '<span class="best-row-badge"><i class="fas fa-star"></i> Best</span>' : ''}
                     </td>
                     <td class="col-sets sets-cell">${setsDisplay}</td>

--- a/apps/gym-tracker/js/views/history-view.js
+++ b/apps/gym-tracker/js/views/history-view.js
@@ -2,7 +2,7 @@
  * History View Controller
  */
 import { app } from '../app.js';
-import { formatDate, showToast, showConfirmModal } from '../utils/helpers.js';
+import { formatDate, showToast, formatSessionDateTime } from '../utils/helpers.js';
 import { DarkCalendar } from '../utils/dark-calendar.js';
 import { DarkSelect } from '../utils/dark-select.js';
 
@@ -97,17 +97,18 @@ class HistoryView {
             sessions = sessions.filter(session => session.date <= this.dateTo);
         }
 
-        // Apply sorting
+        // Apply sorting. Date-asc/date-desc use the full session timestamp so
+        // two workouts on the same calendar day are ordered by time-of-day.
         sessions.sort((a, b) => {
             switch (this.currentSort) {
                 case 'date-asc':
-                    return new Date(a.date) - new Date(b.date);
+                    return new Date(a.sortTimestamp) - new Date(b.sortTimestamp);
                 case 'date-desc':
-                    return new Date(b.date) - new Date(a.date);
+                    return new Date(b.sortTimestamp) - new Date(a.sortTimestamp);
                 case 'volume-desc':
                     return b.totalVolume - a.totalVolume;
                 default:
-                    return new Date(b.date) - new Date(a.date);
+                    return new Date(b.sortTimestamp) - new Date(a.sortTimestamp);
             }
         });
 
@@ -132,9 +133,9 @@ class HistoryView {
                     <div class="workout-card-header">
                         <div class="workout-header-info">
                             <h3>${session.workoutDayName}</h3>
-                            <span class="date">${formatDate(session.date)}</span>
+                            <span class="date">${formatSessionDateTime(session)}</span>
                         </div>
-                        <button class="btn-icon delete-workout-btn" onclick="event.stopPropagation(); window.gymApp.viewControllers.history.deleteWorkout(${session.id})" title="Delete workout">
+                        <button class="btn-icon delete-workout-btn" onclick="event.stopPropagation(); window.gymApp.viewControllers.history.deleteWorkout(${session.id})" title="Delete workout" aria-label="Delete workout">
                             <i class="fas fa-trash"></i>
                         </button>
                     </div>
@@ -214,7 +215,7 @@ class HistoryView {
         // Build the detailed content
         let html = `
             <div class="workout-detail-summary">
-                <div class="detail-date">${formatDate(session.date)}</div>
+                <div class="detail-date">${formatSessionDateTime(session)}</div>
                 <div class="detail-stats">
                     <div class="detail-stat">
                         <span class="label">Duration</span>
@@ -347,36 +348,44 @@ class HistoryView {
         modal.classList.add('active');
     }
 
-    async deleteWorkout(sessionId) {
-        const session = this.app.workoutSessions.find(s => s.id === sessionId);
-        if (!session) return;
+    deleteWorkout(sessionId) {
+        const index = this.app.workoutSessions.findIndex(s => s.id === sessionId);
+        if (index < 0) return;
 
-        const message = `Are you sure you want to delete this workout?<br><br><strong>${session.workoutDayName}</strong><br>${formatDate(session.date)}<br><br>This workout included ${session.exercises.length} exercise${session.exercises.length !== 1 ? 's' : ''} and ${Math.round(session.totalVolume).toLocaleString()}${this.app.settings.weightUnit} total volume.<br><br><strong>This action cannot be undone.</strong>`;
+        // Snapshot the session + its original position so Undo can restore it exactly.
+        const session = this.app.workoutSessions[index];
+        const snapshot = { session, index };
 
-        const confirmed = await showConfirmModal({
-            title: 'Delete Workout',
-            message: message,
-            confirmText: 'Delete Workout',
-            cancelText: 'Cancel',
-            isDangerous: true
-        });
+        this.app.workoutSessions.splice(index, 1);
+        this.app.saveWorkoutSessions();
+        this.app.updateAchievements();
+        this.render();
 
-        if (confirmed) {
-            const index = this.app.workoutSessions.findIndex(s => s.id === sessionId);
-            if (index >= 0) {
-                this.app.workoutSessions.splice(index, 1);
-                this.app.saveWorkoutSessions();
-
-                // Update achievements since workout data changed
-                this.app.updateAchievements();
-
-                // Re-render the list
-                this.render();
-
-                // Show confirmation
-                showToast('Workout deleted', 'info');
+        // 7s gives enough time to notice the toast and tap Undo without being
+        // long enough to be intrusive. Matches the Material "snackbar" guidance.
+        showToast(
+            `Deleted "${session.workoutDayName}" · ${formatSessionDateTime(session)}`,
+            'info',
+            7000,
+            {
+                action: {
+                    label: 'Undo',
+                    onClick: () => this.restoreDeletedWorkout(snapshot),
+                },
             }
-        }
+        );
+    }
+
+    restoreDeletedWorkout(snapshot) {
+        if (!snapshot || !snapshot.session) return;
+        const { session, index } = snapshot;
+        // Clamp to current list length in case other sessions were deleted meanwhile.
+        const insertAt = Math.min(index, this.app.workoutSessions.length);
+        this.app.workoutSessions.splice(insertAt, 0, session);
+        this.app.saveWorkoutSessions();
+        this.app.updateAchievements();
+        this.render();
+        showToast('Workout restored', 'success');
     }
 
     goToProgramDetails(programId) {

--- a/apps/gym-tracker/js/views/history-view.js
+++ b/apps/gym-tracker/js/views/history-view.js
@@ -2,7 +2,7 @@
  * History View Controller
  */
 import { app } from '../app.js';
-import { formatDate, showToast, formatSessionDateTime } from '../utils/helpers.js';
+import { formatDate, showToast, showConfirmModal, formatSessionDateTime } from '../utils/helpers.js';
 import { DarkCalendar } from '../utils/dark-calendar.js';
 import { DarkSelect } from '../utils/dark-select.js';
 
@@ -348,44 +348,32 @@ class HistoryView {
         modal.classList.add('active');
     }
 
-    deleteWorkout(sessionId) {
+    async deleteWorkout(sessionId) {
+        const session = this.app.workoutSessions.find(s => s.id === sessionId);
+        if (!session) return;
+
+        const exerciseCount = session.exercises.length;
+        const exerciseLabel = exerciseCount === 1 ? 'exercise' : 'exercises';
+        const message = `Are you sure you want to delete this workout?<br><br><strong>${session.workoutDayName}</strong><br>${formatSessionDateTime(session)}<br><br>This workout included ${exerciseCount} ${exerciseLabel} and ${Math.round(session.totalVolume).toLocaleString()}${this.app.settings.weightUnit} total volume.<br><br><strong>This action cannot be undone.</strong>`;
+
+        const confirmed = await showConfirmModal({
+            title: 'Delete Workout',
+            message,
+            confirmText: 'Delete Workout',
+            cancelText: 'Cancel',
+            isDangerous: true,
+        });
+
+        if (!confirmed) return;
+
         const index = this.app.workoutSessions.findIndex(s => s.id === sessionId);
         if (index < 0) return;
-
-        // Snapshot the session + its original position so Undo can restore it exactly.
-        const session = this.app.workoutSessions[index];
-        const snapshot = { session, index };
 
         this.app.workoutSessions.splice(index, 1);
         this.app.saveWorkoutSessions();
         this.app.updateAchievements();
         this.render();
-
-        // 7s gives enough time to notice the toast and tap Undo without being
-        // long enough to be intrusive. Matches the Material "snackbar" guidance.
-        showToast(
-            `Deleted "${session.workoutDayName}" · ${formatSessionDateTime(session)}`,
-            'info',
-            7000,
-            {
-                action: {
-                    label: 'Undo',
-                    onClick: () => this.restoreDeletedWorkout(snapshot),
-                },
-            }
-        );
-    }
-
-    restoreDeletedWorkout(snapshot) {
-        if (!snapshot || !snapshot.session) return;
-        const { session, index } = snapshot;
-        // Clamp to current list length in case other sessions were deleted meanwhile.
-        const insertAt = Math.min(index, this.app.workoutSessions.length);
-        this.app.workoutSessions.splice(insertAt, 0, session);
-        this.app.saveWorkoutSessions();
-        this.app.updateAchievements();
-        this.render();
-        showToast('Workout restored', 'success');
+        showToast('Workout deleted', 'info');
     }
 
     goToProgramDetails(programId) {

--- a/apps/gym-tracker/js/views/home-view.js
+++ b/apps/gym-tracker/js/views/home-view.js
@@ -4,8 +4,9 @@
  */
 import { app } from '../app.js';
 import { storageService } from '../services/StorageService.js';
-import { formatDate, formatWeight } from '../utils/helpers.js';
+import { formatDate, formatWeight, showConfirmModal, showToast, formatSessionDateTime } from '../utils/helpers.js';
 import { orderPrograms } from '../utils/program-order.js';
+import { renderPausedBannerHTML, wirePausedBannerActions } from './paused-banner.js';
 
 class HomeView {
     constructor() {
@@ -15,6 +16,14 @@ class HomeView {
 
     init() {
         this.app.viewControllers.home = this;
+        this.wireFab();
+    }
+
+    wireFab() {
+        const fab = document.getElementById('home-workout-fab');
+        if (!fab || fab.dataset.wired) return;
+        fab.addEventListener('click', () => this.handleFabClick());
+        fab.dataset.wired = '1';
     }
 
     render() {
@@ -22,58 +31,87 @@ class HomeView {
         this.renderActiveProgram();
         this.renderRecentWorkouts();
         this.renderRecentAchievements();
+        this.renderFab();
+    }
+
+    /**
+     * The FAB has three states:
+     *   - Hidden when there are no programs yet (nothing to start).
+     *   - "Resume workout" (green) when a paused session exists.
+     *   - "Start workout" (primary) otherwise.
+     * Clicking either state jumps to the workout view; resume re-hydrates.
+     */
+    renderFab() {
+        const fab = document.getElementById('home-workout-fab');
+        if (!fab) return;
+        const hasPrograms = this.app.programs.length > 0;
+        const paused = storageService.getActiveWorkout();
+
+        if (!hasPrograms) {
+            fab.hidden = true;
+            return;
+        }
+
+        fab.hidden = false;
+        const label = fab.querySelector('.workout-fab-label');
+        const icon = fab.querySelector('i');
+
+        if (paused && paused.paused) {
+            fab.classList.add('workout-fab--resume');
+            if (label) label.textContent = 'Resume workout';
+            if (icon) {
+                icon.classList.remove('fa-play');
+                icon.classList.add('fa-play-circle');
+            }
+            fab.setAttribute('aria-label', 'Resume paused workout');
+        } else {
+            fab.classList.remove('workout-fab--resume');
+            if (label) label.textContent = 'Start workout';
+            if (icon) {
+                icon.classList.remove('fa-play-circle');
+                icon.classList.add('fa-play');
+            }
+            fab.setAttribute('aria-label', 'Start workout');
+        }
+    }
+
+    /**
+     * If paused → go to workout view and let it resume automatically.
+     * If exactly one program → auto-start it.
+     * Otherwise → route to the workout view's program picker.
+     */
+    handleFabClick() {
+        const paused = storageService.getActiveWorkout();
+        if (paused && paused.paused) {
+            this.resumeWorkout();
+            return;
+        }
+        if (this.app.programs.length === 1) {
+            const only = this.app.programs[0];
+            if (only.exercises && only.exercises.length > 0) {
+                this.startWorkoutWithProgram(only.id);
+                return;
+            }
+        }
+        this.app.showView('workout');
     }
 
     renderPausedWorkoutBanner() {
         const container = document.getElementById('active-program-card');
-        const pausedWorkout = storageService.getActiveWorkout();
 
         // Remove any existing banner first
         const existingBanner = document.querySelector('.paused-workout-banner');
-        if (existingBanner) {
-            existingBanner.remove();
-        }
+        if (existingBanner) existingBanner.remove();
 
-        if (!pausedWorkout || !pausedWorkout.paused) {
-            return;
-        }
+        const bannerHTML = renderPausedBannerHTML({ location: 'home', withCalendarMeta: false });
+        if (!bannerHTML) return;
 
-        const pausedAt = new Date(pausedWorkout.pausedAt);
-        const elapsed = pausedWorkout.elapsedBeforePause;
-        const minutes = Math.floor(elapsed / 60);
-        const seconds = elapsed % 60;
-
-        // Count total sets saved
-        const totalSets = pausedWorkout.exercises.reduce((sum, ex) =>
-            sum + (ex.sets ? ex.sets.length : 0), 0
-        );
-
-        const bannerHTML = `
-            <div class="paused-workout-banner">
-                <div class="paused-workout-icon">
-                    <i class="fas fa-pause-circle"></i>
-                </div>
-                <div class="paused-workout-info">
-                    <h3>Paused Workout</h3>
-                    <p><strong>${pausedWorkout.workoutDayName}</strong></p>
-                    <p class="paused-workout-meta">
-                        <span><i class="fas fa-clock"></i> ${minutes}:${String(seconds).padStart(2, '0')} elapsed</span>
-                        <span><i class="fas fa-dumbbell"></i> ${totalSets} set${totalSets !== 1 ? 's' : ''}</span>
-                    </p>
-                </div>
-                <div class="paused-workout-actions">
-                    <button class="btn btn-primary" onclick="window.gymApp.viewControllers.home.resumeWorkout()">
-                        <i class="fas fa-play"></i> Resume
-                    </button>
-                    <button class="btn btn-outline btn-danger-outline" onclick="window.gymApp.viewControllers.home.discardPausedWorkout()">
-                        <i class="fas fa-trash"></i> Discard
-                    </button>
-                </div>
-            </div>
-        `;
-
-        // Insert banner before the container
         container.insertAdjacentHTML('beforebegin', bannerHTML);
+        const banner = document.querySelector('.paused-workout-banner');
+        wirePausedBannerActions(banner, {
+            onResume: () => this.resumeWorkout(),
+            onDiscard: () => this.discardPausedWorkout(),
+        });
     }
 
     resumeWorkout() {
@@ -86,7 +124,6 @@ class HomeView {
     }
 
     async discardPausedWorkout() {
-        const { showConfirmModal } = await import('../utils/helpers.js');
         const confirmed = await showConfirmModal({
             title: 'Discard Paused Workout',
             message: 'Are you sure you want to discard this paused workout?<br><br><strong>All progress will be lost.</strong>',
@@ -98,7 +135,6 @@ class HomeView {
         if (confirmed) {
             storageService.clearActiveWorkout();
             this.render();
-            const { showToast } = await import('../utils/helpers.js');
             showToast('Paused workout discarded', 'info');
         }
     }
@@ -169,8 +205,9 @@ class HomeView {
 
     renderRecentWorkouts() {
         const container = document.getElementById('recent-workouts');
+        // Full-timestamp sort so same-day sessions order by time-of-day.
         const recentSessions = [...this.app.workoutSessions]
-            .sort((a, b) => new Date(b.date) - new Date(a.date))
+            .sort((a, b) => new Date(b.sortTimestamp) - new Date(a.sortTimestamp))
             .slice(0, 5);
 
         if (recentSessions.length === 0) {
@@ -189,7 +226,7 @@ class HomeView {
             <div class="workout-card clickable" onclick="window.gymApp.viewControllers.home.showWorkoutDetails(${session.id})">
                 <div class="workout-card-header">
                     <h4>${session.workoutDayName}</h4>
-                    <span class="date">${formatDate(session.date)}</span>
+                    <span class="date">${formatSessionDateTime(session)}</span>
                 </div>
                 <div class="workout-card-stats">
                     <div class="stat">
@@ -256,7 +293,6 @@ class HomeView {
 
         // Check if there's a paused workout
         if (pausedWorkout && pausedWorkout.paused) {
-            const { showConfirmModal } = await import('../utils/helpers.js');
             const confirmed = await showConfirmModal({
                 title: 'Workout In Progress',
                 message: `You have a paused workout "<strong>${pausedWorkout.workoutDayName}</strong>" with saved progress.<br><br>Starting a new workout will <strong>discard</strong> your paused workout.<br><br>Do you want to continue?`,

--- a/apps/gym-tracker/js/views/paused-banner.js
+++ b/apps/gym-tracker/js/views/paused-banner.js
@@ -1,0 +1,83 @@
+/**
+ * Paused Workout Banner
+ * Shared renderer consumed by Home and Workout views so there is one
+ * source of truth for the paused-workout UI.
+ */
+import { storageService } from '../services/StorageService.js';
+import { escapeHtml } from '../utils/helpers.js';
+
+function formatTimeAgo(date) {
+    const now = new Date();
+    const diffMs = now - date;
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMins / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins} min ago`;
+    if (diffHours < 24) return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
+    return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
+}
+
+/**
+ * Returns the banner HTML for the currently paused workout, or null if
+ * no paused workout exists.
+ *
+ * @param {object} [opts]
+ * @param {'home'|'workout'} [opts.location='workout'] Hint used for telemetry
+ *        and allows each host to later tailor its affordances if needed.
+ * @param {boolean} [opts.withCalendarMeta=true] Show the "Paused N days ago" meta
+ */
+export function renderPausedBannerHTML(opts = {}) {
+    const { withCalendarMeta = true } = opts;
+    const pausedWorkout = storageService.getActiveWorkout();
+    if (!pausedWorkout || !pausedWorkout.paused) return null;
+
+    const pausedAt = new Date(pausedWorkout.pausedAt);
+    const elapsed = pausedWorkout.elapsedBeforePause;
+    const minutes = Math.floor(elapsed / 60);
+    const seconds = elapsed % 60;
+    const totalSets = pausedWorkout.exercises.reduce(
+        (sum, ex) => sum + (ex.sets ? ex.sets.length : 0), 0
+    );
+    const name = escapeHtml(pausedWorkout.workoutDayName || 'Workout');
+
+    return `
+        <div class="paused-workout-banner">
+            <div class="paused-workout-icon">
+                <i class="fas fa-pause-circle"></i>
+            </div>
+            <div class="paused-workout-info">
+                <h3>Paused Workout</h3>
+                <p><strong>${name}</strong></p>
+                <p class="paused-workout-meta">
+                    <span><i class="fas fa-clock"></i> ${minutes}:${String(seconds).padStart(2, '0')} elapsed</span>
+                    <span><i class="fas fa-dumbbell"></i> ${totalSets} set${totalSets !== 1 ? 's' : ''}</span>
+                    ${withCalendarMeta
+                        ? `<span><i class="fas fa-calendar"></i> Paused ${formatTimeAgo(pausedAt)}</span>`
+                        : ''}
+                </p>
+            </div>
+            <div class="paused-workout-actions">
+                <button class="btn btn-primary" data-paused-action="resume">
+                    <i class="fas fa-play"></i> Resume
+                </button>
+                <button class="btn btn-outline btn-danger-outline" data-paused-action="discard">
+                    <i class="fas fa-trash"></i> Discard
+                </button>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Bind click handlers on a paused banner's action buttons. The host view
+ * supplies onResume/onDiscard so control flow stays with each view.
+ */
+export function wirePausedBannerActions(container, { onResume, onDiscard }) {
+    if (!container) return;
+    const resumeBtn = container.querySelector('[data-paused-action="resume"]');
+    const discardBtn = container.querySelector('[data-paused-action="discard"]');
+    if (resumeBtn && onResume) resumeBtn.addEventListener('click', onResume);
+    if (discardBtn && onDiscard) discardBtn.addEventListener('click', onDiscard);
+}

--- a/apps/gym-tracker/js/views/programs-view.js
+++ b/apps/gym-tracker/js/views/programs-view.js
@@ -3,7 +3,7 @@
  * Program builder and management
  */
 import { app } from '../app.js';
-import { Program } from '../models/Program.js';
+import { Program, defaultRestForEquipment } from '../models/Program.js';
 import { showToast, showConfirmModal, formatMuscleGroup } from '../utils/helpers.js';
 import { storageService } from '../services/StorageService.js';
 import { DarkSelect } from '../utils/dark-select.js';
@@ -308,6 +308,7 @@ class ProgramsView {
         container.innerHTML = this.currentProgram.exercises.map((exercise, index) => {
             const details = this.app.getExerciseById(exercise.exerciseId);
             const muscle = formatMuscleGroup(details?.muscleGroup);
+            const restLabel = formatRestLabel(exercise.restSeconds);
             return `
             <div class="program-exercise-row" draggable="true" data-exercise-index="${index}">
                 <span class="pex-drag-handle" aria-hidden="true" title="Drag to reorder">
@@ -318,15 +319,58 @@ class ProgramsView {
                     <span class="pex-name-main">${exercise.exerciseName}</span>${muscle ? `
                     <span class="pex-name-sub">(${muscle})</span>` : ''}
                 </div>
+                <div class="pex-targets">
+                    ${stepperHTML('sets', index, exercise.targetSets, 1, 20, 'Sets')}
+                    ${stepperHTML('reps', index, exercise.targetReps, 1, 100, 'Reps')}
+                    ${stepperHTML('rest', index, exercise.restSeconds, 0, 600, 'Rest', 15, restLabel)}
+                </div>
                 <button class="pex-delete"
-                    onclick="window.gymApp.viewControllers.programs.removeExerciseFromProgram(${index})"
-                    title="Remove exercise" type="button">
+                    data-action="remove-exercise"
+                    data-index="${index}"
+                    title="Remove exercise" type="button" aria-label="Remove exercise">
                     <i class="fas fa-xmark"></i>
                 </button>
             </div>
         `;}).join('');
 
         this.wireExerciseDragAndDrop(container);
+        this.wireExerciseRowActions(container);
+    }
+
+    /**
+     * Wire up delete + stepper interactions on each program-exercise row.
+     * Uses data-action delegation so we don't paint inline onclicks (safer
+     * + re-renderable).
+     */
+    wireExerciseRowActions(container) {
+        container.querySelectorAll('[data-action="remove-exercise"]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const idx = Number(btn.dataset.index);
+                this.removeExerciseFromProgram(idx);
+            });
+        });
+
+        container.querySelectorAll('[data-stepper]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const idx = Number(btn.dataset.index);
+                const field = btn.dataset.field; // 'sets' | 'reps' | 'rest'
+                const delta = Number(btn.dataset.delta);
+                this.adjustExerciseTarget(idx, field, delta);
+            });
+        });
+    }
+
+    adjustExerciseTarget(index, field, delta) {
+        if (!this.currentProgram) return;
+        const ex = this.currentProgram.exercises[index];
+        if (!ex) return;
+        const patch = {};
+        if (field === 'sets') patch.targetSets = ex.targetSets + delta;
+        else if (field === 'reps') patch.targetReps = ex.targetReps + delta;
+        else if (field === 'rest') patch.restSeconds = ex.restSeconds + delta;
+        else return;
+        this.currentProgram.updateExercise(index, patch);
+        this.renderProgramExercises();
     }
 
     wireExerciseDragAndDrop(container) {
@@ -481,7 +525,11 @@ class ProgramsView {
 
     openExercisePicker() {
         const modal = document.getElementById('exercise-picker-modal');
+        // Start each picker session with an empty selection — fresh picks,
+        // not leftover state from a previous open.
+        this.pickerSelection = new Map();
         this.renderExercisePicker();
+        this.renderExercisePickerTray();
         modal.classList.add('active');
 
         // Set up search and filter listeners
@@ -503,6 +551,62 @@ class ProgramsView {
         categoryFilter.addEventListener('change', filterExercises);
         equipmentFilter.removeEventListener('change', filterExercises);
         equipmentFilter.addEventListener('change', filterExercises);
+
+        // One-time wire-up for tray controls (idempotent via dataset guard).
+        this.wireExercisePickerTray();
+    }
+
+    wireExercisePickerTray() {
+        const commitBtn = document.getElementById('exercise-picker-commit');
+        const clearBtn = document.getElementById('exercise-picker-tray-clear');
+        const trayList = document.getElementById('exercise-picker-tray-list');
+
+        if (commitBtn && !commitBtn.dataset.wired) {
+            commitBtn.addEventListener('click', () => this.commitExercisePickerSelection());
+            commitBtn.dataset.wired = '1';
+        }
+        if (clearBtn && !clearBtn.dataset.wired) {
+            clearBtn.addEventListener('click', () => {
+                this.pickerSelection = new Map();
+                this.renderExercisePicker(
+                    document.getElementById('exercise-search')?.value || '',
+                    document.getElementById('exercise-category-filter')?.value || '',
+                    document.getElementById('exercise-equipment-filter')?.value || '',
+                );
+                this.renderExercisePickerTray();
+            });
+            clearBtn.dataset.wired = '1';
+        }
+        if (trayList && !trayList.dataset.wired) {
+            // Event delegation: remove buttons + steppers inside the tray.
+            trayList.addEventListener('click', (e) => {
+                const remove = e.target.closest('[data-tray-action="remove"]');
+                if (remove) {
+                    const id = Number(remove.dataset.exerciseId);
+                    this.pickerSelection.delete(id);
+                    this.renderExercisePicker(
+                        document.getElementById('exercise-search')?.value || '',
+                        document.getElementById('exercise-category-filter')?.value || '',
+                        document.getElementById('exercise-equipment-filter')?.value || '',
+                    );
+                    this.renderExercisePickerTray();
+                    return;
+                }
+                const stepper = e.target.closest('[data-tray-stepper]');
+                if (stepper) {
+                    const id = Number(stepper.dataset.exerciseId);
+                    const field = stepper.dataset.field;
+                    const delta = Number(stepper.dataset.delta);
+                    const item = this.pickerSelection.get(id);
+                    if (!item) return;
+                    if (field === 'sets') item.targetSets = clampTray(item.targetSets + delta, 1, 20);
+                    else if (field === 'reps') item.targetReps = clampTray(item.targetReps + delta, 1, 100);
+                    else if (field === 'rest') item.restSeconds = clampTray(item.restSeconds + delta, 0, 600);
+                    this.renderExercisePickerTray();
+                }
+            });
+            trayList.dataset.wired = '1';
+        }
     }
 
     renderExercisePicker(searchTerm = '', category = '', equipment = '') {
@@ -537,16 +641,123 @@ class ProgramsView {
             return;
         }
 
-        container.innerHTML = exercises.map(exercise => `
-            <div class="exercise-picker-card" onclick="window.gymApp.viewControllers.programs.selectExercise(${exercise.id})">
-                <h4>${exercise.name}</h4>
-                <div class="exercise-meta">
-                    <span class="badge">${exercise.category}</span>
-                    <span class="badge">${exercise.equipment}</span>
+        const selection = this.pickerSelection || new Map();
+
+        container.innerHTML = exercises.map(exercise => {
+            const picked = selection.has(exercise.id);
+            return `
+                <div class="exercise-picker-card ${picked ? 'is-picked' : ''}"
+                     data-exercise-id="${exercise.id}"
+                     role="button" tabindex="0" aria-pressed="${picked ? 'true' : 'false'}">
+                    <span class="exercise-picker-check" aria-hidden="true">
+                        <i class="fas ${picked ? 'fa-check-circle' : 'fa-circle'}"></i>
+                    </span>
+                    <h4>${exercise.name}</h4>
+                    <div class="exercise-meta">
+                        <span class="badge">${exercise.category}</span>
+                        <span class="badge">${exercise.equipment}</span>
+                    </div>
+                    <p>${exercise.muscleGroup}</p>
                 </div>
-                <p>${exercise.muscleGroup}</p>
-            </div>
+            `;
+        }).join('');
+
+        // Delegate click/keyboard toggle for picker cards.
+        container.querySelectorAll('.exercise-picker-card').forEach(card => {
+            const id = Number(card.dataset.exerciseId);
+            card.addEventListener('click', () => this.togglePickerExercise(id));
+            card.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    this.togglePickerExercise(id);
+                }
+            });
+        });
+    }
+
+    togglePickerExercise(exerciseId) {
+        if (!this.pickerSelection) this.pickerSelection = new Map();
+        const exercise = this.app.getExerciseById(exerciseId);
+        if (!exercise) return;
+
+        if (this.pickerSelection.has(exerciseId)) {
+            this.pickerSelection.delete(exerciseId);
+        } else {
+            this.pickerSelection.set(exerciseId, {
+                id: exercise.id,
+                name: exercise.name,
+                targetSets: 3,
+                targetReps: 10,
+                restSeconds: defaultRestForEquipment(exercise.equipment),
+            });
+        }
+
+        // Update just the card + tray (not whole list re-render, which kills scroll).
+        const card = document.querySelector(`.exercise-picker-card[data-exercise-id="${exerciseId}"]`);
+        if (card) {
+            const picked = this.pickerSelection.has(exerciseId);
+            card.classList.toggle('is-picked', picked);
+            card.setAttribute('aria-pressed', picked ? 'true' : 'false');
+            const checkIcon = card.querySelector('.exercise-picker-check i');
+            if (checkIcon) {
+                checkIcon.classList.toggle('fa-check-circle', picked);
+                checkIcon.classList.toggle('fa-circle', !picked);
+            }
+        }
+        this.renderExercisePickerTray();
+    }
+
+    renderExercisePickerTray() {
+        const tray = document.getElementById('exercise-picker-tray');
+        const list = document.getElementById('exercise-picker-tray-list');
+        const count = document.getElementById('exercise-picker-tray-count');
+        if (!tray || !list || !count) return;
+
+        const items = Array.from((this.pickerSelection || new Map()).values());
+        const n = items.length;
+
+        tray.hidden = n === 0;
+        count.textContent = `Added ${n}`;
+
+        list.innerHTML = items.map((item) => `
+            <li class="exercise-picker-tray-row" data-exercise-id="${item.id}">
+                <div class="tray-name">${item.name}</div>
+                <div class="tray-steppers">
+                    ${trayStepperHTML(item.id, 'sets', item.targetSets, 'Sets')}
+                    ${trayStepperHTML(item.id, 'reps', item.targetReps, 'Reps')}
+                    ${trayStepperHTML(item.id, 'rest', item.restSeconds, 'Rest', 15, formatRestLabel(item.restSeconds))}
+                </div>
+                <button type="button" class="tray-remove"
+                    data-tray-action="remove" data-exercise-id="${item.id}"
+                    title="Remove from selection" aria-label="Remove from selection">
+                    <i class="fas fa-xmark"></i>
+                </button>
+            </li>
         `).join('');
+    }
+
+    commitExercisePickerSelection() {
+        const items = Array.from((this.pickerSelection || new Map()).values());
+        if (items.length === 0) {
+            showToast('Pick at least one exercise first', 'error');
+            return;
+        }
+        items.forEach(item => {
+            this.currentProgram.addExercise(
+                item.id,
+                item.name,
+                item.targetSets,
+                item.targetReps,
+                '',
+                item.restSeconds,
+            );
+        });
+
+        document.getElementById('exercise-picker-modal').classList.remove('active');
+        this.pickerSelection = new Map();
+        this.renderExercisePickerTray();
+        this.renderProgramExercises();
+        showToast(`Added ${items.length} exercise${items.length === 1 ? '' : 's'}`, 'success');
     }
 
     updatePickerDropdownStates(searchTerm, currentCategory, currentEquipment) {
@@ -594,28 +805,6 @@ class ProgramsView {
         }
     }
 
-    selectExercise(exerciseId) {
-        const exercise = this.app.getExerciseById(exerciseId);
-        if (!exercise) return;
-
-        // Add exercise to current program
-        this.currentProgram.addExercise(
-            exercise.id,
-            exercise.name,
-            3, // default target sets
-            10, // default target reps
-            ''
-        );
-
-        // Close exercise picker
-        document.getElementById('exercise-picker-modal').classList.remove('active');
-
-        // Update the exercise list display
-        this.renderProgramExercises();
-
-        showToast(`Added ${exercise.name}`, 'success');
-    }
-
     removeExerciseFromProgram(index) {
         if (this.currentProgram) {
             this.currentProgram.removeExercise(index);
@@ -648,6 +837,76 @@ class ProgramsView {
             }
         }, 100);
     }
+}
+
+/**
+ * Compact +/- stepper for program-exercise target values.
+ * `valueLabel` overrides the displayed label (used by rest which shows "1:30").
+ */
+function stepperHTML(field, index, value, min, max, label, step = 1, valueLabel = null) {
+    const displayed = valueLabel ?? String(value);
+    const atMin = value <= min;
+    const atMax = value >= max;
+    return `
+        <div class="pex-stepper" data-field="${field}">
+            <span class="pex-stepper-label">${label}</span>
+            <span class="pex-stepper-controls">
+                <button type="button" class="pex-stepper-btn"
+                    data-stepper data-index="${index}" data-field="${field}" data-delta="${-step}"
+                    ${atMin ? 'disabled' : ''}
+                    aria-label="Decrease ${label.toLowerCase()}">
+                    <i class="fas fa-minus"></i>
+                </button>
+                <span class="pex-stepper-value">${displayed}</span>
+                <button type="button" class="pex-stepper-btn"
+                    data-stepper data-index="${index}" data-field="${field}" data-delta="${step}"
+                    ${atMax ? 'disabled' : ''}
+                    aria-label="Increase ${label.toLowerCase()}">
+                    <i class="fas fa-plus"></i>
+                </button>
+            </span>
+        </div>
+    `;
+}
+
+/**
+ * Compact stepper used inside the exercise-picker tray. Differs from the
+ * program-builder stepper in markup (no per-index lookup; keyed by exercise id).
+ */
+function trayStepperHTML(exerciseId, field, value, label, step = 1, valueLabel = null) {
+    const display = valueLabel ?? String(value);
+    return `
+        <span class="pex-stepper" data-field="${field}">
+            <span class="pex-stepper-label">${label}</span>
+            <span class="pex-stepper-controls">
+                <button type="button" class="pex-stepper-btn"
+                    data-tray-stepper data-exercise-id="${exerciseId}" data-field="${field}" data-delta="${-step}"
+                    aria-label="Decrease ${label.toLowerCase()}">
+                    <i class="fas fa-minus"></i>
+                </button>
+                <span class="pex-stepper-value">${display}</span>
+                <button type="button" class="pex-stepper-btn"
+                    data-tray-stepper data-exercise-id="${exerciseId}" data-field="${field}" data-delta="${step}"
+                    aria-label="Increase ${label.toLowerCase()}">
+                    <i class="fas fa-plus"></i>
+                </button>
+            </span>
+        </span>
+    `;
+}
+
+function clampTray(n, min, max) {
+    if (!Number.isFinite(n)) return min;
+    return Math.max(min, Math.min(max, Math.round(n)));
+}
+
+/** "1:30", "45s", "0s" — short display optimized for the stepper pill. */
+function formatRestLabel(seconds) {
+    if (!Number.isFinite(seconds) || seconds <= 0) return '0s';
+    if (seconds < 60) return `${seconds}s`;
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return s === 0 ? `${m}m` : `${m}:${String(s).padStart(2, '0')}`;
 }
 
 // Initialize

--- a/apps/gym-tracker/js/views/settings-view.js
+++ b/apps/gym-tracker/js/views/settings-view.js
@@ -2,7 +2,7 @@
  * Settings View Controller
  */
 import { app } from '../app.js';
-import { showToast, downloadJSON } from '../utils/helpers.js';
+import { showToast, downloadJSON, showConfirmModal } from '../utils/helpers.js';
 import { validateImportData } from '../utils/validators.js';
 import { DarkSelect } from '../utils/dark-select.js';
 
@@ -60,8 +60,16 @@ class SettingsView {
         // Clear data
         const clearBtn = document.getElementById('clear-data-btn');
         if (clearBtn) {
-            clearBtn.addEventListener('click', () => {
-                this.app.clearAllData();
+            clearBtn.addEventListener('click', async () => {
+                const confirmed = await showConfirmModal({
+                    title: 'Clear All Data',
+                    message: 'This will permanently delete every program, workout, achievement, custom exercise, and setting.',
+                    warning: 'This cannot be undone.',
+                    confirmText: 'Delete Everything',
+                    cancelText: 'Cancel',
+                    isDangerous: true,
+                });
+                if (confirmed) this.app.clearAllData();
             });
         }
     }
@@ -119,7 +127,7 @@ class SettingsView {
         if (!file) return;
 
         const reader = new FileReader();
-        reader.onload = (e) => {
+        reader.onload = async (e) => {
             try {
                 const data = JSON.parse(e.target.result);
                 const validationError = validateImportData(data);
@@ -129,7 +137,14 @@ class SettingsView {
                     return;
                 }
 
-                if (confirm('Import this data? This will merge with your existing data.')) {
+                const confirmed = await showConfirmModal({
+                    title: 'Import Data',
+                    message: 'Import this data? It will be merged with your existing programs, workouts, and settings.',
+                    confirmText: 'Import',
+                    cancelText: 'Cancel',
+                    isDangerous: false,
+                });
+                if (confirmed) {
                     this.app.importData(data);
                 }
             } catch (error) {

--- a/apps/gym-tracker/js/views/workout-view.js
+++ b/apps/gym-tracker/js/views/workout-view.js
@@ -8,13 +8,16 @@ import { WorkoutExercise } from '../models/WorkoutExercise.js';
 import { Set } from '../models/Set.js';
 import { timerService } from '../services/TimerService.js';
 import { storageService } from '../services/StorageService.js';
-import { showToast, showConfirmModal, formatMuscleGroup } from '../utils/helpers.js';
+import { showToast, showConfirmModal, formatMuscleGroup, vibrate } from '../utils/helpers.js';
+import { renderPausedBannerHTML, wirePausedBannerActions } from './paused-banner.js';
 
 class WorkoutView {
     constructor() {
         this.app = app;
         this.currentWorkoutSession = null;
         this.navigationBlocked = false;
+        this.activeRestTimerId = null;
+        this.restTimerDuration = 0;
         this.init();
     }
 
@@ -51,6 +54,12 @@ class WorkoutView {
                 this.finishWorkout();
             });
         }
+
+        // Rest timer bar controls
+        const restSkipBtn = document.getElementById('rest-skip-btn');
+        if (restSkipBtn) restSkipBtn.addEventListener('click', () => this.skipRest());
+        const restAddBtn = document.getElementById('rest-add-btn');
+        if (restAddBtn) restAddBtn.addEventListener('click', () => this.extendRest(30));
     }
 
     setupNavigationGuard() {
@@ -230,6 +239,7 @@ class WorkoutView {
 
     discardWorkout() {
         timerService.stopWorkoutTimer();
+        this.skipRest();
         storageService.clearActiveWorkout();
         document.getElementById('active-workout').classList.remove('active');
         document.getElementById('workout-selection').classList.add('active');
@@ -242,19 +252,6 @@ class WorkoutView {
 
     render() {
         this.renderProgramSelection();
-    }
-
-    formatTimeAgo(date) {
-        const now = new Date();
-        const diffMs = now - date;
-        const diffMins = Math.floor(diffMs / 60000);
-        const diffHours = Math.floor(diffMins / 60);
-        const diffDays = Math.floor(diffHours / 24);
-
-        if (diffMins < 1) return 'just now';
-        if (diffMins < 60) return `${diffMins} min ago`;
-        if (diffHours < 24) return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
-        return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
     }
 
     async resumeWorkout() {
@@ -303,48 +300,13 @@ class WorkoutView {
     renderProgramSelection() {
         const container = document.getElementById('workout-program-list');
         const programs = this.app.programs;
-        const pausedWorkout = storageService.getActiveWorkout();
 
         // Start fresh - don't double-add the banner
         let html = '';
 
         // Add paused workout banner if exists
-        if (pausedWorkout && pausedWorkout.paused) {
-            const pausedAt = new Date(pausedWorkout.pausedAt);
-            const elapsed = pausedWorkout.elapsedBeforePause;
-            const minutes = Math.floor(elapsed / 60);
-            const seconds = elapsed % 60;
-
-            // Count total sets saved
-            const totalSets = pausedWorkout.exercises.reduce((sum, ex) =>
-                sum + (ex.sets ? ex.sets.length : 0), 0
-            );
-
-            html += `
-                <div class="paused-workout-banner">
-                    <div class="paused-workout-icon">
-                        <i class="fas fa-pause-circle"></i>
-                    </div>
-                    <div class="paused-workout-info">
-                        <h3>Paused Workout</h3>
-                        <p><strong>${pausedWorkout.workoutDayName}</strong></p>
-                        <p class="paused-workout-meta">
-                            <span><i class="fas fa-clock"></i> ${minutes}:${String(seconds).padStart(2, '0')} elapsed</span>
-                            <span><i class="fas fa-dumbbell"></i> ${totalSets} set${totalSets !== 1 ? 's' : ''} completed</span>
-                            <span><i class="fas fa-calendar"></i> Paused ${this.formatTimeAgo(pausedAt)}</span>
-                        </p>
-                    </div>
-                    <div class="paused-workout-actions">
-                        <button class="btn btn-primary" onclick="window.gymApp.viewControllers.workout.resumeWorkout()">
-                            <i class="fas fa-play"></i> Resume
-                        </button>
-                        <button class="btn btn-outline btn-danger-outline" onclick="window.gymApp.viewControllers.workout.discardPausedWorkout()">
-                            <i class="fas fa-trash"></i> Discard
-                        </button>
-                    </div>
-                </div>
-            `;
-        }
+        const bannerHTML = renderPausedBannerHTML({ location: 'workout', withCalendarMeta: true });
+        if (bannerHTML) html += bannerHTML;
 
         if (programs.length === 0) {
             html += `
@@ -386,6 +348,14 @@ class WorkoutView {
         `;
 
         container.innerHTML = html;
+
+        const banner = container.querySelector('.paused-workout-banner');
+        if (banner) {
+            wirePausedBannerActions(banner, {
+                onResume: () => this.resumeWorkout(),
+                onDiscard: () => this.discardPausedWorkout(),
+            });
+        }
     }
 
     startWorkout(programId) {
@@ -406,6 +376,8 @@ class WorkoutView {
                 exerciseId: ex.exerciseId,
                 exerciseName: ex.exerciseName,
                 targetSets: ex.targetSets,
+                targetReps: ex.targetReps,
+                restSeconds: ex.restSeconds,
                 order: ex.order
             }))
         });
@@ -456,119 +428,271 @@ class WorkoutView {
         this.adjustWorkoutTitleSize();
 
         const container = document.getElementById('workout-exercises-list');
-        container.innerHTML = this.currentWorkoutSession.exercises.map((exercise, index) => {
-            const exerciseData = this.app.getExerciseById(exercise.exerciseId);
-            const isDuration = exerciseData && exerciseData.exerciseType === 'duration';
-            const previousSets = this.getPreviousExerciseData(exercise.exerciseId);
-            const unit = this.app.settings.weightUnit;
+        container.innerHTML = this.currentWorkoutSession.exercises
+            .map((exercise, index) => this.renderExerciseEntry(exercise, index))
+            .join('');
+    }
 
-            let previousDataHTML = '';
-            if (previousSets && previousSets.length > 0) {
-                if (isDuration) {
-                    // Show duration for time-based exercises
-                    previousDataHTML = `
-                        <div class="previous-sets-label">Last time:</div>
-                        <div class="previous-sets-row">
-                            ${previousSets.map((set, i) => {
-                                const mins = Math.floor(set.duration / 60);
-                                const secs = set.duration % 60;
-                                return `
-                                    <div class="previous-set-badge" onclick="window.gymApp.viewControllers.workout.usePreviousDuration(${index}, ${set.duration})" title="Click to use this duration">
-                                        <span class="previous-set-number">${i + 1}</span>
-                                        <span class="previous-set-value">${mins}:${secs.toString().padStart(2, '0')}</span>
-                                    </div>
-                                `;
-                            }).join('')}
-                        </div>
-                    `;
-                } else {
-                    // Show weight × reps for reps-based exercises
-                    previousDataHTML = `
-                        <div class="previous-sets-label">Last time:</div>
-                        <div class="previous-sets-row">
-                            ${previousSets.map((set, i) => `
-                                <div class="previous-set-badge" onclick="window.gymApp.viewControllers.workout.usePreviousSet(${index}, ${set.weight}, ${set.reps})" title="Click to use these values">
-                                    <span class="previous-set-number">${i + 1}</span>
-                                    <span class="previous-set-value">${set.weight.toLocaleString()}${unit} × ${set.reps}</span>
-                                </div>
-                            `).join('')}
-                        </div>
-                    `;
-                }
+    /**
+     * Render a single exercise block: progress header, last-time reference,
+     * and a list of N planned set rows where N = max(targetSets, sets.length).
+     */
+    renderExerciseEntry(exercise, index) {
+        const exerciseData = this.app.getExerciseById(exercise.exerciseId);
+        const isDuration = !!(exerciseData && exerciseData.exerciseType === 'duration');
+        const previousSets = this.getPreviousExerciseData(exercise.exerciseId) || [];
+        const unit = this.app.settings.weightUnit;
+
+        const targetSets = Math.max(1, exercise.targetSets || 3);
+        const completedCount = exercise.sets.length;
+        const totalRows = Math.max(targetSets, completedCount);
+        const isComplete = completedCount >= targetSets && targetSets > 0;
+
+        const muscle = formatMuscleGroup(exerciseData?.muscleGroup);
+        const progressLabel = `${completedCount} / ${targetSets} sets`;
+
+        let rowsHTML = '';
+        for (let i = 0; i < totalRows; i++) {
+            if (i < exercise.sets.length) {
+                rowsHTML += this.renderCompletedRow(exercise.sets[i], index, i, isDuration, unit);
             } else {
-                previousDataHTML = '<div class="previous-sets-label">Last time: <span>No previous data</span></div>';
+                // Default priority for a planned row:
+                //   1. sticky — values the user already typed/committed for this
+                //      slot in this session (survives toggle-off without loss).
+                //   2. prior[i] — matching-index set from the last workout.
+                //   3. prior[last] — global fallback to the most recent set.
+                const sticky = exercise.stickyValues && exercise.stickyValues[i];
+                const prior = sticky
+                    || previousSets[i]
+                    || previousSets[previousSets.length - 1]
+                    || null;
+                rowsHTML += this.renderPlannedRow(index, i, prior, isDuration, unit, exercise.targetReps);
             }
+        }
 
-            // Pre-fill with first set data if available
-            const firstSet = previousSets && previousSets.length > 0 ? previousSets[0] : null;
+        const lastTimeHTML = this.renderLastTimeStrip(previousSets, isDuration, unit);
 
-            // Render inputs based on exercise type
-            let setInputsHTML = '';
-            if (isDuration) {
-                const defaultMins = firstSet ? Math.floor(firstSet.duration / 60) : 0;
-                const defaultSecs = firstSet ? firstSet.duration % 60 : 0;
-                setInputsHTML = `
-                    <div class="set-inputs">
-                        <div class="input-group duration-input">
-                            <label class="input-label">Duration</label>
-                            <div class="duration-inputs">
-                                <input type="number" inputmode="numeric" placeholder="Min" id="duration-min-${index}" min="0" value="${defaultMins}" class="duration-min">
-                                <span class="duration-separator">:</span>
-                                <input type="number" inputmode="numeric" placeholder="Sec" id="duration-sec-${index}" min="0" max="59" value="${defaultSecs.toString().padStart(2, '0')}" class="duration-sec">
-                            </div>
-                        </div>
-                        <button type="button" class="btn-add-set" onclick="window.gymApp.viewControllers.workout.addSet(${index})">
-                            <i class="fas fa-plus"></i> Add Set
-                        </button>
-                    </div>
-                `;
-            } else {
-                setInputsHTML = `
-                    <div class="set-inputs">
-                        <div class="input-group">
-                            <label class="input-label">Weight</label>
-                            <input type="number" inputmode="decimal" placeholder="Weight" id="weight-${index}" step="0.5" min="0" ${firstSet ? `value="${firstSet.weight}"` : ''}>
-                        </div>
-                        <div class="input-group">
-                            <label class="input-label">Reps</label>
-                            <input type="number" inputmode="numeric" placeholder="Reps" id="reps-${index}" min="1" ${firstSet ? `value="${firstSet.reps}"` : ''}>
-                        </div>
-                        <button type="button" class="btn-add-set" onclick="window.gymApp.viewControllers.workout.addSet(${index})">
-                            <i class="fas fa-plus"></i> Add Set
-                        </button>
-                    </div>
-                `;
-            }
-
-            const muscle = formatMuscleGroup(exerciseData?.muscleGroup);
-
-            return `
-                <div class="exercise-entry" id="exercise-${index}" data-exercise-type="${isDuration ? 'duration' : 'reps'}">
-                    <div class="exercise-entry-header">
-                        <h3>
-                            <span class="exercise-name-main">${exercise.exerciseName}</span>${muscle ? `
-                            <span class="exercise-name-sub">(${muscle})</span>` : ''}
-                        </h3>
-                    </div>
-
-                    <div class="previous-data">
-                        ${previousDataHTML}
-                    </div>
-
-                    ${setInputsHTML}
-
-                    <div class="completed-sets" id="completed-sets-${index}">
-                        ${this.renderCompletedSets(exercise.sets, index)}
-                    </div>
+        return `
+            <div class="exercise-entry ${isComplete ? 'exercise-complete' : ''}"
+                 id="exercise-${index}" data-exercise-type="${isDuration ? 'duration' : 'reps'}">
+                <div class="exercise-entry-header">
+                    <h3>
+                        <span class="exercise-name-main">${exercise.exerciseName}</span>${muscle ? `
+                        <span class="exercise-name-sub">(${muscle})</span>` : ''}
+                    </h3>
+                    <span class="exercise-progress ${isComplete ? 'is-complete' : ''}" aria-label="Sets ${progressLabel}">
+                        ${isComplete ? '<i class="fas fa-check"></i>' : ''}
+                        ${progressLabel}
+                    </span>
                 </div>
-            `;
+
+                ${lastTimeHTML}
+
+                <ol class="set-row-list" id="set-row-list-${index}">
+                    ${rowsHTML}
+                </ol>
+
+                <div class="set-row-footer">
+                    ${totalRows > Math.max(1, completedCount) ? `
+                        <button type="button" class="btn-remove-set"
+                            onclick="window.gymApp.viewControllers.workout.removePlannedRow(${index})"
+                            title="Remove last empty set"
+                            aria-label="Remove last empty set row">
+                            <i class="fas fa-minus"></i>
+                        </button>
+                    ` : ''}
+                    <button type="button" class="btn-add-set btn-add-set--extra"
+                        onclick="window.gymApp.viewControllers.workout.addPlannedRow(${index})"
+                        aria-label="Add another set row">
+                        <i class="fas fa-plus"></i> Add set
+                    </button>
+                </div>
+            </div>
+        `;
+    }
+
+    /**
+     * Compact read-only reference strip: "Last time: 60×8 · 60×8 · 55×8".
+     * Purely informational — per-set defaults live inside each planned row.
+     */
+    renderLastTimeStrip(previousSets, isDuration, unit) {
+        if (!previousSets || previousSets.length === 0) {
+            return '<div class="previous-sets-label">Last time: <span>No previous data</span></div>';
+        }
+
+        const chips = previousSets.map((set, i) => {
+            if (isDuration) {
+                const mins = Math.floor(set.duration / 60);
+                const secs = set.duration % 60;
+                return `<span class="prev-chip"><b>${i + 1}</b> ${mins}:${secs.toString().padStart(2, '0')}</span>`;
+            }
+            return `<span class="prev-chip"><b>${i + 1}</b> ${set.weight.toLocaleString()}${unit}×${set.reps}</span>`;
         }).join('');
+
+        return `
+            <div class="previous-data">
+                <div class="previous-sets-label">Last time</div>
+                <div class="previous-sets-row">${chips}</div>
+            </div>
+        `;
+    }
+
+    /**
+     * A set that has not yet been logged. Shows empty (or prefilled-from-prior)
+     * inputs and a pill toggle on the right — tapping the toggle commits the
+     * set and starts the rest timer. The row itself is NOT tappable — users
+     * deliberately flick the toggle to complete.
+     */
+    renderPlannedRow(exerciseIndex, slot, prior, isDuration, unit, targetReps) {
+        const setLabel = `${slot + 1}`;
+        const toggle = this.renderSetToggle(false,
+            `window.gymApp.viewControllers.workout.commitPlannedSet(${exerciseIndex}, ${slot})`,
+            'Mark set complete');
+
+        if (isDuration) {
+            const mins = prior ? Math.floor(prior.duration / 60) : 0;
+            const secs = prior ? prior.duration % 60 : 0;
+            return `
+                <li class="set-row set-row-planned" data-slot="${slot}">
+                    <span class="set-row-num">${setLabel}</span>
+                    <div class="set-row-inputs">
+                        <input type="number" inputmode="numeric" class="duration-min"
+                            id="duration-min-${exerciseIndex}-${slot}" min="0"
+                            value="${mins}" placeholder="Min" aria-label="Minutes">
+                        <span class="duration-separator">:</span>
+                        <input type="number" inputmode="numeric" class="duration-sec"
+                            id="duration-sec-${exerciseIndex}-${slot}" min="0" max="59"
+                            value="${secs.toString().padStart(2, '0')}" placeholder="Sec" aria-label="Seconds">
+                    </div>
+                    ${toggle}
+                </li>
+            `;
+        }
+
+        const weight = prior ? prior.weight : '';
+        const reps = prior ? prior.reps : (targetReps || '');
+        return `
+            <li class="set-row set-row-planned" data-slot="${slot}">
+                <span class="set-row-num">${setLabel}</span>
+                <div class="set-row-inputs">
+                    <input type="number" inputmode="decimal" class="set-weight"
+                        id="weight-${exerciseIndex}-${slot}" min="0" step="0.5"
+                        value="${weight === '' ? '' : weight}" placeholder="Weight" aria-label="Weight">
+                    <span class="set-row-x">×</span>
+                    <input type="number" inputmode="numeric" class="set-reps"
+                        id="reps-${exerciseIndex}-${slot}" min="1"
+                        value="${reps === '' ? '' : reps}" placeholder="Reps" aria-label="Reps">
+                </div>
+                ${toggle}
+            </li>
+        `;
+    }
+
+    /**
+     * Shared pill-toggle markup used for both the "not yet completed" state
+     * (knob-left, muted pill) and the "completed" state (knob-right, green
+     * gradient pill with a crisp check inside the knob). CSS drives the
+     * visuals from `aria-pressed` so the DOM stays identical between states.
+     */
+    renderSetToggle(pressed, onClickExpression, ariaLabel) {
+        return `
+            <button type="button" class="set-toggle"
+                aria-pressed="${pressed ? 'true' : 'false'}"
+                aria-label="${ariaLabel}"
+                onclick="${onClickExpression}">
+                <span class="set-toggle-knob" aria-hidden="true">
+                    <i class="fas fa-check"></i>
+                </span>
+            </button>
+        `;
+    }
+
+    /**
+     * A committed set — shown locked with edit/delete controls and a filled check.
+     */
+    renderCompletedRow(set, exerciseIndex, slot, isDuration, unit) {
+        const setLabel = `${slot + 1}`;
+        let details;
+        if (set.duration > 0) {
+            const mins = Math.floor(set.duration / 60);
+            const secs = set.duration % 60;
+            details = `<span class="duration-value">${mins}:${secs.toString().padStart(2, '0')}</span>`;
+        } else {
+            details = `${set.weight.toLocaleString()}${unit} × ${set.reps}`;
+        }
+
+        const toggle = this.renderSetToggle(true,
+            `window.gymApp.viewControllers.workout.deleteSet(${exerciseIndex}, ${slot}, { silent: true })`,
+            'Unmark set');
+
+        return `
+            <li class="set-row set-row-complete" data-slot="${slot}">
+                <span class="set-row-num">${setLabel}</span>
+                <div class="set-row-details">${details}</div>
+                <div class="set-row-actions">
+                    <button type="button" class="btn-set-action" title="Edit set" aria-label="Edit set"
+                        onclick="window.gymApp.viewControllers.workout.editSet(${exerciseIndex}, ${slot})">
+                        <i class="fas fa-edit"></i>
+                    </button>
+                    <button type="button" class="btn-set-action btn-set-delete" title="Delete set" aria-label="Delete set"
+                        onclick="window.gymApp.viewControllers.workout.deleteSet(${exerciseIndex}, ${slot})">
+                        <i class="fas fa-trash"></i>
+                    </button>
+                </div>
+                ${toggle}
+            </li>
+        `;
+    }
+
+    /**
+     * Add an extra planned row beyond the program's target. Useful when a user
+     * wants to do a drop set or extra backoff set. The new row pulls defaults
+     * from the matching prior-session set (if any) or the last completed set.
+     */
+    addPlannedRow(exerciseIndex) {
+        if (!this.currentWorkoutSession) return;
+        const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
+        if (!exercise) return;
+        exercise.targetSets = Math.max(exercise.targetSets || 0, exercise.sets.length) + 1;
+        this.rerenderExercise(exerciseIndex);
+    }
+
+    /**
+     * Remove the last planned (uncommitted) set row for this exercise. Committed
+     * sets are never touched — users delete those via the row's trash button.
+     * Floors at max(1, sets.length) so we never drop below what's logged and
+     * never leave the exercise with zero visible slots.
+     */
+    removePlannedRow(exerciseIndex) {
+        if (!this.currentWorkoutSession) return;
+        const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
+        if (!exercise) return;
+        const floor = Math.max(1, exercise.sets.length);
+        if ((exercise.targetSets || 0) <= floor) return;
+        exercise.targetSets -= 1;
+        this.rerenderExercise(exerciseIndex);
+    }
+
+    /** Re-render just the given exercise block without touching the others. */
+    rerenderExercise(exerciseIndex) {
+        const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
+        const host = document.getElementById(`exercise-${exerciseIndex}`);
+        if (!exercise || !host) {
+            this.renderActiveWorkout();
+            return;
+        }
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = this.renderExerciseEntry(exercise, exerciseIndex);
+        const fresh = wrapper.firstElementChild;
+        if (fresh && host.parentNode) host.parentNode.replaceChild(fresh, host);
     }
 
     getPreviousExerciseData(exerciseId) {
-        // Get all workout sessions sorted by date (most recent first)
+        // Sort by full timestamp (not just calendar date) so that two workouts
+        // on the same day order by time-of-day — a 6 PM session supersedes a
+        // 9 AM session when computing "Last Time" for the same exercise.
         const sortedSessions = [...this.app.workoutSessions].sort((a, b) =>
-            new Date(b.date) - new Date(a.date)
+            new Date(b.sortTimestamp) - new Date(a.sortTimestamp)
         );
 
         // Find the most recent workout that has this exercise with completed sets
@@ -591,159 +715,74 @@ class WorkoutView {
         return null;
     }
 
-    renderCompletedSets(sets, exerciseIndex) {
-        if (sets.length === 0) return '<p class="no-sets-message"><i class="fas fa-circle-notch"></i> No sets yet - add your first set above</p>';
-
-        const unit = this.app.settings.weightUnit;
-        return sets.map((set, setIndex) => {
-            let setLabel, setDetails;
-            if (set.duration > 0) {
-                // Duration-based set
-                const mins = Math.floor(set.duration / 60);
-                const secs = set.duration % 60;
-                setLabel = `Round ${setIndex + 1}:`;
-                setDetails = `<span class="duration-value">${mins}:${secs.toString().padStart(2, '0')}</span> <span class="duration-label">min</span>`;
-            } else {
-                // Reps-based set
-                setLabel = `Set ${setIndex + 1}:`;
-                setDetails = `${set.weight.toLocaleString()}${unit} × ${set.reps} reps`;
-            }
-
-            return `
-                <div class="completed-set">
-                    <div class="set-check">
-                        <i class="fas fa-check-circle"></i>
-                    </div>
-                    <div class="set-info">
-                        <span class="set-number">${setLabel}</span>
-                        <span class="set-details">${setDetails}</span>
-                    </div>
-                    <div class="set-actions">
-                        <button type="button" class="btn-set-action" onclick="window.gymApp.viewControllers.workout.editSet(${exerciseIndex}, ${setIndex})" title="Edit set" aria-label="Edit set">
-                            <i class="fas fa-edit"></i>
-                        </button>
-                        <button type="button" class="btn-set-action btn-set-delete" onclick="window.gymApp.viewControllers.workout.deleteSet(${exerciseIndex}, ${setIndex})" title="Delete set" aria-label="Delete set">
-                            <i class="fas fa-trash"></i>
-                        </button>
-                    </div>
-                </div>
-            `;
-        }).join('');
-    }
-
-    usePreviousSet(exerciseIndex, weight, reps) {
+    /**
+     * Commit a planned set row: read inputs, push a new Set into the exercise,
+     * then start the rest timer and re-render only this exercise.
+     *
+     * The rest timer is THE feature that makes a gym tracker useful mid-workout.
+     * The equipment-based default lives on the program entry; if a user hasn't
+     * customized it, we fall back to 90s.
+     */
+    commitPlannedSet(exerciseIndex, slot) {
         if (!this.currentWorkoutSession) return;
 
-        const weightInput = document.getElementById(`weight-${exerciseIndex}`);
-        const repsInput = document.getElementById(`reps-${exerciseIndex}`);
-
-        // Fill in the values
-        weightInput.value = weight;
-        repsInput.value = reps;
-
-        // Focus the weight input for easy modification if needed
-        weightInput.focus();
-        weightInput.select();
-
-        const unit = this.app.settings.weightUnit;
-        showToast(`Loaded: ${weight.toLocaleString()}${unit} × ${reps} reps`, 'info');
-    }
-
-    usePreviousDuration(exerciseIndex, durationSeconds) {
-        if (!this.currentWorkoutSession) return;
-
-        const minInput = document.getElementById(`duration-min-${exerciseIndex}`);
-        const secInput = document.getElementById(`duration-sec-${exerciseIndex}`);
-
-        const minutes = Math.floor(durationSeconds / 60);
-        const seconds = durationSeconds % 60;
-
-        // Fill in the values
-        minInput.value = minutes;
-        secInput.value = seconds;
-
-        // Focus the minutes input for easy modification if needed
-        minInput.focus();
-        minInput.select();
-
-        showToast(`Loaded: ${minutes}:${seconds.toString().padStart(2, '0')}`, 'info');
-    }
-
-    addSet(exerciseIndex) {
-        if (!this.currentWorkoutSession) return;
-
-        // Dismiss the mobile keyboard before adding the set — otherwise iOS/Android
-        // keep the keyboard open because a weight/reps input is still focused.
+        // Dismiss the mobile keyboard so the rest bar doesn't get covered.
         if (document.activeElement instanceof HTMLElement && typeof document.activeElement.blur === 'function') {
             document.activeElement.blur();
         }
 
         const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
-        const exerciseEntry = document.getElementById(`exercise-${exerciseIndex}`);
-        const isDuration = exerciseEntry.getAttribute('data-exercise-type') === 'duration';
+        if (!exercise) return;
+        const host = document.getElementById(`exercise-${exerciseIndex}`);
+        const isDuration = host?.getAttribute('data-exercise-type') === 'duration';
 
         let set;
         if (isDuration) {
-            // Handle duration-based exercise
-            const minInput = document.getElementById(`duration-min-${exerciseIndex}`);
-            const secInput = document.getElementById(`duration-sec-${exerciseIndex}`);
-
-            const minutes = parseInt(minInput.value) || 0;
-            const seconds = parseInt(secInput.value) || 0;
+            const minInput = document.getElementById(`duration-min-${exerciseIndex}-${slot}`);
+            const secInput = document.getElementById(`duration-sec-${exerciseIndex}-${slot}`);
+            const minutes = parseInt(minInput?.value, 10) || 0;
+            const seconds = parseInt(secInput?.value, 10) || 0;
             const totalSeconds = (minutes * 60) + seconds;
-
             if (totalSeconds === 0) {
                 showToast('Please enter a duration', 'error');
                 return;
             }
-
             set = new Set({ duration: totalSeconds, weight: 0, reps: 0, completed: true });
-
-            // Keep values visible for the next set, but do not refocus the input
-            minInput.value = minutes;
-            secInput.value = seconds;
-
-            showToast('Set added!', 'success');
         } else {
-            // Handle reps-based exercise
-            const weightInput = document.getElementById(`weight-${exerciseIndex}`);
-            const repsInput = document.getElementById(`reps-${exerciseIndex}`);
-
-            const weight = parseFloat(weightInput.value);
-            const reps = parseInt(repsInput.value);
-
+            const weightInput = document.getElementById(`weight-${exerciseIndex}-${slot}`);
+            const repsInput = document.getElementById(`reps-${exerciseIndex}-${slot}`);
+            const weight = parseFloat(weightInput?.value);
+            const reps = parseInt(repsInput?.value, 10);
             if (isNaN(weight) || weight < 0 || !reps) {
                 showToast('Please enter weight and reps', 'error');
                 return;
             }
-
             set = new Set({ weight, reps, completed: true });
-
-            // Keep values visible for the next set, but do not refocus the input
-            weightInput.value = weight;
-            repsInput.value = reps;
-
-            showToast('Set added!', 'success');
         }
 
-        exercise.addSet(set);
+        // Insert into the exact slot index so the UI mirrors the user's plan.
+        // Sets beyond the current list length just append naturally.
+        if (slot >= exercise.sets.length) {
+            exercise.addSet(set);
+        } else {
+            exercise.sets.splice(slot, 0, set);
+        }
 
-        // Re-render completed sets
-        document.getElementById(`completed-sets-${exerciseIndex}`).innerHTML =
-            this.renderCompletedSets(exercise.sets, exerciseIndex);
+        vibrate(30);
+        this.rerenderExercise(exerciseIndex);
+        this.startRest(exercise.restSeconds || 90);
     }
 
     editSet(exerciseIndex, setIndex) {
         if (!this.currentWorkoutSession) return;
 
         const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
-        const set = exercise.sets[setIndex];
+        const set = exercise?.sets[setIndex];
+        if (!set) return;
 
-        // Show inline editing UI for this set
-        const setElement = document.querySelector(`#completed-sets-${exerciseIndex} .completed-set:nth-child(${setIndex + 1})`);
-        if (!setElement) return;
+        const setRowEl = document.querySelector(`#set-row-list-${exerciseIndex} .set-row[data-slot="${setIndex}"]`);
+        if (!setRowEl) return;
 
-        const unit = this.app.settings.weightUnit;
         const isDuration = set.duration > 0;
 
         let editFormHTML;
@@ -751,45 +790,48 @@ class WorkoutView {
             const mins = Math.floor(set.duration / 60);
             const secs = set.duration % 60;
             editFormHTML = `
-                <div class="set-edit-form">
-                    <span class="set-number">Round ${setIndex + 1}:</span>
-                    <input type="number" class="set-edit-input duration-edit-min" id="edit-duration-min-${exerciseIndex}-${setIndex}" value="${mins}" min="0" placeholder="Min">
-                    <span class="set-edit-x">:</span>
-                    <input type="number" class="set-edit-input duration-edit-sec" id="edit-duration-sec-${exerciseIndex}-${setIndex}" value="${secs}" min="0" max="59" placeholder="Sec">
+                <div class="set-row-inputs">
+                    <input type="number" class="set-edit-input duration-edit-min"
+                        id="edit-duration-min-${exerciseIndex}-${setIndex}" value="${mins}" min="0" placeholder="Min" aria-label="Minutes">
+                    <span class="duration-separator">:</span>
+                    <input type="number" class="set-edit-input duration-edit-sec"
+                        id="edit-duration-sec-${exerciseIndex}-${setIndex}" value="${secs}" min="0" max="59" placeholder="Sec" aria-label="Seconds">
                 </div>
             `;
         } else {
             editFormHTML = `
-                <div class="set-edit-form">
-                    <span class="set-number">Set ${setIndex + 1}:</span>
-                    <input type="number" class="set-edit-input" id="edit-weight-${exerciseIndex}-${setIndex}" value="${set.weight}" step="0.5" min="0" placeholder="Weight">
-                    <span class="set-edit-x">×</span>
-                    <input type="number" class="set-edit-input" id="edit-reps-${exerciseIndex}-${setIndex}" value="${set.reps}" min="1" placeholder="Reps">
+                <div class="set-row-inputs">
+                    <input type="number" class="set-edit-input"
+                        id="edit-weight-${exerciseIndex}-${setIndex}" value="${set.weight}" step="0.5" min="0" placeholder="Weight" aria-label="Weight">
+                    <span class="set-row-x">×</span>
+                    <input type="number" class="set-edit-input"
+                        id="edit-reps-${exerciseIndex}-${setIndex}" value="${set.reps}" min="1" placeholder="Reps" aria-label="Reps">
                 </div>
             `;
         }
 
-        setElement.innerHTML = `
+        setRowEl.classList.remove('set-row-complete');
+        setRowEl.classList.add('set-row-editing');
+        setRowEl.innerHTML = `
+            <span class="set-row-num">${setIndex + 1}</span>
             ${editFormHTML}
-            <div class="set-actions">
-                <button class="btn-set-action btn-set-save" onclick="window.gymApp.viewControllers.workout.saveSetEdit(${exerciseIndex}, ${setIndex})" title="Save">
+            <div class="set-row-actions">
+                <button type="button" class="btn-set-action btn-set-save" title="Save" aria-label="Save set"
+                    onclick="window.gymApp.viewControllers.workout.saveSetEdit(${exerciseIndex}, ${setIndex})">
                     <i class="fas fa-check"></i>
                 </button>
-                <button class="btn-set-action btn-set-cancel" onclick="window.gymApp.viewControllers.workout.cancelSetEdit(${exerciseIndex})" title="Cancel">
+                <button type="button" class="btn-set-action btn-set-cancel" title="Cancel" aria-label="Cancel edit"
+                    onclick="window.gymApp.viewControllers.workout.cancelSetEdit(${exerciseIndex})">
                     <i class="fas fa-times"></i>
                 </button>
             </div>
         `;
 
         // Focus the first input
-        if (isDuration) {
-            const minInput = document.getElementById(`edit-duration-min-${exerciseIndex}-${setIndex}`);
-            minInput.focus();
-            minInput.select();
-        } else {
-            const weightInput = document.getElementById(`edit-weight-${exerciseIndex}-${setIndex}`);
-            weightInput.focus();
-            weightInput.select();
+        const firstInput = setRowEl.querySelector('input');
+        if (firstInput) {
+            firstInput.focus();
+            firstInput.select();
         }
     }
 
@@ -801,69 +843,65 @@ class WorkoutView {
         const isDuration = set.duration > 0;
 
         if (isDuration) {
-            // Handle duration-based set
             const minInput = document.getElementById(`edit-duration-min-${exerciseIndex}-${setIndex}`);
             const secInput = document.getElementById(`edit-duration-sec-${exerciseIndex}-${setIndex}`);
-
-            const minutes = parseInt(minInput.value) || 0;
-            const seconds = parseInt(secInput.value) || 0;
+            const minutes = parseInt(minInput.value, 10) || 0;
+            const seconds = parseInt(secInput.value, 10) || 0;
             const totalSeconds = (minutes * 60) + seconds;
-
             if (totalSeconds === 0) {
                 showToast('Please enter a valid duration', 'error');
                 return;
             }
-
-            // Update the set
             set.duration = totalSeconds;
         } else {
-            // Handle reps-based set
             const weightInput = document.getElementById(`edit-weight-${exerciseIndex}-${setIndex}`);
             const repsInput = document.getElementById(`edit-reps-${exerciseIndex}-${setIndex}`);
-
             const weight = parseFloat(weightInput.value);
-            const reps = parseInt(repsInput.value);
-
+            const reps = parseInt(repsInput.value, 10);
             if (isNaN(weight) || weight < 0 || !reps) {
                 showToast('Please enter valid weight and reps', 'error');
                 return;
             }
-
-            // Update the set
             set.weight = weight;
             set.reps = reps;
         }
 
-        // Re-render completed sets
-        document.getElementById(`completed-sets-${exerciseIndex}`).innerHTML =
-            this.renderCompletedSets(exercise.sets, exerciseIndex);
-
-        showToast('Set updated!', 'success');
+        this.rerenderExercise(exerciseIndex);
+        showToast('Set updated', 'success');
     }
 
     cancelSetEdit(exerciseIndex) {
         if (!this.currentWorkoutSession) return;
-
-        const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
-
-        // Re-render completed sets to cancel edit
-        document.getElementById(`completed-sets-${exerciseIndex}`).innerHTML =
-            this.renderCompletedSets(exercise.sets, exerciseIndex);
+        this.rerenderExercise(exerciseIndex);
     }
 
-    deleteSet(exerciseIndex, setIndex) {
+    /**
+     * Remove a committed set from an exercise. `opts.silent` suppresses the
+     * "Set deleted" toast — used by the pill-toggle un-check flow, where
+     * the knob animation already gives clear visual confirmation and a
+     * duplicate toast would be noise.
+     */
+    deleteSet(exerciseIndex, setIndex, opts = {}) {
         if (!this.currentWorkoutSession) return;
-
         const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
+        const removed = exercise?.sets[setIndex];
+        if (!exercise || !removed) return;
 
-        // Remove the set
         exercise.sets.splice(setIndex, 1);
 
-        // Re-render completed sets
-        document.getElementById(`completed-sets-${exerciseIndex}`).innerHTML =
-            this.renderCompletedSets(exercise.sets, exerciseIndex);
+        // Preserve the deleted set's values so the user's typed edits don't
+        // vanish when a set is unchecked. The values stick to whatever slot
+        // becomes the first planned row after the deletion (the new tail).
+        // This makes toggle-off → re-check flows non-destructive.
+        if (!exercise.stickyValues) exercise.stickyValues = {};
+        exercise.stickyValues[exercise.sets.length] = {
+            weight: removed.weight,
+            reps: removed.reps,
+            duration: removed.duration,
+        };
 
-        showToast('Set deleted', 'success');
+        this.rerenderExercise(exerciseIndex);
+        if (!opts.silent) showToast('Set deleted', 'info');
     }
 
     updateWorkoutTimer(elapsed) {
@@ -871,6 +909,105 @@ class WorkoutView {
         const seconds = elapsed % 60;
         document.getElementById('workout-time').textContent =
             `${minutes}:${String(seconds).padStart(2, '0')}`;
+    }
+
+    // --- Rest timer ---
+
+    /** Start (or restart) the persistent rest bar for `seconds` seconds. */
+    startRest(seconds) {
+        const duration = Math.max(0, Math.floor(seconds || 0));
+        if (duration === 0) return;
+
+        if (this.activeRestTimerId != null) {
+            timerService.stopRestTimer(this.activeRestTimerId);
+        }
+
+        this.restTimerDuration = duration;
+        this.showRestBar(duration);
+
+        this.activeRestTimerId = timerService.startRestTimer(
+            duration,
+            (remaining) => this.onRestTick(remaining),
+            () => this.onRestComplete(),
+        );
+    }
+
+    /** Add N seconds to the in-flight rest timer without restarting it. */
+    extendRest(seconds) {
+        if (this.activeRestTimerId == null) return;
+        const current = timerService.getRestTimerRemaining(this.activeRestTimerId);
+        const newTotal = Math.max(1, current + seconds);
+        // Simplest correct approach: restart with the new remaining duration.
+        timerService.stopRestTimer(this.activeRestTimerId);
+        this.restTimerDuration += seconds;
+        this.showRestBar(newTotal, { resetFillBase: false });
+        this.activeRestTimerId = timerService.startRestTimer(
+            newTotal,
+            (remaining) => this.onRestTick(remaining),
+            () => this.onRestComplete(),
+        );
+    }
+
+    skipRest() {
+        if (this.activeRestTimerId == null) return this.hideRestBar();
+        timerService.stopRestTimer(this.activeRestTimerId);
+        this.activeRestTimerId = null;
+        this.hideRestBar();
+    }
+
+    showRestBar(total) {
+        const bar = document.getElementById('rest-timer-bar');
+        if (!bar) return;
+        bar.hidden = false;
+        bar.classList.remove('rest-timer-done');
+        const valueEl = document.getElementById('rest-timer-value');
+        const fill = document.getElementById('rest-timer-progress-fill');
+        if (valueEl) valueEl.textContent = this.formatRest(total);
+        if (fill) {
+            // Reset transition so the starting frame is 100% width before shrinking.
+            fill.style.transition = 'none';
+            fill.style.transform = 'scaleX(1)';
+            // Force reflow so the next transform transitions smoothly.
+            // eslint-disable-next-line no-unused-expressions
+            fill.offsetHeight;
+            fill.style.transition = 'transform 1s linear';
+        }
+    }
+
+    hideRestBar() {
+        const bar = document.getElementById('rest-timer-bar');
+        if (bar) {
+            bar.hidden = true;
+            bar.classList.remove('rest-timer-done');
+        }
+    }
+
+    onRestTick(remaining) {
+        const valueEl = document.getElementById('rest-timer-value');
+        const fill = document.getElementById('rest-timer-progress-fill');
+        if (valueEl) valueEl.textContent = this.formatRest(remaining);
+        if (fill && this.restTimerDuration > 0) {
+            const ratio = Math.max(0, Math.min(1, remaining / this.restTimerDuration));
+            fill.style.transform = `scaleX(${ratio})`;
+        }
+    }
+
+    onRestComplete() {
+        this.activeRestTimerId = null;
+        const bar = document.getElementById('rest-timer-bar');
+        const valueEl = document.getElementById('rest-timer-value');
+        if (bar) bar.classList.add('rest-timer-done');
+        if (valueEl) valueEl.textContent = 'Done';
+        vibrate([120, 60, 120]);
+        // Auto-hide after a short celebration so the bar doesn't linger.
+        setTimeout(() => this.hideRestBar(), 2500);
+    }
+
+    formatRest(seconds) {
+        const s = Math.max(0, seconds | 0);
+        const m = Math.floor(s / 60);
+        const r = s % 60;
+        return `${m}:${String(r).padStart(2, '0')}`;
     }
 
     openFinishWorkoutModal() {
@@ -939,8 +1076,9 @@ class WorkoutView {
         // Update achievements
         this.app.updateAchievements();
 
-        // Stop timer
+        // Stop timer + rest bar
         timerService.stopWorkoutTimer();
+        this.skipRest();
 
         // Close modal and reset
         document.getElementById('finish-workout-modal').classList.remove('active');
@@ -955,21 +1093,22 @@ class WorkoutView {
 
     async endWorkout() {
         const confirmed = await showConfirmModal({
-            title: 'End Workout',
-            message: 'Are you sure you want to end this workout?<br><br><strong>Your progress will not be saved.</strong>',
-            confirmText: 'End Workout',
+            title: 'Discard Workout',
+            message: 'Are you sure you want to discard this workout?<br><br><strong>Your progress will not be saved.</strong>',
+            confirmText: 'Discard Workout',
             cancelText: 'Continue Workout',
             isDangerous: true
         });
 
         if (confirmed) {
             timerService.stopWorkoutTimer();
+            this.skipRest();
             storageService.clearActiveWorkout();
             document.getElementById('active-workout').classList.remove('active');
             document.getElementById('workout-selection').classList.add('active');
             this.currentWorkoutSession = null;
             this.render();
-            showToast('Workout ended', 'info');
+            showToast('Workout discarded', 'info');
             this.app.showView('home');
         }
     }

--- a/apps/gym-tracker/js/views/workout-view.js
+++ b/apps/gym-tracker/js/views/workout-view.js
@@ -10,6 +10,7 @@ import { timerService } from '../services/TimerService.js';
 import { storageService } from '../services/StorageService.js';
 import { showToast, showConfirmModal, formatMuscleGroup, vibrate } from '../utils/helpers.js';
 import { renderPausedBannerHTML, wirePausedBannerActions } from './paused-banner.js';
+import { orderPrograms } from '../utils/program-order.js';
 
 class WorkoutView {
     constructor() {
@@ -299,7 +300,13 @@ class WorkoutView {
 
     renderProgramSelection() {
         const container = document.getElementById('workout-program-list');
-        const programs = this.app.programs;
+        // Same ordering source-of-truth as Home + Programs: the user's chosen
+        // sort mode + saved custom order are read from storage on every render,
+        // so a reorder on the Programs screen reflects here without any extra
+        // plumbing. `orderPrograms` is the single place that applies sorting.
+        const sortMode = storageService.getProgramSort() || 'custom';
+        const savedOrder = storageService.getProgramOrder() || [];
+        const programs = orderPrograms(this.app.programs, sortMode, savedOrder);
 
         // Start fresh - don't double-add the banner
         let html = '';


### PR DESCRIPTION
## Summary

Full UX/UI pass on the Gym Tracker app covering the five top audit items plus follow-up polish from the day's iteration. ~2.6k lines changed across 15 files.

### Core UX wins
- **Rest timer wired up** — the previously-dead `#rest-timer-modal` replaced by a polished persistent bottom pill bar with Skip / +30s, progress fill, haptics + tone on completion. Auto-starts after every commit.
- **Planned / checkable set rows** — `renderActiveWorkout` now renders N rows per exercise (`max(targetSets, sets.length)`). Committed rows lock with edit/delete; planned rows show prefilled inputs and a pill-toggle that commits + starts rest.
- **Pill-toggle completion control** — replaces the outlined ring with an iOS-style horizontal pill (muted OFF → green gradient ON, white knob with check). Slide animation, press squish, focus ring, `prefers-reduced-motion` aware. Only the toggle marks complete — row-tap was deliberately removed.
- **Program builder with real target prescription** — `targetSets`, `targetReps`, `restSeconds` now editable per exercise via inline steppers. Equipment-based rest defaults (`defaultRestForEquipment`).
- **Multi-select exercise picker** — cards toggle, sticky "Added (N)" tray at the bottom with per-item Sets/Reps/Rest steppers, single commit button. Picker stays open across selections (fixed the "open → pick → reopen 8x" flow).
- **Workout FAB + primary nav slot** — raised Workout pill in the mobile bottom nav; Home FAB auto-routes to resume, single-program start, or picker.
- **Destructive action cleanup** — native `confirm()` calls replaced with styled `showConfirmModal`; Discard/End icon + label mismatch fixed; 44px tap targets in the workout header.

### Mid-workout polish (follow-ups)
- Refined exercise card spacing, hierarchy, and the "Last Time" rail → self-contained pills with consistent height.
- Completed rows: flex-based single-line layout (no more top-heavy stacking), softer green rail, tighter vertical centering.
- Add/Remove set controls at the bottom of each exercise — add is primary, remove is a compact red-tinted icon that appears only when there's an uncommitted slot.
- Sticky values: typing `55×8` over a prior `55×7` persists even if the set is un-toggled. Preserved across pause/resume via `WorkoutExercise.stickyValues`.

### Timestamp correctness
- `WorkoutSession.sortTimestamp` getter with `endTime → startTime → timestamp → date` fallback.
- All six sort sites updated (workout-view `getPreviousExerciseData`, home recent-workouts, history list, calendar day-detail, exercise-history flat + grouped).
- Time-of-day rendered on History cards, workout detail modals, and home recent-workouts via new `formatSessionDateTime` helper. Exercise-history table shows time only when a day has multiple sessions.

### Desktop refinements (Edit Program modal)
- CSS Grid with `auto-fit, minmax(170px, 1fr)` on `.pex-targets` — bounded cells, no overlap, graceful wrap.
- Wider program modal on desktop (720px → 760px), left-aligned list (no centering cap).
- Pill steppers restructured with inner `.pex-stepper-controls` group so `[−] value [+]` keeps uniform spacing regardless of value length (`1:30`, `2:15`, `10:30`).

### Final bug fixes + reverts (today)
- **Start Workout ordering matches Programs/Home** — uses shared `orderPrograms` + storage-backed sort mode / custom order instead of a parallel source.
- **History delete reverted** — confirmation modal with name/timestamp/exercise count/total volume → confirm → delete + toast. Removed the recent undo-toast flow per preference.
- **Set-deleted toast silenced** on toggle-off (pill-toggle un-check); trash button still toasts.

### Theme / system hygiene
- Added `--bottom-nav-height: 64px` to `:root`.
- Consolidated paused-workout banner into a shared `paused-banner.js` module consumed by Home + Workout.
- Global `button { color: #555 !important }` override documented and worked around with `!important` where colors got eaten (Add set, +30s, Skip, rest bar actions).

## Test plan

- [ ] Start a workout, enter weight/reps, tap the pill toggle — knob slides ON, row turns green, rest bar slides up with Skip/+30s and counts down.
- [ ] Tap the green toggle to un-commit — knob slides back, row reverts to planned with typed values preserved (the 55×7 → 55×8 bug).
- [ ] Programs page: drag-reorder or switch Sort to Name (Z→A). Open `#workout` Start Workout list — order matches.
- [ ] Create a program via the multi-select picker: tick several cards, adjust Sets/Reps/Rest per item in the tray, tap Add to program. Verify picker stays open while selecting.
- [ ] History page: tap trash on any workout — confirmation modal shows name + timestamp + stats. Confirm → delete + toast.
- [ ] Do two workouts on the same calendar day (morning + evening). Third workout's "Last Time" should reflect the evening session.
- [ ] Desktop viewport, Edit Program: Sets/Reps/Rest controls sit cleanly in one row; set REST to 2:15 or 10:30 — no overlap; narrow the window → steppers wrap gracefully.
- [ ] Settings → Clear All Data / Import Data → styled confirm modal (not the native browser prompt).
- [ ] Mobile viewport: Workout pill in the bottom nav; Home FAB appears (green "Resume workout" when a paused session exists, else purple "Start workout"). One tap starts/resumes.