### PR TITLE
Site quality modernization: a11y, perf, security, CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,25 @@ jobs:
             node --check "$f"
           done
 
+      # Site-wide classic scripts that ship to the browser. These are
+      # plain (non-module) JS, so node --check parses them as scripts.
+      # jQuery and the vendored *.min.js bundles are skipped — they're
+      # already minified and Node's parser chokes on some legacy syntax
+      # they use.
+      - name: Syntax check (site scripts)
+        run: |
+          set -e
+          for f in assets/js/analytics.js \
+                   assets/js/apex-redirect.js \
+                   assets/js/global-icons.js \
+                   assets/js/language-switcher.js \
+                   assets/js/main.js \
+                   assets/js/pagination.js \
+                   assets/js/passive-events-fix.js \
+                   assets/js/redirect-countdown.js \
+                   assets/js/year-updater.js; do
+            node --check "$f"
+          done
+
       - name: Run tests
         run: npm test

--- a/404.html
+++ b/404.html
@@ -36,7 +36,7 @@
     <div class="inner">
         <header class="special">
             <h2>
-                <img src="/images/full-logo.svg" alt="Shevato – Expert Software Engineering Services Logo" fetchpriority="high" decoding="async">
+                <img src="/images/full-logo.svg" alt="Shevato – Expert Software Engineering Services Logo" width="250" height="219" fetchpriority="high" decoding="async">
             </h2>
             <p>Sorry, we couldn’t find that page.</p>
             <p>

--- a/404.html
+++ b/404.html
@@ -51,21 +51,7 @@
 <div data-include="footer"></div>
 
 <!-- countdown + redirect script -->
-<script>
-    (function() {
-      var sec = 5;
-      var el  = document.getElementById('redirect-countdown');
-      var timer = setInterval(function() {
-        sec--;
-        if (sec <= 0) {
-          clearInterval(timer);
-          window.location.href = '/';
-        } else {
-          el.textContent = sec;
-        }
-      }, 1000);
-    })();
-</script>
+<script defer src="/assets/js/redirect-countdown.js"></script>
 
 <!-- Scripts: deferred so they run in document order after parse, before DOMContentLoaded. -->
 <script defer src="/assets/js/passive-events-fix.js"></script>

--- a/404.html
+++ b/404.html
@@ -32,7 +32,7 @@
 <!-- header include -->
 <div data-include="header"></div>
 
-<section class="wrapper wrapper-inherit-padding">
+<main id="main-content" class="wrapper wrapper-inherit-padding">
     <div class="inner">
         <header class="special">
             <h2>
@@ -41,11 +41,11 @@
             <p>Sorry, we couldn’t find that page.</p>
             <p>
                 Redirecting to our <a href="/">home page</a> in
-                <strong><span id="redirect-countdown">5</span> seconds</strong>.
+                <strong><span id="redirect-countdown" aria-live="polite" aria-atomic="true">5</span> seconds</strong>.
             </p>
         </header>
     </div>
-</section>
+</main>
 
 <!-- footer include -->
 <div data-include="footer"></div>

--- a/apps.html
+++ b/apps.html
@@ -117,7 +117,7 @@
 </head>
 <body class="is-preload">
   <div data-include="header"></div>
-  <section class="wrapper wrapper-inherit-padding">
+  <main id="main-content" class="wrapper wrapper-inherit-padding">
     <div class="inner">
       <header class="special">
         <h2>Apps</h2>
@@ -162,7 +162,7 @@
         </section>
       </div>
     </div>
-  </section>
+  </main>
   <div data-include="footer"></div>
   <!-- Scripts: deferred so they run in document order after parse, before DOMContentLoaded. -->
   <script defer src="assets/js/passive-events-fix.js"></script>

--- a/assets/js/apex-redirect.js
+++ b/assets/js/apex-redirect.js
@@ -1,0 +1,9 @@
+/**
+ * Apex (/) → /home.html client-side redirect.
+ * The <meta http-equiv="refresh"> on /index.html is the no-JS fallback;
+ * this script just runs sooner so the URL change feels instant.
+ *
+ * Lives outside index.html so the page works under a strict CSP without
+ * needing 'unsafe-inline' or a per-deploy script-hash.
+ */
+window.location.replace('/home.html');

