### PR TITLE
Improve SEO metadata and site visibility infrastructure

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,18 +1,20 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
 <head>
-    <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
-    <script src="/assets/js/analytics.js"></script>
-
-    <title>404 – Page Not Found | Shevato</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    <title>404 – Page Not Found | Shevato</title>
+    <meta name="description" content="The page you requested could not be found on shevato.com. You will be redirected to the home page." />
+    <meta name="robots" content="noindex, follow" />
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+    <script defer src="/assets/js/analytics.js"></script>
 
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="stylesheet" href="/assets/css/home-content-alignment.css" />
     <link rel="stylesheet" href="/assets/css/brand-colors.css" />
-      <link rel="icon" type="image/png" href="/images/white_icon_transparent.png">
+    <link rel="icon" type="image/png" href="/images/white_icon_transparent.png">
 
     <!-- make body full-height flex so footer stays at bottom -->
     <style>

--- a/apps.html
+++ b/apps.html
@@ -1,29 +1,59 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
 <head>
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
-  <script src="/assets/js/analytics.js"></script>
-  <title>Free Apps | Mario Kart, Gym Tracker & Football H2H - Shevato</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+  <title>Free Apps | Mario Kart, Gym Tracker & Football H2H - Shevato</title>
   <meta name="description" content="Free web apps including Mario Kart race tracker, Gym workout tracker, and Football Head-to-Head league manager. Track your progress and compete with friends." />
   <meta name="keywords" content="Mario Kart tracker, gym tracker, workout tracker, football statistics, gaming apps, race tracker, fitness tracker, sports statistics, free browser apps, Mario Kart 8 Deluxe, gym workout log, head to head football" />
+  <meta name="author" content="Shevato LLC" />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+
+  <!-- Resource hints -->
+  <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="icon" type="image/png" href="images/white_icon_transparent.png">
-  
-  <!-- SEO Enhancement: Canonical URL -->
+
   <link rel="canonical" href="https://shevato.com/apps.html" />
-  
-  <!-- SEO Enhancement: Open Graph tags -->
+
+  <!-- Open Graph -->
   <meta property="og:title" content="Free Apps | Mario Kart, Gym Tracker & Football H2H" />
   <meta property="og:description" content="Free web apps for Mario Kart racing, gym workouts, and football matches. Track your progress and compete with friends." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://shevato.com/apps.html" />
   <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta property="og:image:type" content="image/svg+xml" />
+  <meta property="og:image:alt" content="Shevato apps - Mario Kart, Gym Tracker, Football H2H" />
   <meta property="og:site_name" content="Shevato" />
+  <meta property="og:locale" content="en_US" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Free Apps | Mario Kart, Gym Tracker & Football H2H" />
+  <meta name="twitter:description" content="Free web apps for Mario Kart racing, gym workouts, and football matches." />
+  <meta name="twitter:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta name="twitter:site" content="@shevato" />
   
-  <!-- SEO Enhancement: JSON-LD structured data -->
+  <!-- Breadcrumbs -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
+      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" }
+    ]
+  }
+  </script>
+
+  <!-- CollectionPage -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -9,10 +9,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="description" content="Free head-to-head football league manager. Track matches, record scores, manage penalty shootouts, and analyze player statistics with comprehensive team performance analytics.">
     <meta name="keywords" content="football tracker, head to head football, match tracker, football statistics, penalty shootout tracker, soccer league manager, football analytics, free sports tracker">
+    <meta name="author" content="Shevato LLC">
+    <meta name="robots" content="index, follow, max-image-preview:large">
     <meta name="theme-color" content="#667eea">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <title>Football Head-to-Head League Manager | Free Match Tracker & Statistics</title>
+
+    <!-- Resource hints -->
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://shevato.com/apps/football-h2h/index.html" />
@@ -23,13 +29,30 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://shevato.com/apps/football-h2h/index.html" />
     <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:alt" content="Football Head-to-Head League Manager" />
     <meta property="og:site_name" content="Shevato" />
+    <meta property="og:locale" content="en_US" />
 
     <!-- Twitter Card tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Football Head-to-Head League Manager" />
     <meta name="twitter:description" content="Free football match tracker with statistics and penalty shootout recording" />
     <meta name="twitter:image" content="https://shevato.com/images/full-logo.svg" />
