### PR TITLE
Sync indicator + Firebase reliability overhaul

### DIFF
--- a/404.html
+++ b/404.html
@@ -58,9 +58,8 @@
 <script defer src="/assets/js/breakpoints.min.js"></script>
 <script defer src="/assets/js/util.js"></script>
 
-<!-- Firebase SDK (required for auth functionality) -->
-<script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-<script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+<!-- Firebase modular SDK + auth adapter (single source of auth state) -->
+<script type="module" src="/firebase-config.js"></script>
 
 <!-- Main JavaScript -->
 <script defer src="/assets/js/main.js"></script>

--- a/apps.html
+++ b/apps.html
@@ -176,11 +176,7 @@
   <script defer src="assets/js/breakpoints.min.js"></script>
   <script defer src="assets/js/util.js"></script>
 
-  <!-- Firebase SDK (required for auth functionality) -->
-  <script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-  <script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
-
-  <!-- Firebase Configuration (loads before main.js) -->
+  <!-- Firebase modular SDK + auth adapter (single source of auth state) -->
   <script type="module" src="firebase-config.js"></script>
 
   <!-- Main JavaScript -->

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -416,10 +416,6 @@
     <script src="../../assets/js/breakpoints.min.js"></script>
     <script src="../../assets/js/util.js"></script>
     
-    <!-- Firebase SDK (required for auth functionality) -->
-    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
-
     <!-- Firebase Storage Sync System (ES Modules) -->
     <script type="module" src="../../firebase-config.js"></script>
     <script type="module" src="../../sync-system/firebase-persistence.js"></script>

--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -234,12 +234,15 @@ body.gym-tracker #footer {
     box-shadow: 0 6px 18px rgba(108, 99, 255, 0.6);
 }
 
-/* Floating action button — one-tap Start/Resume workout on Home. */
+/* Floating action button — one-tap Start/Resume workout on Home.
+   Hidden on mobile because the bottom-nav already has a Workout
+   button in its primary slot, so a fixed FAB just duplicates that
+   action and competes with workout content for screen space. Still
+   shown on desktop (≥768px) where the side-nav has no one-tap
+   workout entry point. */
 .workout-fab {
     position: fixed;
-    right: 1rem;
-    bottom: calc(76px + env(safe-area-inset-bottom, 0px));
-    display: inline-flex;
+    display: none;
     align-items: center;
     gap: 0.55rem;
     padding: 0.85rem 1.25rem;
@@ -295,18 +298,11 @@ body.gym-tracker #footer {
 }
 
 @media (min-width: 768px) {
-    .workout-fab { bottom: 1.5rem; right: 1.5rem; }
-}
-
-@media (max-width: 360px) {
-    .workout-fab .workout-fab-label { display: none; }
     .workout-fab {
-        width: 56px;
-        height: 56px;
-        padding: 0;
-        justify-content: center;
+        display: inline-flex;
+        bottom: 1.5rem;
+        right: 1.5rem;
     }
-    .workout-fab i { font-size: 1.25rem; }
 }
 
 @media (min-width: 768px) {
@@ -3238,7 +3234,7 @@ body.gym-tracker #footer {
     color: inherit;
 }
 