--- a/assets/js/language-switcher.js
+++ b/assets/js/language-switcher.js
@@ -1,8 +1,9 @@
 /**
  * Moadon Alef language switcher.
- * Buttons declare their language via `data-lang`. The function avoids
- * the non-standard global `event` object so it works under strict mode
- * and in non-Chromium browsers.
+ * Buttons declare their language via `data-lang`. Click handling is
+ * delegated from `document` so the buttons need no inline `onclick`
+ * attribute, which keeps the markup compatible with strict CSPs that
+ * disallow inline event handlers.
  *
  * Note: the page's `<html>` element intentionally has NO `lang` attribute.
  * A CSS rule (`[lang]:not([lang="en"]) { display: none; }`) hides per-element
@@ -12,8 +13,12 @@
  */
 
 const LANG_BLOCK_ELEMENTS = new Set(['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'DIV', 'SECTION']);
+const SUPPORTED_LANGS = new Set(['en', 'ru', 'he']);
+const STORAGE_KEY = 'moadon-alef-lang';
 
 function switchLanguage(lang) {
+  if (!SUPPORTED_LANGS.has(lang)) return;
+
   document.querySelectorAll('.lang-btn').forEach(btn => {
     const isActive = btn.dataset.lang === lang;
     btn.classList.toggle('active', isActive);
@@ -34,18 +39,28 @@ function switchLanguage(lang) {
   document.body.dir = (lang === 'he') ? 'rtl' : 'ltr';
 
   try {
-    localStorage.setItem('moadon-alef-lang', lang);
+    localStorage.setItem(STORAGE_KEY, lang);
   } catch (_) {
     // localStorage may be unavailable in private browsing modes.
   }
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+// Expose for legacy callers / tests.
+window.switchLanguage = switchLanguage;
+
+document.addEventListener('DOMContentLoaded', () => {
   let savedLang = 'en';
   try {
-    savedLang = localStorage.getItem('moadon-alef-lang') || 'en';
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && SUPPORTED_LANGS.has(stored)) savedLang = stored;
   } catch (_) {
     // ignore
   }
   switchLanguage(savedLang);
+
+  document.addEventListener('click', (event) => {
+    const btn = event.target.closest('.lang-btn');
+    if (!btn || !btn.dataset.lang) return;
+    switchLanguage(btn.dataset.lang);
+  });
 });

--- a/assets/js/redirect-countdown.js
+++ b/assets/js/redirect-countdown.js
@@ -1,0 +1,26 @@
+/**
+ * 404 page redirect countdown.
+ * Decrements the visible seconds value until it hits zero, then sends
+ * the user to "/". The element already carries aria-live="polite", so
+ * screen readers announce each tick.
+ *
+ * Pulled out of 404.html so the page works under a strict CSP without
+ * needing 'unsafe-inline' or a per-deploy script-hash.
+ */
+(function () {
+  var el = document.getElementById('redirect-countdown');
+  if (!el) return;
+
+  var seconds = parseInt(el.textContent, 10);
+  if (!Number.isFinite(seconds) || seconds <= 0) seconds = 5;
+
+  var timer = setInterval(function () {
+    seconds -= 1;
+    if (seconds <= 0) {
+      clearInterval(timer);
+      window.location.href = '/';
+    } else {
+      el.textContent = String(seconds);
+    }
+  }, 1000);
+})();

--- a/home.html
+++ b/home.html
@@ -172,7 +172,7 @@
     <div class="inner">
       <header class="special">
         <h2>
-          <img src="images/full-logo.svg" alt="Shevato - Expert Software Engineering Services Logo" fetchpriority="high" decoding="async">
+          <img src="images/full-logo.svg" alt="Shevato - Expert Software Engineering Services Logo" width="250" height="219" fetchpriority="high" decoding="async">
         </h2>
         <p>Welcome to Shevato, your trusted partner for expert software engineering services, specializing in REST APIs, Microservices, and Web applications.</p>
       </header>

--- a/home.html
+++ b/home.html
@@ -168,7 +168,7 @@
 </head>
 <body class="is-preload">
   <div data-include="header"></div>
-  <section class="wrapper wrapper-inherit-padding">
+  <main id="main-content" class="wrapper wrapper-inherit-padding">
     <div class="inner">
       <header class="special">
         <h2>
@@ -233,7 +233,7 @@
         </section>
       </div>
     </div>
-  </section>
+  </main>
   <div data-include="footer"></div>
   <!-- Scripts: deferred so they run in document order after parse, before DOMContentLoaded.
        Order is preserved: jquery → util → firebase compat → main.js. The module script

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="robots" content="noindex, follow" />
   <link rel="canonical" href="https://shevato.com/home.html" />
   <meta http-equiv="refresh" content="0; url=/home.html" />
-  <script>window.location.replace('/home.html');</script>
+  <script src="/assets/js/apex-redirect.js"></script>
 </head>
 <body>
   <p>Redirecting to <a href="/home.html">shevato.com/home.html</a>&hellip;</p>

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -183,13 +183,13 @@
         <p lang="he">ברוכים הבאים למועדון אלף, השותף המהימן שלכם לשירותי רפואה מקצועיים עד הבית. אנו מביאים טיפול רפואי איכותי ישירות לביתכם עם צוות רופאים מנוסים הזמינים 24/7.</p>
         
         <div class="lang-switcher" role="group" aria-label="Language selection">
-          <button type="button" class="lang-btn active" onclick="switchLanguage('en')" data-lang="en" aria-pressed="true">
+          <button type="button" class="lang-btn active" data-lang="en" aria-pressed="true">
             🇬🇧 English
           </button>
-          <button type="button" class="lang-btn" onclick="switchLanguage('ru')" data-lang="ru" aria-pressed="false">
+          <button type="button" class="lang-btn" data-lang="ru" aria-pressed="false">
             🇷🇺 Русский
           </button>
-          <button type="button" class="lang-btn" onclick="switchLanguage('he')" data-lang="he" aria-pressed="false">
+          <button type="button" class="lang-btn" data-lang="he" aria-pressed="false">
             🇮🇱 עברית
           </button>
         </div>

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -152,7 +152,7 @@
 </head>
 <body class="is-preload">
   <!-- Main -->
-  <section class="wrapper wrapper-inherit-padding">
+  <main id="main-content" class="wrapper wrapper-inherit-padding">
     <div class="inner">
       <div class="contact-header">
         <!-- SEO Enhancement: Main H1 heading for page topic -->
@@ -287,8 +287,8 @@
         </section>
       </div>
     </div>
-  </section>
-  
+  </main>
+
   <!-- Use Moadon Alef specific footer -->
   <div data-include="footer-moadon-alef"></div>
   

--- a/product.html
+++ b/product.html
@@ -122,7 +122,7 @@
 </head>
 <body class="is-preload">
   <div data-include="header"></div>
-  <section id="main" class="wrapper">
+  <main id="main" class="wrapper">
     <div class="inner">
       <div class="content">
         <header>
@@ -151,7 +151,7 @@
         <p>Every business is unique, and so are its software needs. We offer custom software development services to create solutions that are perfectly aligned with your business processes and objectives.</p>
       </div>
     </div>
-  </section>
+  </main>
   <div data-include="footer"></div>
   <!-- Scripts: deferred so they run in document order after parse, before DOMContentLoaded. -->
   <script defer src="assets/js/passive-events-fix.js"></script>


### PR DESCRIPTION
## Overview

End-to-end quality pass on the static site. Nine commits land on this branch, all preserving the current visual design while moving the codebase toward modern best practices: every top-level page now has proper landmark semantics, every `<script>` ships from a URL (clearing the way to a strict CSP), the LCP element on the home and 404 pages no longer contributes to CLS, the Moadon Alef language switcher is rebuilt around `addEventListener`, and CI now syntax-checks every first-party site script.

The first four commits (already on the branch before this push) addressed pinch-zoom, `aria-label` on icon-only links, deferred non-critical scripts, and per-page metadata standardization. This push adds the next five focused commits.

## What changed and why each change matters

### `feat(a11y): wrap primary content in <main> landmark` — `dae7ae0`
Every top-level page (`home.html`, `apps.html`, `product.html`, `moadon-alef.html`, `404.html`) now exposes exactly one `<main>` landmark. Inner `<section>` blocks (highlight cards, content cards) are unchanged. The `.wrapper` class is element-agnostic in the SCSS, so layout is byte-identical. Also added `aria-live="polite" aria-atomic="true"` to the 404 redirect-countdown span so screen readers announce it tick down.
**Why it matters:** WCAG 2.4.1 / 1.3.1 — landmark navigation lets assistive-tech users jump straight to primary content. Aligns with `.claude_rules` "Semantic HTML first" and "Skip link present" goals.

### `refactor(security): externalize inline redirect scripts` — `6c7d4e2`
Pulled the apex `index.html` redirect and the `404.html` countdown into `assets/js/apex-redirect.js` and `assets/js/redirect-countdown.js`. The countdown rewrite also bails cleanly if the target span is missing and parses its initial value from the DOM.
**Why it matters:** these were the last two `<script>` blocks on the site shipping inline source. With them gone, the `Content-Security-Policy-Report-Only` directive in `netlify.toml` can be graduated to a real `Content-Security-Policy` without `'unsafe-inline'`.

### `refactor(moadon): bind language switcher via addEventListener` — `7b0881d`
Removed the inline `onclick="switchLanguage('…')"` attributes from the three `.lang-btn` buttons in `moadon-alef.html` and bound a single delegated `click` listener in `language-switcher.js` that reads `data-lang`. Also hardened `switchLanguage` and the saved-preference loader against unknown values.
**Why it matters:** clears the last block of inline event handlers — the page now works under a CSP that disallows DOM-0 handlers. Defensive validation also keeps the page out of a "neither EN/RU/HE" stuck state if `localStorage` is corrupted.

### `perf(lcp): reserve space for the hero logo to prevent CLS` — `3de75e8`
Set `width="250" height="219"` on the hero `<img src="…/full-logo.svg">` on `home.html` and `404.html`. The SVG already ships at exactly that natural size; the new attributes just give the layout engine the aspect ratio before the SVG decodes.
**Why it matters:** removes a small but real CLS contribution from the LCP element. No CSS rule constrains this image, so visual sizing is unchanged.

### `ci: syntax-check the site-wide classic scripts on every PR` — `f777084`
`.github/workflows/test.yml` now runs `node --check` over every first-party file in `assets/js/` (the new redirect helpers included). Vendored minified bundles stay excluded.
**Why it matters:** catches typos and unbalanced braces in code-review before they ship. ~1s extra runtime on a passing PR.

## Preserving the current UI

All visual surfaces are byte-identical at default zoom on default viewport widths:
- `.wrapper` is a class — switching the carrier element from `<section>` to `<main>` doesn't change CSS targeting.
- The two new external scripts are loaded with `src` only; no behavior change.
- The `data-lang` / `aria-pressed` markers on the Moadon Alef buttons (added in the previous commit) are sufficient for click delegation.
- `header.special h2 img` has no constraining CSS rule, so adding intrinsic dimensions reserves correct space without resizing the rendered logo.

No screenshots — there are no visible UI changes.

## Testing performed

- `npm test` → **215 / 215 passing**
- `node --check` → exits 0 on every first-party JS file under `assets/js/`
- `grep -n "<script>" *.html partials/*.html` → 0 inline matches
- `grep -n "onclick=" *.html partials/*.html` → 0 inline matches
- `grep -n "<main\\b" *.html` → one match per top-level page
- HTML view-source on each touched page confirms the expected attributes (`width`/`height` on hero img, `aria-live` on countdown span, `<main id="…">` landmarks, `<script src="…">` references, no `onclick`).
- Manual browser smoke (planned, see `TESTING_STEPS.txt` Changes 7–11): apex redirect snaps to `/home.html`, 404 countdown still navigates to `/` after 5 seconds and is announced via screen reader, Moadon Alef language switching still persists via `localStorage` and rejects unknown values, hero logo on home/404 paints without a layout shift.

## Notes for reviewers

- `TESTING_STEPS.txt` is gitignored — local-only working notes; updated to cover Changes 7–11 in the same format as the prior changes.
- The `id="main"` on `product.html` is preserved on purpose: `assets/sass/layout/_main.scss` styles `#main .content` with rounded corners and a shadow. The other pages (which had no id) get `id="main-content"` so a future skip-link target is stable.
- This PR is intentionally CSP-graduation-ready but does NOT flip the CSP directive — that should be a follow-up after a deploy where the report-only logs confirm zero violations.