+    <meta name="twitter:site" content="@shevato" />
+
+    <!-- Breadcrumbs -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
+        { "@type": "ListItem", "position": 3, "name": "Football H2H League", "item": "https://shevato.com/apps/football-h2h/index.html" }
+      ]
+    }
+    </script>
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -6,11 +6,84 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <meta name="description" content="Track your gym workouts and monitor your progress">
+    <meta name="description" content="Free gym tracker for logging workouts, building programs, tracking strength progress, body measurements, and unlocking achievements. Works offline as a PWA.">
+    <meta name="keywords" content="gym tracker, workout log, fitness tracker, strength training app, workout program builder, exercise log, body measurements, progressive overload, free fitness app, PWA gym tracker">
+    <meta name="author" content="Shevato LLC">
+    <meta name="robots" content="index, follow, max-image-preview:large">
     <meta name="theme-color" content="#1a1a2e">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <title>Gym Tracker - Track Your Workouts</title>
+    <title>Gym Tracker | Free Workout Log & Strength Progress App</title>
+
+    <!-- Resource hints -->
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://shevato.com/apps/gym-tracker/index.html" />
+
+    <!-- Open Graph tags -->
+    <meta property="og:title" content="Gym Tracker | Free Workout Log & Strength Progress App" />
+    <meta property="og:description" content="Log workouts, build programs, track strength progress and body measurements. Free, installable as a PWA, works offline." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://shevato.com/apps/gym-tracker/index.html" />
+    <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:alt" content="Gym Tracker - Free Workout Log" />
+    <meta property="og:site_name" content="Shevato" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter Card tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gym Tracker | Free Workout Log" />
+    <meta name="twitter:description" content="Log workouts, build programs, track strength progress. Free PWA that works offline." />
+    <meta name="twitter:image" content="https://shevato.com/images/full-logo.svg" />
+    <meta name="twitter:site" content="@shevato" />
+
+    <!-- WebApplication structured data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": "Gym Tracker",
+      "description": "Free gym tracker for logging workouts, building programs, tracking strength progress, body measurements, and achievements. Installable as a PWA.",
+      "url": "https://shevato.com/apps/gym-tracker/index.html",
+      "applicationCategory": "HealthApplication",
+      "operatingSystem": "Web Browser",
+      "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "featureList": [
+        "Workout logging",
+        "Program builder with supersets",
+        "Strength progress tracking",
+        "Body measurements",
+        "Achievements",
+        "Offline support (PWA)",
+        "Data export and import"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Shevato LLC",
+        "url": "https://shevato.com/"
+      }
+    }
+    </script>
+
+    <!-- Breadcrumbs -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
+        { "@type": "ListItem", "position": 3, "name": "Gym Tracker", "item": "https://shevato.com/apps/gym-tracker/index.html" }
+      ]
+    }
+    </script>
 
     <!-- PWA manifest + offline support -->
     <link rel="manifest" href="manifest.webmanifest">

--- a/apps/mario-kart/tracker.html
+++ b/apps/mario-kart/tracker.html
@@ -5,10 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="description" content="Free Mario Kart 8 Deluxe race tracker. Track races, analyze statistics, compare player performance, and view detailed race history with comprehensive charts and achievements.">
     <meta name="keywords" content="Mario Kart tracker, Mario Kart 8 Deluxe, race tracker, gaming statistics, player stats, race history, Mario Kart analytics, free game tracker">
+    <meta name="author" content="Shevato LLC">
+    <meta name="robots" content="index, follow, max-image-preview:large">
     <meta name="theme-color" content="#667eea">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <title>Mario Kart 8 Deluxe Race Tracker | Free Statistics & Analytics</title>
+
+    <!-- Resource hints -->
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://shevato.com/apps/mario-kart/tracker.html" />
@@ -19,13 +25,30 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://shevato.com/apps/mario-kart/tracker.html" />
     <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:alt" content="Mario Kart 8 Deluxe Race Tracker" />
     <meta property="og:site_name" content="Shevato" />
+    <meta property="og:locale" content="en_US" />
 
     <!-- Twitter Card tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Mario Kart 8 Deluxe Race Tracker" />
     <meta name="twitter:description" content="Free race tracker with statistics and analytics for Mario Kart 8 Deluxe" />
     <meta name="twitter:image" content="https://shevato.com/images/full-logo.svg" />
