### PR TITLE
Site quality polish: redirect resilience, dead-code trim, private-browsing guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ shevato/
 ├── partials/                         # Header/footer fragments loaded by main.js
 │   ├── header.html
 │   ├── footer.html
-│   ├── footer-moadon-alef.html       # Tri-lingual footer for Moadon Alef
-│   └── firebase-auth-scripts.html
+│   └── footer-moadon-alef.html       # Tri-lingual footer for Moadon Alef
 │
 ├── images/                           # Logos, backgrounds, and app artwork
 ├── netlify/, .netlify/               # Netlify functions and build artifacts

--- a/assets/js/apex-redirect.js
+++ b/assets/js/apex-redirect.js
@@ -3,7 +3,12 @@
  * The <meta http-equiv="refresh"> on /index.html is the no-JS fallback;
  * this script just runs sooner so the URL change feels instant.
  *
+ * Preserves the query string and hash so campaign parameters
+ * (`?utm_source=...`) and deep links (`#section`) survive the redirect —
+ * dropping them would silently break analytics attribution and any
+ * inbound link that targets an in-page anchor.
+ *
  * Lives outside index.html so the page works under a strict CSP without
  * needing 'unsafe-inline' or a per-deploy script-hash.
  */
-window.location.replace('/home.html');
+window.location.replace('/home.html' + window.location.search + window.location.hash);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -904,7 +904,11 @@
      */
     showAuthModal() {
       if (!this.isAuthAvailable()) {
-        alert('Firebase authentication is not configured yet. Please see setup-firebase.md for instructions.');
+        // Misconfiguration is a developer-facing problem, not a user-facing
+        // one. The Sign In button is hidden via updateHeaderUI when auth
+        // isn't initialized, so this branch should only fire when something
+        // unusual has gone wrong — log instead of blocking the page.
+        console.warn('Firebase authentication is not configured; cannot open sign-in modal.');
         return;
       }
 

--- a/assets/js/pagination.js
+++ b/assets/js/pagination.js
@@ -23,10 +23,16 @@ const GlobalPaginationManager = (function() {
             config: finalConfig
         };
         
-        // Load saved page size from localStorage
-        const savedPageSize = localStorage.getItem(finalConfig.localStorageKey);
-        if (savedPageSize && finalConfig.pageSizeOptions.includes(parseInt(savedPageSize))) {
-            instances[instanceId].rowsPerPage = parseInt(savedPageSize);
+        // Load saved page size from localStorage. Wrapped because some
+        // private-browsing contexts throw on access — failing here would
+        // abort the whole instance and leave the table unpaginated.
+        try {
+            const savedPageSize = localStorage.getItem(finalConfig.localStorageKey);
+            if (savedPageSize && finalConfig.pageSizeOptions.includes(parseInt(savedPageSize))) {
+                instances[instanceId].rowsPerPage = parseInt(savedPageSize);
+            }
+        } catch (_) {
+            // localStorage unavailable — fall back to the default rowsPerPage.
         }
         
         return instanceId;
@@ -96,7 +102,12 @@ const GlobalPaginationManager = (function() {
         if (instance.config.pageSizeOptions.includes(newSize)) {
             instance.rowsPerPage = newSize;
             instance.currentPage = 1; // Reset to first page
-            localStorage.setItem(instance.config.localStorageKey, newSize);
+            try {
+                localStorage.setItem(instance.config.localStorageKey, newSize);
+            } catch (_) {
+                // localStorage unavailable (e.g. private browsing) —
+                // the new size still applies for this session.
+            }
             if (instance.config.updateCallback) {
                 instance.config.updateCallback();
             }

--- a/assets/js/redirect-countdown.js
+++ b/assets/js/redirect-countdown.js
@@ -1,8 +1,12 @@
 /**
  * 404 page redirect countdown.
  * Decrements the visible seconds value until it hits zero, then sends
- * the user to "/". The element already carries aria-live="polite", so
- * screen readers announce each tick.
+ * the user to "/home.html". The element already carries
+ * aria-live="polite", so screen readers announce each tick.
+ *
+ * Targets /home.html directly rather than "/" — the apex would otherwise
+ * trigger a second hop through the apex-redirect script, costing one
+ * extra navigation and history entry.
  *
  * Pulled out of 404.html so the page works under a strict CSP without
  * needing 'unsafe-inline' or a per-deploy script-hash.
@@ -18,7 +22,7 @@
     seconds -= 1;
     if (seconds <= 0) {
       clearInterval(timer);
-      window.location.href = '/';
+      window.location.href = '/home.html';
     } else {
       el.textContent = String(seconds);
     }

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -2,14 +2,8 @@
 // Uses modular v9+ SDK via CDN imports
 
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
-import { 
-  getFirestore, 
-  connectFirestoreEmulator 
-} from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
-import { 
-  getDatabase, 
-  connectDatabaseEmulator 
-} from "https://www.gstatic.com/firebasejs/10.7.1/firebase-database.js";
+import { getFirestore } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+import { getDatabase } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-database.js";
 import { getAuth } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
 
 // Your Firebase config - using actual project credentials
@@ -34,16 +28,5 @@ export const rtdb = getDatabase(app);
 
 // Expose config to window for compat SDK (used by main.js auth)
 window.firebaseConfig = firebaseConfig;
-
-// Optional: Connect to emulators in development
-if (window.location.hostname === 'localhost') {
-  try {
-    // Uncomment to use emulators
-    // connectFirestoreEmulator(db, 'localhost', 8080);
-    // connectDatabaseEmulator(rtdb, 'localhost', 9000);
-  } catch (e) {
-    // Already connected or emulator not running
-  }
-}
 
 export { app };

--- a/partials/firebase-auth-scripts.html
+++ b/partials/firebase-auth-scripts.html
@@ -1,5 +1,0 @@
-<!-- Firebase SDK -->
-<script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-<script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
-
-<!-- Firebase configuration is now loaded by main.js -->


### PR DESCRIPTION
## Summary
Six small, focused improvements for resilience, maintainability, and a 404 perf nit. No UI/visual changes.

- **fix(redirect): preserve query string and hash on apex redirect** — `/?utm_source=…` and `/#anchor` were silently dropped by `apex-redirect.js`; they're now passed through to `/home.html` so analytics attribution and inbound deep-links survive.
- **chore(firebase-config): drop unused emulator imports and dead try/catch** — `connectFirestoreEmulator` and `connectDatabaseEmulator` were imported solely for a permanently commented-out block, and the surrounding empty try/catch caught nothing. File is leaner; behavior is identical.
- **refactor(auth): replace user-facing alert with console warning** — `AuthUI.showAuthModal` used `alert()` and pointed users at a non-existent `setup-firebase.md` when Firebase wasn't configured. The branch is only reachable in a developer misconfiguration scenario, so a `console.warn` is the right signal.
- **fix(pagination): guard localStorage access for private-browsing modes** — both `getItem` (in `createInstance`) and `setItem` (in `setRowsPerPage`) can throw under aggressive privacy modes. They're now wrapped in try/catch, mirroring `language-switcher.js`.
- **chore: remove unused firebase-auth-scripts partial** — `partials/firebase-auth-scripts.html` was never `data-include`d anywhere; its own comment was stale. Removed and the README directory tree updated.
- **perf(404): redirect countdown straight to /home.html** — the 404 page sent users to `/`, which itself redirects to `/home.html`, costing a chained navigation and an extra history entry. Now goes straight to `/home.html`.

## Why each change
1. **Apex redirect**: utm campaigns and #anchors landing on `/` now reach `/home.html` intact. Marketing attribution and deep-linking work.
2. **firebase-config trim**: less dead code to maintain or misread.
3. **Alert removal**: avoids interrupting users for a problem only a developer can fix; removes a reference to a doc that doesn't exist.
4. **Pagination guard**: pagination on Mario Kart and Football H2H survives private-browsing storage failures instead of throwing out of init and rendering unpaginated.
5. **Dead partial**: removes a stale shim and a misleading README entry.
6. **404 hop**: one fewer navigation, one fewer back-button step, no `index.html` flash on slow connections.

## Testing performed
- `npm test` → **215 / 215 passing** (gym-tracker + football-h2h).
- `node --check` over every first-party file in `assets/js/` and `apps/gym-tracker/js/**/*.js` + `apps/gym-tracker/sw.js` → all clean.
- `node --check --input-type=module < firebase-config.js` → clean.
- `python3 -c \"import xml.etree.ElementTree as ET; ET.parse('sitemap.xml')\"` → clean.
- `grep -n \"alert(\" assets/js/*.js` → zero matches.
- `grep -rn \"firebase-auth-scripts\" .` → zero matches.
- `grep -n \"connectFirestoreEmulator\\|connectDatabaseEmulator\" firebase-config.js` → zero matches.
- Smoke tested via `python3 -m http.server`: `home.html`, `404.html`, `apps.html`, `moadon-alef.html`, the changed scripts, and `firebase-config.js` all serve and parse correctly.
- See `TESTING_STEPS.txt` for the full LOCAL-vs-PROD verification matrix.

## Risk and rollback
- Risk: very low. Each change is isolated to one or two files. The pagination guards add control flow but match a pattern already in production. The apex script change preserves the no-query/no-hash case verbatim (empty strings concatenate to nothing). The dead partial and dead emulator imports were verifiably unreferenced.
- Rollback: revert any single commit independently — they're commit-per-concern.

## Confirmations
- ✅ No serious UI changes. No layout, color, typography, or component-behavior edits. Visual regression check (LOCAL vs PROD pixel compare) shows no diff on any page.
- ✅ No unnecessary refactors. Six commits, each addresses one concern. No reformatting, no churn, no speculative changes.
- ✅ No dependency upgrades, no build-step additions, no file-tree reshuffles.
- ✅ Existing conventions preserved: try/catch pattern for `localStorage` matches `language-switcher.js`; `console.warn` matches the file's other diagnostic logging.