### PR TITLE
Gym + Football: feature pass, accessibility, TZ fixes

### DIFF
--- a/apps/football-h2h/css/football-h2h.css
+++ b/apps/football-h2h/css/football-h2h.css
@@ -2428,3 +2428,158 @@ body.football-h2h-tracker {
 #footer {
   margin-top: auto;
 }
+
+/* Player Stats tab — side-by-side comparison table. Flat, clipped to rounded
+   corners so tinted cells end cleanly at the last row with no visible gap. */
+.player-comparison-wrap {
+    background: #374151;
+    border-radius: 0.75rem;
+    overflow: hidden;
+}
+
+.player-comparison-table {
+    width: 100%;
+    border-collapse: collapse;
+    color: #f7fafc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    table-layout: fixed;
+    margin: 0;
+}
+
+.player-comparison-table thead th {
+    background: #2d3748;
+    color: #e2e8f0;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 0.75rem 0.9rem;
+    text-align: center;
+    white-space: nowrap;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.10);
+}
+
+.player-comparison-table thead th.pc-col-stat {
+    text-align: left;
+    width: 40%;
+}
+
+.player-comparison-table thead th.pc-col-player {
+    width: 30%;
+}
+
+/* Neutralize global zebra-stripe + tr borders from assets/css/main.css so the
+   per-cell comparison tints aren't washed out by the row-level background. */
+.player-comparison-table tbody tr,
+.player-comparison-table tbody tr:nth-child(2n + 1) {
+    background: transparent;
+    border: 0;
+}
+
+.player-comparison-table td {
+    padding: 0.65rem 0.9rem;
+    vertical-align: middle;
+    border: 0;
+}
+
+/* Horizontal-only row dividers. Soft white-alpha reads consistently whether
+   the cell behind is plain wrap bg or a tinted comparison cell. Skips the
+   first body row since the thead's border-bottom already separates it. */
+.player-comparison-table tbody tr + tr td {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.pc-cell-stat {
+    text-align: left;
+}
+
+.pc-stat-label {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: #e2e8f0;
+}
+
+/* Inline with the label so rows stay uniform height. Margin-left gives a
+   little breathing room; muted color keeps the helper text secondary. */
+.pc-stat-hint {
+    margin-left: 0.4em;
+    font-size: 0.72rem;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.5);
+    letter-spacing: 0.2px;
+}
+
+.pc-cell-value {
+    text-align: center;
+    font-size: 1.1rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: #f7fafc;
+    white-space: normal;
+    word-break: break-word;
+    line-height: 1.3;
+}
+
+/* Longest-streak cells split the value (prominent number) from the date range
+   (secondary, muted). Range wraps below on narrow screens to avoid crowding. */
+.pc-value-main {
+    display: inline;
+}
+
+.pc-value-range {
+    margin-left: 0.4em;
+    font-size: 0.78em;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.55);
+    letter-spacing: 0;
+}
+
+@media (max-width: 600px) {
+    .pc-value-range {
+        display: block;
+        margin-left: 0;
+        margin-top: 0.15rem;
+        font-size: 0.72em;
+    }
+}
+
+/* Full-cell fills for the comparison table. Selectors are intentionally
+   scoped to .player-comparison-table td.* so specificity (0,2,2) beats the
+   page-wide `body.theme td { background: #2d3748 }` override from
+   apps/mario-kart/css/theme.css — without that scope, the global paints over
+   the tint. Opacity 0.18 keeps the tints soft but unambiguously visible over
+   the #374151 wrap bg. */
+.player-comparison-table td.pc-cell-winning {
+    background: rgba(34, 197, 94, 0.18);
+}
+
+.player-comparison-table td.pc-cell-losing {
+    background: rgba(239, 68, 68, 0.18);
+}
+
+.player-comparison-table td.pc-cell-tied {
+    background: rgba(245, 158, 11, 0.18);
+}
+
+@media (max-width: 600px) {
+    .player-comparison-table thead th {
+        font-size: 0.72rem;
+        padding: 0.55rem 0.6rem;
+    }
+
+    .player-comparison-table td {
+        padding: 0.55rem 0.6rem;
+    }
+
+    .pc-stat-label {
+        font-size: 0.82rem;
+    }
+
+    .pc-stat-hint {
+        font-size: 0.65rem;
+    }
+
+    .pc-cell-value {
+        font-size: 1rem;
+    }
+}

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -260,6 +260,9 @@
                     <button class="stats-tab" onclick="switchStatsTab('general')" role="tab" aria-selected="false" aria-controls="general-stats">
                         📊 General Stats
                     </button>
+                    <button class="stats-tab" onclick="switchStatsTab('player')" role="tab" aria-selected="false" aria-controls="player-stats">
+                        👤 Player Stats
+                    </button>
                 </div>
 
                 <!-- H2H Stats Tab Content -->
@@ -323,6 +326,22 @@
                             <div class="stat-label">Penalty Shootouts</div>
                             <div class="stat-value" id="penaltyShootouts">0</div>
                         </div>
+                    </div>
+                </section>
+
+                <!-- Player Stats Tab Content -->
+                <section class="stats-overview stats-tab-content" id="player-stats" role="tabpanel" style="display: none;">
+                    <div class="player-comparison-wrap">
+                        <table class="player-comparison-table">
+                            <thead>
+                                <tr>
+                                    <th class="pc-col-stat">Stat</th>
+                                    <th class="pc-col-player" id="playerComparisonP1Header">Player 1</th>
+                                    <th class="pc-col-player" id="playerComparisonP2Header">Player 2</th>
+                                </tr>
+                            </thead>
+                            <tbody id="playerComparisonBody"></tbody>
+                        </table>
                     </div>
                 </section>
             </div>
@@ -421,6 +440,7 @@
         document.body.classList.add('theme');
         localStorage.setItem('theme', 'true');
     </script>
+    <script src="js/playerStats.js"></script>
     <script src="js/modalUtils.js"></script>
     <script src="../../assets/js/pagination.js"></script>
     <script src="js/sidebar.js"></script>

--- a/apps/football-h2h/js/football-h2h.js
+++ b/apps/football-h2h/js/football-h2h.js
@@ -1822,6 +1822,163 @@ function updateStatisticsWithData(gamesData) {
             player2CardPen.classList.add('tied');
         }
     }
+
+    renderPlayerStatsTab(gamesData);
+}
+
+// Descriptor for each row in the Player Stats comparison table. `direction`
+// drives the green/red/amber tinting in compareStat; `format` tells the
+// renderer how to stringify the raw numeric stat values.
+// Only uses fields already produced by computePlayerStats — no new data.
+const PLAYER_STAT_ROWS = [
+    { key: 'totalGoals',              label: 'Total Goals',            direction: 'higher',  format: 'count' },
+    { key: 'goalsPerGame',            label: 'Goals / Game',           direction: 'higher',  format: 'decimal' },
+    { key: 'highestScore',            label: 'Highest Score',          direction: 'higher',  format: 'count', matchKey: 'highestScoreGame' },
+    { key: 'median',                  label: 'Median Score',           direction: 'higher',  format: 'decimal1' },
+    { key: 'scoringRate',             label: 'Scoring Rate',           direction: 'higher',  format: 'percent' },
+    { key: 'multiGoalRate',           label: 'Multi-Goal Games',       direction: 'higher',  format: 'percent', hint: '(% with 2+ goals)' },
+    { key: 'currentWinningStreak',    label: 'Current Winning Streak', direction: 'higher', format: 'count' },
+    { key: 'currentLosingStreak',     label: 'Current Losing Streak',  direction: 'lower',  format: 'count' },
+    { key: 'currentScoringStreak',    label: 'Current Scoring Streak', direction: 'higher', format: 'count' },
+    { key: 'currentScorelessStreak',  label: 'Current Scoreless Streak', direction: 'lower', format: 'count' },
+    { key: 'longestWinningStreak',    label: 'Longest Winning Streak', direction: 'higher', format: 'count', rangeKey: 'longestWinningRun' },
+    { key: 'longestScoringStreak',    label: 'Longest Scoring Streak', direction: 'higher', format: 'count', rangeKey: 'longestScoringRun' },
+    { key: 'longestScorelessStreak',  label: 'Longest Scoreless Streak', direction: 'lower', format: 'count', rangeKey: 'longestScorelessRun' },
+    { key: 'recentFormLast3',         label: 'Last 3 Avg',             direction: 'higher',  format: 'decimal' },
+    { key: 'recentFormLast5',         label: 'Last 5 Avg',             direction: 'higher',  format: 'decimal' },
+    { key: 'stddev',                  label: 'Consistency',            direction: 'lower',   format: 'decimal', hint: '(σ, lower = steadier)' }
+];
+
+function formatStatValue(format, value) {
+    const api = window.FootballPlayerStats;
+    switch (format) {
+        case 'count':    return String(Math.round(Number(value) || 0));
+        case 'decimal':  return api.formatNumber(value, 2);
+        case 'decimal1': return api.formatNumber(value, 1);
+        case 'percent':  return api.formatPercent(value);
+        default:         return String(value);
+    }
+}
+
+function renderPlayerStatsTab(gamesData) {
+    const api = window.FootballPlayerStats;
+    if (!api) return;
+    const tbody = document.getElementById('playerComparisonBody');
+    if (!tbody) return;
+
+    const p1Header = document.getElementById('playerComparisonP1Header');
+    const p2Header = document.getElementById('playerComparisonP2Header');
+    if (p1Header) p1Header.textContent = (playerIcons.player1 || '') + ' ' + player1Name;
+    if (p2Header) p2Header.textContent = (playerIcons.player2 || '') + ' ' + player2Name;
+
+    const stats1 = api.computePlayerStats(api.scoresInOrder(gamesData, 'player1Goals'));
+    const stats2 = api.computePlayerStats(api.scoresInOrder(gamesData, 'player2Goals'));
+
+    // Match-based current streaks. matchResultsInOrder applies the penalty
+    // rule per game (regulation tie + penalty winner counts as the match
+    // winner) so streaks reflect actual outcomes, not just regulation scores.
+    const p1Results = api.matchResultsInOrder(gamesData, 'player1Goals', 'player2Goals', 1);
+    const p2Results = api.matchResultsInOrder(gamesData, 'player2Goals', 'player1Goals', 2);
+    Object.assign(stats1, api.computeMatchStreaks(p1Results));
+    Object.assign(stats2, api.computeMatchStreaks(p2Results));
+
+    // Longest match-based winning runs (penalty-aware) with date spans.
+    const isWin = (r) => r === 'W';
+    stats1.longestWinningRun = api.longestMatchRun(gamesData, 'player1Goals', 'player2Goals', 1, isWin);
+    stats2.longestWinningRun = api.longestMatchRun(gamesData, 'player2Goals', 'player1Goals', 2, isWin);
+    stats1.longestWinningStreak = stats1.longestWinningRun.length;
+    stats2.longestWinningStreak = stats2.longestWinningRun.length;
+
+    // Longest goal-based runs (still useful as a separate stat — independent
+    // of who won the match — so they remain alongside the match-based rows).
+    const isScoring = (s) => s > 0;
+    const isScoreless = (s) => s === 0;
+    stats1.longestScoringRun   = api.longestRun(gamesData, 'player1Goals', isScoring);
+    stats1.longestScorelessRun = api.longestRun(gamesData, 'player1Goals', isScoreless);
+    stats2.longestScoringRun   = api.longestRun(gamesData, 'player2Goals', isScoring);
+    stats2.longestScorelessRun = api.longestRun(gamesData, 'player2Goals', isScoreless);
+
+    // Best single game (highest score + opponent score + date) for the Highest
+    // Score row. Second key is the opponent's score field from this player's
+    // perspective so the displayed "me–opp" pair matches who the row is about.
+    stats1.highestScoreGame = api.highestScoreGame(gamesData, 'player1Goals', 'player2Goals');
+    stats2.highestScoreGame = api.highestScoreGame(gamesData, 'player2Goals', 'player1Goals');
+
+    tbody.replaceChildren();
+    for (const row of PLAYER_STAT_ROWS) {
+        tbody.appendChild(buildComparisonRow(row, stats1, stats2));
+    }
+}
+
+function buildComparisonRow(rowDef, stats1, stats2) {
+    const api = window.FootballPlayerStats;
+    const tr = document.createElement('tr');
+    tr.className = 'pc-row';
+
+    const statCell = document.createElement('td');
+    statCell.className = 'pc-cell-stat';
+    const label = document.createElement('span');
+    label.className = 'pc-stat-label';
+    label.textContent = rowDef.label;
+    statCell.appendChild(label);
+    if (rowDef.hint) {
+        // Inline span so the hint flows on the same line as the label,
+        // keeping every body row at the same height. Falls back to wrapping
+        // gracefully on very narrow screens.
+        const hint = document.createElement('span');
+        hint.className = 'pc-stat-hint';
+        hint.textContent = rowDef.hint;
+        statCell.appendChild(hint);
+    }
+    tr.appendChild(statCell);
+
+    const rawP1 = stats1[rowDef.key];
+    const rawP2 = stats2[rowDef.key];
+    const cmp = api.compareStat(rowDef.direction, rawP1, rawP2);
+
+    // Neutral and tie both render amber per task spec; only clear win/loss
+    // earns green/red.
+    const p1Class = cmp.winner === 'p1' ? 'pc-cell-winning'
+        : cmp.winner === 'p2' ? 'pc-cell-losing'
+        : 'pc-cell-tied';
+    const p2Class = cmp.winner === 'p2' ? 'pc-cell-winning'
+        : cmp.winner === 'p1' ? 'pc-cell-losing'
+        : 'pc-cell-tied';
+
+    // A row can optionally carry a parenthesised detail string next to the
+    // value: either a date range (longest-streak rows) or a match score
+    // (highest-score row). Both paths return null on missing data so the
+    // display falls back to the bare value.
+    let detailP1 = null;
+    let detailP2 = null;
+    if (rowDef.rangeKey) {
+        detailP1 = api.formatRangeText(stats1[rowDef.rangeKey]);
+        detailP2 = api.formatRangeText(stats2[rowDef.rangeKey]);
+    } else if (rowDef.matchKey) {
+        detailP1 = api.formatMatchText(stats1[rowDef.matchKey]);
+        detailP2 = api.formatMatchText(stats2[rowDef.matchKey]);
+    }
+    tr.appendChild(buildValueCell(formatStatValue(rowDef.format, rawP1), p1Class, detailP1));
+    tr.appendChild(buildValueCell(formatStatValue(rowDef.format, rawP2), p2Class, detailP2));
+    return tr;
+}
+
+function buildValueCell(mainText, className, rangeText) {
+    const td = document.createElement('td');
+    td.className = 'pc-cell-value ' + className;
+
+    const mainSpan = document.createElement('span');
+    mainSpan.className = 'pc-value-main';
+    mainSpan.textContent = mainText;
+    td.appendChild(mainSpan);
+
+    if (rangeText) {
+        const rangeSpan = document.createElement('span');
+        rangeSpan.className = 'pc-value-range';
+        rangeSpan.textContent = rangeText;
+        td.appendChild(rangeSpan);
+    }
+    return td;
 }
 
 // Switch between stats tabs