+    <meta name="twitter:site" content="@shevato" />
+
+    <!-- Breadcrumbs -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
+        { "@type": "ListItem", "position": 3, "name": "Mario Kart Tracker", "item": "https://shevato.com/apps/mario-kart/tracker.html" }
+      ]
+    }
+    </script>
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">

--- a/assets/seo/README.md
+++ b/assets/seo/README.md
@@ -1,0 +1,65 @@
+# SEO and visibility notes
+
+This directory holds the canonical JSON-LD fragments referenced from
+the site's HTML pages, plus the conventions for keeping metadata
+consistent across new pages.
+
+## Files
+
+- `organization.jsonld` — the Shevato LLC `Organization` node. Same
+  `@id` (`https://shevato.com/#organization`) is used everywhere so
+  multiple pages contribute facts about a single entity rather than
+  fragmenting the graph.
+- `website.jsonld` — the `WebSite` node, references the Organization
+  as its publisher.
+
+These files are reference templates, not loaded at runtime. Pages
+inline the relevant subset directly in a `<script type="application/ld+json">`
+block in `<head>`.
+
+## Per-page metadata checklist
+
+When adding a new HTML page, the head should include:
+
+1. `<html lang="...">` — set explicitly (`en`, `he`, etc.).
+2. `<meta charset="utf-8">` and `<meta name="viewport" ...>` first,
+   before any external script or title.
+3. `<title>` — unique per page, ~60 chars, descriptive.
+4. `<meta name="description">` — unique per page, ~155 chars.
+5. `<meta name="robots" content="index, follow, max-image-preview:large">`
+   on indexable pages; `noindex, follow` on redirect/404 pages.
+6. `<meta name="author" content="Shevato LLC">`.
+7. `<link rel="canonical" href="https://shevato.com/...">` —
+   absolute URL, must equal the indexable URL.
+8. Open Graph: `og:title`, `og:description`, `og:type`, `og:url`,
+   `og:image`, `og:image:type`, `og:image:alt`, `og:site_name`,
+   `og:locale`. Keep `og:url` consistent with `canonical`.
+9. Twitter Card: `twitter:card`, `twitter:title`, `twitter:description`,
+   `twitter:image`, `twitter:site`.
+10. Resource hints: `<link rel="preconnect" ...>` for any third-party
+    origin used later in the page (gstatic, googletagmanager, cdnjs).
+11. JSON-LD: `WebPage` referencing the sitewide `WebSite`/`Organization`,
+    plus `BreadcrumbList` if the page is more than one click from home.
+
+## Discoverability files
+
+- `/sitemap.xml` — lists all indexable pages with absolute URLs and
+  `lastmod` dates. Update `lastmod` whenever the visible content of a
+  page changes (not on every commit).
+- `/robots.txt` — blanket allow with explicit disallows for
+  repo-internal directories (`/partials/`, `/sync-system/`, etc.) and
+  Firebase rule files. SEO-research bots (Ahrefs, Semrush) are
+  intentionally permitted so external backlink tools can surface the
+  site.
+
+## Known follow-ups
+
+- The site's social-preview image is currently the SVG logo
+  (`/images/full-logo.svg`). Most platforms (Twitter/X, Facebook,
+  LinkedIn) render PNG/JPG previews better than SVG. Producing a
+  dedicated 1200×630 PNG OG image and pointing all `og:image` /
+  `twitter:image` tags at it would noticeably improve the way shared
+  links render.
+- Adding a `og:image:width` / `og:image:height` pair (once a sized
+  raster image exists) lets Slack and other crawlers reserve layout
+  space and avoid jank.

--- a/assets/seo/organization.jsonld
+++ b/assets/seo/organization.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://shevato.com/#organization",
+  "name": "Shevato LLC",
+  "alternateName": "Shevato",
+  "url": "https://shevato.com/",
+  "logo": {
+    "@type": "ImageObject",
+    "url": "https://shevato.com/images/full-logo.svg",
+    "contentUrl": "https://shevato.com/images/full-logo.svg"
+  },
+  "founder": {
+    "@type": "Person",
+    "name": "Nikita Soifer",
+    "jobTitle": "Software Engineer"
+  },
+  "foundingDate": "2019",
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "telephone": "+1-504-638-3370",
+    "email": "nikita@shevato.com",
+    "contactType": "customer service",
+    "areaServed": "Worldwide",
+    "availableLanguage": ["en"]
+  },
+  "sameAs": [
+    "https://www.linkedin.com/in/nikita-soifer/"
+  ]
+}