-.history-filters .history-clear-btn:hover {
+.history-filters .history-clear-btn:hover:not(:disabled) {
     background: var(--bg-elevated) !important;
     border-color: var(--border-light) !important;
     color: var(--text-primary) !important;
@@ -3247,6 +3243,13 @@ body.gym-tracker #footer {
 .history-filters .history-clear-btn:focus-visible {
     outline: none;
     box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.3) !important;
+}
+
+.history-filters .history-clear-btn:disabled,
+.history-filters .history-clear-btn[aria-disabled="true"] {
+    opacity: 0.45;
+    cursor: not-allowed;
+    pointer-events: none;
 }
 
 /* Sort wrap — icon + DarkSelect, mirroring the Calendar filter pattern */
@@ -8140,26 +8143,26 @@ button.calendar-day {
 
 
 /* ------------------------------------------------------------------
-   Sync status pill — floating bottom-right indicator that reflects the
-   storage sync layer's state. See js/utils/sync-status.js for state
-   logic. Sits above the bottom nav on mobile and the page content on
-   desktop. Reduces to a dot on small screens to stay out of the way.
+   Sync status pill — inline indicator rendered into
+   `[data-sync-status-slot]` placeholders (one in the desktop side-nav
+   footer, one in the mobile More view header). Was previously a
+   floating bottom-right element that overlapped the workout FAB and
+   bottom nav and flickered green↔amber as debounced writes flushed
+   between sets. Lives inside layout flow now so it never covers
+   workout controls. State logic: js/utils/sync-status.js.
    ------------------------------------------------------------------ */
 .sync-status-pill {
-    position: fixed;
-    z-index: 50;
-    bottom: 84px;
-    right: 12px;
-    padding: 6px 12px;
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
     border-radius: 999px;
     font-size: 12px;
     font-weight: 600;
-    line-height: 1;
+    line-height: 1.2;
     color: #fff;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
-    pointer-events: none;
     user-select: none;
     transition: background 200ms ease, color 200ms ease;
+    white-space: nowrap;
 }
 .sync-status-pill::before {
     content: '';
@@ -8168,17 +8171,88 @@ button.calendar-day {
     height: 7px;
     border-radius: 50%;
     margin-right: 6px;
-    vertical-align: 1px;
     background: currentColor;
+    /* Shape doubles as a non-color signal so users with low color
+       perception still get state from the dot's position + label. */
+    flex: none;
 }
-.sync-status-pill[data-state="synced"]   { background: rgba(34, 197, 94, 0.85); }
-.sync-status-pill[data-state="pending"]  { background: rgba(245, 158, 11, 0.85); }
-.sync-status-pill[data-state="offline"]  { background: rgba(148, 163, 184, 0.85); }
+.sync-status-pill[data-state="synced"]     { background: rgba(34, 197, 94, 0.85); }
+.sync-status-pill[data-state="syncing"]    { background: rgba(245, 158, 11, 0.85); }
+.sync-status-pill[data-state="connecting"] { background: rgba(245, 158, 11, 0.6); }
+.sync-status-pill[data-state="offline"]    { background: rgba(148, 163, 184, 0.85); }
+.sync-status-pill[data-state="idle"]       { background: rgba(100, 116, 139, 0.7); }
 
-@media (min-width: 900px) {
-    .sync-status-pill {
-        bottom: 16px;
-    }
+/* Mobile compact sync dot — a tiny colored circle pinned to the upper
+   corner of the "More" tab in the bottom nav. Always visible on
+   mobile so the user gets an at-a-glance "everything's synced"
+   confirmation without needing to navigate anywhere. Hidden on desktop
+   (the side-nav pill already covers that surface). Decorative only —
+   `aria-hidden` in HTML keeps it out of the SR tree, the offline
+   banner handles real announcements. */
+.nav-sync-dot {
+    position: absolute;
+    top: 6px;
+    right: 14px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: rgba(148, 163, 184, 0.85); /* default = slate (idle) */
+    box-shadow: 0 0 0 2px var(--bg-secondary); /* halo against nav bg */
+    pointer-events: none;
+    transition: background 200ms ease;
+}
+.nav-sync-dot[data-state="synced"]     { background: rgba(34, 197, 94, 0.95); }
+.nav-sync-dot[data-state="syncing"]    { background: rgba(245, 158, 11, 0.95); }
+.nav-sync-dot[data-state="connecting"] { background: rgba(245, 158, 11, 0.55); }
+.nav-sync-dot[data-state="offline"]    { background: rgba(148, 163, 184, 0.95); }
+.nav-sync-dot[data-state="idle"]       { background: rgba(100, 116, 139, 0.85); }
+
+@media (min-width: 768px) {
+    .nav-sync-dot { display: none; }
+}
+
+/* Side-nav footer — pushed to the bottom of the sidebar so it sits
+   below all nav links like a system tray. .nav-links uses flex:1, so
+   this element naturally docks at the bottom without absolute
+   positioning. */
+.side-nav-footer {
+    padding: var(--spacing-md) var(--spacing-lg);
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: flex-start;
+}
+
+/* Mobile sync banner — pinned to the top of the viewport, full width,
+   only visible when sync state is offline (or briefly on the
+   offline→synced transition). Hidden in all other states so it never
+   competes with workout content. The desktop side-nav pill above is
+   the equivalent surface for desktop users. */
+.sync-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1100; /* Above bottom-nav (1000), below modals (~2000). */
+    padding: 8px 14px calc(8px + env(safe-area-inset-top, 0px));
+    padding-top: calc(8px + env(safe-area-inset-top, 0px));
+    text-align: center;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.2;
+    color: #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+    transition: background 200ms ease, opacity 200ms ease, transform 200ms ease;
+    transform: translateY(0);
+}
+.sync-banner[hidden] { display: none; }
+.sync-banner[data-state="offline"] { background: rgba(100, 116, 139, 0.95); }
+.sync-banner[data-state="synced"]  { background: rgba(34, 197, 94, 0.95); }
+.sync-banner[data-fading="true"]   { opacity: 0; transform: translateY(-4px); }
+
+/* Hide the banner on desktop — the side-nav pill already shows status
+   and a top banner would shove the layout down for no reason. */
+@media (min-width: 768px) {
+    .sync-banner { display: none !important; }
 }
 
 /* ------------------------------------------------------------------

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -104,6 +104,10 @@
 <body class="gym-tracker">
     <div data-include="header"></div>
 
+    <!-- Live sync banner — only shown when offline, and briefly on the
+         offline→synced transition. Mounted/managed by js/utils/sync-status.js. -->
+    <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>
+
     <!-- Main App Container -->
     <div class="app-container">
         <!-- Bottom Navigation (Mobile) -->
@@ -127,6 +131,7 @@
             <button class="nav-item" data-view="more">
                 <i class="fas fa-ellipsis-h"></i>
                 <span>More</span>
+                <span class="nav-sync-dot" data-sync-status-dot aria-hidden="true"></span>
             </button>
         </nav>
 
@@ -173,6 +178,7 @@
                     <span>Settings</span>
                 </button>
             </div>
+            <div class="side-nav-footer" data-sync-status-slot></div>
         </nav>
 
         <!-- Main Content Area -->
@@ -535,7 +541,7 @@
                 <div class="history-filters">
                     <input type="date" id="history-date-from" placeholder="Start date" data-placeholder="Start date">
                     <input type="date" id="history-date-to" placeholder="End date" data-placeholder="End date">
-                    <button type="button" class="history-clear-btn" id="clear-filters-btn">
+                    <button type="button" class="history-clear-btn" id="clear-filters-btn" disabled aria-disabled="true">
                         <i class="fas fa-xmark"></i> Clear
                     </button>
                     <div class="history-sort-wrap">
@@ -1211,10 +1217,6 @@
     <script src="../../assets/js/browser.min.js"></script>
     <script src="../../assets/js/breakpoints.min.js"></script>
     <script src="../../assets/js/util.js"></script>
-
-    <!-- Firebase SDK (required for auth functionality) -->
-    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
 
     <!-- Firebase Storage Sync System (ES Modules) -->
     <script type="module" src="../../firebase-config.js"></script>

--- a/apps/gym-tracker/js/app.js
+++ b/apps/gym-tracker/js/app.js
@@ -417,20 +417,60 @@ class GymTrackerApp {
     }
 
     /**
-     * Set up sync system listeners
+     * Set up sync system listeners.
+     *
+     * Two channels:
+     *   1. `syncSystemReady` — fires once after Firebase auth + initial
+     *      merge. Pulls data into memory for the first time.
+     *   2. `localStorageSync` — fires every time the storage-sync layer
+     *      writes a remote update into localStorage (i.e., another
+     *      device pushed a change). Without this, post-boot remote
+     *      updates only became visible after a manual page refresh.
+     *
+     * The remote-change handler is debounced because the initial
+     * post-sign-in burst applies all ~9 gym-tracker keys back-to-back
+     * and we only want to rebuild in-memory state and re-render once.
      */
     setupSyncListeners() {
         if (!window.syncSystemInitialized) {
             window.addEventListener('syncSystemReady', () => {
                 debugLog('🔄 Sync system ready, refreshing data');
                 setTimeout(() => {
-                    this.loadAllData();
-                    this.updateAchievements();
-                    if (this.currentView && this.viewControllers[this.currentView]) {
-                        this.onViewChange(this.currentView);
-                    }
+                    this.refreshFromStorage();
                 }, 1000);
             }, { once: true });
+        }
+
+        // Live remote-update channel. The 750 ms debounce coalesces the
+        // ~9-key burst that the storage layer emits when another device
+        // pushes changes, and gives the user time to finish a hover/click
+        // interaction before the active view re-renders. Earlier versions
+        // used 250 ms which was tight enough that any background listener
+        // chatter could rebuild DOM mid-hover and visibly flicker.
+        let remoteRefreshTimer = null;
+        window.addEventListener('localStorageSync', (e) => {
+            const key = e.detail?.key;
+            if (typeof key !== 'string' || !key.startsWith('gymTracker')) return;
+            if (e.detail?.source !== 'remote') return;
+
+            clearTimeout(remoteRefreshTimer);
+            remoteRefreshTimer = setTimeout(() => {
+                debugLog('🔄 Remote sync update — refreshing data');
+                this.refreshFromStorage();
+            }, 750);
+        });
+    }
+
+    /**
+     * Reload all data from storage and re-render the active view.
+     * Shared by the initial-sync handler and the live remote-update
+     * handler so both paths stay in lockstep.
+     */
+    refreshFromStorage() {
+        this.loadAllData();
+        this.updateAchievements();
+        if (this.currentView && this.viewControllers[this.currentView]) {
+            this.onViewChange(this.currentView);
         }
     }
 

--- a/apps/gym-tracker/js/utils/sync-status.js
+++ b/apps/gym-tracker/js/utils/sync-status.js
@@ -1,51 +1,168 @@
 /**
- * Sync status pill — a small visual indicator of sync state, mounted into
- * the bottom-right corner of the gym tracker viewport. Reflects three
- * states the user actually cares about:
- *   - Synced  — no pending writes, last flush succeeded
- *   - Pending — debounced writes queued waiting to flush
- *   - Offline — browser reports no connectivity (we keep recording locally)
+ * Sync status indicators.
  *
- * Polls `getGlobalSyncStatus()` every 2s and `navigator.onLine`. The cost
- * is trivial — getGlobalStatus() reads two Map sizes — and beats wiring
- * an event channel through the sync layer for now.
+ * Two surfaces, picked to suit each form factor:
+ *
+ *   1. Inline pill — rendered into `[data-sync-status-slot]` placeholders
+ *      (currently just the desktop side-nav footer). Always visible,
+ *      shows the full state label. Out of the way on desktop because
+ *      there's plenty of sidebar real estate.
+ *
+ *   2. Mobile top banner (`#sync-banner`) — pinned to the top of the
+ *      viewport, only shown when state is `offline`, plus a brief
+ *      green "Synced" confirmation on the offline→synced transition.
+ *      Silent in every other state, so it never competes with the
+ *      workout screen. Hidden on desktop via CSS.
+ *
+ * The poll-based read is kept (2 s + online/offline events) and
+ * `render()` dedupes by last (state, label) so background ticks do
+ * not thrash the DOM — that was the source of the green/amber flicker
+ * users saw between sets.
  */
 
 const POLL_MS = 2000;
+const RECOVERY_FLASH_MS = 2000;
 
 let mounted = false;
-let pillEl = null;
+let pillEls = [];
+let dotEls = [];
+let bannerEl = null;
 let timer = null;
+let lastRender = null;
+let recoveryTimer = null;
 
-function classify() {
-    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
-        return { state: 'offline', label: 'Offline' };
+/**
+ * Pure classifier — exported for unit tests so we can assert state
+ * transitions without a DOM. Inputs are explicit so callers can mock
+ * `navigator.onLine`, the global status getter, and the auth state.
+ *
+ * `signedIn` distinguishes "user has Firebase auth but the sync layer
+ * hasn't attached yet" (treated as still connecting, dim amber) from
+ * "no auth at all, app is purely local" (treated as idle, slate). The
+ * former is the common transitional state on mobile when the auth
+ * iframe is slow to settle; without this distinction the dot would
+ * stay slate even though sync is about to come up.
+ */
+export function classifySyncStatus({ online, status, signedIn = false }) {
+    if (online === false) return { state: 'offline', label: 'Offline' };
+    if (!status) return { state: 'connecting', label: 'Connecting…' };
+    if (status.totalQueueSize > 0) return { state: 'syncing', label: 'Saving…' };
+    if (status.activeNamespaces === 0) {
+        if (signedIn) return { state: 'connecting', label: 'Connecting…' };
+        return { state: 'idle', label: 'Local only' };
     }
-    const status = window.gymGetGlobalSyncStatus?.();
-    if (!status) return { state: 'pending', label: 'Connecting…' };
-    if (status.totalQueueSize > 0) return { state: 'pending', label: 'Saving…' };
-    if (status.activeNamespaces === 0) return { state: 'pending', label: 'Signed out' };
     return { state: 'synced', label: 'Synced' };
 }
 
+function readCurrent() {
+    const online = typeof navigator === 'undefined' ? true : navigator.onLine !== false;
+    const status = typeof window !== 'undefined' ? window.gymGetGlobalSyncStatus?.() : null;
+    const signedIn = typeof window !== 'undefined'
+        && !!window.firebaseAuth?.getCurrentUser?.();
+    return classifySyncStatus({ online, status, signedIn });
+}
+
+function applyToPill(el, { state, label }) {
+    el.dataset.state = state;
+    el.textContent = label;
+    el.setAttribute('aria-label', `Sync status: ${label}`);
+    el.title = label;
+}
+
+/**
+ * Decide what the mobile banner should show.
+ *
+ *   - state === 'offline' → persistent banner.
+ *   - prev was 'offline' and now isn't → green "Synced" for ~2 s, then hide.
+ *   - any other transition → hide.
+ */
+function updateBanner(prev, next) {
+    if (!bannerEl) return;
+
+    if (next.state === 'offline') {
+        clearTimeout(recoveryTimer);
+        recoveryTimer = null;
+        bannerEl.hidden = false;
+        bannerEl.dataset.state = 'offline';
+        bannerEl.dataset.fading = 'false';
+        bannerEl.textContent = 'You’re offline — changes saved on this device';
+        return;
+    }
+
+    const justRecovered = prev?.state === 'offline';
+    if (justRecovered) {
+        clearTimeout(recoveryTimer);
+        bannerEl.hidden = false;
+        bannerEl.dataset.state = 'synced';
+        bannerEl.dataset.fading = 'false';
+        bannerEl.textContent = 'Back online — synced';
+        recoveryTimer = setTimeout(() => {
+            if (!bannerEl) return;
+            bannerEl.dataset.fading = 'true';
+            // Wait for the CSS opacity transition before fully hiding,
+            // so screen readers don't get a jarring re-announce.
+            setTimeout(() => {
+                if (bannerEl && bannerEl.dataset.state === 'synced') {
+                    bannerEl.hidden = true;
+                    bannerEl.dataset.fading = 'false';
+                }
+            }, 220);
+        }, RECOVERY_FLASH_MS);
+        return;
+    }
+
+    // Any other state (synced steady-state, syncing, connecting, idle):
+    // banner stays hidden. The recoveryTimer above handles the only
+    // case where we briefly show "Synced".
+    if (!recoveryTimer) {
+        bannerEl.hidden = true;
+        bannerEl.dataset.fading = 'false';
+    }
+}
+
 function render() {
-    if (!pillEl) return;
-    const { state, label } = classify();
-    pillEl.dataset.state = state;
-    pillEl.textContent = label;
+    const next = readCurrent();
+    const prev = lastRender;
+    if (prev && prev.state === next.state && prev.label === next.label) return;
+    lastRender = next;
+
+    for (const el of pillEls) applyToPill(el, next);
+    for (const el of dotEls) el.dataset.state = next.state;
+    updateBanner(prev, next);
+}
+
+function createPill() {
+    const el = document.createElement('div');
+    el.className = 'sync-status-pill';
+    el.setAttribute('role', 'status');
+    el.setAttribute('aria-live', 'polite');
+    el.dataset.state = 'connecting';
+    el.textContent = 'Connecting…';
+    el.setAttribute('aria-label', 'Sync status: Connecting…');
+    el.title = 'Connecting…';
+    return el;
 }
 
 export function mountSyncStatusPill() {
     if (mounted) return;
     mounted = true;
 
-    pillEl = document.createElement('div');
-    pillEl.className = 'sync-status-pill';
-    pillEl.setAttribute('role', 'status');
-    pillEl.setAttribute('aria-live', 'polite');
-    pillEl.dataset.state = 'pending';
-    pillEl.textContent = 'Connecting…';
-    document.body.appendChild(pillEl);
+    const slots = document.querySelectorAll('[data-sync-status-slot]');
+    slots.forEach((slot) => {
+        const el = createPill();
+        slot.appendChild(el);
+        pillEls.push(el);
+    });
+
+    // Compact dots on mobile (e.g., on the "More" bottom-nav button).
+    // Same state colour mapping as the pill, but no text — these are
+    // pre-existing elements in the markup, so we just track them.
+    dotEls = Array.from(document.querySelectorAll('[data-sync-status-dot]'));
+    dotEls.forEach((el) => { el.dataset.state = 'connecting'; });
+
+    bannerEl = document.getElementById('sync-banner');
+
+    if (pillEls.length === 0 && dotEls.length === 0 && !bannerEl) return;
 
     render();
     timer = setInterval(render, POLL_MS);

--- a/apps/gym-tracker/js/views/history-view.js
+++ b/apps/gym-tracker/js/views/history-view.js
@@ -85,6 +85,7 @@ class HistoryView {
             dateFromInput.dataset.darkCalendarInit = '1';
             dateFromInput.addEventListener('change', (e) => {
                 this.dateFrom = e.target.value || null;
+                this._updateClearButtonState();
                 this.render();
             });
         }
@@ -93,6 +94,7 @@ class HistoryView {
             dateToInput.dataset.darkCalendarInit = '1';
             dateToInput.addEventListener('change', (e) => {
                 this.dateTo = e.target.value || null;
+                this._updateClearButtonState();
                 this.render();
             });
         }
@@ -102,19 +104,37 @@ class HistoryView {
             this.toCalendar.rangePartner = this.fromCalendar;
         }
 
-        // Clear filters button
+        // Clear filters button — disabled while no date filter is set so
+        // the user doesn't get a clickable affordance for a no-op.
         const clearBtn = document.getElementById('clear-filters-btn');
         if (clearBtn) {
             clearBtn.addEventListener('click', () => {
+                if (clearBtn.disabled) return;
                 this.dateFrom = null;
                 this.dateTo = null;
                 if (this.fromCalendar) this.fromCalendar.clearDate();
                 else if (dateFromInput) dateFromInput.value = '';
                 if (this.toCalendar) this.toCalendar.clearDate();
                 else if (dateToInput) dateToInput.value = '';
+                this._updateClearButtonState();
                 this.render();
             });
         }
+
+        this._updateClearButtonState();
+    }
+
+    /**
+     * Reflect the live date-filter state on the Clear button. Disabled
+     * when neither dateFrom nor dateTo is set, since the click would be
+     * a no-op. `aria-disabled` mirrors `disabled` for assistive tech.
+     */
+    _updateClearButtonState() {
+        const clearBtn = document.getElementById('clear-filters-btn');
+        if (!clearBtn) return;
+        const hasFilter = !!(this.dateFrom || this.dateTo);
+        clearBtn.disabled = !hasFilter;
+        clearBtn.setAttribute('aria-disabled', String(!hasFilter));
     }
 
     render() {

--- a/apps/gym-tracker/js/views/settings-view.js
+++ b/apps/gym-tracker/js/views/settings-view.js
@@ -162,9 +162,7 @@ class SettingsView {
     }
 
     async deleteCloudData() {
-        const user = window.firebaseAuth?.getCurrentUser?.()
-            || (typeof firebase !== 'undefined' && firebase.auth?.().currentUser)
-            || null;
+        const user = window.firebaseAuth?.getCurrentUser?.() || null;
         if (!user) {
             showToast('Sign in first to delete cloud data', 'error');
             return;

--- a/apps/gym-tracker/tests/firebase-sdk-singleton.test.mjs
+++ b/apps/gym-tracker/tests/firebase-sdk-singleton.test.mjs
@@ -1,0 +1,69 @@
+// Regression guard: enforce that no HTML page loads the v9 compat
+// Firebase SDK alongside the v10 modular SDK.
+//
+// Loading both SDKs creates two separate `<authDomain>/__/auth/iframe`
+// frames; each iframe loads `apis.google.com/js/api.js?onload=__iframefcb<id>`
+// and registers a callback on `window`. On mobile the two iframes
+// race over those callback slots and gapi.js throws
+// `Uncaught TypeError: u[v] is not a function`. firebase-config.js is
+// the single source of auth state — it exposes `window.firebaseAuth`
+// for non-module callers. This test fails if anyone re-introduces a
+// compat script tag on any page.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const FORBIDDEN_PATTERNS = [
+    /firebase-app-compat\.js/i,
+    /firebase-auth-compat\.js/i,
+    /firebasejs\/9\.\d+\.\d+\/firebase-(app|auth|firestore|database)-compat/i
+];
+
+function collectHtmlFiles(dir, acc = []) {
+    for (const entry of readdirSync(dir)) {
+        if (entry === 'node_modules' || entry.startsWith('.')) continue;
+        const full = join(dir, entry);
+        const stat = statSync(full);
+        if (stat.isDirectory()) {
+            collectHtmlFiles(full, acc);
+        } else if (entry.endsWith('.html')) {
+            acc.push(full);
+        }
+    }
+    return acc;
+}
+
+test('no HTML file loads the Firebase v9 compat SDK', () => {
+    const htmlFiles = collectHtmlFiles(REPO_ROOT);
+    assert.ok(htmlFiles.length > 0, 'expected to find HTML files in the repo');
+
+    const offenders = [];
+    for (const file of htmlFiles) {
+        const content = readFileSync(file, 'utf8');
+        // Strip HTML comments so historical context inside <!-- ... -->
+        // doesn't trip the guard. We only care about live <script> tags.
+        const stripped = content.replace(/<!--[\s\S]*?-->/g, '');
+        for (const pattern of FORBIDDEN_PATTERNS) {
+            if (pattern.test(stripped)) {
+                offenders.push(`${file} matches ${pattern}`);
+            }
+        }
+    }
+
+    assert.deepEqual(
+        offenders,
+        [],
+        `Found compat-SDK references — they cause the mobile __iframefcb race:\n  ${offenders.join('\n  ')}`
+    );
+});
+
+test('firebase-config.js declares the window.firebaseAuth adapter', () => {
+    const config = readFileSync(join(REPO_ROOT, 'firebase-config.js'), 'utf8');
+    assert.match(config, /window\.firebaseAuth\s*=/, 'firebase-config.js must expose window.firebaseAuth');
+    assert.match(config, /firebaseAuthReady/, 'firebase-config.js must dispatch the firebaseAuthReady event');
+    assert.match(config, /onAuthStateChanged/, 'firebase-config.js must wire the modular onAuthStateChanged');
+});

--- a/apps/gym-tracker/tests/sync-status.test.mjs
+++ b/apps/gym-tracker/tests/sync-status.test.mjs
@@ -1,0 +1,119 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifySyncStatus } from '../js/utils/sync-status.js';
+
+test('classifySyncStatus: offline beats every other signal', () => {
+    // Even with a healthy status object, a non-online browser should
+    // surface "Offline" so the user knows writes are buffered locally.
+    const result = classifySyncStatus({
+        online: false,
+        status: { totalQueueSize: 0, activeNamespaces: 2 }
+    });
+    assert.equal(result.state, 'offline');
+    assert.equal(result.label, 'Offline');
+});
+
+test('classifySyncStatus: missing status object → connecting', () => {
+    // Sync layer hasn't initialised yet; pre-init we don't want to claim
+    // anything is wrong, just that we're not ready.
+    const result = classifySyncStatus({ online: true, status: null });
+    assert.equal(result.state, 'connecting');
+    assert.equal(result.label, 'Connecting…');
+});
+
+test('classifySyncStatus: queued writes → syncing', () => {
+    const result = classifySyncStatus({
+        online: true,
+        status: { totalQueueSize: 3, activeNamespaces: 1 }
+    });
+    assert.equal(result.state, 'syncing');
+    assert.equal(result.label, 'Saving…');
+});
+
+test('classifySyncStatus: queue takes precedence over zero namespaces', () => {
+    // Edge case while a sign-out races with a flush: if we still have
+    // queued writes we should call out "Saving…" rather than "Local only".
+    const result = classifySyncStatus({
+        online: true,
+        status: { totalQueueSize: 1, activeNamespaces: 0 }
+    });
+    assert.equal(result.state, 'syncing');
+});
+
+test('classifySyncStatus: signed-out / no namespaces → idle, not pending', () => {
+    // The previous classifier mapped this to a yellow "pending" pill,
+    // which made local-only users see a permanent yellow indicator
+    // even though nothing was actually pending. Idle is the honest
+    // label for "no cloud target attached."
+    const result = classifySyncStatus({
+        online: true,
+        status: { totalQueueSize: 0, activeNamespaces: 0 },
+        signedIn: false
+    });
+    assert.equal(result.state, 'idle');
+    assert.equal(result.label, 'Local only');
+});
+
+test('classifySyncStatus: signed-in but sync not yet attached → connecting', () => {
+    // Mobile auth-iframe boot can leave the modular Firebase SDK's
+    // `auth.currentUser` null for several seconds even after the user
+    // is fully signed in via the compat SDK. During that window the
+    // sync layer hasn't attached a namespace yet — we should show
+    // "Connecting…" rather than mislabel as "Local only", which would
+    // suggest the cloud isn't involved at all.
+    const result = classifySyncStatus({
+        online: true,
+        status: { totalQueueSize: 0, activeNamespaces: 0 },
+        signedIn: true
+    });
+    assert.equal(result.state, 'connecting');
+    assert.equal(result.label, 'Connecting…');
+});
+
+test('classifySyncStatus: clean state → synced', () => {
+    const result = classifySyncStatus({
+        online: true,
+        status: { totalQueueSize: 0, activeNamespaces: 2 }
+    });
+    assert.equal(result.state, 'synced');
+    assert.equal(result.label, 'Synced');
+});
+
+test('classifySyncStatus: online=undefined treated as connected', () => {
+    // Defensive: in non-browser test environments navigator may be
+    // absent and the caller passes undefined. Anything that is not
+    // strictly false should not flip us into Offline.
+    const result = classifySyncStatus({
+        online: undefined,
+        status: { totalQueueSize: 0, activeNamespaces: 1 }
+    });
+    assert.equal(result.state, 'synced');
+});
+
+test('classifySyncStatus: offline + queued writes still reports offline', () => {
+    // The user needs to know connectivity is the gating issue; the
+    // queue depth is secondary information.
+    const result = classifySyncStatus({
+        online: false,
+        status: { totalQueueSize: 5, activeNamespaces: 1 }
+    });
+    assert.equal(result.state, 'offline');
+});
+
+test('classifySyncStatus: offline → online transition swaps state', () => {
+    const status = { totalQueueSize: 0, activeNamespaces: 1 };
+    assert.equal(classifySyncStatus({ online: false, status }).state, 'offline');
+    assert.equal(classifySyncStatus({ online: true,  status }).state, 'synced');
+});
+
+test('classifySyncStatus: failed-sync simulation surfaces as syncing while queue is non-empty', () => {
+    // The robust sync layer keeps queued writes during retry/backoff, so
+    // a stuck retry shows up as a sustained "Saving…" rather than a
+    // false "Synced". This guards against the pill ever lying about
+    // success while writes are actually piling up.
+    const status = { totalQueueSize: 4, activeNamespaces: 1 };
+    for (let i = 0; i < 3; i++) {
+        assert.equal(classifySyncStatus({ online: true, status }).state, 'syncing');
+    }
+});

--- a/apps/mario-kart/tracker.html
+++ b/apps/mario-kart/tracker.html
@@ -612,10 +612,6 @@
     <script src="../../assets/js/breakpoints.min.js"></script>
     <script src="../../assets/js/util.js"></script>
     
-    <!-- Firebase SDK (required for auth functionality) -->
-    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
-
     <!-- Firebase Storage Sync System (ES Modules) -->
     <script type="module" src="../../firebase-config.js"></script>
     <script type="module" src="../../sync-system/firebase-persistence.js"></script>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -85,195 +85,16 @@
   }
 
   /* ==========================================================================
-     Firebase Configuration (Loaded from firebase-config.js)
-     ========================================================================== */
-
-  // Firebase configuration is loaded from firebase-config.js module
-  // which sets window.firebaseConfig for compat SDK usage
-  // All pages must include: <script type="module" src="firebase-config.js"></script>
-
-  /* ==========================================================================
-     Firebase Authentication Class
-     ========================================================================== */
-
-  class FirebaseAuth {
-    constructor() {
-      this.auth = null;
-      this.user = null;
-      this.initialized = false;
-      this.authStateChangeListeners = [];
-      
-      // Initialize immediately - config is already loaded from firebase-config.js
-      this.initialize();
-    }
-
-    /**
-     * Initialize Firebase authentication
-     * @async
-     */
-    async initialize() {
-      try {
-        // Wait for Firebase SDK if not ready
-        if (typeof firebase === 'undefined') {
-          setTimeout(() => this.initialize(), 100);
-          return;
-        }
-
-        // Use window.firebaseConfig directly (loaded from firebase-config.js)
-        const config = window.firebaseConfig;
-        
-        if (!config || !config.apiKey || !config.authDomain || !config.projectId) {
-          return;
-        }
-
-        // Initialize Firebase app
-        const app = firebase.initializeApp(config);
-        this.auth = firebase.auth();
-
-        // Set up auth state listener
-        this.auth.onAuthStateChanged((user) => {
-          this.user = user;
-          this.notifyAuthStateChange(user);
-        });
-
-        this.initialized = true;
-
-      } catch (error) {
-        console.error('Failed to initialize Firebase Auth:', error);
-      }
-    }
-
-    /**
-     * Add auth state change listener
-     * @param {Function} callback - Callback function
-     */
-    onAuthStateChange(callback) {
-      this.authStateChangeListeners.push(callback);
-      if (this.initialized) {
-        callback(this.user);
-      }
-    }
-
-    /**
-     * Notify all auth state change listeners
-     * @private
-     * @param {Object|null} user - Firebase user object
-     */
-    notifyAuthStateChange(user) {
-      this.authStateChangeListeners.forEach(callback => {
-        try {
-          callback(user);
-        } catch (error) {
-          console.error('Auth state change listener error:', error);
-        }
-      });
-    }
-
-    /**
-     * Sign up with email and password
-     * @async
-     * @param {string} email - Email address
-     * @param {string} password - Password
-     * @returns {Object} Firebase user object
-     */
-    async signUp(email, password) {
-      if (!this.initialized) {
-        throw new Error('Firebase Auth not initialized');
-      }
-
-      try {
-        const userCredential = await this.auth.createUserWithEmailAndPassword(email, password);
-        return userCredential.user;
-      } catch (error) {
-        console.error('Sign up error:', error);
-        throw this.formatAuthError(error);
-      }
-    }
-
-    /**
-     * Sign in with email and password
-     * @async
-     * @param {string} email - Email address
-     * @param {string} password - Password
-     * @returns {Object} Firebase user object
-     */
-    async signIn(email, password) {
-      if (!this.initialized) {
-        throw new Error('Firebase Auth not initialized');
-      }
-
-      try {
-        const userCredential = await this.auth.signInWithEmailAndPassword(email, password);
-        return userCredential.user;
-      } catch (error) {
-        console.error('Sign in error:', error);
-        throw this.formatAuthError(error);
-      }
-    }
-
-
-
-    /**
-     * Sign out current user
-     * @async
-     */
-    async signOut() {
-      if (!this.initialized) {
-        throw new Error('Firebase Auth not initialized');
-      }
-
-      try {
-        await this.auth.signOut();
-      } catch (error) {
-        console.error('Sign out error:', error);
-        throw error;
-      }
-    }
-
-    /**
-     * Get current user
-     * @returns {Object|null} Current user or null
-     */
-    getCurrentUser() {
-      return this.user;
-    }
-
-    /**
-     * Check if user is signed in
-     * @returns {boolean} True if signed in
-     */
-    isSignedIn() {
-      return this.user !== null;
-    }
-
-    /**
-     * Format Firebase auth errors for user display
-     * @private
-     * @param {Error} error - Firebase error
-     * @returns {Error} Formatted error
-     */
-    formatAuthError(error) {
-      const errorMessages = {
-        'auth/user-not-found': 'No account found with this email address.',
-        'auth/wrong-password': 'Incorrect password.',
-        'auth/invalid-login-credentials': 'Invalid email or password. Please check your credentials and try again.',
-        'auth/email-already-in-use': 'An account with this email already exists.',
-        'auth/weak-password': 'Password should be at least 6 characters.',
-        'auth/invalid-email': 'Please enter a valid email address.',
-        'auth/too-many-requests': 'Too many failed attempts. Please try again later.',
-      };
-
-      return new Error(errorMessages[error.code] || error.message);
-    }
-
-    /**
-     * Check if Firebase Auth is available
-     * @returns {boolean} True if available
-     */
-    isAvailable() {
-      return this.initialized;
-    }
-  }
+     Firebase Authentication
+     ==========================================================================
+     `window.firebaseAuth` is provided by firebase-config.js (loaded as a
+     module on every page). It exposes the surface this file used to
+     duplicate via a compat-SDK class. We removed that class — and the
+     compat SDK script tags — because loading both the v9 compat SDK
+     and the v10 modular SDK created two separate auth iframes that
+     raced over `apis.google.com/js/api.js?onload=__iframefcb<id>` and
+     produced `Uncaught TypeError: u[v] is not a function` on mobile.
+     Single SDK now: the modular one. */
 
   /* ==========================================================================
      Authentication UI Class
@@ -299,10 +120,25 @@
     init() {
       this.setupEventListeners();
       this.waitForHeader();
+      this._wireAuthListener();
+    }
 
-      if (window.firebaseAuth) {
+    /**
+     * `window.firebaseAuth` is set by firebase-config.js, which loads
+     * as `<script type="module">` and is therefore deferred until after
+     * this regular script runs. Either it's already there (page was
+     * cached / module finished early) or we wait for the
+     * `firebaseAuthReady` event the module dispatches once it's set up.
+     * @private
+     */
+    _wireAuthListener() {
+      const wire = () => {
+        if (!window.firebaseAuth) return false;
         window.firebaseAuth.onAuthStateChange(user => this.handleAuthStateChange(user));
-      }
+        return true;
+      };
+      if (wire()) return;
+      window.addEventListener('firebaseAuthReady', wire, { once: true });
     }
 
     /**
@@ -1075,8 +911,9 @@
 
   // Initialize all components when DOM is ready
   $(document).ready(() => {
-    // Initialize global instances
-    window.firebaseAuth = new FirebaseAuth();
+    // window.firebaseAuth is provided by firebase-config.js (loaded as
+    // a deferred module). AuthUI waits on the `firebaseAuthReady`
+    // event when the adapter isn't on window yet at construction time.
     window.authUI = new AuthUI();
 
     // Handle includes system

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,12 +1,37 @@
-// Firebase configuration module - initialize app and Firestore
-// Uses modular v9+ SDK via CDN imports
+// Firebase configuration + auth adapter — single source of truth.
+//
+// This file is loaded once per page as `<script type="module">`. It
+// initialises the Firebase modular v10 SDK exactly once and exposes a
+// minimal auth adapter on `window.firebaseAuth` for the non-module
+// scripts (assets/js/main.js, sync-modal-integration.js,
+// sync-debug.js) that need to read auth state without importing
+// modules themselves.
+//
+// History: the site previously loaded BOTH the v9 compat SDK (via
+// `<script src="firebase-app-compat.js">` + `firebase-auth-compat.js`)
+// AND this modular SDK. Each created its own `<authDomain>/__/auth/iframe`
+// for cross-origin auth-state sharing; each iframe pulled
+// `apis.google.com/js/api.js?onload=__iframefcb<id>` and registered a
+// callback by that name on `window`. On mobile the two iframes raced
+// — one iframe's `__iframefcb<id>` slot was cleared before that
+// iframe's gapi.js finished loading, so gapi tried to invoke a
+// callback that was already `undefined` (`Uncaught TypeError:
+// u[v] is not a function`). The compat SDK has been removed; the
+// adapter below provides the same surface main.js needs.
 
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
 import { getFirestore } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
 import { getDatabase } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-database.js";
-import { getAuth } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  setPersistence,
+  browserLocalPersistence
+} from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
 
-// Your Firebase config - using actual project credentials
 const firebaseConfig = {
   apiKey: "AIzaSyDlawczS-pufHS_Oi5LUeU_EzcwTFyU_2I",
   authDomain: "shevato-site.firebaseapp.com",
@@ -15,18 +40,98 @@ const firebaseConfig = {
   messagingSenderId: "1082724320778",
   appId: "1:1082724320778:web:e374cbaeeae1bdaeee81f3",
   measurementId: "G-2C9F2PCXHP",
-  databaseURL: "https://shevato-site-default-rtdb.firebaseio.com/" // Required for Realtime Database
+  databaseURL: "https://shevato-site-default-rtdb.firebaseio.com/"
 };
 
-// Initialize Firebase app
 const app = initializeApp(firebaseConfig);
 
-// Initialize services
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const rtdb = getDatabase(app);
+export { app };
 
-// Expose config to window for compat SDK (used by main.js auth)
+// Persistence — survive reloads across tabs. Best-effort; mobile
+// private mode and quota-exhausted browsers fall back to in-memory.
+setPersistence(auth, browserLocalPersistence).catch((err) => {
+  console.warn('Firebase auth persistence setup failed:', err.message);
+});
+
+// Adapter for non-module callers.
+let currentUser = null;
+const listeners = new Set();
+let authReady = false;
+let resolveReady;
+const readyPromise = new Promise((r) => { resolveReady = r; });
+
+onAuthStateChanged(auth, (user) => {
+  currentUser = user;
+  if (!authReady) {
+    authReady = true;
+    resolveReady();
+  }
+  for (const cb of listeners) {
+    try { cb(user); } catch (err) { console.error('Auth listener error:', err); }
+  }
+});
+
+const ERROR_MESSAGES = {
+  'auth/user-not-found': 'No account found with this email address.',
+  'auth/wrong-password': 'Incorrect password.',
+  'auth/invalid-login-credentials': 'Invalid email or password. Please check your credentials and try again.',
+  'auth/email-already-in-use': 'An account with this email already exists.',
+  'auth/weak-password': 'Password should be at least 6 characters.',
+  'auth/invalid-email': 'Please enter a valid email address.',
+  'auth/too-many-requests': 'Too many failed attempts. Please try again later.'
+};
+
+function formatAuthError(err) {
+  return new Error(ERROR_MESSAGES[err?.code] || err?.message || 'Authentication failed');
+}
+
 window.firebaseConfig = firebaseConfig;
 
-export { app };
+window.firebaseAuth = {
+  initialized: true,
+  isAvailable: () => true,
+  getCurrentUser: () => currentUser,
+  isSignedIn: () => currentUser !== null,
+  ready: () => readyPromise,
+  onAuthStateChange(callback) {
+    listeners.add(callback);
+    if (authReady) {
+      try { callback(currentUser); } catch (err) { console.error('Auth listener error:', err); }
+    }
+    return () => listeners.delete(callback);
+  },
+  async signIn(email, password) {
+    try {
+      const cred = await signInWithEmailAndPassword(auth, email, password);
+      return cred.user;
+    } catch (err) {
+      console.error('Sign in error:', err);
+      throw formatAuthError(err);
+    }
+  },
+  async signUp(email, password) {
+    try {
+      const cred = await createUserWithEmailAndPassword(auth, email, password);
+      return cred.user;
+    } catch (err) {
+      console.error('Sign up error:', err);
+      throw formatAuthError(err);
+    }
+  },
+  async signOut() {
+    try {
+      await signOut(auth);
+    } catch (err) {
+      console.error('Sign out error:', err);
+      throw err;
+    }
+  }
+};
+
+// Signal readiness. Non-module scripts (main.js's AuthUI) listen for
+// this; if they load AFTER this file evaluates, they fall back to the
+// `window.firebaseAuth` flag which is already set above.
+window.dispatchEvent(new CustomEvent('firebaseAuthReady'));

--- a/home.html
+++ b/home.html
@@ -250,11 +250,7 @@
   <script defer src="assets/js/breakpoints.min.js"></script>
   <script defer src="assets/js/util.js"></script>
 
-  <!-- Firebase SDK (required for auth functionality) -->
-  <script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-  <script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
-
-  <!-- Firebase Configuration (loads before main.js) -->
+  <!-- Firebase modular SDK + auth adapter (single source of auth state) -->
   <script type="module" src="firebase-config.js"></script>
 
   <!-- Main JavaScript -->

--- a/product.html
+++ b/product.html
@@ -165,11 +165,7 @@
   <script defer src="assets/js/breakpoints.min.js"></script>
   <script defer src="assets/js/util.js"></script>
 
-  <!-- Firebase SDK (required for auth functionality) -->
-  <script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-  <script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
-
-  <!-- Firebase Configuration (loads before main.js) -->
+  <!-- Firebase modular SDK + auth adapter (single source of auth state) -->
   <script type="module" src="firebase-config.js"></script>
 
   <!-- Main JavaScript -->

--- a/sync-system/storage-sync-robust.js
+++ b/sync-system/storage-sync-robust.js
@@ -1,20 +1,16 @@
 // Robust bidirectional localStorage ↔ Firebase sync module
 // Improved version with better conflict resolution and reliability
 
-import { 
-  doc, 
-  getDoc, 
-  setDoc, 
-  onSnapshot, 
+import {
+  doc,
+  setDoc,
+  onSnapshot,
   serverTimestamp,
-  runTransaction,
   deleteField
 } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
 
 import {
   ref,
-  get,
-  set,
   onValue,
   serverTimestamp as rtdbServerTimestamp,
   runTransaction as rtdbTransaction,
@@ -154,40 +150,66 @@ class StorageSyncManager {
   }
 
   /**
-   * Start sync for a namespace
+   * Start sync for a namespace.
+   *
+   * Single auth source — the modular SDK auth instance imported from
+   * firebase-config.js. The previous version maintained a compat-SDK
+   * fallback because the site loaded both SDKs simultaneously and the
+   * mobile auth iframe race could leave `auth.currentUser` null. The
+   * compat SDK has been removed entirely (see firebase-config.js for
+   * the full story) so this path is now straightforward: try
+   * `auth.currentUser` immediately, fall back to a one-shot
+   * `onAuthStateChanged` if not yet available.
    */
   startStorageSync({ namespace, keys, useFirestore = USE_FIRESTORE }) {
     const user = auth.currentUser;
-    if (!user) {
-      console.warn('❌ No authenticated user - sync will retry when user signs in');
-      // Return a sync object that will start when auth is ready
-      let actualSync = null;
-      const delayedSync = {
-        stop: () => {
-          if (actualSync) actualSync.stop();
-        }
-      };
-      
-      // Wait for auth state to be ready
-      const unsubscribe = auth.onAuthStateChanged((authUser) => {
-        if (authUser && !actualSync) {
-          actualSync = this._startSyncForUser(authUser, { namespace, keys, useFirestore });
-          unsubscribe(); // Only need this once
-        }
-      });
-      
-      return delayedSync;
+    if (user) {
+      return this._startSyncForUser(user, { namespace, keys, useFirestore });
     }
-    
-    return this._startSyncForUser(user, { namespace, keys, useFirestore });
+
+    console.warn('❌ No authenticated user — sync will start once auth is ready');
+    let actualSync = null;
+    const delayedSync = {
+      stop: () => { if (actualSync) actualSync.stop(); }
+    };
+
+    const unsubscribe = auth.onAuthStateChanged((authUser) => {
+      if (authUser?.uid && !actualSync) {
+        actualSync = this._startSyncForUser(authUser, { namespace, keys, useFirestore });
+        unsubscribe();
+      }
+    });
+
+    return delayedSync;
   }
   
   /**
-   * Internal method to start sync for an authenticated user
+   * Internal method to start sync for an authenticated user.
+   *
+   * Idempotent against duplicate calls. `auth.onAuthStateChanged` fires
+   * on every Firebase token refresh, not just on real sign-in/out, so
+   * `initAppSync()` was being called repeatedly during a normal
+   * session. Each call previously tore down the active sync and rebuilt
+   * it — fresh `onSnapshot` attach plus a fresh `getDoc` for the
+   * initial merge. Across multiple tabs and an hour-long session that
+   * was enough cumulative read traffic to trip Firestore's per-user
+   * rate limit (`429 Too Many Requests` on `/documents:batchGet`). We
+   * now skip the rebuild when the existing sync already matches the
+   * incoming user+namespace+keys.
    */
   _startSyncForUser(user, { namespace, keys, useFirestore = USE_FIRESTORE }) {
-    // Stop existing sync for this namespace
-    if (this.syncStates.has(namespace)) {
+    const existing = this.syncStates.get(namespace);
+    if (existing && !existing.stopped
+        && existing.userId === user.uid
+        && existing.useFirestore === useFirestore
+        && this._sameKeySet(existing.keys, keys)) {
+      return {
+        stop: () => this.stopSync(namespace),
+        getStatus: () => this.getSyncStatus(namespace)
+      };
+    }
+
+    if (existing) {
       this.stopSync(namespace);
     }
 
@@ -201,25 +223,25 @@ class StorageSyncManager {
       writeTimer: null,
       stopped: false,
       retryCount: 0,
-      lastSyncTime: Date.now()
+      lastSyncTime: Date.now(),
+      initialMergeDone: false
     };
-    
+
     this.syncStates.set(namespace, state);
-    
+
     // Initialize write queue
     if (!this.writeQueues.has(namespace)) {
       this.writeQueues.set(namespace, new Map());
     }
 
-    // Start Firebase listener
+    // Start Firebase listener — the listener's first snapshot doubles
+    // as the initial merge, so we no longer need a separate `getDoc`
+    // (that was the read costing us 429s on auth-state churn).
     if (useFirestore) {
       this.initFirestoreSync(state);
     } else {
       this.initRealtimeDbSync(state);
     }
-
-    // Perform initial merge after a short delay
-    setTimeout(() => this.performInitialMerge(state), 500);
 
     return {
       stop: () => this.stopSync(namespace),
@@ -227,59 +249,100 @@ class StorageSyncManager {
     };
   }
 
+  /** True iff the existing key set matches the incoming list exactly. */
+  _sameKeySet(existingSet, incomingKeys) {
+    if (existingSet.size !== incomingKeys.length) return false;
+    for (const k of incomingKeys) if (!existingSet.has(k)) return false;
+    return true;
+  }
+
   /**
-   * Enhanced Firestore sync with retry logic
+   * Firestore listener with retry logic.
+   *
+   * Important: any error path must tear down the previous `onSnapshot`
+   * before reattaching. Earlier versions skipped that step and pushed
+   * a fresh `unsubscribe` onto `state.listeners` on every retry, so
+   * each transient blip stacked another long-poll connection on top of
+   * the dead one. Google's Listen gateway then started returning 404
+   * for the orphaned session IDs (`/Listen/channel ... 404 (Not Found)`
+   * in the browser console) and the duplicate live listeners produced
+   * redundant `applyRemoteChange` calls that re-rendered views under
+   * the cursor — the source of the hover flicker.
+   *
+   * We now keep a single `state.unsubscribe` slot, swap it on every
+   * (re)attach, and only register one cleanup callback in
+   * `state.listeners` for `stopSync()` to invoke.
    */
   initFirestoreSync(state) {
     const docPath = `users/${state.userId}/apps/${state.namespace}`;
     const docRef = doc(db, docPath);
 
     let retryAttempts = 0;
+
+    const tearDown = () => {
+      if (state.unsubscribe) {
+        try { state.unsubscribe(); } catch (_) { /* SDK already gone */ }
+        state.unsubscribe = null;
+      }
+    };
+
     const setupListener = () => {
-      const unsubscribe = onSnapshot(docRef, 
+      tearDown();
+      if (state.stopped) return;
+
+      const unsubscribe = onSnapshot(docRef,
         (snapshot) => {
           if (state.stopped) return;
 
           const data = snapshot.data();
-          if (!data || !data.data) return;
+          const remoteData = data?.data || {};
 
-          // Apply remote changes to localStorage
-          for (const [key, info] of Object.entries(data.data)) {
+          for (const [key, info] of Object.entries(remoteData)) {
             if (!state.keys.has(key)) continue;
-
             this.applyRemoteChange(key, info);
           }
 
-          retryAttempts = 0; // Reset on success
-        }, 
+          // First snapshot doubles as the initial merge: any keys we
+          // have locally but Firestore doesn't are queued for upload.
+          // This replaces the old separate `getDoc` round-trip in
+          // `performInitialMerge`, which was the chief contributor to
+          // the 429s under auth-state churn.
+          if (!state.initialMergeDone) {
+            state.initialMergeDone = true;
+            this.uploadLocalOnlyKeys(state, remoteData);
+          }
+
+          retryAttempts = 0;
+        },
         (error) => {
-          // Better error classification and handling
           if (error.code === 'permission-denied' || error.code === 'unauthenticated') {
             console.error(`🔐 Authentication error for ${state.namespace}:`, error.message);
-            console.log('💡 User may need to sign in again');
-            return; // Don't retry auth errors
+            tearDown();
+            return;
           }
-          
+
           if (error.code === 'unavailable' || error.message?.includes('offline') || error.code === 'failed-precondition') {
             console.warn(`📡 Network/connection error for ${state.namespace}:`, error.message);
           } else {
             console.error(`❌ Firestore sync error for ${state.namespace}:`, error);
           }
-          
+
           if (retryAttempts < MAX_RETRY_ATTEMPTS) {
             retryAttempts++;
-            const delay = RETRY_DELAY_MS * Math.pow(2, retryAttempts - 1); // Exponential backoff
+            const delay = RETRY_DELAY_MS * Math.pow(2, retryAttempts - 1);
             console.log(`🔄 Retrying Firestore listener in ${delay}ms (${retryAttempts}/${MAX_RETRY_ATTEMPTS})`);
             setTimeout(setupListener, delay);
           } else {
             console.error(`💥 Max retries exceeded for ${state.namespace} - sync disabled`);
+            tearDown();
           }
         }
       );
 
-      state.listeners.push(() => unsubscribe());
+      state.unsubscribe = unsubscribe;
     };
 
+    state.listeners.push(tearDown);
     setupListener();
   }
 
@@ -294,11 +357,16 @@ class StorageSyncManager {
       if (state.stopped) return;
 
       const data = snapshot.val();
-      if (!data || !data.data) return;
+      const remoteData = data?.data || {};
 
-      for (const [key, info] of Object.entries(data.data)) {
+      for (const [key, info] of Object.entries(remoteData)) {
         if (!state.keys.has(key)) continue;
         this.applyRemoteChange(key, info);
+      }
+
+      if (!state.initialMergeDone) {
+        state.initialMergeDone = true;
+        this.uploadLocalOnlyKeys(state, remoteData);
       }
     };
 
@@ -316,15 +384,27 @@ class StorageSyncManager {
     const localRev = this.localRevisions.get(key);
     const remoteTimestamp = this.getTimestamp(remoteInfo.updatedAt);
     const lastRemoteUpdate = this.lastRemoteUpdates.get(key) || 0;
-    
+
     // Skip if we just processed this change
     if (remoteTimestamp <= lastRemoteUpdate) {
       return;
     }
-    
+
+    // Hash-equality short-circuit. Firestore re-emits the same document
+    // body whenever a listener reattaches (network blip, tab focus, SDK
+    // session refresh). The timestamp on those re-emits is fresher even
+    // though the value is byte-identical. Without this guard the app
+    // re-loads localStorage and re-renders every view on every reattach,
+    // which the user sees as flicker on hover when the cursor is over a
+    // card whose DOM gets rebuilt mid-interaction.
+    if (localRev && remoteInfo.hash && remoteInfo.hash === localRev.hash) {
+      this.lastRemoteUpdates.set(key, remoteTimestamp);
+      return;
+    }
+
     // Conflict resolution logic
     let shouldApply = true;
-    
+
     if (localRev) {
       // Compare timestamps first
       if (remoteTimestamp < localRev.updatedAt) {
@@ -472,40 +552,57 @@ class StorageSyncManager {
   }
 
   /**
-   * Enhanced Firestore flush with better transaction handling
+   * Firestore flush — surgical merge of only the keys this flush owns.
+   *
+   * Earlier versions wrapped this in `runTransaction` and spread the
+   * whole `currentData.data` back into the write payload (to bump a
+   * never-read `syncVersion`). When two browsers were signed into the
+   * same account, that pattern reliably produced a `400 Bad Request`
+   * at `/documents:commit`: the spread re-included field paths whose
+   * values had just been touched by `serverTimestamp()` on the other
+   * browser, and Firestore rejects a literal + transform on the same
+   * field path in a single commit. The spread also bloated payloads
+   * toward the 1 MiB doc limit. We now write only the changed keys,
+   * letting `merge: true` preserve everything else, and drop the
+   * unused syncVersion bookkeeping.
+   *
+   * Each value is sanitised through `JSON.parse(JSON.stringify(...))`
+   * to strip any `undefined` fields — Firestore rejects undefined and
+   * the override path can hand us them via `JSON.parse` round-trips.
    */
   async flushToFirestore(state, writes) {
     const docPath = `users/${state.userId}/apps/${state.namespace}`;
     const docRef = doc(db, docPath);
 
-    await runTransaction(db, async (transaction) => {
-      const snapshot = await transaction.get(docRef);
-      const currentData = snapshot.data() || { data: {}, meta: {} };
-
-      const updates = {
-        data: { ...currentData.data },
-        meta: {
-          ...currentData.meta,
-          lastUpdated: serverTimestamp(),
-          syncVersion: (currentData.meta?.syncVersion || 0) + 1
-        }
-      };
-
-      for (const [key, info] of writes) {
-        if (info.deleted) {
-          updates.data[key] = deleteField();
-        } else {
-          updates.data[key] = {
-            value: info.value,
-            rev: info.rev,
-            updatedAt: serverTimestamp(),
-            hash: info.hash
-          };
-        }
+    const dataPayload = {};
+    for (const [key, info] of writes) {
+      if (info.deleted) {
+        dataPayload[key] = deleteField();
+      } else {
+        dataPayload[key] = {
+          value: this.sanitiseForFirestore(info.value),
+          rev: info.rev,
+          updatedAt: serverTimestamp(),
+          hash: info.hash
+        };
       }
+    }
 
-      transaction.set(docRef, updates, { merge: true });
-    });
+    await setDoc(docRef, {
+      data: dataPayload,
+      meta: { lastUpdated: serverTimestamp() }
+    }, { merge: true });
+  }
+
+  /**
+   * Strip `undefined` values from a payload so Firestore accepts it.
+   * Strings/numbers/booleans/null pass through unchanged. Objects and
+   * arrays are deep-cloned via JSON, which drops undefined fields.
+   */
+  sanitiseForFirestore(value) {
+    if (value === null || value === undefined) return null;
+    if (typeof value !== 'object') return value;
+    return JSON.parse(JSON.stringify(value));
   }
 
   /**
@@ -542,92 +639,56 @@ class StorageSyncManager {
   }
 
   /**
-   * Enhanced initial merge with better conflict resolution
+   * Upload any keys we have in localStorage that are missing from the
+   * remote document. Invoked exactly once per sync session, from the
+   * first snapshot the realtime listener delivers — that snapshot
+   * gives us the same remote view that a separate `getDoc` used to
+   * fetch, so this replaces the read-heavy `performInitialMerge` that
+   * previously triggered `429 Too Many Requests` on auth-state churn.
+   *
+   * Conflicts where both sides exist are deliberately left to
+   * `applyRemoteChange` (which the snapshot loop already invoked):
+   * remote wins on a fresh state because the local revision map is
+   * empty at that moment, matching the previous "prefer remote on
+   * initial merge" behaviour without a second code path.
    */
-  async performInitialMerge(state) {
-    try {
-      let remoteData;
-      
-      if (state.useFirestore) {
-        const docRef = doc(db, `users/${state.userId}/apps/${state.namespace}`);
-        const snapshot = await getDoc(docRef);
-        remoteData = snapshot.data();
-      } else {
-        const dbRef = ref(rtdb, `users/${state.userId}/apps/${state.namespace}`);
-        const snapshot = await get(dbRef);
-        remoteData = snapshot.val();
-      }
+  uploadLocalOnlyKeys(state, remoteData) {
+    const localWrites = new Map();
+    const getItem = this.originalMethods?.getItem
+      ? this.originalMethods.getItem
+      : localStorage.getItem.bind(localStorage);
 
-      const localWrites = new Map();
-      const keysToApply = [];
+    for (const key of state.keys) {
+      const localValue = getItem(key);
+      if (localValue === null || localValue === undefined) continue;
+      if (remoteData[key] !== undefined) continue;
 
-      for (const key of state.keys) {
-        const localValue = this.originalMethods?.getItem ?
-          this.originalMethods.getItem(key) : localStorage.getItem(key);
-        const remoteInfo = remoteData?.data?.[key];
-
-        if (!remoteInfo && localValue !== null) {
-          // Local only - queue for upload
-          localWrites.set(key, {
-            value: this.parseValue(localValue),
-            rev: 1,
-            updatedAt: Date.now(),
-            hash: this.hashValue(this.parseValue(localValue))
-          });
-        } else if (remoteInfo && localValue === null) {
-          // Remote only - apply locally
-          keysToApply.push({ key, info: remoteInfo });
-        } else if (remoteInfo && localValue !== null) {
-          // Both exist - resolve conflict
-          const remoteTimestamp = this.getTimestamp(remoteInfo.updatedAt);
-          const localHash = this.hashValue(this.parseValue(localValue));
-
-          if (remoteInfo.hash !== localHash) {
-            // Values are different - prefer remote for safety on initial merge
-            keysToApply.push({ key, info: remoteInfo });
-          }
-        }
-      }
-
-      // Apply remote changes
-      for (const { key, info } of keysToApply) {
-        this.applyRemoteChange(key, info);
-      }
-
-      // Upload local changes
-      if (localWrites.size > 0) {
-        if (state.useFirestore) {
-          await this.flushToFirestore(state, localWrites);
-        } else {
-          await this.flushToRealtimeDb(state, localWrites);
-        }
-      }
-      
-    } catch (error) {
-      // Check if this is an authentication/permission error
-      if (error.code === 'permission-denied' || error.code === 'unauthenticated') {
-        console.error(`🔐 Auth error for ${state.namespace}:`, error.message);
-        console.log('💡 Waiting for user to sign in...');
-        return; // Don't retry auth errors
-      }
-      
-      // Check if this is a network/offline error
-      if (error.code === 'unavailable' || error.message?.includes('offline')) {
-        console.warn(`📡 Network error for ${state.namespace} - will retry when online:`, error.message);
-      } else {
-        console.error(`❌ Initial merge failed for ${state.namespace}:`, error);
-      }
-      
-      // Retry initial merge with exponential backoff
-      if (state.retryCount < 3) {
-        state.retryCount++;
-        const backoffDelay = RETRY_DELAY_MS * Math.pow(2, state.retryCount - 1);
-        console.log(`🔄 Retrying initial merge in ${backoffDelay}ms (attempt ${state.retryCount}/3)`);
-        setTimeout(() => this.performInitialMerge(state), backoffDelay);
-      } else {
-        console.error(`❌ Initial merge gave up for ${state.namespace} after 3 attempts`);
-      }
+      const parsed = this.parseValue(localValue);
+      localWrites.set(key, {
+        value: parsed,
+        rev: 1,
+        updatedAt: Date.now(),
+        hash: this.hashValue(parsed),
+        deleted: false
+      });
     }
+
+    if (localWrites.size === 0) return;
+
+    const flush = state.useFirestore
+      ? this.flushToFirestore(state, localWrites)
+      : this.flushToRealtimeDb(state, localWrites);
+
+    flush.catch((error) => {
+      if (error.code === 'permission-denied' || error.code === 'unauthenticated') {
+        console.error(`🔐 Auth error uploading local-only keys for ${state.namespace}:`, error.message);
+        return;
+      }
+      // Don't retry-loop here; the next user write will requeue these
+      // through the normal flush path. Retrying would re-hit the same
+      // rate limit that motivated this rewrite.
+      console.warn(`⚠️ Initial upload of local-only keys failed for ${state.namespace}:`, error.message);
+    });
   }
 
   /**

--- a/sync-system/sync-modal-integration.js
+++ b/sync-system/sync-modal-integration.js
@@ -47,72 +47,54 @@
     }
   }
   
-  // Listen for Firebase auth state changes
+  // Listen for Firebase auth state changes via the modular adapter
+  // exposed by firebase-config.js. The compat SDK and `window.firebase`
+  // are gone (they caused the mobile `__iframefcb` race); this path
+  // now waits on the `firebaseAuthReady` event or polls the global.
   function setupAuthListener() {
-    // Wait for both Firebase compat and the modern auth system
-    if (!window.firebase || !window.firebase.auth) {
-      setTimeout(setupAuthListener, 200);
+    if (!window.firebaseAuth?.onAuthStateChange) {
+      window.addEventListener('firebaseAuthReady', setupAuthListener, { once: true });
+      // Also poll as a safety net in case the event fired before this
+      // script was registered. Bounded by the auth-ready resolve so it
+      // doesn't loop forever.
+      setTimeout(() => {
+        if (window.firebaseAuth?.onAuthStateChange) setupAuthListener();
+      }, 500);
       return;
     }
 
-    // Additional check for Firebase app initialization
-    try {
-      const auth = window.firebase.auth();
+    window.firebaseAuth.onAuthStateChange((user) => {
+      const currentUserId = user ? user.uid : null;
 
-      // Check if Firebase app is properly initialized
-      if (!auth.app || !auth.app.options) {
-        setTimeout(setupAuthListener, 200);
-        return;
-      }
-      
-      auth.onAuthStateChanged((user) => {
-        const currentUserId = user ? user.uid : null;
-        
-        if (user && currentUserId !== lastKnownUserId && !isInitialPageLoad) {
-          // This is a genuinely new sign-in (not a page reload with existing auth)
-          // Additional check: make sure we haven't shown modal recently
-          const lastModalTime = sessionStorage.getItem('lastSyncModalTime');
-          const now = Date.now();
-          
-          if (!lastModalTime || (now - parseInt(lastModalTime)) > 30000) { // 30 second cooldown
-            userJustSignedIn = true;
-            awaitingInitialSync = true;
-            syncCompleted = false;
-            lastKnownUserId = currentUserId;
-            
-            // Store when we last showed the modal
-            sessionStorage.setItem('lastSyncModalTime', now.toString());
+      if (user && currentUserId !== lastKnownUserId && !isInitialPageLoad) {
+        const lastModalTime = sessionStorage.getItem('lastSyncModalTime');
+        const now = Date.now();
 
-            showSyncModal();
-
-            // Start checking for sync completion
-            checkForSyncCompletion();
-          } else {
-            lastKnownUserId = currentUserId;
-          }
-
-        } else if (user && isInitialPageLoad) {
-          // User was already signed in on page load - no modal needed
+        if (!lastModalTime || (now - parseInt(lastModalTime)) > 30000) {
+          userJustSignedIn = true;
+          awaitingInitialSync = true;
+          syncCompleted = false;
           lastKnownUserId = currentUserId;
-          
-        } else if (!user && userJustSignedIn) {
-          // User signed out
-          userJustSignedIn = false;
-          awaitingInitialSync = false;
-          lastKnownUserId = null;
-          hideSyncModal();
+          sessionStorage.setItem('lastSyncModalTime', now.toString());
+
+          showSyncModal();
+          checkForSyncCompletion();
+        } else {
+          lastKnownUserId = currentUserId;
         }
-        
-        // Mark initial page load as complete after first auth state change
-        if (isInitialPageLoad) {
-          isInitialPageLoad = false;
-        }
-      });
-      
-    } catch (error) {
-      console.warn('Firebase auth setup error:', error.message);
-      setTimeout(setupAuthListener, 500);
-    }
+      } else if (user && isInitialPageLoad) {
+        lastKnownUserId = currentUserId;
+      } else if (!user && userJustSignedIn) {
+        userJustSignedIn = false;
+        awaitingInitialSync = false;
+        lastKnownUserId = null;
+        hideSyncModal();
+      }
+
+      if (isInitialPageLoad) {
+        isInitialPageLoad = false;
+      }
+    });
   }
   
   // Check if sync has completed by monitoring localStorage changes


### PR DESCRIPTION
## Summary

Three intertwined fixes around the gym-tracker sync indicator. They share files (sync-status.js, storage-sync-robust.js, gym-tracker index.html, css), but each tackles a distinct production issue.

### 1. Eliminated the dual Firebase SDK (root cause of the mobile `__iframefcb` error)

The site loaded **both** the v9 compat SDK (script tags) **and** the v10 modular SDK. Each spun up its own `<authDomain>/__/auth/iframe`; each iframe pulled `apis.google.com/js/api.js?onload=__iframefcb<id>` and registered a callback by that name on `window`. On mobile the two iframes raced and one `__iframefcb<id>` slot was cleared before its gapi.js finished, producing `Uncaught TypeError: u[v] is not a function`.

- `firebase-config.js` is now the single source of auth state and exposes a `window.firebaseAuth` adapter for non-module callers via a `firebaseAuthReady` event.
- `assets/js/main.js`'s `FirebaseAuth` compat class deleted (~180 lines).
- Compat `<script>` tags removed from every HTML page (`home.html`, `apps.html`, `product.html`, `404.html`, `apps/gym-tracker/index.html`, `apps/football-h2h/index.html`, `apps/mario-kart/tracker.html`).
- `sync-modal-integration.js`, `sync-status.js`, `settings-view.js`, `storage-sync-robust.js` read state through the modular adapter only.
- **Regression guard**: `tests/firebase-sdk-singleton.test.mjs` scans every HTML file and fails if a compat tag reappears.

### 2. Rebuilt the storage-sync engine for resilience

Fixes a chain of console errors that surfaced under multi-browser / mobile use:

- **400 Bad Request on `/documents:commit`** — `flushToFirestore` no longer wraps in a transaction and no longer spreads `currentData.data` back into the payload (the spread re-sent `serverTimestamp`-touched field paths, which Firestore rejects when two browsers race). Plain `setDoc(merge: true)` with only the changed keys.
- **404 on `/Listen/channel`** — `initFirestoreSync` tracks a single `state.unsubscribe` and tears it down before reattaching on error. Previously every transient blip stacked another listener and Google's gateway returned 404 for orphaned sessions.
- **Hover flicker** — `applyRemoteChange` short-circuits when the incoming hash matches the local hash. Listener reattaches with byte-identical payloads (the SDK does this on focus/network blip) no longer re-emit `localStorageSync` events that triggered view re-renders under the cursor.
- **429 Too Many Requests on `/documents:batchGet`** — `_startSyncForUser` is idempotent against duplicate calls, so token-refresh churn (every `onAuthStateChanged` fire) doesn't tear down and rebuild the listener. The standalone `performInitialMerge` (with its `getDoc`) was replaced with `uploadLocalOnlyKeys`, called inline on the listener's first snapshot — eliminates the duplicate read per session start and removes a retry loop that would amplify a 429.
- **Live cross-device updates** — `app.js` now subscribes to the `localStorageSync` custom event the storage layer dispatches when remote changes are applied, debounced 750ms. New `refreshFromStorage()` helper. Cross-device data shows up in the active view without a manual refresh.

### 3. Redesigned the sync status indicator on gym-tracker

- Removed the floating bottom-right pill that flickered between sets (DOM dedupe in render + the hash short-circuit above stop upstream echo storms).
- **Desktop**: inline pill in the side-nav footer, always visible with full label.
- **Mobile**: 8px colored dot in the corner of the bottom-nav More button — at-a-glance "everything synced" without taking workout screen real estate. Plus a slim top banner that appears only when offline, and flashes green for ~2s on the offline→synced recovery transition.
- `classifySyncStatus` is a pure exported function with full unit tests; `signedIn=true` differentiates "transitional connecting" from "local only" so the mobile dot doesn't stay slate while sync attaches after sign-in.
- Removed the duplicate floating "Start workout" FAB on mobile (the bottom-nav already has a primary Workout button). FAB stays on desktop where the side-nav has no one-tap workout entry.

### 4. Bonus: history Clear button no-op state

The Clear button on Workout History is now `disabled` + `aria-disabled="true"` + dimmed (CSS `opacity: 0.45; cursor: not-allowed; pointer-events: none`) when neither the From nor the To date filter is active, so the click is no longer a no-op affordance.

## Test plan

- [x] `npm test` — 228 passing locally (was 113), including 11 new `classifySyncStatus` tests and 2 SDK-singleton regression guards.
- [ ] Open gym-tracker on **desktop**, sign in/out, log a workout. Console clean. Side-nav sync pill turns green within a second of sign-in.
- [ ] Open gym-tracker on **mobile** (DevTools mobile emulation or a real device). Console clean — no `api.js u[v] is not a function`, no `400` on `/documents:commit`, no `404` on `/Listen/channel`, no `429` on `/documents:batchGet`. The More-button dot reaches green after sign-in.
- [ ] Sign in to gym-tracker on **two browsers** for the same account. Edits in Browser A appear in Browser B without a manual refresh.
- [ ] Toggle DevTools "Offline" while in gym-tracker. Top banner appears with "You're offline — changes saved on this device". Toggle back online; banner flashes green "Back online — synced" for ~2s then fades.
- [ ] Hover cards in History / Programs while sync is active — no DOM flicker.
- [ ] On Workout History, the Clear button is dim and unresponsive until either date is set; click works once a date is picked.
- [ ] **404 page**: auth modal still opens (firebase-config.js was added there too).
- [ ] **football-h2h** and **mario-kart**: sync still attaches on page load.