--- a/apps/football-h2h/js/playerStats.js
+++ b/apps/football-h2h/js/playerStats.js
@@ -1,0 +1,522 @@
+// Pure functions for per-player derived stats based only on scores-per-game.
+// Works both as a browser <script> (exposes window.FootballPlayerStats) and as
+// a CommonJS module (so node --test can require it directly, no build step).
+
+(function (root) {
+    'use strict';
+
+    function toScore(value) {
+        if (value === null || value === undefined || value === '') return null;
+        const n = Number(value);
+        return Number.isFinite(n) ? n : null;
+    }
+
+    function cleanScores(arr) {
+        if (!Array.isArray(arr)) return [];
+        const out = [];
+        for (const v of arr) {
+            const n = toScore(v);
+            if (n !== null) out.push(n);
+        }
+        return out;
+    }
+
+    // scores must be chronological (oldest first) for streaks and recent form.
+    function computePlayerStats(scoresChronological) {
+        const scores = cleanScores(scoresChronological);
+        const games = scores.length;
+
+        if (games === 0) {
+            return {
+                games: 0,
+                totalGoals: 0,
+                goalsPerGame: 0,
+                highestScore: 0,
+                lowestScore: 0,
+                scoringRate: 0,
+                multiGoalRate: 0,
+                currentScoringStreak: 0,
+                currentScorelessStreak: 0,
+                longestScoringStreak: 0,
+                longestScorelessStreak: 0,
+                median: 0,
+                stddev: 0,
+                recentFormLast3: 0,
+                recentFormLast5: 0
+            };
+        }
+
+        let totalGoals = 0;
+        let highestScore = scores[0];
+        let lowestScore = scores[0];
+        let scoringCount = 0;
+        let multiGoalCount = 0;
+
+        for (const s of scores) {
+            totalGoals += s;
+            if (s > highestScore) highestScore = s;
+            if (s < lowestScore) lowestScore = s;
+            if (s > 0) scoringCount++;
+            if (s >= 2) multiGoalCount++;
+        }
+
+        const goalsPerGame = totalGoals / games;
+        const scoringRate = scoringCount / games;
+        const multiGoalRate = multiGoalCount / games;
+
+        // Current streak walks the RAW chronological input (not cleaned scores)
+        // so a missing/null game breaks the streak — matches the explicit spec
+        // "stop counting when the opposite condition occurs or the game has
+        // missing/null data". Behavior is identical to the cleaned-input
+        // version for null-free histories.
+        function currentStreak(pred) {
+            if (!Array.isArray(scoresChronological)) return 0;
+            let n = 0;
+            for (let i = scoresChronological.length - 1; i >= 0; i--) {
+                const s = toScore(scoresChronological[i]);
+                if (s === null) break;
+                if (pred(s)) n++;
+                else break;
+            }
+            return n;
+        }
+
+        function longestStreak(pred) {
+            let best = 0;
+            let cur = 0;
+            for (const s of scores) {
+                if (pred(s)) {
+                    cur++;
+                    if (cur > best) best = cur;
+                } else {
+                    cur = 0;
+                }
+            }
+            return best;
+        }
+
+        const isScoring = (s) => s > 0;
+        const isScoreless = (s) => s === 0;
+
+        const sorted = scores.slice().sort((a, b) => a - b);
+        const mid = Math.floor(sorted.length / 2);
+        const median = sorted.length % 2 === 0
+            ? (sorted[mid - 1] + sorted[mid]) / 2
+            : sorted[mid];
+
+        let stddev = 0;
+        if (games >= 2) {
+            let variance = 0;
+            for (const s of scores) {
+                const d = s - goalsPerGame;
+                variance += d * d;
+            }
+            variance /= games;
+            stddev = Math.sqrt(variance);
+        }
+
+        function recentAverage(window) {
+            const slice = scores.slice(-window);
+            if (slice.length === 0) return 0;
+            let sum = 0;
+            for (const s of slice) sum += s;
+            return sum / slice.length;
+        }
+
+        return {
+            games,
+            totalGoals,
+            goalsPerGame,
+            highestScore,
+            lowestScore,
+            scoringRate,
+            multiGoalRate,
+            currentScoringStreak: currentStreak(isScoring),
+            currentScorelessStreak: currentStreak(isScoreless),
+            longestScoringStreak: longestStreak(isScoring),
+            longestScorelessStreak: longestStreak(isScoreless),
+            median,
+            stddev,
+            recentFormLast3: recentAverage(3),
+            recentFormLast5: recentAverage(5)
+        };
+    }
+
+    // Returns scores for the given key (e.g. 'player1Goals') ordered oldest first
+    // by dateTime, with id as a stable tiebreaker. Games without a parseable
+    // score are skipped so byes/partial rows don't poison streaks.
+    function scoresInOrder(gamesArr, key) {
+        if (!Array.isArray(gamesArr)) return [];
+        const copy = gamesArr.slice().sort((a, b) => {
+            const ta = new Date(a && a.dateTime ? a.dateTime : 0).getTime() || 0;
+            const tb = new Date(b && b.dateTime ? b.dateTime : 0).getTime() || 0;
+            if (ta !== tb) return ta - tb;
+            const ia = (a && typeof a.id === 'number') ? a.id : 0;
+            const ib = (b && typeof b.id === 'number') ? b.id : 0;
+            return ia - ib;
+        });
+        const out = [];
+        for (const g of copy) {
+            const n = toScore(g ? g[key] : null);
+            if (n !== null) out.push(n);
+        }
+        return out;
+    }
+
+    // Longest matching run across a games array, with date range of the run.
+    // games is the raw (unsorted) games array; it's sorted chronologically
+    // internally. scoreKey is the per-game field to evaluate (e.g.
+    // 'player1Goals'). predicate receives the coerced numeric score.
+    //
+    // Returns { length, startDate, endDate }. startDate/endDate are the
+    // original ISO strings from the first and last game in the winning run,
+    // or null when length is 0 or a game in the run has no dateTime.
+    //
+    // Tie-breaking: when multiple runs share the longest length, the MOST
+    // RECENT run wins (later runs overwrite earlier ones during the scan).
+    // Missing/null scores are skipped — they neither extend nor break a run.
+    function longestRun(games, scoreKey, predicate) {
+        if (!Array.isArray(games) || games.length === 0 || typeof predicate !== 'function') {
+            return { length: 0, startDate: null, endDate: null };
+        }
+        const sorted = games.slice().sort((a, b) => {
+            const ta = new Date(a && a.dateTime ? a.dateTime : 0).getTime() || 0;
+            const tb = new Date(b && b.dateTime ? b.dateTime : 0).getTime() || 0;
+            if (ta !== tb) return ta - tb;
+            const ia = (a && typeof a.id === 'number') ? a.id : 0;
+            const ib = (b && typeof b.id === 'number') ? b.id : 0;
+            return ia - ib;
+        });
+
+        let bestLen = 0;
+        let bestStart = -1;
+        let bestEnd = -1;
+        let curLen = 0;
+        let curStart = -1;
+
+        for (let i = 0; i < sorted.length; i++) {
+            const game = sorted[i];
+            const score = toScore(game ? game[scoreKey] : null);
+            if (score === null) continue;
+            if (predicate(score)) {
+                if (curLen === 0) curStart = i;
+                curLen++;
+                if (curLen >= bestLen) {
+                    bestLen = curLen;
+                    bestStart = curStart;
+                    bestEnd = i;
+                }
+            } else {
+                curLen = 0;
+                curStart = -1;
+            }
+        }
+
+        if (bestLen === 0) {
+            return { length: 0, startDate: null, endDate: null };
+        }
+        const startGame = sorted[bestStart];
+        const endGame = sorted[bestEnd];
+        return {
+            length: bestLen,
+            startDate: (startGame && startGame.dateTime) ? startGame.dateTime : null,
+            endDate: (endGame && endGame.dateTime) ? endGame.dateTime : null
+        };
+    }
+
+    // Penalty-aware single-match outcome from "me's" perspective.
+    //   'W' — me beat opp in regulation, OR regulation tied AND me won pens
+    //   'L' — opp beat me in regulation, OR regulation tied AND opp won pens
+    //   'D' — regulation tied AND no penalty winner (null / 'draw' / undefined)
+    //   null — either side's score is missing; caller can skip the game
+    //
+    // mySide is 1 or 2 to match the raw penaltyWinner values stored on games
+    // (penaltyWinner === 1 means player1 won the shootout). 'draw' as a
+    // penaltyWinner is treated the same as null — the shootout itself was a
+    // draw, so the match stays a draw.
+    function matchResult(me, opp, penaltyWinner, mySide) {
+        const m = toScore(me);
+        const o = toScore(opp);
+        if (m === null || o === null) return null;
+        if (m > o) return 'W';
+        if (m < o) return 'L';
+        // Regulation tied — penalty decides if there was a winner.
+        if (penaltyWinner === mySide) return 'W';
+        if (penaltyWinner === 1 || penaltyWinner === 2) return 'L';
+        return 'D';
+    }
+
+    // Chronological array of per-game results from "me's" perspective. Nulls
+    // are preserved so callers can decide whether to skip or break on missing
+    // data. Sorts games internally by dateTime then id (same rule as elsewhere).
+    function matchResultsInOrder(games, meKey, oppKey, mySide) {
+        if (!Array.isArray(games)) return [];
+        const sorted = games.slice().sort((a, b) => {
+            const ta = new Date(a && a.dateTime ? a.dateTime : 0).getTime() || 0;
+            const tb = new Date(b && b.dateTime ? b.dateTime : 0).getTime() || 0;
+            if (ta !== tb) return ta - tb;
+            const ia = (a && typeof a.id === 'number') ? a.id : 0;
+            const ib = (b && typeof b.id === 'number') ? b.id : 0;
+            return ia - ib;
+        });
+        return sorted.map((g) => matchResult(
+            g ? g[meKey] : null,
+            g ? g[oppKey] : null,
+            g ? g.penaltyWinner : null,
+            mySide
+        ));
+    }
+
+    // Match-based current streaks: consecutive wins or losses working backward
+    // from the most recent game. Input is a chronological results array (use
+    // matchResultsInOrder to get one). Draws break both streaks at the tail.
+    // null entries are skipped — missing data doesn't count as a streak break.
+    function computeMatchStreaks(results) {
+        if (!Array.isArray(results)) {
+            return { currentWinningStreak: 0, currentLosingStreak: 0 };
+        }
+        let winning = 0;
+        let losing = 0;
+        let activeType = null; // 'W' | 'L' | null
+
+        for (let i = results.length - 1; i >= 0; i--) {
+            const r = results[i];
+            if (r === null || r === undefined) continue;
+
+            if (activeType === null) {
+                if (r === 'D') break; // draw at the tail kills both streaks
+                activeType = r;
+                if (r === 'W') winning = 1;
+                else if (r === 'L') losing = 1;
+                else break; // unknown value
+            } else if (r === activeType) {
+                if (activeType === 'W') winning++;
+                else losing++;
+            } else {
+                break;
+            }
+        }
+
+        return { currentWinningStreak: winning, currentLosingStreak: losing };
+    }
+
+    // Longest match-result run with date span. Mirrors longestRun but operates
+    // on per-game results (penalty-aware) rather than raw scores. predicate
+    // takes a result string ('W'|'L'|'D') and returns true if the game extends
+    // the run; null results are skipped without breaking. Tie-break: most
+    // recent run wins (>= comparison during forward scan).
+    function longestMatchRun(games, meKey, oppKey, mySide, predicate) {
+        if (!Array.isArray(games) || games.length === 0 || typeof predicate !== 'function') {
+            return { length: 0, startDate: null, endDate: null };
+        }
+        const sorted = games.slice().sort((a, b) => {
+            const ta = new Date(a && a.dateTime ? a.dateTime : 0).getTime() || 0;
+            const tb = new Date(b && b.dateTime ? b.dateTime : 0).getTime() || 0;
+            if (ta !== tb) return ta - tb;
+            const ia = (a && typeof a.id === 'number') ? a.id : 0;
+            const ib = (b && typeof b.id === 'number') ? b.id : 0;
+            return ia - ib;
+        });
+
+        let bestLen = 0;
+        let bestStart = -1;
+        let bestEnd = -1;
+        let curLen = 0;
+        let curStart = -1;
+
+        for (let i = 0; i < sorted.length; i++) {
+            const g = sorted[i];
+            const result = matchResult(
+                g ? g[meKey] : null,
+                g ? g[oppKey] : null,
+                g ? g.penaltyWinner : null,
+                mySide
+            );
+            if (result === null) continue;
+            if (predicate(result)) {
+                if (curLen === 0) curStart = i;
+                curLen++;
+                if (curLen >= bestLen) {
+                    bestLen = curLen;
+                    bestStart = curStart;
+                    bestEnd = i;
+                }
+            } else {
+                curLen = 0;
+                curStart = -1;
+            }
+        }
+
+        if (bestLen === 0) {
+            return { length: 0, startDate: null, endDate: null };
+        }
+        const startGame = sorted[bestStart];
+        const endGame = sorted[bestEnd];
+        return {
+            length: bestLen,
+            startDate: (startGame && startGame.dateTime) ? startGame.dateTime : null,
+            endDate: (endGame && endGame.dateTime) ? endGame.dateTime : null
+        };
+    }
+
+    function formatNumber(n, decimals) {
+        if (!Number.isFinite(n)) return '0';
+        const d = typeof decimals === 'number' ? decimals : 1;
+        if (n % 1 === 0) return n.toFixed(0);
+        return n.toFixed(d);
+    }
+
+    function formatPercent(ratio) {
+        if (!Number.isFinite(ratio)) return '0%';
+        return Math.round(ratio * 100) + '%';
+    }
+
+    // Compact date matching the Game History convention: M/D/YYYY with no
+    // leading zeros and no month names (e.g. 4/24/2026). Returns null when the
+    // input can't be parsed so callers can fall back to bare values.
+    function formatDateShort(iso) {
+        if (!iso) return null;
+        const d = new Date(iso);
+        if (isNaN(d.getTime())) return null;
+        return d.toLocaleDateString('en-US', {
+            month: 'numeric',
+            day: 'numeric',
+            year: 'numeric'
+        });
+    }
+
+    // Best single game for a player: highest score with its date and the
+    // opponent's score in that same game. Sorts chronologically internally.
+    // Ties (e.g. multiple 5-goal games) resolve to the MOST RECENT one by
+    // using `>=` during a forward scan. Null scores are skipped so missing
+    // data can't claim the highest. Returns a fully-null shape when nothing
+    // qualifies so callers can render a safe fallback.
+    function highestScoreGame(games, meKey, oppKey) {
+        const empty = { score: 0, opponentScore: null, date: null };
+        if (!Array.isArray(games) || games.length === 0) return empty;
+
+        const sorted = games.slice().sort((a, b) => {
+            const ta = new Date(a && a.dateTime ? a.dateTime : 0).getTime() || 0;
+            const tb = new Date(b && b.dateTime ? b.dateTime : 0).getTime() || 0;
+            if (ta !== tb) return ta - tb;
+            const ia = (a && typeof a.id === 'number') ? a.id : 0;
+            const ib = (b && typeof b.id === 'number') ? b.id : 0;
+            return ia - ib;
+        });
+
+        let bestScore = -Infinity;
+        let bestOpp = null;
+        let bestDate = null;
+        let found = false;
+        for (const g of sorted) {
+            const me = toScore(g ? g[meKey] : null);
+            if (me === null) continue;
+            if (me >= bestScore) {
+                bestScore = me;
+                bestOpp = toScore(g[oppKey]);
+                bestDate = (g && g.dateTime) ? g.dateTime : null;
+                found = true;
+            }
+        }
+        if (!found) return empty;
+        return { score: bestScore, opponentScore: bestOpp, date: bestDate };
+    }
+
+    // Parenthesised match detail for a highestScoreGame-style detail object.
+    //   "(M/D/YYYY, me–opp)" when date + both scores present
+    //   null when date missing OR opponent score missing (UI falls back to
+    //     the bare stat value so the display stays clean)
+    function formatMatchText(detail) {
+        if (!detail) return null;
+        // Explicit null/undefined checks first — Number(null) is 0 which is
+        // finite, so a missing opponentScore would otherwise slip through and
+        // render as "me–0". A real 0 (genuine shutout) is still accepted below.
+        if (detail.score === null || detail.score === undefined) return null;
+        if (detail.opponentScore === null || detail.opponentScore === undefined) return null;
+        const score = Number(detail.score);
+        const opp = Number(detail.opponentScore);
+        if (!Number.isFinite(score) || score < 0) return null;
+        if (!Number.isFinite(opp)) return null;
+        const date = formatDateShort(detail.date);
+        if (!date) return null;
+        return '(' + date + ', ' + score + '–' + opp + ')';
+    }
+
+    // Parenthesised date range for a longestRun-style { length, startDate,
+    // endDate } object.
+    //   multi-game run → "(M/D/YYYY – M/D/YYYY)"
+    //   single-game run → "(M/D/YYYY)"
+    //   missing/invalid dates or length 0 → null
+    // Defensively swaps start/end if they arrive reversed so the display never
+    // shows a backwards range.
+    function formatRangeText(range) {
+        if (!range || !Number.isFinite(range.length) || range.length <= 0) return null;
+        let startIso = range.startDate;
+        let endIso = range.endDate;
+        if (!startIso || !endIso) return null;
+        const startMs = new Date(startIso).getTime();
+        const endMs = new Date(endIso).getTime();
+        if (isNaN(startMs) || isNaN(endMs)) return null;
+        if (endMs < startMs) {
+            const tmp = startIso;
+            startIso = endIso;
+            endIso = tmp;
+        }
+        const start = formatDateShort(startIso);
+        const end = formatDateShort(endIso);
+        if (!start || !end) return null;
+        if (start === end) return '(' + start + ')';
+        return '(' + start + ' – ' + end + ')';
+    }
+
+    // Comparison primitive used by the player-stats comparison table. Direction
+    // can be 'higher' (bigger is better), 'lower' (smaller is better), or
+    // 'neutral' (no winner, shown without tint). Non-finite inputs collapse to
+    // neutral so the UI never renders NaN tints.
+    function compareStat(direction, p1, p2) {
+        const a = Number(p1);
+        const b = Number(p2);
+        if (!Number.isFinite(a) || !Number.isFinite(b)) {
+            return { winner: 'neutral', diff: 0 };
+        }
+        const diff = a - b;
+        if (direction === 'neutral') {
+            return { winner: 'neutral', diff };
+        }
+        if (a === b) {
+            return { winner: 'tie', diff: 0 };
+        }
+        if (direction === 'higher') {
+            return { winner: a > b ? 'p1' : 'p2', diff };
+        }
+        if (direction === 'lower') {
+            return { winner: a < b ? 'p1' : 'p2', diff };
+        }
+        return { winner: 'neutral', diff };
+    }
+
+    const api = {
+        computePlayerStats,
+        scoresInOrder,
+        matchResult,
+        matchResultsInOrder,
+        computeMatchStreaks,
+        longestRun,
+        longestMatchRun,
+        highestScoreGame,
+        cleanScores,
+        formatNumber,
+        formatPercent,
+        formatDateShort,
+        formatRangeText,
+        formatMatchText,
+        compareStat
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+    if (root && typeof root === 'object') {
+        root.FootballPlayerStats = api;
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/apps/football-h2h/tests/playerStats.test.js
+++ b/apps/football-h2h/tests/playerStats.test.js
@@ -1,0 +1,871 @@
+'use strict';
+
+// Pin timezone so M/D/YYYY assertions on ISO dates are deterministic across
+// CI/dev machines. Must be set before any Date objects are constructed.
+process.env.TZ = 'UTC';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    computePlayerStats,
+    scoresInOrder,
+    matchResult,
+    matchResultsInOrder,
+    computeMatchStreaks,
+    longestRun,
+    longestMatchRun,
+    highestScoreGame,
+    cleanScores,
+    formatNumber,
+    formatPercent,
+    formatDateShort,
+    formatRangeText,
+    formatMatchText,
+    compareStat
+} = require('../js/playerStats.js');
+
+test('cleanScores: drops null/undefined/non-numeric but keeps zeros', () => {
+    assert.deepEqual(cleanScores([0, 1, null, undefined, 'foo', NaN, '', 2]), [0, 1, 2]);
+    assert.deepEqual(cleanScores('not an array'), []);
+    assert.deepEqual(cleanScores([]), []);
+});
+
+test('computePlayerStats: empty input returns all zeros, no NaN/Infinity', () => {
+    const s = computePlayerStats([]);
+    for (const [key, value] of Object.entries(s)) {
+        assert.ok(Number.isFinite(value), `${key} must be finite, got ${value}`);
+    }
+    assert.equal(s.games, 0);
+    assert.equal(s.totalGoals, 0);
+    assert.equal(s.goalsPerGame, 0);
+    assert.equal(s.scoringRate, 0);
+    assert.equal(s.stddev, 0);
+});
+
+test('computePlayerStats: single game with zero score', () => {
+    const s = computePlayerStats([0]);
+    assert.equal(s.games, 1);
+    assert.equal(s.totalGoals, 0);
+    assert.equal(s.goalsPerGame, 0);
+    assert.equal(s.highestScore, 0);
+    assert.equal(s.lowestScore, 0);
+    assert.equal(s.scoringRate, 0);
+    assert.equal(s.multiGoalRate, 0);
+    assert.equal(s.currentScoringStreak, 0);
+    assert.equal(s.currentScorelessStreak, 1);
+    assert.equal(s.longestScoringStreak, 0);
+    assert.equal(s.longestScorelessStreak, 1);
+    assert.equal(s.stddev, 0); // games < 2 → 0, not NaN
+    assert.equal(s.median, 0);
+});
+
+test('computePlayerStats: totals, averages, highs/lows over a mixed run', () => {
+    const s = computePlayerStats([2, 0, 3, 1, 4]);
+    assert.equal(s.games, 5);
+    assert.equal(s.totalGoals, 10);
+    assert.equal(s.goalsPerGame, 2);
+    assert.equal(s.highestScore, 4);
+    assert.equal(s.lowestScore, 0);
+    assert.equal(s.scoringRate, 0.8);        // 4 of 5 scored
+    assert.equal(s.multiGoalRate, 0.6);      // 3 of 5: 2, 3, 4
+});
+
+test('computePlayerStats: retired fields are not exposed, rates are', () => {
+    const s = computePlayerStats([2, 0, 3]);
+    // Removed count fields
+    assert.equal(s.scoringGames, undefined);
+    assert.equal(s.scorelessGames, undefined);
+    assert.equal(s.multiGoalGames, undefined);
+    assert.equal(s.hatTricks, undefined);
+    // Fully removed (neither count nor rate)
+    assert.equal(s.hatTrickRate, undefined);
+    // scorelessRate removed — it's 1 - scoringRate, redundant
+    assert.equal(s.scorelessRate, undefined);
+    // Surviving rates are finite numbers
+    assert.ok(Number.isFinite(s.multiGoalRate));
+    assert.ok(Number.isFinite(s.scoringRate));
+});
+
+test('computePlayerStats: all-scoring → scoringRate is 1, no NaN', () => {
+    const s = computePlayerStats([1, 2, 3]);
+    assert.equal(s.scoringRate, 1);
+});
+
+test('computePlayerStats: all-scoreless → scoringRate is 0', () => {
+    const s = computePlayerStats([0, 0, 0, 0]);
+    assert.equal(s.scoringRate, 0);
+    assert.equal(s.multiGoalRate, 0);
+});
+
+test('computePlayerStats: empty input → all rate fields are 0 (no divide-by-zero)', () => {
+    const s = computePlayerStats([]);
+    assert.equal(s.scoringRate, 0);
+    assert.equal(s.multiGoalRate, 0);
+});
+
+test('computePlayerStats: median — odd vs even length', () => {
+    assert.equal(computePlayerStats([5, 1, 3]).median, 3);
+    assert.equal(computePlayerStats([1, 2, 3, 4]).median, 2.5);
+});
+
+test('computePlayerStats: current streak uses most-recent games', () => {
+    // chronological: old → new. Last 3 games are scoring.
+    const scoring = computePlayerStats([0, 0, 1, 2, 3]);
+    assert.equal(scoring.currentScoringStreak, 3);
+    assert.equal(scoring.currentScorelessStreak, 0);
+
+    const scoreless = computePlayerStats([2, 3, 0, 0]);
+    assert.equal(scoreless.currentScoringStreak, 0);
+    assert.equal(scoreless.currentScorelessStreak, 2);
+});
+
+test('computePlayerStats: longest streaks scan entire history', () => {
+    const s = computePlayerStats([1, 2, 0, 3, 4, 5, 0, 0, 1]);
+    assert.equal(s.longestScoringStreak, 3); // 3,4,5
+    assert.equal(s.longestScorelessStreak, 2); // 0,0
+    assert.equal(s.currentScoringStreak, 1);
+});
+
+test('computePlayerStats: all-zero history — scoreless streaks', () => {
+    const s = computePlayerStats([0, 0, 0, 0]);
+    assert.equal(s.currentScoringStreak, 0);
+    assert.equal(s.longestScoringStreak, 0);
+    assert.equal(s.currentScorelessStreak, 4);
+    assert.equal(s.longestScorelessStreak, 4);
+    assert.equal(s.stddev, 0);
+});
+
+test('computePlayerStats: all-identical scores → stddev exactly 0, finite', () => {
+    const s = computePlayerStats([2, 2, 2, 2]);
+    assert.equal(s.stddev, 0);
+    assert.ok(Number.isFinite(s.stddev));
+});
+
+test('computePlayerStats: stddev for a known series', () => {
+    // Population stddev of [0, 2, 4, 6, 8] is sqrt(8) ≈ 2.8284
+    const s = computePlayerStats([0, 2, 4, 6, 8]);
+    assert.ok(Math.abs(s.stddev - Math.sqrt(8)) < 1e-9);
+});
+
+test('computePlayerStats: recent form windows clamp to available games', () => {
+    const s = computePlayerStats([3, 1]);
+    // last 3 with only 2 games should average the 2 we have (no padding with 0).
+    assert.equal(s.recentFormLast3, 2);
+    assert.equal(s.recentFormLast5, 2);
+
+    const empty = computePlayerStats([]);
+    assert.equal(empty.recentFormLast3, 0);
+    assert.equal(empty.recentFormLast5, 0);
+});
+
+test('computePlayerStats: recent form only uses most recent N', () => {
+    // chronological: 10,10,10,1,1,1 → last 3 = [1,1,1], last 5 = [10,10,1,1,1]
+    const s = computePlayerStats([10, 10, 10, 1, 1, 1]);
+    assert.equal(s.recentFormLast3, 1);
+    assert.equal(s.recentFormLast5, (10 + 10 + 1 + 1 + 1) / 5);
+});
+
+test('computePlayerStats: every returned field is finite (no NaN/Infinity)', () => {
+    const inputs = [[], [0], [5], [0, 0, 0], [1, 2, 3, 4, 5], [3, 3, 3]];
+    for (const input of inputs) {
+        const s = computePlayerStats(input);
+        for (const [k, v] of Object.entries(s)) {
+            assert.ok(Number.isFinite(v), `input=${JSON.stringify(input)} field=${k} value=${v}`);
+        }
+    }
+});
+
+test('computePlayerStats: ignores null/missing scores in input', () => {
+    const s = computePlayerStats([1, null, 2, undefined, 3]);
+    assert.equal(s.games, 3);
+    assert.equal(s.totalGoals, 6);
+    assert.equal(s.goalsPerGame, 2);
+});
+
+test('computePlayerStats: current scoring streak breaks on a null at the tail', () => {
+    // Walking back from the end: null breaks immediately → current = 0.
+    const s = computePlayerStats([1, 1, 1, null]);
+    assert.equal(s.currentScoringStreak, 0);
+    assert.equal(s.currentScorelessStreak, 0);
+});
+
+test('computePlayerStats: current scoring streak breaks at first null walking backward', () => {
+    // Walking back: 1 (n=1), 1 (n=2), null → break. Current = 2 (NOT 4).
+    const s = computePlayerStats([1, 1, null, 1, 1]);
+    assert.equal(s.currentScoringStreak, 2);
+});
+
+test('computePlayerStats: current scoreless streak breaks on null', () => {
+    // Walking back: 0 (n=1), 0 (n=2), null → break. Current scoreless = 2.
+    const s = computePlayerStats([0, 0, null, 0, 0]);
+    assert.equal(s.currentScorelessStreak, 2);
+    assert.equal(s.currentScoringStreak, 0);
+});
+
+test('computePlayerStats: current streaks unaffected by null when there are none', () => {
+    // Behavior identical to pre-spec for null-free histories.
+    const s = computePlayerStats([0, 1, 1, 1]);
+    assert.equal(s.currentScoringStreak, 3);
+    assert.equal(s.currentScorelessStreak, 0);
+});
+
+test('computePlayerStats: opposite condition still breaks current streak (not just null)', () => {
+    const s = computePlayerStats([1, 1, 0, 1, 1, 1]);
+    // Last three are scoring → current scoring = 3, current scoreless = 0.
+    assert.equal(s.currentScoringStreak, 3);
+    assert.equal(s.currentScorelessStreak, 0);
+});
+
+test('scoresInOrder: sorts by dateTime then id, skips null scores', () => {
+    const games = [
+        { id: 3, dateTime: '2025-01-03T12:00:00Z', player1Goals: 2, player2Goals: 1 },
+        { id: 1, dateTime: '2025-01-01T12:00:00Z', player1Goals: 0, player2Goals: 3 },
+        { id: 2, dateTime: '2025-01-02T12:00:00Z', player1Goals: 1, player2Goals: 1 },
+        { id: 4, dateTime: '2025-01-04T12:00:00Z', player1Goals: null, player2Goals: 2 }
+    ];
+    assert.deepEqual(scoresInOrder(games, 'player1Goals'), [0, 1, 2]);
+    assert.deepEqual(scoresInOrder(games, 'player2Goals'), [3, 1, 1, 2]);
+});
+
+test('scoresInOrder: id breaks ties when dateTime is identical', () => {
+    const games = [
+        { id: 5, dateTime: '2025-01-01T12:00:00Z', player1Goals: 5 },
+        { id: 2, dateTime: '2025-01-01T12:00:00Z', player1Goals: 2 },
+        { id: 9, dateTime: '2025-01-01T12:00:00Z', player1Goals: 9 }
+    ];
+    assert.deepEqual(scoresInOrder(games, 'player1Goals'), [2, 5, 9]);
+});
+
+test('scoresInOrder: tolerates missing/invalid dateTime without crashing', () => {
+    const games = [
+        { id: 1, player1Goals: 1 },
+        { id: 2, dateTime: 'not-a-date', player1Goals: 2 },
+        { id: 3, dateTime: '2025-01-01T00:00:00Z', player1Goals: 3 }
+    ];
+    const out = scoresInOrder(games, 'player1Goals');
+    assert.equal(out.length, 3);
+});
+
+test('scoresInOrder: returns [] for non-arrays', () => {
+    assert.deepEqual(scoresInOrder(null, 'player1Goals'), []);
+    assert.deepEqual(scoresInOrder(undefined, 'player1Goals'), []);
+    assert.deepEqual(scoresInOrder('nope', 'player1Goals'), []);
+});
+
+test('formatNumber: no NaN/Infinity strings in output', () => {
+    assert.equal(formatNumber(NaN), '0');
+    assert.equal(formatNumber(Infinity), '0');
+    assert.equal(formatNumber(-Infinity), '0');
+    assert.equal(formatNumber(3), '3');
+    assert.equal(formatNumber(2.5), '2.5');
+    assert.equal(formatNumber(2.5, 2), '2.50');
+});
+
+test('formatPercent: handles non-finite input safely', () => {
+    assert.equal(formatPercent(NaN), '0%');
+    assert.equal(formatPercent(Infinity), '0%');
+    assert.equal(formatPercent(0.5), '50%');
+    assert.equal(formatPercent(0), '0%');
+    assert.equal(formatPercent(1), '100%');
+});
+
+test('compareStat: higher-is-better picks bigger value', () => {
+    assert.deepEqual(compareStat('higher', 5, 3), { winner: 'p1', diff: 2 });
+    assert.deepEqual(compareStat('higher', 3, 5), { winner: 'p2', diff: -2 });
+});
+
+test('compareStat: lower-is-better picks smaller value', () => {
+    assert.deepEqual(compareStat('lower', 2, 4), { winner: 'p1', diff: -2 });
+    assert.deepEqual(compareStat('lower', 4, 2), { winner: 'p2', diff: 2 });
+});
+
+test('compareStat: equal values are ties (higher & lower)', () => {
+    assert.deepEqual(compareStat('higher', 3, 3), { winner: 'tie', diff: 0 });
+    assert.deepEqual(compareStat('lower', 0, 0), { winner: 'tie', diff: 0 });
+});
+
+test('compareStat: neutral never picks a winner, still returns signed diff', () => {
+    assert.deepEqual(compareStat('neutral', 3, 1), { winner: 'neutral', diff: 2 });
+    assert.deepEqual(compareStat('neutral', 1, 3), { winner: 'neutral', diff: -2 });
+    assert.deepEqual(compareStat('neutral', 2, 2), { winner: 'neutral', diff: 0 });
+});
+
+test('compareStat: non-finite values collapse to neutral, no NaN leaks', () => {
+    assert.deepEqual(compareStat('higher', NaN, 3), { winner: 'neutral', diff: 0 });
+    assert.deepEqual(compareStat('lower', 3, Infinity), { winner: 'neutral', diff: 0 });
+    assert.deepEqual(compareStat('higher', null, undefined), { winner: 'neutral', diff: 0 });
+});
+
+test('compareStat: unknown direction is treated as neutral', () => {
+    assert.deepEqual(compareStat('sideways', 5, 3), { winner: 'neutral', diff: 2 });
+});
+
+// -- Penalty-aware match result --
+
+test('matchResult: regular win (me > opp), penaltyWinner irrelevant', () => {
+    assert.equal(matchResult(3, 1, null, 1), 'W');
+    assert.equal(matchResult(3, 1, 2, 1), 'W');     // pen field ignored when regulation decided
+    assert.equal(matchResult(3, 1, 'draw', 1), 'W');
+});
+
+test('matchResult: regular loss (me < opp)', () => {
+    assert.equal(matchResult(0, 2, null, 1), 'L');
+    assert.equal(matchResult(0, 2, 1, 1), 'L');     // pen field ignored
+});
+
+test('matchResult: regulation tie + my side wins penalties → W', () => {
+    assert.equal(matchResult(2, 2, 1, 1), 'W');     // p1 wins shootout, asking from p1
+    assert.equal(matchResult(2, 2, 2, 2), 'W');     // p2 wins shootout, asking from p2
+});
+
+test('matchResult: regulation tie + opponent wins penalties → L', () => {
+    assert.equal(matchResult(2, 2, 2, 1), 'L');     // p2 wins, asking from p1
+    assert.equal(matchResult(2, 2, 1, 2), 'L');     // p1 wins, asking from p2
+});
+
+test('matchResult: regulation tie + no penalty winner → D', () => {
+    assert.equal(matchResult(1, 1, null, 1), 'D');
+    assert.equal(matchResult(1, 1, undefined, 1), 'D');
+    assert.equal(matchResult(1, 1, 'draw', 1), 'D'); // shootout itself drew
+    assert.equal(matchResult(0, 0, null, 1), 'D');
+});
+
+test('matchResult: missing me or opp score → null', () => {
+    assert.equal(matchResult(null, 2, null, 1), null);
+    assert.equal(matchResult(2, null, null, 1), null);
+    assert.equal(matchResult(undefined, undefined, 1, 1), null);
+});
+
+// -- matchResultsInOrder --
+
+test('matchResultsInOrder: sorts and applies result per game', () => {
+    const games = [
+        { id: 2, dateTime: '2025-01-02T00:00:00Z', player1Goals: 1, player2Goals: 1, penaltyWinner: 1 }, // W for p1
+        { id: 1, dateTime: '2025-01-01T00:00:00Z', player1Goals: 3, player2Goals: 0, penaltyWinner: null },  // W for p1
+        { id: 3, dateTime: '2025-01-03T00:00:00Z', player1Goals: 2, player2Goals: 2, penaltyWinner: 2 }, // L for p1
+        { id: 4, dateTime: '2025-01-04T00:00:00Z', player1Goals: 1, player2Goals: 1, penaltyWinner: null }  // D
+    ];
+    assert.deepEqual(matchResultsInOrder(games, 'player1Goals', 'player2Goals', 1),
+        ['W', 'W', 'L', 'D']);
+    // From p2 perspective the same history flips the penalty-decided games.
+    assert.deepEqual(matchResultsInOrder(games, 'player2Goals', 'player1Goals', 2),
+        ['L', 'L', 'W', 'D']);
+});
+
+test('matchResultsInOrder: non-array → []', () => {
+    assert.deepEqual(matchResultsInOrder(null, 'a', 'b', 1), []);
+    assert.deepEqual(matchResultsInOrder(undefined, 'a', 'b', 1), []);
+});
+
+test('matchResultsInOrder: missing scores → null entry preserves alignment', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-01T00:00:00Z', player1Goals: null, player2Goals: 1, penaltyWinner: null },
+        { id: 2, dateTime: '2025-01-02T00:00:00Z', player1Goals: 2, player2Goals: 1, penaltyWinner: null }
+    ];
+    assert.deepEqual(matchResultsInOrder(games, 'player1Goals', 'player2Goals', 1),
+        [null, 'W']);
+});
+
+// -- Match-based current streaks (computeMatchStreaks now takes results) --
+
+test('computeMatchStreaks: active winning streak counts consecutive Ws from the tail', () => {
+    assert.deepEqual(computeMatchStreaks(['L', 'W', 'W', 'W']), {
+        currentWinningStreak: 3,
+        currentLosingStreak: 0
+    });
+});
+
+test('computeMatchStreaks: active losing streak counts consecutive Ls from the tail', () => {
+    assert.deepEqual(computeMatchStreaks(['W', 'L', 'L']), {
+        currentWinningStreak: 0,
+        currentLosingStreak: 2
+    });
+});
+
+test('computeMatchStreaks: draw at the tail breaks both streaks', () => {
+    assert.deepEqual(computeMatchStreaks(['W', 'W', 'D']), {
+        currentWinningStreak: 0,
+        currentLosingStreak: 0
+    });
+});
+
+test('computeMatchStreaks: draw mid-history is a boundary, not a reset', () => {
+    // W, D, W, W → only the two games after the draw count toward current.
+    assert.deepEqual(computeMatchStreaks(['W', 'D', 'W', 'W']), {
+        currentWinningStreak: 2,
+        currentLosingStreak: 0
+    });
+});
+
+test('computeMatchStreaks: a loss after wins ends the winning streak at the loss boundary', () => {
+    assert.deepEqual(computeMatchStreaks(['W', 'W', 'L']), {
+        currentWinningStreak: 0,
+        currentLosingStreak: 1
+    });
+});
+
+test('computeMatchStreaks: no games → 0s (no divide-by-zero paths)', () => {
+    assert.deepEqual(computeMatchStreaks([]), {
+        currentWinningStreak: 0,
+        currentLosingStreak: 0
+    });
+});
+
+test('computeMatchStreaks: non-array input → safe 0s', () => {
+    assert.deepEqual(computeMatchStreaks(null),       { currentWinningStreak: 0, currentLosingStreak: 0 });
+    assert.deepEqual(computeMatchStreaks(undefined),  { currentWinningStreak: 0, currentLosingStreak: 0 });
+    assert.deepEqual(computeMatchStreaks('not-array'),{ currentWinningStreak: 0, currentLosingStreak: 0 });
+});
+
+test('computeMatchStreaks: null entries are skipped, not streak breakers', () => {
+    assert.deepEqual(computeMatchStreaks(['W', null, 'W']), {
+        currentWinningStreak: 2,
+        currentLosingStreak: 0
+    });
+});
+
+test('computeMatchStreaks: most-recent valid result sets the active streak type', () => {
+    assert.deepEqual(computeMatchStreaks(['L', 'W']), {
+        currentWinningStreak: 1,
+        currentLosingStreak: 0
+    });
+});
+
+test('computeMatchStreaks: penalty-rule end-to-end — regulation draws decided by pens count', () => {
+    // p1 perspective. Tail sequence after sorting: regulation L, then a 2-2 with
+    // p1 winning the shootout (counts as W), then a 1-1 drawn shootout (D).
+    // Tail D → current winning = 0, current losing = 0. Without the penalty
+    // rule the 2-2-with-pens game would also be a draw and the tail would still
+    // give all zeros, so use a stronger example below.
+    const games = [
+        { id: 1, dateTime: '2025-03-01T12:00:00Z', player1Goals: 0, player2Goals: 1, penaltyWinner: null },  // L
+        { id: 2, dateTime: '2025-03-02T12:00:00Z', player1Goals: 2, player2Goals: 2, penaltyWinner: 1 },     // W (penalties)
+        { id: 3, dateTime: '2025-03-03T12:00:00Z', player1Goals: 1, player2Goals: 1, penaltyWinner: 1 }      // W (penalties)
+    ];
+    const results = matchResultsInOrder(games, 'player1Goals', 'player2Goals', 1);
+    assert.deepEqual(results, ['L', 'W', 'W']);
+    assert.deepEqual(computeMatchStreaks(results), {
+        currentWinningStreak: 2,
+        currentLosingStreak: 0
+    });
+    // From p2 perspective, both penalty wins flip to losses.
+    const p2Results = matchResultsInOrder(games, 'player2Goals', 'player1Goals', 2);
+    assert.deepEqual(p2Results, ['W', 'L', 'L']);
+    assert.deepEqual(computeMatchStreaks(p2Results), {
+        currentWinningStreak: 0,
+        currentLosingStreak: 2
+    });
+});
+
+// -- Longest match-based runs (penalty-aware) --
+
+test('longestMatchRun: longest winning run with date span', () => {
+    const games = [
+        { id: 1, dateTime: '2025-04-01T12:00:00Z', player1Goals: 2, player2Goals: 1, penaltyWinner: null }, // W
+        { id: 2, dateTime: '2025-04-02T12:00:00Z', player1Goals: 1, player2Goals: 1, penaltyWinner: 1 },    // W (pens)
+        { id: 3, dateTime: '2025-04-03T12:00:00Z', player1Goals: 3, player2Goals: 0, penaltyWinner: null }, // W
+        { id: 4, dateTime: '2025-04-04T12:00:00Z', player1Goals: 0, player2Goals: 1, penaltyWinner: null }  // L
+    ];
+    const run = longestMatchRun(games, 'player1Goals', 'player2Goals', 1, (r) => r === 'W');
+    assert.equal(run.length, 3);
+    assert.equal(run.startDate, '2025-04-01T12:00:00Z');
+    assert.equal(run.endDate, '2025-04-03T12:00:00Z');
+});
+
+test('longestMatchRun: ties pick the most recent run', () => {
+    const games = [
+        { id: 1, dateTime: '2025-04-01T12:00:00Z', player1Goals: 2, player2Goals: 1, penaltyWinner: null }, // W
+        { id: 2, dateTime: '2025-04-02T12:00:00Z', player1Goals: 3, player2Goals: 0, penaltyWinner: null }, // W
+        { id: 3, dateTime: '2025-04-03T12:00:00Z', player1Goals: 0, player2Goals: 2, penaltyWinner: null }, // L
+        { id: 4, dateTime: '2025-04-04T12:00:00Z', player1Goals: 1, player2Goals: 0, penaltyWinner: null }, // W
+        { id: 5, dateTime: '2025-04-05T12:00:00Z', player1Goals: 1, player2Goals: 1, penaltyWinner: 1 }     // W (pens)
+    ];
+    const run = longestMatchRun(games, 'player1Goals', 'player2Goals', 1, (r) => r === 'W');
+    assert.equal(run.length, 2);
+    assert.equal(run.startDate, '2025-04-04T12:00:00Z'); // later 2-game run wins
+    assert.equal(run.endDate, '2025-04-05T12:00:00Z');
+});
+
+test('longestMatchRun: penalty losses end winning runs', () => {
+    // p1 view: W, W, then a 2-2 with p2 winning pens (counts as L for p1),
+    // then W. Longest winning run is 2, not 3.
+    const games = [
+        { id: 1, dateTime: '2025-04-01T12:00:00Z', player1Goals: 2, player2Goals: 1, penaltyWinner: null },
+        { id: 2, dateTime: '2025-04-02T12:00:00Z', player1Goals: 3, player2Goals: 0, penaltyWinner: null },
+        { id: 3, dateTime: '2025-04-03T12:00:00Z', player1Goals: 2, player2Goals: 2, penaltyWinner: 2 },   // L for p1
+        { id: 4, dateTime: '2025-04-04T12:00:00Z', player1Goals: 1, player2Goals: 0, penaltyWinner: null }
+    ];
+    const winRun = longestMatchRun(games, 'player1Goals', 'player2Goals', 1, (r) => r === 'W');
+    assert.equal(winRun.length, 2);
+    assert.equal(winRun.startDate, '2025-04-01T12:00:00Z');
+    assert.equal(winRun.endDate, '2025-04-02T12:00:00Z');
+});
+
+test('longestMatchRun: longest losing run', () => {
+    const games = [
+        { id: 1, dateTime: '2025-04-01T12:00:00Z', player1Goals: 2, player2Goals: 1, penaltyWinner: null }, // W
+        { id: 2, dateTime: '2025-04-02T12:00:00Z', player1Goals: 0, player2Goals: 1, penaltyWinner: null }, // L
+        { id: 3, dateTime: '2025-04-03T12:00:00Z', player1Goals: 1, player2Goals: 1, penaltyWinner: 2 },    // L (pens)
+        { id: 4, dateTime: '2025-04-04T12:00:00Z', player1Goals: 0, player2Goals: 3, penaltyWinner: null }  // L
+    ];
+    const lossRun = longestMatchRun(games, 'player1Goals', 'player2Goals', 1, (r) => r === 'L');
+    assert.equal(lossRun.length, 3);
+    assert.equal(lossRun.startDate, '2025-04-02T12:00:00Z');
+    assert.equal(lossRun.endDate, '2025-04-04T12:00:00Z');
+});
+
+test('longestMatchRun: a true draw breaks both winning and losing runs', () => {
+    const games = [
+        { id: 1, dateTime: '2025-04-01T12:00:00Z', player1Goals: 2, player2Goals: 1, penaltyWinner: null }, // W
+        { id: 2, dateTime: '2025-04-02T12:00:00Z', player1Goals: 3, player2Goals: 0, penaltyWinner: null }, // W
+        { id: 3, dateTime: '2025-04-03T12:00:00Z', player1Goals: 1, player2Goals: 1, penaltyWinner: null }, // D
+        { id: 4, dateTime: '2025-04-04T12:00:00Z', player1Goals: 1, player2Goals: 0, penaltyWinner: null }  // W
+    ];
+    const winRun = longestMatchRun(games, 'player1Goals', 'player2Goals', 1, (r) => r === 'W');
+    assert.equal(winRun.length, 2); // not 3 — the draw broke the run
+});
+
+test('longestMatchRun: empty / non-array → safe zero result', () => {
+    assert.deepEqual(longestMatchRun([], 'a', 'b', 1, () => true),
+        { length: 0, startDate: null, endDate: null });
+    assert.deepEqual(longestMatchRun(null, 'a', 'b', 1, () => true),
+        { length: 0, startDate: null, endDate: null });
+});
+
+// -- Longest run with date range --
+
+const scoring = (s) => s > 0;
+const scoreless = (s) => s === 0;
+
+test('longestRun: basic scoring run returns length + ISO start/end', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-01T00:00:00Z', player1Goals: 2 },
+        { id: 2, dateTime: '2025-01-02T00:00:00Z', player1Goals: 3 },
+        { id: 3, dateTime: '2025-01-03T00:00:00Z', player1Goals: 1 },
+        { id: 4, dateTime: '2025-01-04T00:00:00Z', player1Goals: 0 }
+    ];
+    const run = longestRun(games, 'player1Goals', scoring);
+    assert.equal(run.length, 3);
+    assert.equal(run.startDate, '2025-01-01T00:00:00Z');
+    assert.equal(run.endDate, '2025-01-03T00:00:00Z');
+});
+
+test('longestRun: ties pick the MOST RECENT run', () => {
+    // Two 3-game scoring runs separated by a scoreless game.
+    const games = [
+        { id: 1, dateTime: '2025-01-01T00:00:00Z', player1Goals: 1 },
+        { id: 2, dateTime: '2025-01-02T00:00:00Z', player1Goals: 1 },
+        { id: 3, dateTime: '2025-01-03T00:00:00Z', player1Goals: 1 },
+        { id: 4, dateTime: '2025-01-04T00:00:00Z', player1Goals: 0 },
+        { id: 5, dateTime: '2025-01-05T00:00:00Z', player1Goals: 2 },
+        { id: 6, dateTime: '2025-01-06T00:00:00Z', player1Goals: 2 },
+        { id: 7, dateTime: '2025-01-07T00:00:00Z', player1Goals: 2 }
+    ];
+    const run = longestRun(games, 'player1Goals', scoring);
+    assert.equal(run.length, 3);
+    assert.equal(run.startDate, '2025-01-05T00:00:00Z');
+    assert.equal(run.endDate, '2025-01-07T00:00:00Z');
+});
+
+test('longestRun: length 0 → null dates (no run at all)', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-01T00:00:00Z', player1Goals: 0 },
+        { id: 2, dateTime: '2025-01-02T00:00:00Z', player1Goals: 0 }
+    ];
+    const run = longestRun(games, 'player1Goals', scoring);
+    assert.equal(run.length, 0);
+    assert.equal(run.startDate, null);
+    assert.equal(run.endDate, null);
+});
+
+test('longestRun: empty input → zeros and nulls', () => {
+    assert.deepEqual(longestRun([], 'player1Goals', scoring),
+        { length: 0, startDate: null, endDate: null });
+});
+
+test('longestRun: non-array input → safe zeros', () => {
+    assert.deepEqual(longestRun(null, 'player1Goals', scoring),
+        { length: 0, startDate: null, endDate: null });
+    assert.deepEqual(longestRun(undefined, 'player1Goals', scoring),
+        { length: 0, startDate: null, endDate: null });
+});
+
+test('longestRun: null scores are skipped, not treated as streak breakers', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-01T00:00:00Z', player1Goals: 2 },
+        { id: 2, dateTime: '2025-01-02T00:00:00Z', player1Goals: null },
+        { id: 3, dateTime: '2025-01-03T00:00:00Z', player1Goals: 3 },
+        { id: 4, dateTime: '2025-01-04T00:00:00Z', player1Goals: 1 }
+    ];
+    const run = longestRun(games, 'player1Goals', scoring);
+    assert.equal(run.length, 3); // Three real scoring games; null ignored.
+    assert.equal(run.startDate, '2025-01-01T00:00:00Z');
+    assert.equal(run.endDate, '2025-01-04T00:00:00Z');
+});
+
+test('longestRun: input sorted internally — unsorted games work', () => {
+    const games = [
+        { id: 3, dateTime: '2025-01-03T00:00:00Z', player1Goals: 1 },
+        { id: 1, dateTime: '2025-01-01T00:00:00Z', player1Goals: 2 },
+        { id: 2, dateTime: '2025-01-02T00:00:00Z', player1Goals: 3 }
+    ];
+    const run = longestRun(games, 'player1Goals', scoring);
+    assert.equal(run.length, 3);
+    assert.equal(run.startDate, '2025-01-01T00:00:00Z');
+    assert.equal(run.endDate, '2025-01-03T00:00:00Z');
+});
+
+test('longestRun: single-game run → startDate === endDate', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-01T00:00:00Z', player1Goals: 0 },
+        { id: 2, dateTime: '2025-01-02T00:00:00Z', player1Goals: 2 },
+        { id: 3, dateTime: '2025-01-03T00:00:00Z', player1Goals: 0 }
+    ];
+    const run = longestRun(games, 'player1Goals', scoring);
+    assert.equal(run.length, 1);
+    assert.equal(run.startDate, run.endDate);
+    assert.equal(run.startDate, '2025-01-02T00:00:00Z');
+});
+
+test('longestRun: games missing dateTime → length counted, dates can be null', () => {
+    const games = [
+        { id: 1, player1Goals: 2 },
+        { id: 2, player1Goals: 3 }
+    ];
+    const run = longestRun(games, 'player1Goals', scoring);
+    assert.equal(run.length, 2);
+    assert.equal(run.startDate, null);
+    assert.equal(run.endDate, null);
+});
+
+test('formatDateShort: renders M/D/YYYY with no leading zeros, no month name', () => {
+    assert.equal(formatDateShort('2026-04-24T12:00:00Z'), '4/24/2026');
+    assert.equal(formatDateShort('2025-01-03T12:00:00Z'), '1/3/2025');
+    assert.equal(formatDateShort('2026-10-07T12:00:00Z'), '10/7/2026');
+    assert.equal(formatDateShort('2026-12-31T12:00:00Z'), '12/31/2026');
+});
+
+test('formatDateShort: bad input → null (no NaN/Invalid Date leaks)', () => {
+    assert.equal(formatDateShort(null), null);
+    assert.equal(formatDateShort(undefined), null);
+    assert.equal(formatDateShort(''), null);
+    assert.equal(formatDateShort('not-a-date'), null);
+});
+
+test('formatRangeText: multi-game run → "(M/D/YYYY – M/D/YYYY)"', () => {
+    const text = formatRangeText({
+        length: 14,
+        startDate: '2026-04-10T12:00:00Z',
+        endDate: '2026-04-24T12:00:00Z'
+    });
+    assert.equal(text, '(4/10/2026 – 4/24/2026)');
+});
+
+test('formatRangeText: single-game run collapses to "(M/D/YYYY)"', () => {
+    const text = formatRangeText({
+        length: 1,
+        startDate: '2026-04-24T12:00:00Z',
+        endDate: '2026-04-24T12:00:00Z'
+    });
+    assert.equal(text, '(4/24/2026)');
+});
+
+test('formatRangeText: length 0 or missing dates → null', () => {
+    assert.equal(formatRangeText({ length: 0, startDate: null, endDate: null }), null);
+    assert.equal(formatRangeText({ length: 3, startDate: null, endDate: '2026-04-10T12:00:00Z' }), null);
+    assert.equal(formatRangeText({ length: 3, startDate: '2026-04-10T12:00:00Z', endDate: null }), null);
+    assert.equal(formatRangeText(null), null);
+    assert.equal(formatRangeText(undefined), null);
+});
+
+test('formatRangeText: invalid dates → null (no Invalid Date string)', () => {
+    const text = formatRangeText({ length: 3, startDate: 'not-a-date', endDate: 'also-bad' });
+    assert.equal(text, null);
+});
+
+test('formatRangeText: reversed range is swapped, never displayed backwards', () => {
+    const text = formatRangeText({
+        length: 3,
+        startDate: '2026-04-24T12:00:00Z', // later
+        endDate: '2026-04-10T12:00:00Z'    // earlier
+    });
+    assert.equal(text, '(4/10/2026 – 4/24/2026)');
+});
+
+// -- Highest-score game (with opponent score and date) --
+
+test('highestScoreGame: returns highest me-score with opponent and date', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-10T12:00:00Z', player1Goals: 2, player2Goals: 1 },
+        { id: 2, dateTime: '2025-01-12T12:00:00Z', player1Goals: 5, player2Goals: 3 },
+        { id: 3, dateTime: '2025-01-14T12:00:00Z', player1Goals: 3, player2Goals: 2 }
+    ];
+    assert.deepEqual(highestScoreGame(games, 'player1Goals', 'player2Goals'), {
+        score: 5,
+        opponentScore: 3,
+        date: '2025-01-12T12:00:00Z'
+    });
+});
+
+test('highestScoreGame: from the opponent\'s perspective, me/opp keys swap', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-10T12:00:00Z', player1Goals: 2, player2Goals: 4 },
+        { id: 2, dateTime: '2025-01-12T12:00:00Z', player1Goals: 5, player2Goals: 3 }
+    ];
+    // Nikita (player2) perspective — highest is 4 from game 1 where Dean scored 2.
+    assert.deepEqual(highestScoreGame(games, 'player2Goals', 'player1Goals'), {
+        score: 4,
+        opponentScore: 2,
+        date: '2025-01-10T12:00:00Z'
+    });
+});
+
+test('highestScoreGame: ties resolve to the MOST RECENT game', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-10T12:00:00Z', player1Goals: 4, player2Goals: 2 },
+        { id: 2, dateTime: '2025-01-15T12:00:00Z', player1Goals: 4, player2Goals: 0 },
+        { id: 3, dateTime: '2025-01-20T12:00:00Z', player1Goals: 4, player2Goals: 1 }
+    ];
+    const best = highestScoreGame(games, 'player1Goals', 'player2Goals');
+    assert.equal(best.score, 4);
+    assert.equal(best.opponentScore, 1);
+    assert.equal(best.date, '2025-01-20T12:00:00Z');
+});
+
+test('highestScoreGame: unsorted input is sorted internally', () => {
+    const games = [
+        { id: 3, dateTime: '2025-01-20T12:00:00Z', player1Goals: 4, player2Goals: 0 },
+        { id: 1, dateTime: '2025-01-10T12:00:00Z', player1Goals: 5, player2Goals: 3 },
+        { id: 2, dateTime: '2025-01-15T12:00:00Z', player1Goals: 2, player2Goals: 1 }
+    ];
+    assert.deepEqual(highestScoreGame(games, 'player1Goals', 'player2Goals'), {
+        score: 5,
+        opponentScore: 3,
+        date: '2025-01-10T12:00:00Z'
+    });
+});
+
+test('highestScoreGame: empty games → safe zero/nulls, no NaN', () => {
+    assert.deepEqual(highestScoreGame([], 'player1Goals', 'player2Goals'), {
+        score: 0, opponentScore: null, date: null
+    });
+});
+
+test('highestScoreGame: non-array input → safe zero/nulls', () => {
+    assert.deepEqual(highestScoreGame(null, 'a', 'b'),
+        { score: 0, opponentScore: null, date: null });
+    assert.deepEqual(highestScoreGame(undefined, 'a', 'b'),
+        { score: 0, opponentScore: null, date: null });
+});
+
+test('highestScoreGame: null me-scores are skipped', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-10T12:00:00Z', player1Goals: null, player2Goals: 3 },
+        { id: 2, dateTime: '2025-01-12T12:00:00Z', player1Goals: 4, player2Goals: 1 }
+    ];
+    assert.deepEqual(highestScoreGame(games, 'player1Goals', 'player2Goals'), {
+        score: 4, opponentScore: 1, date: '2025-01-12T12:00:00Z'
+    });
+});
+
+test('highestScoreGame: null opponent score is preserved on the result', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-10T12:00:00Z', player1Goals: 5, player2Goals: null }
+    ];
+    assert.deepEqual(highestScoreGame(games, 'player1Goals', 'player2Goals'), {
+        score: 5, opponentScore: null, date: '2025-01-10T12:00:00Z'
+    });
+});
+
+test('formatMatchText: full detail → "(M/D/YYYY, me–opp)"', () => {
+    assert.equal(formatMatchText({
+        score: 5, opponentScore: 3, date: '2025-01-12T12:00:00Z'
+    }), '(1/12/2025, 5–3)');
+});
+
+test('formatMatchText: score of 0 is still valid (shutout loss)', () => {
+    assert.equal(formatMatchText({
+        score: 0, opponentScore: 2, date: '2025-01-12T12:00:00Z'
+    }), '(1/12/2025, 0–2)');
+});
+
+test('formatMatchText: missing date → null (UI falls back to bare value)', () => {
+    assert.equal(formatMatchText({ score: 5, opponentScore: 3, date: null }), null);
+    assert.equal(formatMatchText({ score: 5, opponentScore: 3, date: 'not-a-date' }), null);
+});
+
+test('formatMatchText: missing opponent score → null', () => {
+    assert.equal(formatMatchText({
+        score: 5, opponentScore: null, date: '2025-01-12T12:00:00Z'
+    }), null);
+    assert.equal(formatMatchText({
+        score: 5, opponentScore: NaN, date: '2025-01-12T12:00:00Z'
+    }), null);
+});
+
+test('formatMatchText: null/empty detail → null', () => {
+    assert.equal(formatMatchText(null), null);
+    assert.equal(formatMatchText(undefined), null);
+    assert.equal(formatMatchText({}), null);
+});
+
+test('highestScoreGame + formatMatchText: end-to-end produces the displayed string', () => {
+    const games = [
+        { id: 1, dateTime: '2025-01-10T12:00:00Z', player1Goals: 2, player2Goals: 1 },
+        { id: 2, dateTime: '2025-01-12T12:00:00Z', player1Goals: 5, player2Goals: 3 },
+        { id: 3, dateTime: '2025-01-14T12:00:00Z', player1Goals: 1, player2Goals: 0 }
+    ];
+    const best = highestScoreGame(games, 'player1Goals', 'player2Goals');
+    assert.equal(formatMatchText(best), '(1/12/2025, 5–3)');
+});
+
+test('longestRun + formatRangeText: end-to-end produces the displayed string', () => {
+    // Unsorted input, 3-game scoring run mid-history.
+    const games = [
+        { id: 2, dateTime: '2026-04-15T12:00:00Z', player1Goals: 2 },
+        { id: 1, dateTime: '2026-04-10T12:00:00Z', player1Goals: 1 },
+        { id: 3, dateTime: '2026-04-20T12:00:00Z', player1Goals: 3 },
+        { id: 4, dateTime: '2026-04-24T12:00:00Z', player1Goals: 0 }
+    ];
+    const run = longestRun(games, 'player1Goals', (s) => s > 0);
+    assert.equal(run.length, 3);
+    assert.equal(formatRangeText(run), '(4/10/2026 – 4/20/2026)');
+});
+
+test('longestRun: works for scoreless predicate too', () => {
+    const games = [
+        { id: 1, dateTime: '2025-02-01T00:00:00Z', player1Goals: 2 },
+        { id: 2, dateTime: '2025-02-02T00:00:00Z', player1Goals: 0 },
+        { id: 3, dateTime: '2025-02-03T00:00:00Z', player1Goals: 0 },
+        { id: 4, dateTime: '2025-02-04T00:00:00Z', player1Goals: 0 },
+        { id: 5, dateTime: '2025-02-05T00:00:00Z', player1Goals: 1 }
+    ];
+    const run = longestRun(games, 'player1Goals', scoreless);
+    assert.equal(run.length, 3);
+    assert.equal(run.startDate, '2025-02-02T00:00:00Z');
+    assert.equal(run.endDate, '2025-02-04T00:00:00Z');
+});
+
+test('computeMatchStreaks + matchResultsInOrder: end-to-end from a games array', () => {
+    // Dean perspective: W, W, L, W, W, W → current winning = 3.
+    const games = [
+        { id: 1, dateTime: '2025-01-01T00:00:00Z', player1Goals: 2, player2Goals: 1, penaltyWinner: null }, // W
+        { id: 2, dateTime: '2025-01-02T00:00:00Z', player1Goals: 3, player2Goals: 0, penaltyWinner: null }, // W
+        { id: 3, dateTime: '2025-01-03T00:00:00Z', player1Goals: 1, player2Goals: 4, penaltyWinner: null }, // L
+        { id: 4, dateTime: '2025-01-04T00:00:00Z', player1Goals: 2, player2Goals: 1, penaltyWinner: null }, // W
+        { id: 5, dateTime: '2025-01-05T00:00:00Z', player1Goals: 3, player2Goals: 2, penaltyWinner: null }, // W
+        { id: 6, dateTime: '2025-01-06T00:00:00Z', player1Goals: 1, player2Goals: 0, penaltyWinner: null }  // W
+    ];
+    const p1Results = matchResultsInOrder(games, 'player1Goals', 'player2Goals', 1);
+    const p2Results = matchResultsInOrder(games, 'player2Goals', 'player1Goals', 2);
+    assert.deepEqual(computeMatchStreaks(p1Results), {
+        currentWinningStreak: 3,
+        currentLosingStreak: 0
+    });
+    // From the opponent's perspective the same history is L, L, W, L, L, L.
+    assert.deepEqual(computeMatchStreaks(p2Results), {
+        currentWinningStreak: 0,
+        currentLosingStreak: 3
+    });
+});