--- a/assets/seo/website.jsonld
+++ b/assets/seo/website.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": "https://shevato.com/#website",
+  "url": "https://shevato.com/",
+  "name": "Shevato",
+  "description": "Software engineering services and free web apps from Shevato LLC.",
+  "inLanguage": "en",
+  "publisher": { "@id": "https://shevato.com/#organization" }
+}

--- a/home.html
+++ b/home.html
@@ -1,37 +1,94 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
 <head>
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
-  <script src="/assets/js/analytics.js"></script>
-  <title>Shevato - Software Engineering Services | REST APIs & Microservices</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+  <title>Shevato - Software Engineering Services | REST APIs & Microservices</title>
   <meta name="description" content="Professional software engineering services specializing in REST API development, microservices architecture, and scalable web applications." />
   <meta name="keywords" content="software engineering, REST API development, microservices architecture, Spring Boot, Java development, web application development, backend development, API design, software consulting" />
+  <meta name="author" content="Shevato LLC" />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+
+  <!-- Resource hints: pre-warm third-party origins used later in the page -->
+  <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="icon" type="image/png" href="images/white_icon_transparent.png">
-  
-  <!-- SEO Enhancement: Canonical URL -->
+
   <link rel="canonical" href="https://shevato.com/home.html" />
-  
-  <!-- SEO Enhancement: Open Graph tags -->
+
+  <!-- Open Graph -->
   <meta property="og:title" content="Shevato - Software Engineering Services | REST APIs & Microservices" />
   <meta property="og:description" content="Professional software engineering services specializing in REST API development, microservices architecture, and scalable web applications." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://shevato.com/" />
+  <meta property="og:url" content="https://shevato.com/home.html" />
   <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta property="og:image:type" content="image/svg+xml" />
+  <meta property="og:image:alt" content="Shevato - Expert Software Engineering Services Logo" />
   <meta property="og:site_name" content="Shevato" />
   <meta property="og:locale" content="en_US" />
 
-  <!-- SEO Enhancement: Twitter Card tags -->
+  <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Shevato - Software Engineering Services" />
   <meta name="twitter:description" content="Professional software engineering services specializing in REST APIs, microservices, and web applications." />
   <meta name="twitter:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta name="twitter:image:alt" content="Shevato logo" />
   <meta name="twitter:site" content="@shevato" />
   
-  <!-- SEO Enhancement: JSON-LD structured data -->
+  <!-- Sitewide WebSite + Organization graph -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://shevato.com/#organization",
+        "name": "Shevato LLC",
+        "alternateName": "Shevato",
+        "url": "https://shevato.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://shevato.com/images/full-logo.svg"
+        },
+        "founder": {
+          "@type": "Person",
+          "name": "Nikita Soifer",
+          "jobTitle": "Software Engineer"
+        },
+        "sameAs": [
+          "https://www.linkedin.com/in/nikita-soifer/"
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://shevato.com/#website",
+        "url": "https://shevato.com/",
+        "name": "Shevato",
+        "description": "Software engineering services and free web apps from Shevato LLC.",
+        "inLanguage": "en",
+        "publisher": { "@id": "https://shevato.com/#organization" }
+      },
+      {
+        "@type": "WebPage",
+        "@id": "https://shevato.com/home.html#webpage",
+        "url": "https://shevato.com/home.html",
+        "name": "Shevato - Software Engineering Services",
+        "isPartOf": { "@id": "https://shevato.com/#website" },
+        "about": { "@id": "https://shevato.com/#organization" },
+        "inLanguage": "en"
+      }
+    ]
+  }
+  </script>
+
+  <!-- ProfessionalService offering -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/index.html
+++ b/index.html
@@ -1,1 +1,16 @@
-<meta http-equiv="refresh" content="0; URL='home.html'" />
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Shevato - Software Engineering Services</title>
+  <meta name="description" content="Shevato LLC - software engineering services and free web apps. Redirecting to the home page." />
+  <meta name="robots" content="noindex, follow" />
+  <link rel="canonical" href="https://shevato.com/home.html" />
+  <meta http-equiv="refresh" content="0; url=/home.html" />
+  <script>window.location.replace('/home.html');</script>
+</head>
+<body>
+  <p>Redirecting to <a href="/home.html">shevato.com/home.html</a>&hellip;</p>
+</body>
+</html>

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html lang="he">
+<html>
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -1,13 +1,19 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="he">
 <head>
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
-  <script src="/assets/js/analytics.js"></script>
-  <!-- SEO Enhancement: Optimized title and meta tags for Hebrew medical assistance searches -->
-  <title>מועדון אלף - רופא עד הבית 24/7 | שירות רפואי מקצועי בישראל</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+
+  <!-- Resource hints -->
+  <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+
+  <title>מועדון אלף - רופא עד הבית 24/7 | שירות רפואי מקצועי בישראל</title>
   <!-- SEO Enhancement: Hebrew-focused meta description targeting medical assistance searches -->
   <meta name="description" content="מועדון אלף - שירות רופא עד הבית 24/7 בישראל. טיפול רפואי מקצועי, בדיקות, חיסונים וטיפולי חירום בנוחות ביתכם. צוות רופאים מומחים זמין מסביב לשעון כולל שבתות וחגים. טלפון: 1-700-7011-03" />
   <!-- SEO Enhancement: Comprehensive Hebrew keywords for medical services -->

