### PR TITLE
cleanup: remove unused code and files

### DIFF
--- a/apps/gym-tracker/js/utils/helpers.js
+++ b/apps/gym-tracker/js/utils/helpers.js
@@ -262,20 +262,6 @@ export function generateNumericId() {
 }
 
 /**
- * Get today's date in YYYY-MM-DD format
- */
-export function getTodayString() {
-    return new Date().toISOString().split('T')[0];
-}
-
-/**
- * Check if date is today
- */
-export function isToday(dateString) {
-    return dateString === getTodayString();
-}
-
-/**
  * Download JSON file
  */
 export function downloadJSON(data, filename) {

--- a/apps/gym-tracker/js/utils/helpers.js
+++ b/apps/gym-tracker/js/utils/helpers.js
@@ -428,28 +428,6 @@ export function showConfirmModal(options = {}) {
 }
 
 /**
- * Group array by key
- */
-export function groupBy(array, key) {
-    return array.reduce((groups, item) => {
-        const group = item[key];
-        if (!groups[group]) {
-            groups[group] = [];
-        }
-        groups[group].push(item);
-        return groups;
-    }, {});
-}
-
-/**
- * Calculate percentage
- */
-export function percentage(value, total) {
-    if (total === 0) return 0;
-    return Math.round((value / total) * 100);
-}
-
-/**
  * Vibrate device (if supported). Defensive against non-browser contexts
  * where `navigator` is undefined (Node tests, Workers without DOM, etc.)
  * so importing this module never throws at load.

--- a/assets/js/global-icons.js
+++ b/assets/js/global-icons.js
@@ -23,31 +23,6 @@ window.GlobalIcons = {
     // Utility function to get all icons
     getAllIcons: function() {
         return [...this.SPORTS, ...this.ANIMALS, ...this.GENERAL];
-    },
-    
-    // Utility function to get icons by category
-    getIconsByCategory: function(category) {
-        switch(category.toUpperCase()) {
-            case 'SPORTS':
-                return this.SPORTS;
-            case 'ANIMALS':
-                return this.ANIMALS;
-            case 'GENERAL':
-                return this.GENERAL;
-            default:
-                return [];
-        }
-    },
-    
-    // Utility function to get random icon from a category
-    getRandomIcon: function(category = null) {
-        let iconArray;
-        if (category) {
-            iconArray = this.getIconsByCategory(category);
-        } else {
-            iconArray = this.getAllIcons();
-        }
-        return iconArray[Math.floor(Math.random() * iconArray.length)];
     }
 };
 


### PR DESCRIPTION
## Summary

This PR removes six unused exported functions identified through a fresh full-repo audit on top of PR #60. No functional changes — every removed export had zero call sites across `apps/`, `partials/`, `sync-system/`, `assets/`, and the `.mjs` test suite. Three atomic commits, 61 deleted lines, 0 added lines.

## Changes

- **apps/gym-tracker/js/utils/helpers.js** — Removed `getTodayString` and `isToday` (14 lines). PR #57's testing notes explicitly kept these under "Items intentionally NOT removed" because `isToday` was assumed to be imported externally; on the current tip neither name is imported anywhere. The two `isToday` mentions outside helpers.js are LOCAL `const isToday = …` declarations in `mario-kart/js/achievements.js:1203` and `gym-tracker/js/views/calendar-view.js:182`, not imports of the helper. The pair drops together because `isToday` only ever called `getTodayString`.
- **apps/gym-tracker/js/utils/helpers.js** — Removed `groupBy` and `percentage` (22 lines). Both are leaf utilities with zero `import { … }` statements anywhere. The remaining `groupBy` mentions in `AnalyticsService.getVolumeTrends(sessions, groupBy = 'week')` and `percentage` mentions in `mario-kart/charts.js` / `achievements.js` are LOCAL parameter / property names, independent of the helper.
- **assets/js/global-icons.js** — Removed `getIconsByCategory` and `getRandomIcon` (25 lines). The script is loaded by `football-h2h/index.html` and `mario-kart/tracker.html`, but the only consumers are `window.GlobalIcons.getAllIcons()` (mario-kart/js/sidebarPlayerSettings.js:10) and direct array access on `SPORTS` / `ANIMALS` / `GENERAL` (football-h2h/js/football-h2h.js, six lines). Neither app picks a random icon programmatically or queries by category name.

## Testing

- `npm test` → 215 / 215 pass on the branch tip (verified after each commit).
- `node --check apps/gym-tracker/js/utils/helpers.js` → exit 0.
- `node --check assets/js/global-icons.js` → exit 0.
- Repo-wide word-boundary grep for each removed name returns no import sites; only LOCAL identifiers (parameter names, property keys, locally-declared `const isToday`) remain, all of which are independent of the removed helpers.
- Manual sanity checks documented in the gitignored `TESTING_STEPS.txt` testing notes (gym-tracker calendar / insights views, football-h2h icon picker, mario-kart sidebar player settings).

## Risk

Low — only removals of confirmed dead code. No logic changes. No API changes. No dependency version changes. No service-worker `CACHE_VERSION` bump needed (both files still exist and still resolve to non-empty modules).