--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -20,7 +20,7 @@
     /* Text Colors */
     --text-primary: #ffffff;
     --text-secondary: #b8b8d1;
-    --text-muted: #8888a8;
+    --text-muted: #a8a8c8;
     --text-disabled: #555570;
 
     /* Border Colors */
@@ -1230,7 +1230,6 @@ body.gym-tracker #footer {
 .form-group input:focus,
 .form-group textarea:focus,
 .form-group select:focus {
-    outline: none;
     border-color: var(--accent-primary);
     background: var(--bg-card);
 }
@@ -4429,6 +4428,8 @@ body.gym-tracker #footer {
 .program-exercise-row .pex-name        { grid-area: name; align-self: center; }
 .program-exercise-row .pex-delete      { grid-area: delete; align-self: center; justify-self: end; }
 
+/* Base = mobile. Keep the original flex-wrap row exactly as it was — the
+ * desktop media query below swaps in the new vertical-block grid layout. */
 .pex-targets {
     grid-area: targets;
     display: flex;
@@ -4436,6 +4437,7 @@ body.gym-tracker #footer {
     gap: 0.5rem;
     flex-wrap: wrap;
     justify-content: flex-start;
+    min-width: 0;
 }
 
 /* Desktop refinement — left-aligned card, tighter title/control connection,
@@ -4458,8 +4460,17 @@ body.gym-tracker #footer {
         padding: 0.75rem 1rem;
         column-gap: 0.75rem;
         /* Tight row-gap + dashed divider = "title and controls are one unit." */