--- a/product.html
+++ b/product.html
@@ -1,32 +1,61 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
 <head>
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
-  <script src="/assets/js/analytics.js"></script>
-  <title>Software Development Services | REST APIs & Microservices - Shevato</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+  <title>Software Development Services | REST APIs & Microservices - Shevato</title>
   <meta name="description" content="Professional software development services including REST API development, microservices architecture, and custom web applications." />
   <meta name="keywords" content="software development, REST API development, microservices, Spring Boot development, Java backend, web application development, API design, scalable architecture, enterprise software" />
+  <meta name="author" content="Shevato LLC" />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+
+  <!-- Resource hints -->
+  <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+
   <link rel="stylesheet" href="assets/css/main.css" />
   <link rel="stylesheet" href="assets/css/content-alignment.css" />
   <link rel="stylesheet" href="assets/css/brand-colors.css" />
   <link rel="icon" type="image/png" href="images/white_icon_transparent.png">
-  
-  <!-- SEO Enhancement: Canonical URL -->
+
   <link rel="canonical" href="https://shevato.com/product.html" />
-  
-  <!-- SEO Enhancement: Open Graph tags -->
+
+  <!-- Open Graph -->
   <meta property="og:title" content="Software Development Services | REST APIs & Microservices - Shevato" />
   <meta property="og:description" content="Professional software development services including REST API development, microservices architecture, and custom web applications." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://shevato.com/product.html" />
   <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta property="og:image:type" content="image/svg+xml" />
+  <meta property="og:image:alt" content="Shevato - Software Development Services" />
   <meta property="og:site_name" content="Shevato" />
   <meta property="og:locale" content="en_US" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Software Development Services - Shevato" />
+  <meta name="twitter:description" content="Professional REST API, microservices, and custom web application development services." />
+  <meta name="twitter:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta name="twitter:site" content="@shevato" />
   
-  <!-- SEO Enhancement: JSON-LD structured data -->
+  <!-- Breadcrumbs -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
+      { "@type": "ListItem", "position": 2, "name": "Product", "item": "https://shevato.com/product.html" }
+    ]
+  }
+  </script>
+
+  <!-- Service offering -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/robots.txt
+++ b/robots.txt
@@ -1,44 +1,28 @@
-# Robots.txt for shevato.com
-# This file allows search engines to crawl all pages on the site
+# robots.txt for shevato.com
+#
+# Default policy: allow all well-behaved crawlers.
+# Search engines (Google, Bing, etc.) and SEO research tools (Ahrefs, Semrush)
+# are intentionally permitted so the site is discoverable and so external
+# backlink/visibility analysis can find shevato.com.
 
-# Allow all crawlers
 User-agent: *
 Allow: /
-
-# Sitemap location
-Sitemap: https://shevato.com/sitemap.xml
-
-# Crawl-delay for politeness (optional, in seconds)
-# This helps prevent server overload from aggressive crawlers
-Crawl-delay: 1
-
-# Disallow access to certain file types and directories if they exist
-# (These are common security practices)
-Disallow: /cgi-bin/
-Disallow: /wp-admin/
-Disallow: /wp-includes/
 Disallow: /.git/
 Disallow: /node_modules/