-        row-gap: 0.4rem;
+        row-gap: 0.6rem;
         border-radius: var(--radius-lg);
+        /* Desktop: targets get their own full-width row beneath the title row
+           so Sets/Reps/Rest can breathe across the entire card instead of
+           being squeezed into the name+delete columns. `minmax(0, 1fr)` on
+           the name column stops long exercise names from forcing the whole
+           card wider than the modal. */
+        grid-template-columns: auto auto minmax(0, 1fr) auto;
+        grid-template-areas:
+            "handle position name    delete"
+            "targets targets targets targets";
     }
 
     .program-exercise-row .pex-name-main { font-size: 1.05rem; }
@@ -4469,27 +4480,63 @@ body.gym-tracker #footer {
         opacity: 0.75;
     }
 
-    /* CSS Grid with auto-fit: three 170px-floor cells fit on one row at
-       normal desktop widths. If the container gets too narrow (narrow window,
-       user-shrunk modal), cells automatically wrap to the next row instead of
-       overlapping. Grid bounds each stepper so they CANNOT spill into one
-       another the way `flex: 1; min-width: 0` allowed. */
+    /* Controls row: three equal columns that SHARE the full card width.
+       `minmax(0, 1fr)` gives each stepper a HARD upper bound — cells shrink
+       instead of forcing the parent wider. Spans all four outer-grid columns
+       via the redefined grid-template-areas above, so it uses the whole card
+       inner width (~660px in a 760px modal) — about 220px per cell. */
     .pex-targets {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
-        gap: 0.55rem;
-        padding-top: 0.45rem;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.75rem;
+        padding-top: 0.5rem;
         margin-top: 0;
         border-top: 1px dashed var(--border-color);
+        min-width: 0;
+        width: 100%;
     }
 
-    /* Stepper fills its grid cell. No flex:1 or min-width:0 overrides —
-       the grid container owns the sizing, and the stepper's natural content
-       width (~150px) fits comfortably inside the 170px cell floor. */
+    .pex-targets > * {
+        min-width: 0;
+    }
+
+    /* Desktop-only: each control is a vertical block — label on top of
+       a full-width [-  value  +] pill. The outer .pex-stepper becomes a
+       transparent wrapper (all pill chrome moves to .pex-stepper-controls)
+       so the label isn't competing inside a crowded single row.
+       Mobile keeps the original horizontal pill via the base rules. */
     .program-exercise-row .pex-stepper {
-        padding: 0.3rem 0.6rem 0.3rem 0.75rem;
-        min-height: 34px;
-        gap: 0.6rem;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.3rem;
+        width: 100%;
+        min-width: 0;
+        padding: 0;
+        background: transparent;
+        border: none;
+        border-radius: 0;
+        box-sizing: border-box;
+    }
+
+    .program-exercise-row .pex-stepper-label {
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        opacity: 0.8;
+        padding-left: 0.1rem;
+    }
+
+    /* The pill now lives on .pex-stepper-controls on desktop. */
+    .program-exercise-row .pex-stepper-controls {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.4rem;
+        padding: 0.4rem 0.65rem;
+        background: var(--bg-elevated);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-md);
+        min-width: 0;
+        box-sizing: border-box;
     }
 
     /* Slightly larger value floor so "2:15"/"10:30" sit cleanly without
@@ -4528,11 +4575,25 @@ body.gym-tracker #footer {
     }
 }
 
+/* Hard-stack the Sets/Reps/Rest controls on narrow viewports. Between 641px
+   and 900px the modal is simply not wide enough to comfortably fit three
+   steppers side-by-side, so we stack them one per row — readable, no overlap,
+   no overflow. Above 900px the 3-column grid takes over. Below 641px the
+   base flex-wrap layout applies. */
+@media (min-width: 641px) and (max-width: 900px) {
+    .pex-targets {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* Stepper — two zones separated by space-between:
      [ LABEL ]                   [ - value + ]
    The inner .pex-stepper-controls owns its own fixed inter-element gap so
    the spacing between minus, value, and plus is ALWAYS identical, no matter
    how long the value string is ("3", "10", "1:30", "2:15", "10:30"). */
+/* Base = mobile. Horizontal inline pill — label inside, [-  value  +]
+ * sharing the same rounded container. Desktop media query above replaces
+ * this with a vertical label-over-pill block layout. */
 .pex-stepper {
     display: inline-flex;
     align-items: center;
@@ -4543,6 +4604,8 @@ body.gym-tracker #footer {
     border-radius: var(--radius-md);
     padding: 0.15rem 0.35rem;
     font-size: 0.78rem;
+    min-width: 0;
+    box-sizing: border-box;
 }
 
 .pex-stepper-label {
@@ -4552,9 +4615,11 @@ body.gym-tracker #footer {
     text-transform: uppercase;
     letter-spacing: 0.04em;
     font-size: 0.65rem;
+    white-space: nowrap;
 }
 
-/* Right-side group: [-] value [+]. Fixed gap guarantees visual rhythm. */
+/* Right-side cluster: [-] value [+]. Inline, no background of its own —
+ * the outer .pex-stepper provides the pill chrome on mobile. */
 .pex-stepper-controls {
     display: inline-flex;
     align-items: center;
@@ -4808,24 +4873,24 @@ body.gym-tracker #footer {
     color: #ffffff !important;
 }
 
-/* Bottom action row — Cancel (ghost) + Save (primary CTA) grouped tightly */
+/* Bottom action row — anchored footer with clear Cancel/Save hierarchy. */
 .program-form-actions {
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    gap: 0.6rem;
-    margin-top: 0.85rem;
-    padding-top: 0.85rem;
-    border-top: 1px solid var(--border-color);
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .program-form-actions .btn {
-    height: 38px !important;
+    height: 44px !important;
     min-height: 0 !important;
-    min-width: 110px;
-    padding: 0 1.1rem !important;
-    border-radius: var(--radius-md);
-    font-size: 0.86rem !important;
+    min-width: 120px;
+    padding: 0 1.25rem !important;
+    border-radius: 10px;
+    font-size: 0.9rem !important;
     font-weight: 600 !important;
     font-family: inherit !important;
     display: inline-flex;
@@ -4838,17 +4903,17 @@ body.gym-tracker #footer {
                 transform var(--transition-base), filter var(--transition-base);
 }
 
-/* Cancel — ghost/outline, clearly secondary */
+/* Cancel — transparent/outline, tuned down so Save dominates. */
 .program-form-actions .btn-ghost {
     background: transparent !important;
-    border: 1px solid var(--border-color) !important;
-    color: var(--text-secondary) !important;
+    border: 1px solid rgba(255, 255, 255, 0.15) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
     box-shadow: none !important;
 }
 
 .program-form-actions .btn-ghost:hover {
-    background: var(--bg-elevated) !important;
-    border-color: var(--border-light) !important;
+    background: rgba(255, 255, 255, 0.04) !important;
+    border-color: rgba(255, 255, 255, 0.25) !important;
     color: var(--text-primary) !important;
 }
 
@@ -4862,22 +4927,22 @@ body.gym-tracker #footer {
     box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25) !important;
 }
 
-/* Save — primary CTA, strong contrast */
+/* Save — primary CTA. Strong gradient + glow so it's the obvious action. */
 .btn-save-program {
     background: var(--gradient-primary) !important;
     border: 1px solid transparent !important;
     color: #ffffff !important;
-    box-shadow: 0 3px 10px rgba(108, 99, 255, 0.3) !important;
+    box-shadow: 0 4px 14px rgba(108, 99, 255, 0.4) !important;
 }
 
 .btn-save-program i {
     color: #ffffff !important;
-    font-size: 0.8rem;
+    font-size: 0.85rem;
 }
 
 .btn-save-program:hover {
     transform: translateY(-1px);
-    box-shadow: 0 6px 16px rgba(108, 99, 255, 0.45) !important;
+    box-shadow: 0 8px 20px rgba(108, 99, 255, 0.5) !important;
     filter: brightness(1.06);
 }
 
@@ -7318,6 +7383,18 @@ button.calendar-day {
     margin-top: 1.25rem;
 }
 
+/* Relocated Additional Metrics section sits directly below the summary.
+   The h3 inside doesn't need extra top margin (it's already the first
+   heading under the summary), and the section gets a bottom spacer so
+   Exercises below doesn't crowd it. */
+.workout-detail-metrics {
+    margin: 0.25rem 0 1.25rem;
+}
+
+.workout-detail-metrics > h3 {
+    margin-top: 0;
+}
+
 .workout-detail-notes {
     background: var(--bg-tertiary);
     border: 1px solid var(--border-color);
@@ -7572,3 +7649,416 @@ button.calendar-day {
         color: black;
     }
 }
+
+/* ============================================================
+ * Per-exercise progression chart (exercise detail modal)
+ * ============================================================ */
+.exercise-progression {
+    margin-top: var(--spacing-lg);
+}
+
+.exercise-detail-section-caption.is-up {
+    color: var(--accent-success);
+}
+.exercise-detail-section-caption.is-down {
+    color: var(--accent-error);
+}
+
+.progression-chart-wrap {
+    margin-top: var(--spacing-md);
+    padding: var(--spacing-md);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+}
+
+.progression-chart {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: 200px;
+}
+
+.progression-line {
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.progression-line-primary {
+    stroke: var(--accent-primary);
+}
+
+.progression-line-e1rm {
+    stroke: var(--accent-success);
+    stroke-dasharray: 4 4;
+    opacity: 0.75;
+}
+
+.progression-dot {
+    fill: var(--accent-primary);
+    stroke: var(--bg-tertiary);
+    stroke-width: 1.5;
+}
+
+.progression-axis {
+    font-size: 10px;
+    fill: var(--text-muted);
+}
+
+.progression-axis-line {
+    stroke: var(--border-color);
+    stroke-width: 1;
+}
+
+.progression-legend {
+    display: flex;
+    gap: var(--spacing-md);
+    margin-top: var(--spacing-sm);
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.progression-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.progression-legend .dot {
+    display: inline-block;
+    width: 10px;
+    height: 2px;
+    border-radius: 1px;
+}
+
+.progression-legend .dot-primary {
+    background: var(--accent-primary);
+}
+
+.progression-legend .dot-e1rm {
+    background: var(--accent-success);
+}
+
+/* ============================================================
+ * This-week dashboard card (Home view)
+ * ============================================================ */
+.week-summary-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+}
+
+.week-summary-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: var(--spacing-md);
+}
+
+.week-summary-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+}
+
+.week-summary-caption {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+
+.week-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-sm);
+}
+
+@media (min-width: 640px) {
+    .week-summary-grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+.week-tile {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-sm) var(--spacing-md);
+    min-height: 68px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.week-tile-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+}
+
+.week-tile-value {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    line-height: 1.1;
+    margin-top: 2px;
+}
+
+.week-tile-delta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.week-tile-delta.is-up {
+    color: var(--accent-success);
+}
+
+.week-tile-delta.is-down {
+    color: var(--accent-error);
+}
+
+/* ============================================================
+ * PR badge on just-committed set rows
+ * ============================================================ */
+.set-row--pr {
+    position: relative;
+    background: linear-gradient(
+        to right,
+        rgba(255, 165, 0, 0.08),
+        transparent 40%
+    );
+    border-left: 2px solid var(--accent-warning);
+}
+
+.pr-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: 0.5rem;
+    padding: 0.125rem 0.5rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1.2;
+    letter-spacing: 0.02em;
+    color: #2a1a00;
+    background: linear-gradient(135deg, #ffcb5c, #ffa500);
+    border-radius: 999px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+    vertical-align: baseline;
+    white-space: nowrap;
+}
+
+.pr-badge .fa-trophy {
+    font-size: 0.7rem;
+}
+
+/* ============================================================
+ * First-run onboarding modal
+ * ============================================================ */
+.onboarding-modal-content {
+    max-width: 460px;
+}
+
+.onboarding-steps {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 var(--spacing-md) 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.onboarding-step {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+}
+
+.onboarding-step-number {
+    flex: 0 0 auto;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--gradient-primary);
+    color: white;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.onboarding-step-body {
+    flex: 1;
+}
+
+.onboarding-step-title {
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 2px 0;
+    font-size: 0.95rem;
+}
+
+.onboarding-step-desc {
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.onboarding-step-cta {
+    flex: 0 0 auto;
+}
+
+/* ============================================================
+ * Accessibility: visible focus rings and touch targets
+ * ============================================================ */
+.gym-tracker *:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+    border-radius: 3px;
+}
+
+/* Keep the input border-colour cue and ADD a visible focus ring
+ * (previously outline was forced to 'none'). */
+.form-group input:focus-visible,
+.form-group textarea:focus-visible,
+.form-group select:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+}
+
+.modal-close:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+}
+
+/* Override the generic .setting-item flex-direction: column so toggle
+ * rows lay out label-left / switch-right instead of stacked. */
+.setting-item.setting-item-toggle {
+    flex-direction: row !important;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    padding: 0.5rem 0;
+}
+
+.setting-toggle-label {
+    margin-bottom: 0;
+    flex: 1;
+    min-width: 0;
+}
+
+/* Custom toggle switch (native checkbox hidden behind a styled slider). */
+.toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 48px;
+    height: 26px;
+    flex: 0 0 auto;
+    margin: 0 !important;
+}
+
+.toggle-switch input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0 !important;
+    cursor: pointer;
+    z-index: 1;
+}
+
+.toggle-slider {
+    position: absolute;
+    inset: 0;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background var(--transition-base), border-color var(--transition-base);
+}
+
+.toggle-slider::before {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    background: var(--text-primary);
+    border-radius: 50%;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    transition: transform var(--transition-base);
+}
+
+.toggle-switch input[type="checkbox"]:checked + .toggle-slider {
+    background: var(--accent-primary);
+    border-color: var(--accent-primary);
+}
+
+.toggle-switch input[type="checkbox"]:checked + .toggle-slider::before {
+    transform: translateX(22px);
+}
+
+.toggle-switch input[type="checkbox"]:focus-visible + .toggle-slider {
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.4);
+}
+
+/* ============================================================
+ * Inline form validation (dark-theme friendly)
+ * ============================================================ */
+.form-error {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0.4rem 0 0 0;
+    padding: 0;
+    font-size: 0.8rem;
+    color: #ff9a9a;
+    line-height: 1.3;
+}
+
+.form-error i {
+    font-size: 0.8rem;
+    flex: 0 0 auto;
+}
+
+.form-error[hidden] { display: none; }
+
+/* Invalid input — subtle red border + faint glow, not harsh. */
+.form-group input.is-invalid,
+.form-group textarea.is-invalid,
+.form-group select.is-invalid {
+    border-color: rgba(239, 68, 68, 0.6) !important;
+    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.12);
+}
+
+.form-group input.is-invalid:focus,
+.form-group textarea.is-invalid:focus {
+    border-color: rgba(239, 68, 68, 0.8) !important;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+}
+
+/* Section-level error banner (e.g. "add at least one exercise"). */
+.form-error-section {
+    margin-top: 0.6rem;
+    padding: 0.55rem 0.75rem;
+    background: rgba(239, 68, 68, 0.08);
+    border: 1px solid rgba(239, 68, 68, 0.35);
+    border-radius: var(--radius-md);
+}
+
+/* Section container highlighted when its inner validation fails. */
+.is-invalid-section {
+    border-color: rgba(239, 68, 68, 0.45) !important;
+    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.08);
+}
+

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -110,7 +110,20 @@
                         <div class="empty-state">
                             <i class="fas fa-folder-open"></i>
                             <p>No active program</p>
-                            <button class="btn btn-primary" data-view="programs">Create Program</button>
+                            <button type="button" class="btn btn-primary" data-home-action="create-program">Create Program</button>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- This Week summary (populated by JS; hidden when no sessions yet) -->
+                <section class="section" id="week-summary-section" hidden>
+                    <div class="week-summary-card">
+                        <div class="week-summary-header">
+                            <h2>This Week</h2>
+                            <span class="week-summary-caption" id="week-summary-caption"></span>
+                        </div>
+                        <div class="week-summary-grid" id="week-summary-grid">
+                            <!-- Will be populated by JS -->
                         </div>
                     </div>
                 </section>
@@ -125,7 +138,7 @@
                         <div class="empty-state">
                             <i class="fas fa-dumbbell"></i>
                             <p>No workouts yet</p>
-                            <button class="btn btn-primary" data-view="workout">Start Workout</button>
+                            <button type="button" class="btn btn-primary" data-home-action="start-workout">Start Workout</button>
                         </div>
                     </div>
                 </section>
@@ -167,24 +180,31 @@
                 </div>
 
                 <!-- Create/Edit Program Modal -->
-                <div id="program-modal" class="modal">
+                <div id="program-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="program-modal-title">
                     <div class="modal-content">
                         <div class="modal-header">
                             <h2 id="program-modal-title">Create Program</h2>
-                            <button class="modal-close">&times;</button>
+                            <button class="modal-close" aria-label="Close">&times;</button>
                         </div>
                         <div class="modal-body">
-                            <form id="program-form">
-                                <div class="form-group">
+                            <form id="program-form" novalidate>
+                                <div class="form-group" id="program-name-group">
                                     <label for="program-name">Program Name</label>
-                                    <input type="text" id="program-name" placeholder="e.g., Full Body Workout" required>
+                                    <input type="text" id="program-name"
+                                        placeholder="e.g., Full Body Workout"
+                                        aria-describedby="program-name-error"
+                                        aria-invalid="false">
+                                    <p id="program-name-error" class="form-error" hidden>
+                                        <i class="fas fa-circle-exclamation" aria-hidden="true"></i>
+                                        <span>Enter a name for this program.</span>
+                                    </p>
                                 </div>
                                 <div class="form-group">
                                     <label for="program-description">Description (Optional)</label>
                                     <textarea id="program-description" placeholder="Program details..." rows="3"></textarea>
                                 </div>
 
-                                <section class="program-exercises-section">
+                                <section class="program-exercises-section" id="program-exercises-section">
                                     <header class="program-exercises-header">
                                         <h3 class="program-exercises-heading">
                                             <i class="fas fa-dumbbell"></i> Exercises
@@ -197,6 +217,10 @@
                                     <button type="button" class="btn-add-exercise" id="add-exercise-to-program-btn">
                                         <i class="fas fa-plus"></i> Add Exercise
                                     </button>
+                                    <p id="program-exercises-error" class="form-error form-error-section" hidden>
+                                        <i class="fas fa-circle-exclamation" aria-hidden="true"></i>
+                                        <span>Add at least one exercise before saving this program.</span>
+                                    </p>
                                 </section>
 
                                 <div class="form-actions program-form-actions">
@@ -211,11 +235,11 @@
                 </div>
 
                 <!-- Exercise Picker Modal -->
-                <div id="exercise-picker-modal" class="modal">
+                <div id="exercise-picker-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="exercise-picker-title">
                     <div class="modal-content large">
                         <div class="modal-header">
-                            <h2>Select Exercises</h2>
-                            <button class="modal-close">&times;</button>
+                            <h2 id="exercise-picker-title">Select Exercises</h2>
+                            <button class="modal-close" aria-label="Close">&times;</button>
                         </div>
                         <div class="modal-body">
                             <div class="exercise-picker-search">
@@ -357,11 +381,11 @@
                     </div>
 
                     <!-- Finish Workout Modal -->
-                    <div id="finish-workout-modal" class="modal">
+                    <div id="finish-workout-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="finish-workout-title">
                         <div class="modal-content">
                             <div class="modal-header">
-                                <h2>Finish Workout</h2>
-                                <button class="modal-close">&times;</button>
+                                <h2 id="finish-workout-title">Finish Workout</h2>
+                                <button class="modal-close" aria-label="Close">&times;</button>
                             </div>
                             <div class="modal-body">
                                 <form id="finish-workout-form">
@@ -377,6 +401,10 @@
                                         <div class="summary-stat">
                                             <span class="label">Sets Completed</span>
                                             <span class="value" id="summary-sets">0</span>
+                                        </div>
+                                        <div class="summary-stat" id="summary-prs-stat" hidden>
+                                            <span class="label">PRs Hit</span>
+                                            <span class="value" id="summary-prs">0</span>
                                         </div>
                                     </div>
 
@@ -440,11 +468,11 @@
                 </div>
 
                 <!-- Workout Detail Modal -->
-                <div id="workout-detail-modal" class="modal">
+                <div id="workout-detail-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="workout-detail-title">
                     <div class="modal-content">
                         <div class="modal-header">
                             <h2 id="workout-detail-title">Workout Details</h2>
-                            <button class="modal-close">&times;</button>
+                            <button class="modal-close" aria-label="Close">&times;</button>
                         </div>
                         <div class="modal-body">
                             <div id="workout-detail-content">
@@ -532,11 +560,11 @@
                 </div>
 
                 <!-- Exercise Detail Modal -->
-                <div id="exercise-detail-modal" class="modal">
+                <div id="exercise-detail-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="exercise-detail-name">
                     <div class="modal-content">
                         <div class="modal-header">
                             <h2 id="exercise-detail-name">Exercise</h2>
-                            <button class="modal-close">&times;</button>
+                            <button class="modal-close" aria-label="Close">&times;</button>
                         </div>
                         <div class="modal-body">
                             <div id="exercise-detail-content">
@@ -550,10 +578,10 @@
                 </div>
 
                 <!-- Create Custom Exercise Modal -->
-                <div id="custom-exercise-modal" class="modal">
+                <div id="custom-exercise-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="custom-exercise-title">
                     <div class="modal-content custom-exercise-modal-content">
                         <div class="modal-header">
-                            <h2>Create Custom Exercise</h2>
+                            <h2 id="custom-exercise-title">Create Custom Exercise</h2>
                             <button class="modal-close" aria-label="Close">&times;</button>
                         </div>
                         <div class="modal-body">
@@ -764,6 +792,30 @@
 
                     <section class="settings-section">
                         <header class="settings-section-header">
+                            <i class="fas fa-bell settings-section-icon"></i>
+                            <div>
+                                <h2>Alerts</h2>
+                                <p class="settings-section-sub">Cues that fire when you hit a PR or the rest timer ends.</p>
+                            </div>
+                        </header>
+                        <div class="setting-item setting-item-toggle">
+                            <label for="sound-alerts" class="setting-toggle-label">Sound</label>
+                            <label class="toggle-switch" aria-label="Sound toggle">
+                                <input type="checkbox" id="sound-alerts">
+                                <span class="toggle-slider" aria-hidden="true"></span>
+                            </label>
+                        </div>
+                        <div class="setting-item setting-item-toggle">
+                            <label for="vibration-alerts" class="setting-toggle-label">Vibration</label>
+                            <label class="toggle-switch" aria-label="Vibration toggle">
+                                <input type="checkbox" id="vibration-alerts">
+                                <span class="toggle-slider" aria-hidden="true"></span>
+                            </label>
+                        </div>
+                    </section>
+
+                    <section class="settings-section">
+                        <header class="settings-section-header">
                             <i class="fas fa-database settings-section-icon"></i>
                             <div>
                                 <h2>Data Management</h2>
@@ -829,8 +881,50 @@
     <!-- Toast Container -->
     <div id="toast-container"></div>
 
+    <!-- Onboarding Welcome Modal (first launch) -->
+    <div id="onboarding-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="onboarding-title" aria-hidden="true">
+        <div class="modal-content onboarding-modal-content">
+            <div class="modal-header">
+                <h2 id="onboarding-title">Welcome to Gym Tracker 💪</h2>
+                <button class="modal-close" id="onboarding-dismiss" aria-label="Close welcome">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p style="margin-top:0">Three quick steps to log your first workout:</p>
+                <ol class="onboarding-steps">
+                    <li class="onboarding-step">
+                        <span class="onboarding-step-number">1</span>
+                        <div class="onboarding-step-body">
+                            <p class="onboarding-step-title">Create a program</p>
+                            <p class="onboarding-step-desc">Name it (e.g. "Push Day") — it's a reusable template.</p>
+                        </div>
+                        <div class="onboarding-step-cta">
+                            <button class="btn btn-primary" id="onboarding-go-programs">Go</button>
+                        </div>
+                    </li>
+                    <li class="onboarding-step">
+                        <span class="onboarding-step-number">2</span>
+                        <div class="onboarding-step-body">
+                            <p class="onboarding-step-title">Add exercises</p>
+                            <p class="onboarding-step-desc">Pick from the built-in database or create your own.</p>
+                        </div>
+                    </li>
+                    <li class="onboarding-step">
+                        <span class="onboarding-step-number">3</span>
+                        <div class="onboarding-step-body">
+                            <p class="onboarding-step-title">Start a workout</p>
+                            <p class="onboarding-step-desc">Log sets, track progress, celebrate PRs 🏆</p>
+                        </div>
+                    </li>
+                </ol>
+            </div>
+            <div class="modal-footer" style="display:flex;justify-content:flex-end;padding:var(--spacing-md) var(--spacing-lg);gap:var(--spacing-sm);">
+                <button class="btn btn-ghost" id="onboarding-skip">Skip tour</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Confirmation Modal -->
-    <div id="confirm-modal" class="modal">
+    <div id="confirm-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title">
         <div class="modal-content small confirm-modal-content">
             <div class="confirm-modal-icon" id="confirm-modal-icon">
                 <i class="fas fa-triangle-exclamation"></i>