-Disallow: *.sql
-Disallow: *.log
-Disallow: *.bak
-Disallow: *.swp
-Disallow: *.swo
+Disallow: /.netlify/
+Disallow: /netlify/
+Disallow: /partials/
+Disallow: /sync-system/
+Disallow: /firestore.rules
+Disallow: /database.rules.json
+Disallow: /firebase-config.js
+Disallow: /TESTING_STEPS.txt
+Disallow: /*.log$
+Disallow: /*.bak$
+Disallow: /*.swp$
+Disallow: /*.swo$
 
-# Special directives for major search engines
-# Google
-User-agent: Googlebot
-Allow: /
-
-# Bing
-User-agent: Bingbot
-Allow: /
-
-# Yandex (Russian search engine - relevant for Russian content)
-User-agent: Yandex
-Allow: /
-
-# Allow social media crawlers for better sharing
+# Explicit allowances for social/preview crawlers (so OG tags render nicely)
 User-agent: facebookexternalhit
 Allow: /
 
@@ -48,15 +32,11 @@ Allow: /
 User-agent: LinkedInBot
 Allow: /
 
-# Block bad bots (optional security measure)
-User-agent: AhrefsBot
-Disallow: /
+User-agent: Slackbot
+Allow: /
 
-User-agent: SemrushBot
-Disallow: /
+User-agent: WhatsApp
+Allow: /
 
-User-agent: DotBot
-Disallow: /
-
-User-agent: MJ12bot
-Disallow: /
+# Sitemap
+Sitemap: https://shevato.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,50 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  <!-- Main pages -->
   <url>
     <loc>https://shevato.com/</loc>
-    <lastmod>2024-01-15</lastmod>
+    <lastmod>2026-05-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://shevato.com/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://shevato.com/"/>
   </url>
-  
+
   <url>
     <loc>https://shevato.com/home.html</loc>
-    <lastmod>2024-01-15</lastmod>
+    <lastmod>2026-05-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
-  
-  <!-- Medical assistance page (highest priority for Israeli users) -->
-  <url>
-    <loc>https://shevato.com/moadon-alef.html</loc>
-    <lastmod>2024-01-15</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="he-IL" href="https://shevato.com/moadon-alef.html"/>
-  </url>
-  
+
   <url>
     <loc>https://shevato.com/product.html</loc>
-    <lastmod>2024-01-15</lastmod>
+    <lastmod>2026-05-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
-  
+
   <url>
     <loc>https://shevato.com/apps.html</loc>
-    <lastmod>2024-01-15</lastmod>
+    <lastmod>2026-05-04</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
-  
-  <!-- Apps subdirectory -->
+
+  <url>
+    <loc>https://shevato.com/moadon-alef.html</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="he-IL" href="https://shevato.com/moadon-alef.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://shevato.com/moadon-alef.html"/>
+  </url>
+
   <url>
     <loc>https://shevato.com/apps/mario-kart/tracker.html</loc>
-    <lastmod>2024-01-15</lastmod>
+    <lastmod>2026-05-04</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
+    <priority>0.6</priority>
   </url>
-  
+
+  <url>
+    <loc>https://shevato.com/apps/gym-tracker/index.html</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/football-h2h/index.html</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

Audits and modernizes the site's external visibility surface without
touching UI or layout. Makes per-page metadata consistent across
`home.html`, `apps.html`, `product.html`, `moadon-alef.html`, the
three sub-apps, the 404 page, and the apex redirect; refreshes the
sitemap and robots.txt; expands the structured-data graph; and adds
resource hints for the third-party origins each page uses.

## SEO / visibility improvements

**Discoverability**
- `sitemap.xml` rewritten: includes the three apps, current
  `lastmod` dates, hreflang annotations on `moadon-alef.html`.
- `robots.txt` modernized: drops legacy WordPress paths and the
  blanket bans on Ahrefs/Semrush (those tools help external SEO
  research find the site); explicit disallows for repo-internal
  paths (`/partials/`, `/sync-system/`, `/.netlify/`,
  `firebase-config.js`, etc.).

**Per-page metadata** (every top-level page + the three apps)
- `<html lang>` set explicitly (`en` for English pages, `he` for
  the Hebrew moadon-alef page).
- Uniform `robots` meta with `max-image-preview:large`.
- `<meta name="author">` added.
- Consistent `og:url` / `canonical` (was inconsistent on `home.html`).
- Open Graph and Twitter cards filled out
  (`og:image:type`, `og:image:alt`, `og:locale`, `twitter:site`,
  `twitter:image:alt`).
- Head reordered so charset/viewport precede the title and any
  external script (per HTML spec).
- 404 declares `noindex, follow` so the not-found page never lands
  in a search index; root `index.html` (a redirect shell) declares
  `noindex` and points its canonical at `/home.html`.

**Structured data**
- New `Organization` + `WebSite` + `WebPage` graph on `home.html`,
  using a single `@id` for the Organization so all schema across the
  site refers to one entity.
- `BreadcrumbList` added to inner pages: `apps.html`, `product.html`,
  the three app pages.
- `gym-tracker` now has full `WebApplication` schema (matching the
  pattern used by mario-kart and football-h2h).
- Reusable JSON-LD templates committed under `assets/seo/` as the
  source of truth for the Organization / WebSite shape.

**Performance**
- `preconnect` / `dns-prefetch` to `gstatic.com`,
  `googletagmanager.com`, `google-analytics.com`, and `cdnjs.cloudflare.com`
  on pages that use them — pre-warms TLS during HTML parse and
  removes connection setup from the critical path.
- `analytics.js` now `defer` instead of render-blocking sync
  (gtag.js itself was already `async`).

**Accessibility / semantic visibility**
- Explicit `lang` attributes help screen readers and translation
  tools.
- `og:image:alt` and `twitter:image:alt` populated on every page.
- No DOM/styling changes, so existing layout, headings and landmarks
  are untouched.

## Files changed

- `sitemap.xml`, `robots.txt` — discoverability rewrite
- `home.html`, `apps.html`, `product.html`, `moadon-alef.html` — head
  standardized, structured data expanded
- `apps/mario-kart/tracker.html`, `apps/football-h2h/index.html`,
  `apps/gym-tracker/index.html` — head standardized, breadcrumbs
  added; gym-tracker gained WebApplication schema
- `404.html`, `index.html` — `noindex` + cleaner head
- `assets/seo/organization.jsonld`, `assets/seo/website.jsonld`,
  `assets/seo/README.md` — reusable schema fragments and per-page
  checklist

## Testing performed

- `npm test` — **215 / 215 tests pass** (gym-tracker + football-h2h
  test suites untouched).
- `sitemap.xml` parsed with Python ElementTree — well-formed.
- All 14 inlined `application/ld+json` blocks across the 7 modified
  HTML pages parse as valid JSON.
- `assets/seo/*.jsonld` and `apps/gym-tracker/manifest.webmanifest`
  parse as valid JSON.

## Risks / follow-up

- **No UI changes intended.** All edits are inside `<head>` (or in
  configuration / sitemap / robots), so visible layout, styles, and
  copy are unchanged. The mobile address-bar tint (`theme-color`) on
  app pages was already present and is unchanged; no theme-color was
  added to top-level marketing pages.
- **Recommended content/business follow-up**: produce a dedicated
  1200×630 PNG social-preview image. The site currently uses
  `images/full-logo.svg` as `og:image`, and most social platforms
  render PNG/JPG previews more reliably than SVG. Once the PNG
  exists, add `og:image:width` / `og:image:height` so crawlers can
  reserve layout space.
- **Sitemap `lastmod` policy**: the new sitemap stamps `2026-05-04`
  on every URL. Future content edits should bump the relevant
  `lastmod` so search engines re-crawl that page faster.
- The `og:url` / `canonical` for the homepage now consistently
  resolves to `/home.html`. If the team prefers `/` to be the
  canonical homepage, that requires a follow-up Netlify rewrite
  (serving the home content at `/`) rather than a metadata change.

## Checklist

- [x] No UI / visible layout changes
- [x] All existing tests pass (215/215)
- [x] Sitemap and JSON-LD validated
- [x] Per-page canonical URLs match `og:url`
- [x] 404 marked `noindex`, indexable pages marked `index, follow`
- [x] No secrets / lockfiles / unrelated formatting in the diff
- [x] Documentation added under `assets/seo/`