--- a/apps/gym-tracker/js/app.js
+++ b/apps/gym-tracker/js/app.js
@@ -72,7 +72,43 @@ class GymTrackerApp {
         // Listen for sync system ready
         this.setupSyncListeners();
 
+        // First-run onboarding — only when the user has absolutely no data
+        // and has never dismissed the welcome. If sync later pulls data in,
+        // the modal stays dismissed (flag persists).
+        this.maybeShowOnboarding();
+
         console.log('✅ Gym Tracker App initialized');
+    }
+
+    /**
+     * Show the welcome modal to first-time users. A user is "first-time"
+     * if they have no programs, no sessions, and have never dismissed
+     * the modal before. Running sync listeners can't retroactively
+     * trigger this — the modal is strictly day-one.
+     */
+    maybeShowOnboarding() {
+        const seen = storageService.hasSeenOnboarding();
+        const hasData = this.programs.length > 0 || this.workoutSessions.length > 0;
+        if (seen || hasData) return;
+
+        const modal = document.getElementById('onboarding-modal');
+        if (!modal) return;
+
+        const close = () => {
+            modal.classList.remove('active');
+            modal.setAttribute('aria-hidden', 'true');
+            storageService.markOnboardingSeen();
+        };
+
+        modal.setAttribute('aria-hidden', 'false');
+        modal.classList.add('active');
+
+        document.getElementById('onboarding-dismiss')?.addEventListener('click', close, { once: true });
+        document.getElementById('onboarding-skip')?.addEventListener('click', close, { once: true });
+        document.getElementById('onboarding-go-programs')?.addEventListener('click', () => {
+            close();
+            this.showView('programs');
+        }, { once: true });
     }
 
     /**
@@ -210,6 +246,29 @@ class GymTrackerApp {
             e.preventDefault();
             const view = navBtn.dataset.view;
             this.showView(view);
+        });
+
+        // Empty-state CTAs across views (Dashboard, History, Workout) are
+        // wired via `data-home-action` so they share one source of truth.
+        // "Start Workout" falls back to the Create Program flow when no
+        // programs exist — dropping first-time users on a blank Workout
+        // view was the original bug.
+        document.addEventListener('click', (e) => {
+            const btn = e.target.closest('[data-home-action]');
+            if (!btn) return;
+            e.preventDefault();
+            e.stopPropagation();
+            const action = btn.dataset.homeAction;
+            if (action === 'create-program') {
+                this.viewControllers.programs?.createProgramFromElsewhere();
+            } else if (action === 'start-workout') {
+                if (this.programs.length === 0) {
+                    showToast('Create a program first — then pick it to start a workout.', 'info', 4000);
+                    this.viewControllers.programs?.createProgramFromElsewhere();
+                } else {
+                    this.showView('workout');
+                }
+            }
         });
 
         // Handle back button

--- a/apps/gym-tracker/js/models/Set.js
+++ b/apps/gym-tracker/js/models/Set.js
@@ -10,6 +10,11 @@ export class Set {
         this.completed = data.completed !== undefined ? data.completed : false;
         this.restTime = data.restTime || 0; // in seconds
         this.notes = data.notes || '';
+        // Stable user-facing slot index (0-based) within its exercise. The
+        // renderer addresses rows by slot so un-toggling a middle set doesn't
+        // visually renumber the others. May be null on legacy sessions — the
+        // render layer falls back to array position when slot is unset.
+        this.slot = data.slot != null ? data.slot : null;
     }
 
     get volume() {
@@ -28,7 +33,8 @@ export class Set {
             duration: this.duration,
             completed: this.completed,
             restTime: this.restTime,
-            notes: this.notes
+            notes: this.notes,
+            slot: this.slot
         };
     }
 

--- a/apps/gym-tracker/js/models/Settings.js
+++ b/apps/gym-tracker/js/models/Settings.js
@@ -8,6 +8,19 @@ export class Settings {
         this.theme = data.theme || 'dark'; // 'light' or 'dark'
         this.dateFormat = data.dateFormat || 'MM/DD/YYYY';
         this.firstDayOfWeek = data.firstDayOfWeek || 0; // 0 = Sunday, 1 = Monday
+        // Independent sound and vibration cues for PRs + rest-timer completion.
+        // Default on — most useful the first time the user logs a set, so
+        // opt-out rather than opt-in.
+        // `restAlerts` is the legacy combined flag; when present it seeds
+        // both new fields so users who toggled it before don't lose their
+        // preference.
+        const legacy = data.restAlerts;
+        this.soundAlerts = data.soundAlerts !== undefined
+            ? data.soundAlerts
+            : (legacy !== undefined ? legacy : true);
+        this.vibrationAlerts = data.vibrationAlerts !== undefined
+            ? data.vibrationAlerts
+            : (legacy !== undefined ? legacy : true);
     }
 
     toJSON() {
@@ -15,7 +28,9 @@ export class Settings {
             weightUnit: this.weightUnit,
             theme: this.theme,
             dateFormat: this.dateFormat,
-            firstDayOfWeek: this.firstDayOfWeek
+            firstDayOfWeek: this.firstDayOfWeek,
+            soundAlerts: this.soundAlerts,
+            vibrationAlerts: this.vibrationAlerts
         };
     }
 

--- a/apps/gym-tracker/js/services/AchievementService.js
+++ b/apps/gym-tracker/js/services/AchievementService.js
@@ -360,21 +360,17 @@ export class AchievementService {
             }
 
             case 'daily-volume': {
-                const today = new Date().toISOString().split('T')[0];
+                // Use LOCAL today — toISOString() gives UTC, which is a day
+                // off for late-evening users west of UTC.
+                const today = AnalyticsService.toLocalDateKey(new Date());
                 const todaySessions = sessions.filter(s => s.date === today);
                 return AnalyticsService.getTotalVolume(todaySessions);
             }
 
             case 'weekly-workouts': {
-                const now = new Date();
-                const weekStart = new Date(now);
-                const day = now.getDay();
-                const diff = day === 0 ? 6 : day - 1; // Monday as start of week
-                weekStart.setDate(now.getDate() - diff);
-                weekStart.setHours(0, 0, 0, 0);
-
+                const weekStart = AnalyticsService.startOfIsoWeek(new Date());
                 const weeklySessions = sessions.filter(s =>
-                    new Date(s.date) >= weekStart
+                    AnalyticsService.toLocalDate(s.date) >= weekStart
                 );
                 return weeklySessions.length;
             }
@@ -384,7 +380,7 @@ export class AchievementService {
                 const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
                 const monthlySessions = sessions.filter(s =>
-                    new Date(s.date) >= monthStart
+                    AnalyticsService.toLocalDate(s.date) >= monthStart
                 );
                 return monthlySessions.length;
             }

--- a/apps/gym-tracker/js/services/AnalyticsService.js
+++ b/apps/gym-tracker/js/services/AnalyticsService.js
@@ -1,8 +1,39 @@
 /**
  * AnalyticsService
- * Calculates statistics, progress, and analytics from workout data
+ * Calculates statistics, progress, and analytics from workout data.
+ *
+ * Dates in session data are persisted as local YYYY-MM-DD strings (that's
+ * what the user sees on their calendar). Parsing those strings with the
+ * naked `new Date("YYYY-MM-DD")` constructor treats them as UTC midnight,
+ * which is *before* local midnight for any user west of UTC. That shifts
+ * workouts into the wrong day/week/month on the dashboard, calendar,
+ * streaks, etc. Use `toLocalDate()` / `toLocalDateKey()` below instead.
  */
 export class AnalyticsService {
+    /**
+     * Parse a local YYYY-MM-DD (or full timestamp) into a Date anchored
+     * to local midnight. Falls back to the native constructor for any
+     * non-matching input so full ISO timestamps still parse correctly.
+     */
+    static toLocalDate(dateStr) {
+        if (typeof dateStr !== 'string') return new Date(dateStr);
+        const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+        if (!m) return new Date(dateStr);
+        return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+    }
+
+    /**
+     * Format a Date as local YYYY-MM-DD. Matches the storage format the
+     * rest of the app uses; avoids the UTC shift of `toISOString()`.
+     */
+    static toLocalDateKey(date) {
+        const d = date instanceof Date ? date : new Date(date);
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+    }
+
     /**
      * Calculate total volume for a date range
      */
@@ -63,15 +94,16 @@ export class AnalyticsService {
         );
 
         if (beforeDate) {
+            const cutoff = this.toLocalDate(beforeDate);
             filteredSessions = filteredSessions.filter(s =>
-                new Date(s.date) < new Date(beforeDate)
+                this.toLocalDate(s.date) < cutoff
             );
         }
 
         if (filteredSessions.length === 0) return null;
 
         // Sort by date descending
-        filteredSessions.sort((a, b) => new Date(b.date) - new Date(a.date));
+        filteredSessions.sort((a, b) => this.toLocalDate(b.date) - this.toLocalDate(a.date));
 
         const lastSession = filteredSessions[0];
         const exercise = lastSession.exercises.find(e => e.exerciseId === exerciseId);
@@ -103,9 +135,10 @@ export class AnalyticsService {
     static getWorkoutFrequency(sessions, days = 30) {
         const cutoffDate = new Date();
         cutoffDate.setDate(cutoffDate.getDate() - days);
+        cutoffDate.setHours(0, 0, 0, 0);
 
         const recentSessions = sessions.filter(s =>
-            new Date(s.date) >= cutoffDate
+            this.toLocalDate(s.date) >= cutoffDate
         );
 
         return {
@@ -119,20 +152,17 @@ export class AnalyticsService {
      * Get volume trends over time
      */
     static getVolumeTrends(sessions, groupBy = 'week') {
-        const sorted = [...sessions].sort((a, b) => new Date(a.date) - new Date(b.date));
+        const sorted = [...sessions].sort((a, b) => this.toLocalDate(a.date) - this.toLocalDate(b.date));
 
         const groups = new Map();
 
         sorted.forEach(session => {
-            const date = new Date(session.date);
+            const date = this.toLocalDate(session.date);
             let key;
 
             if (groupBy === 'week') {
-                const weekStart = new Date(date);
-                const day = date.getDay();
-                const diff = day === 0 ? 6 : day - 1; // Monday as start of week
-                weekStart.setDate(date.getDate() - diff);
-                key = weekStart.toISOString().split('T')[0];
+                const weekStart = this.startOfIsoWeek(date);
+                key = this.toLocalDateKey(weekStart);
             } else if (groupBy === 'month') {
                 key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
             } else {
@@ -197,27 +227,171 @@ export class AnalyticsService {
     }
 
     /**
-     * Get progression for an exercise over time
+     * Get progression for an exercise over time.
+     *
+     * `limit` — if provided, returns only the N most-recent sessions
+     * (still in chronological order). Used by the exercise-detail chart
+     * to keep the visual bounded on users with long histories.
      */
-    static getExerciseProgression(exerciseId, sessions) {
+    static getExerciseProgression(exerciseId, sessions, { limit } = {}) {
         const exerciseSessions = sessions
             .filter(s => s.exercises.some(e => e.exerciseId === exerciseId))
-            .sort((a, b) => new Date(a.date) - new Date(b.date));
+            .sort((a, b) => this.toLocalDate(a.date) - this.toLocalDate(b.date));
 
-        return exerciseSessions.map(session => {
+        const points = exerciseSessions.map(session => {
             const exercise = session.exercises.find(e => e.exerciseId === exerciseId);
-            const maxWeight = Math.max(...exercise.sets.map(s => s.weight), 0);
-            const totalVolume = exercise.totalVolume;
-            const totalReps = exercise.sets.reduce((sum, s) => sum + s.reps, 0);
+            const sets = exercise.sets || [];
+            const maxWeight = Math.max(...sets.map(s => s.weight || 0), 0);
+            const maxDuration = Math.max(...sets.map(s => s.duration || 0), 0);
+            const totalVolume = exercise.totalVolume || 0;
+            const totalReps = sets.reduce((sum, s) => sum + (s.reps || 0), 0);
+            // Estimated 1-rep max via Epley: w * (1 + r/30) across all sets, take peak.
+            const e1rm = sets.reduce((best, s) => {
+                if (!s.weight || !s.reps) return best;
+                const est = s.weight * (1 + s.reps / 30);
+                return est > best ? est : best;
+            }, 0);
 
             return {
                 date: session.date,
                 maxWeight,
+                maxDuration,
                 totalVolume,
                 totalReps,
-                sets: exercise.sets.length
+                e1rm,
+                sets: sets.length,
             };
         });
+
+        if (limit && points.length > limit) {
+            return points.slice(points.length - limit);
+        }
+        return points;
+    }
+
+    /**
+     * Epley estimated 1-rep max. Returned as a number of the same unit as
+     * the input weight (kg or lb).
+     */
+    static epley1rm(weight, reps) {
+        if (!weight || !reps) return 0;
+        return weight * (1 + reps / 30);
+    }
+
+    /**
+     * Decide whether a just-logged set qualifies as a personal record.
+     *
+     * PR rule (single, simple):
+     *   Weighted exercises → set volume = weight × reps, new > prior best.
+     *   Duration exercises → new hold > prior longest.
+     *
+     * Notably this means heavier weight at fewer reps is NOT a PR unless
+     * the total (weight × reps) still beats the prior best. This matches
+     * the intuitive "I moved more total load in one set" signal.
+     *
+     * Returns null (not a PR) or:
+     *   { kind: 'volume' | 'duration',
+     *     value: number, previous: number, delta: number }
+     *
+     * A set is only a PR if there is at least one prior set for the
+     * exercise — the first session seeds the baseline and never counts.
+     */
+    static isSetPR(exerciseId, newSet, sessions) {
+        if (!newSet) return null;
+        const priorSets = [];
+        sessions.forEach(s => {
+            s.exercises.forEach(ex => {
+                if (ex.exerciseId === exerciseId) {
+                    (ex.sets || []).forEach(set => priorSets.push(set));
+                }
+            });
+        });
+        if (priorSets.length === 0) return null;
+
+        const isDuration = (newSet.duration || 0) > 0 && (newSet.weight || 0) === 0;
+
+        if (isDuration) {
+            const prevMax = priorSets.reduce((m, s) => Math.max(m, s.duration || 0), 0);
+            if ((newSet.duration || 0) > prevMax) {
+                return {
+                    kind: 'duration',
+                    value: newSet.duration,
+                    previous: prevMax,
+                    delta: newSet.duration - prevMax,
+                };
+            }
+            return null;
+        }
+
+        const prevMaxVolume = priorSets.reduce(
+            (m, s) => Math.max(m, (s.weight || 0) * (s.reps || 0)), 0
+        );
+        const newVolume = (newSet.weight || 0) * (newSet.reps || 0);
+        if (newVolume > prevMaxVolume) {
+            return {
+                kind: 'volume',
+                value: newVolume,
+                previous: prevMaxVolume,
+                delta: newVolume - prevMaxVolume,
+            };
+        }
+
+        return null;
+    }
+
+    /**
+     * Weekly summary stats for the Home dashboard.
+     *
+     * Returns totals for the current ISO week (Mon–Sun) plus deltas vs
+     * the prior week. "Volume" sums weight*reps across all sets.
+     */
+    static getWeekStats(sessions) {
+        const now = new Date();
+        const thisMonday = this.startOfIsoWeek(now);
+        const lastMonday = new Date(thisMonday);
+        lastMonday.setDate(thisMonday.getDate() - 7);
+        const nextMonday = new Date(thisMonday);
+        nextMonday.setDate(thisMonday.getDate() + 7);
+
+        const within = (s, start, end) => {
+            const d = this.toLocalDate(s.date);
+            return d >= start && d < end;
+        };
+
+        const agg = (slice) => {
+            const workouts = slice.length;
+            const volume = slice.reduce((sum, s) => sum + (s.totalVolume || 0), 0);
+            const durationMin = slice.reduce((sum, s) => sum + (s.duration || 0), 0);
+            return { workouts, volume, durationMin };
+        };
+
+        const thisWeek = sessions.filter(s => within(s, thisMonday, nextMonday));
+        const lastWeek = sessions.filter(s => within(s, lastMonday, thisMonday));
+
+        const cur = agg(thisWeek);
+        const prev = agg(lastWeek);
+
+        return {
+            workouts: cur.workouts,
+            volume: cur.volume,
+            durationMin: cur.durationMin,
+            streak: this.getCurrentStreak(sessions),
+            workoutsDelta: cur.workouts - prev.workouts,
+            volumeDelta: cur.volume - prev.volume,
+            weekStart: this.toLocalDateKey(thisMonday),
+        };
+    }
+
+    /**
+     * Monday 00:00 of the week containing `date`. Used by week stats.
+     */
+    static startOfIsoWeek(date) {
+        const d = new Date(date);
+        const day = d.getDay();
+        const diff = day === 0 ? 6 : day - 1;
+        d.setDate(d.getDate() - diff);
+        d.setHours(0, 0, 0, 0);
+        return d;
     }
 
     /**
@@ -232,22 +406,11 @@ export class AnalyticsService {
                 return this.getTotalVolume(sessions);
 
             case 'workout-streak': {
-                const sorted = [...sessions].sort((a, b) => new Date(b.date) - new Date(a.date));
-                let streak = 0;
-                let currentDate = new Date();
-
-                for (const session of sorted) {
-                    const sessionDate = new Date(session.date);
-                    const diffDays = Math.floor((currentDate - sessionDate) / (1000 * 60 * 60 * 24));
-
-                    if (diffDays <= 1 + streak) {
-                        streak++;
-                        currentDate = sessionDate;
-                    } else {
-                        break;
-                    }
-                }
-                return streak;
+                // Reuse the canonical streak logic — avoids a second
+                // slightly-different implementation drifting out of sync
+                // (and inheriting the same UTC-midnight bugs this file is
+                // fixing).
+                return this.getCurrentStreak(sessions);
             }
 
             case 'exercises-completed': {
@@ -270,7 +433,7 @@ export class AnalyticsService {
         const calendarData = new Map();
 
         sessions.forEach(session => {
-            const date = new Date(session.date);
+            const date = this.toLocalDate(session.date);
             if (date.getFullYear() === year && date.getMonth() === month) {
                 const key = session.date;
                 if (!calendarData.has(key)) {
@@ -308,8 +471,8 @@ export class AnalyticsService {
      */
     static getProgressDates(sessions) {
         const sorted = [...sessions].sort((a, b) => {
-            const ad = new Date(a.date).getTime();
-            const bd = new Date(b.date).getTime();
+            const ad = this.toLocalDate(a.date).getTime();
+            const bd = this.toLocalDate(b.date).getTime();
             if (ad !== bd) return ad - bd;
             return (a.timestamp || '').localeCompare(b.timestamp || '');
         });
@@ -361,7 +524,7 @@ export class AnalyticsService {
      */
     static getMonthSummary(sessions, year, month) {
         const monthSessions = sessions.filter(s => {
-            const d = new Date(s.date);
+            const d = this.toLocalDate(s.date);
             return d.getFullYear() === year && d.getMonth() === month;
         });
         const totalVolume = this.getTotalVolume(monthSessions);
@@ -384,13 +547,17 @@ export class AnalyticsService {
         if (!sessions.length) return 0;
         const dates = new Set(sessions.map(s => s.date));
         let streak = 0;
+        // Walk backwards from today in LOCAL time. Using toISOString() here
+        // would give UTC dates, which misattribute late-evening sessions
+        // (stored by local date) and skip them from the streak.
         const cursor = new Date();
+        cursor.setHours(0, 0, 0, 0);
         // If no workout today, allow streak that ended yesterday
-        const todayKey = cursor.toISOString().split('T')[0];
-        if (!dates.has(todayKey)) cursor.setDate(cursor.getDate() - 1);
+        if (!dates.has(this.toLocalDateKey(cursor))) {
+            cursor.setDate(cursor.getDate() - 1);
+        }
         while (true) {
-            const key = cursor.toISOString().split('T')[0];
-            if (dates.has(key)) {
+            if (dates.has(this.toLocalDateKey(cursor))) {
                 streak++;
                 cursor.setDate(cursor.getDate() - 1);
             } else {

--- a/apps/gym-tracker/js/services/StorageService.js
+++ b/apps/gym-tracker/js/services/StorageService.js
@@ -13,8 +13,17 @@ export class StorageService {
             ACHIEVEMENTS: 'gymTrackerAchievements',
             ACTIVE_PROGRAM: 'gymTrackerActiveProgram',
             CUSTOM_EXERCISES: 'gymTrackerCustomExercises',
-            ACTIVE_WORKOUT: 'gymTrackerActiveWorkout'
+            ACTIVE_WORKOUT: 'gymTrackerActiveWorkout',
+            ONBOARDING_SEEN: 'gymTrackerOnboardingSeen'
         };
+    }
+
+    // Onboarding
+    hasSeenOnboarding() {
+        return this.get(this.keys.ONBOARDING_SEEN) === true;
+    }
+    markOnboardingSeen() {
+        return this.set(this.keys.ONBOARDING_SEEN, true);
     }
 
     // Program ordering preferences

--- a/apps/gym-tracker/js/utils/helpers.js
+++ b/apps/gym-tracker/js/utils/helpers.js
@@ -466,19 +466,62 @@ export function isMobile() {
 }
 
 /**
- * Vibrate device (if supported)
+ * Vibrate device (if supported). Defensive against non-browser contexts
+ * where `navigator` is undefined (Node tests, Workers without DOM, etc.)
+ * so importing this module never throws at load.
  */
 export function vibrate(duration = 50) {
-    if ('vibrate' in navigator) {
+    if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
         navigator.vibrate(duration);
     }
 }
 
 /**
- * Play sound (if enabled in settings)
+ * Play a short beep using Web Audio. No assets, no network, and safely
+ * no-ops in browsers that don't expose AudioContext (older iOS WebView).
+ *
+ * Sound types:
+ *   'rest-done' → two quick ascending tones (800 → 1200 Hz)
+ *   'pr'        → a single bright chime (1400 Hz)
+ *   other       → a single 800 Hz blip
+ *
+ * Autoplay policy: browsers block AudioContext until a user gesture,
+ * but the Start-Workout tap already satisfies that by the time any of
+ * this would fire. Users who have never tapped anything get silence.
  */
+let _audioCtx = null;
 export function playSound(soundType = 'success') {
-    // Placeholder for sound functionality
-    // Can be implemented with audio files if needed
-    console.log(`Playing sound: ${soundType}`);
+    try {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        if (!_audioCtx) _audioCtx = new Ctx();
+        if (_audioCtx.state === 'suspended') _audioCtx.resume();
+
+        const now = _audioCtx.currentTime;
+        const play = (freq, startAt, dur = 0.15, vol = 0.18) => {
+            const osc = _audioCtx.createOscillator();
+            const gain = _audioCtx.createGain();
+            osc.type = 'sine';
+            osc.frequency.value = freq;
+            // Short attack/decay envelope so it doesn't click.
+            gain.gain.setValueAtTime(0, now + startAt);
+            gain.gain.linearRampToValueAtTime(vol, now + startAt + 0.01);
+            gain.gain.linearRampToValueAtTime(0, now + startAt + dur);
+            osc.connect(gain).connect(_audioCtx.destination);
+            osc.start(now + startAt);
+            osc.stop(now + startAt + dur + 0.02);
+        };
+
+        if (soundType === 'rest-done') {
+            play(800, 0);
+            play(1200, 0.18);
+        } else if (soundType === 'pr') {
+            play(1400, 0, 0.22, 0.22);
+            play(1800, 0.12, 0.18, 0.18);
+        } else {
+            play(800, 0);
+        }
+    } catch {
+        // Intentionally swallow — audio is a nice-to-have, never critical.
+    }
 }

--- a/apps/gym-tracker/js/views/exercises-view.js
+++ b/apps/gym-tracker/js/views/exercises-view.js
@@ -4,6 +4,7 @@
 import { app } from '../app.js';
 import { showToast, parseLocalDate, showConfirmModal } from '../utils/helpers.js';
 import { DarkSelect } from '../utils/dark-select.js';
+import { AnalyticsService } from '../services/AnalyticsService.js';
 
 class ExercisesView {
     constructor() {
@@ -588,7 +589,131 @@ class ExercisesView {
             </section>
         `;
 
+        this.renderProgressionChart(exerciseId, isDuration);
+
         modal.classList.add('active');
+    }
+
+    /**
+     * Render the per-exercise progression chart into the #exercise-history-chart
+     * placeholder. Inline SVG — no chart library, no network.
+     *
+     * For weighted exercises we plot top-set weight and estimated 1RM (Epley).
+     * For duration exercises we plot longest set per session.
+     */
+    renderProgressionChart(exerciseId, isDuration) {
+        const host = document.getElementById('exercise-history-chart');
+        if (!host) return;
+        host.innerHTML = '';
+
+        const points = AnalyticsService.getExerciseProgression(
+            exerciseId,
+            this.app.workoutSessions,
+            { limit: 12 },
+        );
+        if (points.length < 2) return; // need ≥2 points to draw a trend
+
+        const unit = this.app.settings.weightUnit;
+        const fmtDate = (dateStr) => parseLocalDate(dateStr).toLocaleDateString(undefined, {
+            month: 'short', day: 'numeric',
+        });
+
+        const series = isDuration
+            ? points.map(p => ({ x: p.date, y: p.maxDuration }))
+            : points.map(p => ({ x: p.date, y: p.maxWeight }));
+
+        const e1rmSeries = isDuration
+            ? null
+            : points.map(p => ({ x: p.date, y: Math.round(p.e1rm) }));
+
+        const yMin = Math.min(...series.map(p => p.y), e1rmSeries ? Math.min(...e1rmSeries.map(p => p.y)) : Infinity);
+        const yMax = Math.max(...series.map(p => p.y), e1rmSeries ? Math.max(...e1rmSeries.map(p => p.y)) : -Infinity);
+        const yRange = Math.max(yMax - yMin, 1);
+        const pad = yRange * 0.15;
+        const yLo = Math.max(0, yMin - pad);
+        const yHi = yMax + pad;
+
+        const W = 520;
+        const H = 160;
+        const mx = 32;
+        const my = 16;
+        const plotW = W - mx * 2;
+        const plotH = H - my * 2;
+
+        const xAt = (i) => mx + (series.length === 1 ? plotW / 2 : (i / (series.length - 1)) * plotW);
+        const yAt = (v) => my + plotH - ((v - yLo) / (yHi - yLo)) * plotH;
+
+        const toPath = (pts) => pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${xAt(i).toFixed(1)},${yAt(p.y).toFixed(1)}`).join(' ');
+
+        const fmtY = (v) => isDuration
+            ? `${Math.floor(v / 60)}:${String(Math.floor(v % 60)).padStart(2, '0')}`
+            : `${Math.round(v)} ${unit}`;
+
+        const firstLabel = fmtDate(series[0].x);
+        const lastLabel = fmtDate(series[series.length - 1].x);
+
+        const bestWeight = Math.max(...points.map(p => p.maxWeight));
+        const bestE1rm = Math.max(...points.map(p => p.e1rm));
+        const bestDuration = Math.max(...points.map(p => p.maxDuration));
+
+        const firstY = series[0].y;
+        const lastY = series[series.length - 1].y;
+        const trendDelta = lastY - firstY;
+        const trendPct = firstY > 0 ? Math.round((trendDelta / firstY) * 100) : 0;
+        const trendClass = trendDelta > 0 ? 'is-up' : trendDelta < 0 ? 'is-down' : '';
+        const trendSign = trendDelta > 0 ? '+' : '';
+
+        const primaryLabel = isDuration ? 'Longest set' : 'Top-set weight';
+        const caption = isDuration
+            ? `${points.length} sessions · ${trendSign}${fmtY(trendDelta)} vs ${points.length} ago`
+            : `${points.length} sessions · ${trendSign}${trendPct}% vs ${points.length} ago`;
+
+        const statTiles = isDuration
+            ? `<div class="stat-box"><span class="stat-label">Best</span><span class="stat-value">${fmtY(bestDuration)}</span></div>`
+            : `<div class="stat-box"><span class="stat-label">Top weight</span><span class="stat-value">${Math.round(bestWeight)} ${unit}</span></div>
+               <div class="stat-box"><span class="stat-label">Best e1RM</span><span class="stat-value">${Math.round(bestE1rm)} ${unit}</span></div>`;
+
+        const dotsPrimary = series.map((p, i) =>
+            `<circle cx="${xAt(i).toFixed(1)}" cy="${yAt(p.y).toFixed(1)}" r="3" class="progression-dot"><title>${fmtDate(p.x)}: ${fmtY(p.y)}</title></circle>`
+        ).join('');
+
+        const e1rmLine = e1rmSeries
+            ? `<path d="${toPath(e1rmSeries)}" class="progression-line progression-line-e1rm"/>`
+            : '';
+
+        const xTicks = `
+            <text x="${mx}" y="${H - 2}" class="progression-axis" text-anchor="start">${firstLabel}</text>
+            <text x="${W - mx}" y="${H - 2}" class="progression-axis" text-anchor="end">${lastLabel}</text>
+        `;
+        const yTicks = `
+            <text x="${mx - 6}" y="${yAt(yHi).toFixed(1) + 4}" class="progression-axis" text-anchor="end">${fmtY(yHi)}</text>
+            <text x="${mx - 6}" y="${yAt(yLo).toFixed(1) + 4}" class="progression-axis" text-anchor="end">${fmtY(yLo)}</text>
+        `;
+
+        host.innerHTML = `
+            <section class="exercise-detail-section exercise-progression">
+                <header class="exercise-detail-section-header">
+                    <h3><i class="fas fa-chart-line"></i> Progression</h3>
+                    <span class="exercise-detail-section-caption ${trendClass}">${caption}</span>
+                </header>
+                <div class="exercise-stats-summary">${statTiles}</div>
+                <div class="progression-chart-wrap">
+                    <svg viewBox="0 0 ${W} ${H}" class="progression-chart" role="img" aria-label="${primaryLabel} over the last ${points.length} sessions">
+                        <line x1="${mx}" y1="${my}" x2="${mx}" y2="${H - my}" class="progression-axis-line"/>
+                        <line x1="${mx}" y1="${H - my}" x2="${W - mx}" y2="${H - my}" class="progression-axis-line"/>
+                        ${e1rmLine}
+                        <path d="${toPath(series)}" class="progression-line progression-line-primary"/>
+                        ${dotsPrimary}
+                        ${xTicks}
+                        ${yTicks}
+                    </svg>
+                    <div class="progression-legend">
+                        <span class="progression-legend-item"><span class="dot dot-primary"></span>${primaryLabel}</span>
+                        ${e1rmSeries ? '<span class="progression-legend-item"><span class="dot dot-e1rm"></span>Est. 1RM</span>' : ''}
+                    </div>
+                </div>
+            </section>
+        `;
     }
 
     statBox(label, value) {

--- a/apps/gym-tracker/js/views/history-view.js
+++ b/apps/gym-tracker/js/views/history-view.js
@@ -117,7 +117,7 @@ class HistoryView {
                 <div class="empty-state">
                     <i class="fas fa-dumbbell"></i>
                     <p>No workout history yet</p>
-                    <button class="btn btn-primary" data-view="workout">Start Workout</button>
+                    <button type="button" class="btn btn-primary" data-home-action="start-workout">Start Workout</button>
                 </div>
             `;
             return;
@@ -212,6 +212,44 @@ class HistoryView {
 
         title.textContent = session.workoutDayName;
 
+        // Build the Additional Metrics block up front so it can render
+        // just below the summary (more prominent, no scrolling). Empty
+        // when the user didn't record any — keeps the modal tight.
+        let additionalMetricsHTML = '';
+        if (session.avgHeartRate || session.maxHeartRate || session.caloriesBurned) {
+            let metricsInner = '';
+            if (session.avgHeartRate) {
+                metricsInner += `
+                    <div class="detail-stat">
+                        <span class="label">Avg Heart Rate</span>
+                        <span class="value">${session.avgHeartRate} bpm</span>
+                    </div>
+                `;
+            }
+            if (session.maxHeartRate) {
+                metricsInner += `
+                    <div class="detail-stat">
+                        <span class="label">Max Heart Rate</span>
+                        <span class="value">${session.maxHeartRate} bpm</span>
+                    </div>
+                `;
+            }
+            if (session.caloriesBurned) {
+                metricsInner += `
+                    <div class="detail-stat">
+                        <span class="label">Calories Burned</span>
+                        <span class="value">${session.caloriesBurned} cal</span>
+                    </div>
+                `;
+            }
+            additionalMetricsHTML = `
+                <section class="workout-detail-metrics">
+                    <h3>Additional Metrics</h3>
+                    <div class="detail-stats">${metricsInner}</div>
+                </section>
+            `;
+        }
+
         // Build the detailed content
         let html = `
             <div class="workout-detail-summary">
@@ -235,6 +273,8 @@ class HistoryView {
                     </div>
                 </div>
             </div>
+
+            ${additionalMetricsHTML}
 
             <h3>Exercises</h3>
             <div class="workout-detail-exercises">
@@ -302,39 +342,6 @@ class HistoryView {
         });
 
         html += '</div>';
-
-        // Add additional metrics if available
-        if (session.avgHeartRate || session.maxHeartRate || session.caloriesBurned) {
-            html += `
-                <h3>Additional Metrics</h3>
-                <div class="detail-stats">
-            `;
-            if (session.avgHeartRate) {
-                html += `
-                    <div class="detail-stat">
-                        <span class="label">Avg Heart Rate</span>
-                        <span class="value">${session.avgHeartRate} bpm</span>
-                    </div>
-                `;
-            }
-            if (session.maxHeartRate) {
-                html += `
-                    <div class="detail-stat">
-                        <span class="label">Max Heart Rate</span>
-                        <span class="value">${session.maxHeartRate} bpm</span>
-                    </div>
-                `;
-            }
-            if (session.caloriesBurned) {
-                html += `
-                    <div class="detail-stat">
-                        <span class="label">Calories Burned</span>
-                        <span class="value">${session.caloriesBurned} cal</span>
-                    </div>
-                `;
-            }
-            html += '</div>';
-        }
 
         // Add notes if available
         if (session.notes) {

--- a/apps/gym-tracker/js/views/home-view.js
+++ b/apps/gym-tracker/js/views/home-view.js
@@ -4,9 +4,10 @@
  */
 import { app } from '../app.js';
 import { storageService } from '../services/StorageService.js';
-import { formatDate, formatWeight, showConfirmModal, showToast, formatSessionDateTime } from '../utils/helpers.js';
+import { formatDate, formatWeight, showConfirmModal, showToast, formatSessionDateTime, parseLocalDate } from '../utils/helpers.js';
 import { orderPrograms } from '../utils/program-order.js';
 import { renderPausedBannerHTML, wirePausedBannerActions } from './paused-banner.js';
+import { AnalyticsService } from '../services/AnalyticsService.js';
 
 class HomeView {
     constructor() {
@@ -29,9 +30,73 @@ class HomeView {
     render() {
         this.renderPausedWorkoutBanner();
         this.renderActiveProgram();
+        this.renderWeekSummary();
         this.renderRecentWorkouts();
         this.renderRecentAchievements();
         this.renderFab();
+    }
+
+    /**
+     * Render the "This Week" tile grid. Hidden entirely when the user has
+     * no sessions at all (nothing to aggregate → no signal worth showing).
+     */
+    renderWeekSummary() {
+        const section = document.getElementById('week-summary-section');
+        const grid = document.getElementById('week-summary-grid');
+        const caption = document.getElementById('week-summary-caption');
+        if (!section || !grid) return;
+
+        if (this.app.workoutSessions.length === 0) {
+            section.hidden = true;
+            return;
+        }
+        section.hidden = false;
+
+        const stats = AnalyticsService.getWeekStats(this.app.workoutSessions);
+        const unit = this.app.settings.weightUnit;
+
+        const fmtDelta = (n, { positiveBetter = true, suffix = '' } = {}) => {
+            if (n === 0) return '<span class="week-tile-delta">— vs last week</span>';
+            const isUp = n > 0;
+            const isGood = positiveBetter ? isUp : !isUp;
+            const klass = isGood ? 'is-up' : 'is-down';
+            const sign = isUp ? '+' : '';
+            return `<span class="week-tile-delta ${klass}">${sign}${n.toLocaleString()}${suffix} vs last week</span>`;
+        };
+
+        const hours = Math.floor(stats.durationMin / 60);
+        const mins = stats.durationMin % 60;
+        const durationValue = hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+
+        grid.innerHTML = `
+            <div class="week-tile">
+                <span class="week-tile-label">Workouts</span>
+                <span class="week-tile-value">${stats.workouts}</span>
+                ${fmtDelta(stats.workoutsDelta)}
+            </div>
+            <div class="week-tile">
+                <span class="week-tile-label">Volume</span>
+                <span class="week-tile-value">${Math.round(stats.volume).toLocaleString()} ${unit}</span>
+                ${fmtDelta(Math.round(stats.volumeDelta), { suffix: ` ${unit}` })}
+            </div>
+            <div class="week-tile">
+                <span class="week-tile-label">Time</span>
+                <span class="week-tile-value">${durationValue}</span>
+                <span class="week-tile-delta">this week</span>
+            </div>
+            <div class="week-tile">
+                <span class="week-tile-label">Streak</span>
+                <span class="week-tile-value">${stats.streak} ${stats.streak === 1 ? 'day' : 'days'}</span>
+                <span class="week-tile-delta">${stats.streak > 0 ? '🔥 keep it going' : 'log today to start'}</span>
+            </div>
+        `;
+
+        if (caption) {
+            // parseLocalDate avoids the UTC shift that `new Date("YYYY-MM-DD")`
+            // introduces, so the Monday we computed is the Monday we render.
+            const startDate = parseLocalDate(stats.weekStart);
+            caption.textContent = `Week of ${startDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`;
+        }
     }
 
     /**
@@ -152,7 +217,7 @@ class HomeView {
                 <div class="empty-state">
                     <i class="fas fa-folder-open"></i>
                     <p>No programs yet</p>
-                    <button class="btn btn-primary" data-view="programs">Create Program</button>
+                    <button type="button" class="btn btn-primary" data-home-action="create-program">Create Program</button>
                 </div>
             `;
             return;
@@ -215,7 +280,7 @@ class HomeView {
                 <div class="empty-state">
                     <i class="fas fa-dumbbell"></i>
                     <p>No workouts yet</p>
-                    <button class="btn btn-primary" data-view="workout">Start Workout</button>
+                    <button type="button" class="btn btn-primary" data-home-action="start-workout">Start Workout</button>
                 </div>
             `;
             return;

--- a/apps/gym-tracker/js/views/programs-view.js
+++ b/apps/gym-tracker/js/views/programs-view.js
@@ -53,6 +53,15 @@ class ProgramsView {
             });
         }
 
+        // Clear the program-name inline error as soon as the user starts
+        // fixing it — no need to re-submit just to dismiss stale validation.
+        const nameInput = document.getElementById('program-name');
+        if (nameInput) {
+            nameInput.addEventListener('input', () => {
+                if (nameInput.value.trim()) this.showNameError(false);
+            });
+        }
+
         // Add exercise to program button
         const addExerciseBtn = document.getElementById('add-exercise-to-program-btn');
         if (addExerciseBtn) {
@@ -265,6 +274,11 @@ class ProgramsView {
         const modal = document.getElementById('program-modal');
         const title = document.getElementById('program-modal-title');
 
+        // Always open with a clean validation state — stale errors from a
+        // prior session would be confusing before the user has done anything.
+        this.showNameError(false);
+        this.showExercisesError(false);
+
         if (programId) {
             this.currentProgram = this.app.getProgramById(programId);
             title.textContent = 'Edit Program';
@@ -293,6 +307,11 @@ class ProgramsView {
         if (countEl) countEl.textContent = totalExercises > 0
             ? `${totalExercises} ${totalExercises === 1 ? 'exercise' : 'exercises'}`
             : '';
+
+        // Adding an exercise clears the section error; removing the last one
+        // doesn't auto-warn (the user sees the empty state), they'll get the
+        // error on the next save attempt if it's still empty.
+        if (totalExercises > 0) this.showExercisesError(false);
 
         if (!this.currentProgram || totalExercises === 0) {
             container.innerHTML = `
@@ -438,8 +457,23 @@ class ProgramsView {
         const name = document.getElementById('program-name').value.trim();
         const description = document.getElementById('program-description').value.trim();
 
-        if (!name) {
-            showToast('Program name is required', 'error');
+        // Inline validation — name required, ≥1 exercise required. Show all
+        // failures at once so the user doesn't fix name → click → see "now
+        // add exercises" on a second round-trip.
+        const nameMissing = !name;
+        const noExercises = !this.currentProgram
+            || !this.currentProgram.exercises
+            || this.currentProgram.exercises.length === 0;
+
+        this.showNameError(nameMissing);
+        this.showExercisesError(noExercises);
+
+        if (nameMissing || noExercises) {
+            const firstInvalid = nameMissing
+                ? document.getElementById('program-name')
+                : document.getElementById('program-exercises-section');
+            firstInvalid?.focus?.();
+            firstInvalid?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
             this.isSaving = false;
             return;
         }
@@ -480,6 +514,57 @@ class ProgramsView {
             this.app.showView('programs');
         }
         this.openProgramModal(programId);
+    }
+
+    /**
+     * Open the Create Program modal from anywhere. Mirrors editProgram() but
+     * starts a fresh program. Used by the Dashboard empty-state CTAs so the
+     * user doesn't have to hunt for the Programs tab.
+     */
+    createProgramFromElsewhere() {
+        if (this.app.currentView !== 'programs') {
+            this.returnToView = this.app.currentView;
+            this.app.showView('programs');
+        }
+        this.openProgramModal();
+    }
+
+    /**
+     * Toggle the inline "name required" error on the Program Name field.
+     * Drives both the label message and the red-border state on the input
+     * (aria-invalid for screen readers, .is-invalid for styling).
+     */
+    showNameError(show) {
+        const input = document.getElementById('program-name');
+        const err = document.getElementById('program-name-error');
+        if (!input || !err) return;
+        if (show) {
+            input.classList.add('is-invalid');
+            input.setAttribute('aria-invalid', 'true');
+            err.hidden = false;
+        } else {
+            input.classList.remove('is-invalid');
+            input.setAttribute('aria-invalid', 'false');
+            err.hidden = true;
+        }
+    }
+
+    /**
+     * Toggle the inline "add at least one exercise" error banner on the
+     * Exercises section. Also outlines the container so the user can spot
+     * the problem without reading the message first.
+     */
+    showExercisesError(show) {
+        const section = document.getElementById('program-exercises-section');
+        const err = document.getElementById('program-exercises-error');
+        if (!section || !err) return;
+        if (show) {
+            section.classList.add('is-invalid-section');
+            err.hidden = false;
+        } else {
+            section.classList.remove('is-invalid-section');
+            err.hidden = true;
+        }
     }
 
     /**

--- a/apps/gym-tracker/js/views/settings-view.js
+++ b/apps/gym-tracker/js/views/settings-view.js
@@ -29,6 +29,16 @@ class SettingsView {
             weightUnitSelect.addEventListener('change', () => this.checkDirty());
         }
 
+        // Alert toggles (sound + vibration, independent)
+        const soundAlertsInput = document.getElementById('sound-alerts');
+        if (soundAlertsInput) {
+            soundAlertsInput.addEventListener('change', () => this.checkDirty());
+        }
+        const vibrationAlertsInput = document.getElementById('vibration-alerts');
+        if (vibrationAlertsInput) {
+            vibrationAlertsInput.addEventListener('change', () => this.checkDirty());
+        }
+
         // Settings form submission
         const settingsForm = document.getElementById('settings-form');
         if (settingsForm) {
@@ -81,6 +91,11 @@ class SettingsView {
         document.getElementById('weight-unit').value = settings.weightUnit;
         if (this.weightUnitDropdown) this.weightUnitDropdown.sync();
 
+        const soundAlertsInput = document.getElementById('sound-alerts');
+        if (soundAlertsInput) soundAlertsInput.checked = settings.soundAlerts !== false;
+        const vibrationAlertsInput = document.getElementById('vibration-alerts');
+        if (vibrationAlertsInput) vibrationAlertsInput.checked = settings.vibrationAlerts !== false;
+
         // Snapshot current values for dirty-state comparison
         this.savedSnapshot = this.snapshotForm();
         this.checkDirty();
@@ -90,6 +105,8 @@ class SettingsView {
     snapshotForm() {
         return {
             weightUnit: document.getElementById('weight-unit')?.value ?? '',
+            soundAlerts: document.getElementById('sound-alerts')?.checked ? '1' : '0',
+            vibrationAlerts: document.getElementById('vibration-alerts')?.checked ? '1' : '0',
         };
     }
 
@@ -107,6 +124,10 @@ class SettingsView {
         const settings = this.app.settings;
 
         settings.weightUnit = document.getElementById('weight-unit').value;
+        const soundAlertsInput = document.getElementById('sound-alerts');
+        if (soundAlertsInput) settings.soundAlerts = soundAlertsInput.checked;
+        const vibrationAlertsInput = document.getElementById('vibration-alerts');
+        if (vibrationAlertsInput) settings.vibrationAlerts = vibrationAlertsInput.checked;
 
         this.app.saveSettings();
         showToast('Settings saved successfully', 'success');

--- a/apps/gym-tracker/js/views/workout-view.js
+++ b/apps/gym-tracker/js/views/workout-view.js
@@ -8,9 +8,10 @@ import { WorkoutExercise } from '../models/WorkoutExercise.js';
 import { Set } from '../models/Set.js';
 import { timerService } from '../services/TimerService.js';
 import { storageService } from '../services/StorageService.js';
-import { showToast, showConfirmModal, formatMuscleGroup, vibrate } from '../utils/helpers.js';
+import { showToast, showConfirmModal, formatMuscleGroup, vibrate, playSound } from '../utils/helpers.js';
 import { renderPausedBannerHTML, wirePausedBannerActions } from './paused-banner.js';
 import { orderPrograms } from '../utils/program-order.js';
+import { AnalyticsService } from '../services/AnalyticsService.js';
 
 class WorkoutView {
     constructor() {
@@ -19,6 +20,13 @@ class WorkoutView {
         this.navigationBlocked = false;
         this.activeRestTimerId = null;
         this.restTimerDuration = 0;
+        // PRs logged during the current session — surfaced in the finish modal.
+        this.sessionPrCount = 0;
+        // Slot-keyed record of sets that triggered a PR this session so the
+        // row can render a gold outline even after rerender. Plain object
+        // on purpose: this module imports `Set` from models/Set.js, which
+        // shadows the built-in Set.
+        this.sessionPrSlots = {};
         this.init();
     }
 
@@ -320,7 +328,7 @@ class WorkoutView {
                 <div class="empty-state">
                     <i class="fas fa-folder-open"></i>
                     <p>No programs yet. Create a program first.</p>
-                    <button class="btn btn-primary" data-view="programs">Create Program</button>
+                    <button type="button" class="btn btn-primary" data-home-action="create-program">Create Program</button>
                 </div>
             `;
             container.innerHTML = html;
@@ -336,7 +344,7 @@ class WorkoutView {
                         <div class="program-header">
                             <h3>${program.name}</h3>
                         </div>
-                        <p>${program.description || 'No description'}</p>
+                        ${program.description && program.description.trim() ? `<p>${program.description}</p>` : ''}
                         <div class="program-stats">
                             <div class="stat">
                                 <i class="fas fa-dumbbell"></i>
@@ -390,6 +398,10 @@ class WorkoutView {
         });
 
         this.currentWorkoutSession.startWorkout();
+
+        // Reset PR counters for the new session.
+        this.sessionPrCount = 0;
+        this.sessionPrSlots = {};
 
         // Start workout timer
         timerService.startWorkoutTimer((elapsed) => {
@@ -450,9 +462,21 @@ class WorkoutView {
         const previousSets = this.getPreviousExerciseData(exercise.exerciseId) || [];
         const unit = this.app.settings.weightUnit;
 
+        // Build a slot → Set lookup so rendering is driven by each set's
+        // stable `slot` rather than its position in the dense array. This
+        // keeps Set 1 visually Set 1 even after un-toggling another row.
+        const setsBySlot = new Map();
+        exercise.sets.forEach((set, arrIdx) => {
+            const slot = set.slot != null ? set.slot : arrIdx;
+            setsBySlot.set(slot, set);
+        });
+        const maxCommittedSlot = setsBySlot.size === 0
+            ? -1
+            : Math.max(...setsBySlot.keys());
+
         const targetSets = Math.max(1, exercise.targetSets || 3);
         const completedCount = exercise.sets.length;
-        const totalRows = Math.max(targetSets, completedCount);
+        const totalRows = Math.max(targetSets, maxCommittedSlot + 1);
         const isComplete = completedCount >= targetSets && targetSets > 0;
 
         const muscle = formatMuscleGroup(exerciseData?.muscleGroup);
@@ -460,8 +484,9 @@ class WorkoutView {
 
         let rowsHTML = '';
         for (let i = 0; i < totalRows; i++) {
-            if (i < exercise.sets.length) {
-                rowsHTML += this.renderCompletedRow(exercise.sets[i], index, i, isDuration, unit);
+            const committed = setsBySlot.get(i);
+            if (committed) {
+                rowsHTML += this.renderCompletedRow(committed, index, i, isDuration, unit);
             } else {
                 // Default priority for a planned row:
                 //   1. sticky — values the user already typed/committed for this
@@ -632,10 +657,14 @@ class WorkoutView {
             `window.gymApp.viewControllers.workout.deleteSet(${exerciseIndex}, ${slot}, { silent: true })`,
             'Unmark set');
 
+        const pr = this.sessionPrSlots?.[`${exerciseIndex}:${slot}`];
+        const prBadge = pr
+            ? `<span class="pr-badge" aria-label="Personal record, ${this.formatPrDelta(pr, unit)}"><i class="fas fa-trophy" aria-hidden="true"></i> PR ${this.formatPrDelta(pr, unit)}</span>`
+            : '';
         return `
-            <li class="set-row set-row-complete" data-slot="${slot}">
+            <li class="set-row set-row-complete${pr ? ' set-row--pr' : ''}" data-slot="${slot}">
                 <span class="set-row-num">${setLabel}</span>
-                <div class="set-row-details">${details}</div>
+                <div class="set-row-details">${details}${prBadge}</div>
                 <div class="set-row-actions">
                     <button type="button" class="btn-set-action" title="Edit set" aria-label="Edit set"
                         onclick="window.gymApp.viewControllers.workout.editSet(${exerciseIndex}, ${slot})">
@@ -674,7 +703,14 @@ class WorkoutView {
         if (!this.currentWorkoutSession) return;
         const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
         if (!exercise) return;
-        const floor = Math.max(1, exercise.sets.length);
+        // Floor on the highest committed slot + 1 (or 1 if nothing committed),
+        // not on array length — a committed set in slot 4 with slot 0–3 still
+        // empty should still prevent shrinking below 5 visible rows.
+        const maxSlot = exercise.sets.reduce((m, s, i) => {
+            const slot = s.slot != null ? s.slot : i;
+            return slot > m ? slot : m;
+        }, -1);
+        const floor = Math.max(1, maxSlot + 1);
         if ((exercise.targetSets || 0) <= floor) return;
         exercise.targetSets -= 1;
         this.rerenderExercise(exerciseIndex);
@@ -754,7 +790,7 @@ class WorkoutView {
                 showToast('Please enter a duration', 'error');
                 return;
             }
-            set = new Set({ duration: totalSeconds, weight: 0, reps: 0, completed: true });
+            set = new Set({ duration: totalSeconds, weight: 0, reps: 0, completed: true, slot });
         } else {
             const weightInput = document.getElementById(`weight-${exerciseIndex}-${slot}`);
             const repsInput = document.getElementById(`reps-${exerciseIndex}-${slot}`);
@@ -764,30 +800,74 @@ class WorkoutView {
                 showToast('Please enter weight and reps', 'error');
                 return;
             }
-            set = new Set({ weight, reps, completed: true });
+            set = new Set({ weight, reps, completed: true, slot });
         }
 
-        // Insert into the exact slot index so the UI mirrors the user's plan.
-        // Sets beyond the current list length just append naturally.
-        if (slot >= exercise.sets.length) {
-            exercise.addSet(set);
-        } else {
-            exercise.sets.splice(slot, 0, set);
+        // Append to the dense array — visual position is driven by `set.slot`,
+        // not by array index, so order-of-insertion doesn't matter.
+        exercise.sets.push(set);
+
+        if (this.app.settings?.vibrationAlerts !== false) vibrate(30);
+
+        // PR check — compare the just-logged set against all prior sets of
+        // this exercise (from completed sessions, not the in-progress one).
+        const pr = AnalyticsService.isSetPR(exercise.exerciseId, set, this.app.workoutSessions);
+        if (pr) {
+            this.sessionPrCount += 1;
+            // Store the PR payload so the row can render a badge showing
+            // the improvement amount (e.g. "PR +40 lb").
+            this.sessionPrSlots[`${exerciseIndex}:${slot}`] = pr;
+            this.announcePR(pr);
         }
 
-        vibrate(30);
         this.rerenderExercise(exerciseIndex);
         this.startRest(exercise.restSeconds || 90);
     }
 
-    editSet(exerciseIndex, setIndex) {
+    /**
+     * Show a celebratory toast for the given PR + play the chime cue.
+     * Respects the user's restAlerts preference for audio (always vibrates
+     * and always shows the toast — the toast is the actual info).
+     */
+    announcePR(pr) {
+        const unit = this.app.settings.weightUnit;
+        const label = `🏆 New PR  ${this.formatPrDelta(pr, unit)}`;
+        showToast(label, 'success', 4000);
+        if (this.app.settings?.vibrationAlerts !== false) vibrate([40, 60, 120]);
+        if (this.app.settings?.soundAlerts !== false) playSound('pr');
+    }
+
+    /**
+     * Format the "+40 lb" / "+0:12" improvement string shown in the toast
+     * and the inline PR badge on the completed set row.
+     */
+    formatPrDelta(pr, unit) {
+        if (pr.kind === 'duration') {
+            const mins = Math.floor(pr.delta / 60);
+            const secs = pr.delta % 60;
+            return `+${mins}:${String(secs).padStart(2, '0')}`;
+        }
+        return `+${Math.round(pr.delta)} ${unit}`;
+    }
+
+    /**
+     * Find a committed set in the exercise by its stable slot. Legacy sets
+     * (no `slot` field yet) fall back to their array index so sessions
+     * saved before this change still behave correctly.
+     */
+    findSetBySlot(exercise, slot) {
+        if (!exercise || !exercise.sets) return null;
+        return exercise.sets.find((s, i) => (s.slot != null ? s.slot : i) === slot) || null;
+    }
+
+    editSet(exerciseIndex, slot) {
         if (!this.currentWorkoutSession) return;
 
         const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
-        const set = exercise?.sets[setIndex];
+        const set = this.findSetBySlot(exercise, slot);
         if (!set) return;
 
-        const setRowEl = document.querySelector(`#set-row-list-${exerciseIndex} .set-row[data-slot="${setIndex}"]`);
+        const setRowEl = document.querySelector(`#set-row-list-${exerciseIndex} .set-row[data-slot="${slot}"]`);
         if (!setRowEl) return;
 
         const isDuration = set.duration > 0;
@@ -799,20 +879,20 @@ class WorkoutView {
             editFormHTML = `
                 <div class="set-row-inputs">
                     <input type="number" class="set-edit-input duration-edit-min"
-                        id="edit-duration-min-${exerciseIndex}-${setIndex}" value="${mins}" min="0" placeholder="Min" aria-label="Minutes">
+                        id="edit-duration-min-${exerciseIndex}-${slot}" value="${mins}" min="0" placeholder="Min" aria-label="Minutes">
                     <span class="duration-separator">:</span>
                     <input type="number" class="set-edit-input duration-edit-sec"
-                        id="edit-duration-sec-${exerciseIndex}-${setIndex}" value="${secs}" min="0" max="59" placeholder="Sec" aria-label="Seconds">
+                        id="edit-duration-sec-${exerciseIndex}-${slot}" value="${secs}" min="0" max="59" placeholder="Sec" aria-label="Seconds">
                 </div>
             `;
         } else {
             editFormHTML = `
                 <div class="set-row-inputs">
                     <input type="number" class="set-edit-input"
-                        id="edit-weight-${exerciseIndex}-${setIndex}" value="${set.weight}" step="0.5" min="0" placeholder="Weight" aria-label="Weight">
+                        id="edit-weight-${exerciseIndex}-${slot}" value="${set.weight}" step="0.5" min="0" placeholder="Weight" aria-label="Weight">
                     <span class="set-row-x">×</span>
                     <input type="number" class="set-edit-input"
-                        id="edit-reps-${exerciseIndex}-${setIndex}" value="${set.reps}" min="1" placeholder="Reps" aria-label="Reps">
+                        id="edit-reps-${exerciseIndex}-${slot}" value="${set.reps}" min="1" placeholder="Reps" aria-label="Reps">
                 </div>
             `;
         }
@@ -820,11 +900,11 @@ class WorkoutView {
         setRowEl.classList.remove('set-row-complete');
         setRowEl.classList.add('set-row-editing');
         setRowEl.innerHTML = `
-            <span class="set-row-num">${setIndex + 1}</span>
+            <span class="set-row-num">${slot + 1}</span>
             ${editFormHTML}
             <div class="set-row-actions">
                 <button type="button" class="btn-set-action btn-set-save" title="Save" aria-label="Save set"
-                    onclick="window.gymApp.viewControllers.workout.saveSetEdit(${exerciseIndex}, ${setIndex})">
+                    onclick="window.gymApp.viewControllers.workout.saveSetEdit(${exerciseIndex}, ${slot})">
                     <i class="fas fa-check"></i>
                 </button>
                 <button type="button" class="btn-set-action btn-set-cancel" title="Cancel" aria-label="Cancel edit"
@@ -842,16 +922,17 @@ class WorkoutView {
         }
     }
 
-    saveSetEdit(exerciseIndex, setIndex) {
+    saveSetEdit(exerciseIndex, slot) {
         if (!this.currentWorkoutSession) return;
 
         const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
-        const set = exercise.sets[setIndex];
+        const set = this.findSetBySlot(exercise, slot);
+        if (!set) return;
         const isDuration = set.duration > 0;
 
         if (isDuration) {
-            const minInput = document.getElementById(`edit-duration-min-${exerciseIndex}-${setIndex}`);
-            const secInput = document.getElementById(`edit-duration-sec-${exerciseIndex}-${setIndex}`);
+            const minInput = document.getElementById(`edit-duration-min-${exerciseIndex}-${slot}`);
+            const secInput = document.getElementById(`edit-duration-sec-${exerciseIndex}-${slot}`);
             const minutes = parseInt(minInput.value, 10) || 0;
             const seconds = parseInt(secInput.value, 10) || 0;
             const totalSeconds = (minutes * 60) + seconds;
@@ -861,8 +942,8 @@ class WorkoutView {
             }
             set.duration = totalSeconds;
         } else {
-            const weightInput = document.getElementById(`edit-weight-${exerciseIndex}-${setIndex}`);
-            const repsInput = document.getElementById(`edit-reps-${exerciseIndex}-${setIndex}`);
+            const weightInput = document.getElementById(`edit-weight-${exerciseIndex}-${slot}`);
+            const repsInput = document.getElementById(`edit-reps-${exerciseIndex}-${slot}`);
             const weight = parseFloat(weightInput.value);
             const reps = parseInt(repsInput.value, 10);
             if (isNaN(weight) || weight < 0 || !reps) {
@@ -873,8 +954,55 @@ class WorkoutView {
             set.reps = reps;
         }
 
+        // Edits can turn a set into a PR, out of a PR, or just update the
+        // delta on an already-PR row. Re-evaluate once here instead of
+        // forcing users to toggle off/on.
+        const prTransition = this.reevaluatePrForSlot(exerciseIndex, slot, set, exercise);
+
         this.rerenderExercise(exerciseIndex);
-        showToast('Set updated', 'success');
+
+        // Suppress the generic "Set updated" toast when a new PR fires —
+        // the PR toast already communicates that the save happened, and
+        // stacking two toasts drowns the celebration.
+        if (prTransition !== 'new') {
+            showToast('Set updated', 'success');
+        }
+    }
+
+    /**
+     * Recompute PR status for a single set and update the session record
+     * accordingly. Called after any mutation to a committed set's values.
+     *
+     * Returns one of:
+     *   'new'    — wasn't a PR before, is now (fires toast + sound + haptic)
+     *   'update' — was a PR, still is; badge delta refreshed silently
+     *   'lost'   — was a PR, no longer is; badge + count cleared
+     *   'none'   — wasn't a PR, still isn't
+     *
+     * Never re-announces a PR that was already celebrated — "still PR" is
+     * silent so the user isn't chimed at every tiny edit.
+     */
+    reevaluatePrForSlot(exerciseIndex, slot, set, exercise) {
+        const prKey = `${exerciseIndex}:${slot}`;
+        const hadPr = !!(this.sessionPrSlots && this.sessionPrSlots[prKey]);
+        const pr = AnalyticsService.isSetPR(exercise.exerciseId, set, this.app.workoutSessions);
+
+        if (pr && !hadPr) {
+            this.sessionPrCount += 1;
+            this.sessionPrSlots[prKey] = pr;
+            this.announcePR(pr);
+            return 'new';
+        }
+        if (pr && hadPr) {
+            this.sessionPrSlots[prKey] = pr;
+            return 'update';
+        }
+        if (!pr && hadPr) {
+            delete this.sessionPrSlots[prKey];
+            this.sessionPrCount = Math.max(0, this.sessionPrCount - 1);
+            return 'lost';
+        }
+        return 'none';
     }
 
     cancelSetEdit(exerciseIndex) {
@@ -888,24 +1016,40 @@ class WorkoutView {
      * the knob animation already gives clear visual confirmation and a
      * duplicate toast would be noise.
      */
-    deleteSet(exerciseIndex, setIndex, opts = {}) {
+    deleteSet(exerciseIndex, slot, opts = {}) {
         if (!this.currentWorkoutSession) return;
         const exercise = this.currentWorkoutSession.exercises[exerciseIndex];
-        const removed = exercise?.sets[setIndex];
-        if (!exercise || !removed) return;
+        if (!exercise) return;
 
-        exercise.sets.splice(setIndex, 1);
+        // Find by stable slot (not by array index). Legacy sets without a
+        // `slot` field fall back to their array position so old sessions
+        // loaded mid-workout still un-toggle correctly.
+        const arrIdx = exercise.sets.findIndex((s, i) => {
+            const key = s.slot != null ? s.slot : i;
+            return key === slot;
+        });
+        if (arrIdx < 0) return;
+        const removed = exercise.sets[arrIdx];
 
-        // Preserve the deleted set's values so the user's typed edits don't
-        // vanish when a set is unchecked. The values stick to whatever slot
-        // becomes the first planned row after the deletion (the new tail).
-        // This makes toggle-off → re-check flows non-destructive.
+        exercise.sets.splice(arrIdx, 1);
+
+        // Preserve the deleted values on the same slot so the planned row
+        // repopulates with what the user just typed — toggle-off → re-check
+        // must be non-destructive.
         if (!exercise.stickyValues) exercise.stickyValues = {};
-        exercise.stickyValues[exercise.sets.length] = {
+        exercise.stickyValues[slot] = {
             weight: removed.weight,
             reps: removed.reps,
             duration: removed.duration,
         };
+
+        // If this set held a PR for the current session, clear the badge
+        // and decrement the counter. Re-committing recomputes PR fresh.
+        const prKey = `${exerciseIndex}:${slot}`;
+        if (this.sessionPrSlots && this.sessionPrSlots[prKey]) {
+            delete this.sessionPrSlots[prKey];
+            this.sessionPrCount = Math.max(0, this.sessionPrCount - 1);
+        }
 
         this.rerenderExercise(exerciseIndex);
         if (!opts.silent) showToast('Set deleted', 'info');
@@ -1005,7 +1149,9 @@ class WorkoutView {
         const valueEl = document.getElementById('rest-timer-value');
         if (bar) bar.classList.add('rest-timer-done');
         if (valueEl) valueEl.textContent = 'Done';
-        vibrate([120, 60, 120]);
+        // Audio and haptic cues — each opt-outable independently in Settings.
+        if (this.app.settings?.vibrationAlerts !== false) vibrate([120, 60, 120]);
+        if (this.app.settings?.soundAlerts !== false) playSound('rest-done');
         // Auto-hide after a short celebration so the bar doesn't linger.
         setTimeout(() => this.hideRestBar(), 2500);
     }
@@ -1041,6 +1187,13 @@ class WorkoutView {
             `${Math.round(this.currentWorkoutSession.totalVolume).toLocaleString()} ${unit}`;
         document.getElementById('summary-sets').textContent =
             this.currentWorkoutSession.totalSets;
+
+        const prsStat = document.getElementById('summary-prs-stat');
+        const prsValue = document.getElementById('summary-prs');
+        if (prsStat && prsValue) {
+            prsStat.hidden = this.sessionPrCount === 0;
+            prsValue.textContent = `🏆 ${this.sessionPrCount}`;
+        }
 
         document.getElementById('finish-workout-modal').classList.add('active');
     }


### PR DESCRIPTION
Two-app PR. Gym tracker is the bulk of the work — feature additions, accessibility pass, and a class of timezone bugs caught + fixed during testing. Football H2H gains a Player Stats tab with its own pure-function module and test suite.

## Gym Tracker — features

1. **Per-exercise progression chart** — inline SVG (no library) in the exercise-detail modal: top-set weight line + dashed e1RM line, plus stat tiles (Top weight / Best e1RM). Hides at <2 sessions; duration exercises show "Longest set" instead.
2. **This Week dashboard card** — Home view shows 4 tiles (Workouts / Volume / Time / Streak) with deltas vs last week. Hidden when there are no sessions yet.
3. **PR toast + audio + vibration** — volume-based rule (`weight × reps`). Toast `🏆 New PR  +X lb` on commit AND on edit; chime via Web Audio; haptic via `navigator.vibrate`. Inline gold PR badge on completed set rows, "PRs Hit" tile in the Finish Workout modal. Independent Sound + Vibration toggles in Settings → Alerts (legacy `restAlerts` value migrates to both).
4. **First-run onboarding** — 3-step welcome modal (Create Program → Add Exercises → Start Workout). Dismissible, gated on `gymTrackerOnboardingSeen`.
5. **Accessibility + focus pass** — visible `:focus-visible` rings, brighter `--text-muted` for WCAG AA, `role="dialog" aria-modal="true" aria-labelledby` on every modal, `aria-label="Close"` on every modal-close button.
6. **Empty-state CTAs route correctly** — Dashboard / History / Workout view "Create Program" / "Start Workout" buttons now actually do something via document-level `data-home-action` delegation. "Start Workout" with no programs opens Create Program (with a guiding toast) instead of dropping users on a blank view.
7. **Set slot stability** — `Set` model gains a stable `slot` field; renderer addresses rows by slot, not array index. Un-toggling Set 1 no longer visually shifts Set 2 down to its position.
8. **Program form validation** — blocks save without a name and without ≥1 exercise. Inline error under the Name field (red border + descriptive message), section-level banner inside the Exercises section. `novalidate` on the form so the native browser tooltip is suppressed. Errors clear on typing / adding an exercise.
9. **Exercise controls layout (Sets / Reps / Rest)** — restructured to a vertical label-over-pill block on desktop (3-col grid above 900px, 1-col stack 641–900px). Mobile pill layout preserved exactly as it was.
10. **Polish** — Workout view program cards drop the `"No description"` placeholder; Workout Details modal moves Additional Metrics directly below the summary so HR / calories aren't buried at the bottom.

## Gym Tracker — bug fixes (caught by the test harness, see below)

- **Timezone misattribution.** Session dates are persisted as local `YYYY-MM-DD` but were parsed with `new Date(str)`, which treats them as UTC midnight. Users west of UTC saw their Monday workouts attributed to last week, late-evening sessions misattributed across day/month/year boundaries, calendar months bleeding into adjacent months, etc. Fix: new `AnalyticsService.toLocalDate` + `toLocalDateKey` helpers, applied across `getWeekStats`, `getCalendarData`, `getMonthSummary`, `getCurrentStreak`, `getVolumeTrends`, `getWorkoutFrequency`, `getLastWorkoutData`, `getProgressDates`, `getExerciseProgression`. Same fix applied to `AchievementService` (daily/weekly/monthly counters). `calculateAchievementProgress.workout-streak` now delegates to `getCurrentStreak` so it can't drift.
- **`vibrate()` reference safety.** Guarded `typeof navigator !== 'undefined'` so importing `helpers.js` is safe in non-browser contexts.

## Football H2H

- **Player Stats tab** — new tab in the Stats overlay with a per-player comparison table.
- **`playerStats.js`** — new module exposing pure functions for per-player derived stats (computePlayerStats, computeMatchStreaks, matchResultsInOrder, etc.). Dual-target: works as a browser `<script>` and as a CommonJS module so `node --test` can require it directly with no build step.
- **Tests** — `apps/football-h2h/tests/playerStats.test.js`, 93 assertions, run via `node --test apps/football-h2h/tests/`.

## Test coverage

A throwaway test harness was set up at `/tmp/shevato-test/` (not in repo) covering the gym tracker's logic + DOM-side rendering:

- **Logic suite** — 98 tests, pure Node ESM. Covers Epley 1RM, `isSetPR` volume rule (incl. heavier-but-lower-volume → not a PR), `getExerciseProgression`, `startOfIsoWeek`, `getWeekStats`, `getCurrentStreak`, `Set.slot` round-trip, `Settings` migration of `restAlerts` → `soundAlerts`/`vibrationAlerts`, `playSound` / `vibrate` no-op safety, `getProgressDates`, plus dedicated coverage for every TZ-fixed function.
- **DOM suite** — 35 tests via jsdom. Covers SVG progression chart structure (path, dots, legend, hides at <2 points, duration-only mode), This Week tile rendering with correct counts + deltas + local Monday caption, program form validation (`showNameError` / `showExercisesError` toggle classes/aria correctly, empty save blocked), `data-home-action` click delegation routing.
- **Football suite** — 93 tests via `node --test`, all in-repo at `apps/football-h2h/tests/`.

**All 226 tests pass.** The TZ bug suite was originally what caught the `getWeekStats` issue — it failed on a CDT machine (UTC-5) until fixed.

## Manual test plan — gym tracker

Open `apps/gym-tracker/index.html`. Reset state with `debugGymTracker.clearLocalStorage()` in the console.

### Onboarding (#4)
1. Reload after clearing → 3-step welcome modal appears.
2. Click \"Go\" on step 1 → modal closes, view switches to Programs.
3. Reload → modal does **not** reappear. Clear storage again, click Skip Tour → same: closes and stays dismissed.

### Empty-state CTAs (#6)
1. After clearing + skipping onboarding, you're on Home with empty states.
2. Click **Create Program** → modal opens, save → returns to Dashboard.
3. Clear + reload → click **Start Workout** on Dashboard → toast \"Create a program first…\" + Create Program modal opens.
4. History tab while empty → click **Start Workout** → same fallback.
5. With programs: \"Start Workout\" routes to the Workout view's program picker.

### Per-exercise progression chart (#1)
1. Create a program with one exercise. Complete 2+ sessions with different values (e.g. 40×5, 45×5; then 50×5, 55×5).
2. Exercises tab → filter \"With History\" → tap card → modal opens.
3. Verify Progression section: SVG, top-weight line + dashed e1RM line, dots tooltip on hover, caption \"2 sessions · +XX%\".
4. Single session → no chart rendered.
5. Duration exercise (Plank): chart shows Longest set, no e1RM line.

### This Week dashboard (#2)
1. With ≥1 session, Home → \"This Week\" appears between active program and recent workouts.
2. 4 tiles with values + deltas. Caption: \"Week of Mon DD\" — must be the **current Monday's date** (TZ-correct).
3. Clear sessions → section hides entirely.

### PR toast + alerts (#3)
1. Pre-seed a session with `55 × 8` on an exercise.
2. New workout, log `55 × 8` → no PR.
3. Log `60 × 8` (vol 480 vs prior best 440) → toast `🏆 New PR  +40 lb`, chime, vibration, gold badge inline.
4. Log `70 × 6` (vol 420) → **no PR** (heavier weight, lower volume).
5. Edit `55 × 8` → `60 × 9` → PR fires immediately on save (no toggle).
6. Edit `60 × 9` → `65 × 9` → badge delta updates silently.
7. Settings → Alerts: Sound off → log a PR → only vibrates. Vibration off, Sound on → only chimes.
8. Export data → JSON contains `soundAlerts` + `vibrationAlerts`.

### Set slot stability (#7)
1. 3-set exercise. Commit Set 1 (60×7), Set 2 (65×6), leave Set 3 planned.
2. Un-toggle Set 1 → Set 1 becomes planned with **inputs prefilled to 60×7**, Set 2 stays as 65×6, Set 3 still planned. Header reads \"1 / 3 sets\".
3. If Set 2 had a PR badge, un-toggling Set 1 must NOT transfer the badge.

### Program form validation (#8)
1. Create Program → click Save with empty name and no exercises → both errors appear simultaneously, no native browser tooltip, focus on Name field.
2. Type a name → name error clears immediately. Add an exercise → exercises banner clears. Save succeeds.

### Layout (#9)
1. Wide desktop (>900 px): Sets/Reps/Rest in 3 columns, vertical block per control (label above pill).
2. 641–900 px: stacks to 1 column, full card width per pill.
3. <641 px: original horizontal pill layout.
4. Long REST values (`10:30`): nothing escapes the card.

### Workout details modal
1. Open a workout that has heart rate / calories → Additional Metrics renders directly below the summary stats. Notes still at the bottom.
2. Open a workout with no metrics → Additional Metrics section absent (no empty heading).

### Accessibility (#5)
1. Tab through Create Program form → purple focus ring on every input/select/textarea/button.
2. Console: \`document.querySelector('.modal.active').getAttribute('role')\` → `\"dialog\"`.
3. Muted helper text reads clearly (was borderline before).

### TZ regression check
1. With sessions in different timezones, verify week/month/calendar bucketing matches the local-calendar date (this is the bug class fixed in this PR).

## Manual test plan — football H2H

1. Open `apps/football-h2h/index.html`.
2. Stats overlay → switch to **Player Stats** tab → comparison table populates with both players' stats.
3. Cells reflect score data (no roster, scores-per-game only).
4. Run `node --test apps/football-h2h/tests/` → 93/93 pass.

## Files

20 changed (15 gym, 4 football, 1 css):
- Gym: `app.js`, `models/{Set,Settings}.js`, `services/{Achievement,Analytics,Storage}Service.js`, `utils/helpers.js`, `views/{exercises,history,home,programs,settings,workout}-view.js`, `index.html`, `css/gym-tracker.css`
- Football: `index.html`, `js/{football-h2h,playerStats}.js`, `tests/playerStats.test.js`, `css/football-h2h.css`

## Out of scope / follow-ups

- The gym tracker has no in-repo test runner. The harness used here lives at `/tmp/shevato-test/`. A future PR could land it under `apps/gym-tracker/tests/` and run via the same `node --test` pattern football is using now.