### PR TITLE
Rising Seasons: per-season year, Sherlock fixes, cleaner show modal

### DIFF
--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -1206,16 +1206,6 @@ button.shape-tag.is-clickable:hover {
   background: var(--accent-soft);
   color: var(--accent);
 }
-/* "Varied across seasons" hint — rendered when the show-level shape
-   intersection is empty. Reads as a quiet note, not a tag claim. */
-.shape-tag.varied-hint {
-  background: transparent;
-  color: var(--muted);
-  border: 1px dashed rgba(255, 255, 255, 0.18);
-  font-style: italic;
-  font-weight: 500;
-  letter-spacing: 0.005em;
-}
 
 .best-badge {
   display: inline-block;

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -76,6 +76,13 @@ const els = {
 const state = {
   shapes: new Set(),
   search: '',
+  // When the user picks a series from the search suggestions, we lock the
+  // results to that exact seriesId. The displayed search value is the
+  // title ("Sherlock"), but the filter ignores `search` and exact-matches
+  // `lockedSeriesId` so we don't fuzzy-match other shows that share a
+  // word in the title (e.g., "Sherlock Holmes"). Cleared the moment the
+  // user edits the search input again.
+  lockedSeriesId: null,
   minEpisodes: null,
   maxEpisodes: null,
   minVotes: null,
@@ -462,7 +469,12 @@ function buildNonShapeChecker() {
     if (minYear && yearForFilter && yearForFilter < minYear) return false;
     if (maxYear && yearForFilter && yearForFilter > maxYear) return false;
     if (seriesType !== 'all' && m.type !== seriesType) return false;
-    if (q) {
+    if (state.lockedSeriesId) {
+      // Suggestion-locked: exact-match the chosen series; ignore the
+      // (display-only) search text. The lock is cleared the moment the
+      // user edits the search input.
+      if (m.seriesId !== state.lockedSeriesId) return false;
+    } else if (q) {
       const titleHit = m.title.toLowerCase().includes(q);
       const idHit = m.seriesId.toLowerCase().includes(q);
       if (!titleHit && !idHit) return false;
@@ -1513,6 +1525,11 @@ function selectSuggestion(i) {
   if (!s) return;
   els.search.value = s.title;
   state.search = s.title;
+  // Pin the results to this exact series — substring-match on title
+  // would otherwise pull in unrelated shows that share a word
+  // (e.g., picking BBC "Sherlock" would also surface "Sherlock Holmes"
+  // and "The Case-Book of Sherlock Holmes").
+  state.lockedSeriesId = s.seriesId;
   closeSuggestions();
   state.page = 1;
   writeStateToURL();
@@ -1557,6 +1574,9 @@ function bindEvents() {
     els[id].addEventListener('input', onToolbarChange);
     els[id].addEventListener('change', onToolbarChange);
   }
+  // Any direct keystroke in the search box releases the suggestion lock —
+  // the user is now searching freeform, not riding a picked series.
+  els.search.addEventListener('input', () => { state.lockedSeriesId = null; });
 
   if (els.labelFilters) {
     for (const btn of els.labelFilters.querySelectorAll('.label-chip')) {
@@ -1610,6 +1630,7 @@ function bindEvents() {
   els.resetFilters.addEventListener('click', () => {
     state.shapes.clear();
     state.search = '';
+    state.lockedSeriesId = null;
     state.minEpisodes = null;
     state.maxEpisodes = null;
     state.minVotes = null;
@@ -1691,6 +1712,7 @@ function bindKeyboard() {
         document.body.classList.remove('is-menu-visible');
       } else if (document.activeElement === els.search && els.search.value) {
         els.search.value = '';
+        state.lockedSeriesId = null;
         onToolbarChange();
       }
       return;

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -454,8 +454,13 @@ function buildNonShapeChecker() {
     if (minVotes && m.minVotes < minVotes) return false;
     if (minAvg && m.avgRating < minAvg) return false;
     if (minClimb && (m.lastRating - m.firstRating) < minClimb) return false;
-    if (minYear && m.year && m.year < minYear) return false;
-    if (maxYear && m.year && m.year > maxYear) return false;
+    // Year filter compares against the season's own air year (falls back
+    // to the show's start year if the season year is missing) so users
+    // searching "year >= 2020" see the seasons that actually aired in 2020+,
+    // not just shows that PREMIERED before then.
+    const yearForFilter = m.seasonYear || m.year;
+    if (minYear && yearForFilter && yearForFilter < minYear) return false;
+    if (maxYear && yearForFilter && yearForFilter > maxYear) return false;
     if (seriesType !== 'all' && m.type !== seriesType) return false;
     if (q) {
       const titleHit = m.title.toLowerCase().includes(q);
@@ -501,7 +506,7 @@ function filterAndSort() {
       case 'climb':  primary = (b.lastRating - b.firstRating) - (a.lastRating - a.firstRating); break;
       case 'finale': primary = b.lastRating - a.lastRating; break;
       case 'avg':    primary = b.avgRating - a.avgRating; break;
-      case 'recent': primary = (b.year || 0) - (a.year || 0); break;
+      case 'recent': primary = ((b.seasonYear || b.year) || 0) - ((a.seasonYear || a.year) || 0); break;
       case 'popularity':
       default:       primary = b.minVotes - a.minVotes; break;
     }
@@ -814,7 +819,7 @@ function buildCard(m) {
 
   node.querySelector('.card-title').textContent = m.title;
   node.querySelector('.card-season').textContent = `S${m.season} · ${m.episodes.length} eps`;
-  node.querySelector('.card-year').textContent = m.year || 'year unknown';
+  node.querySelector('.card-year').textContent = (m.seasonYear || m.year) || 'year unknown';
   node.querySelector('.card-genres').textContent = m.genres.slice(0, 3).join(' · ');
 
   const badge = maybeBestBadge(m);
@@ -867,7 +872,7 @@ function buildRow(m) {
 
   node.querySelector('.row-title').textContent = m.title;
   node.querySelector('.row-season').textContent = `S${m.season} · ${m.episodes.length} eps`;
-  node.querySelector('.row-year').textContent = m.year || '';
+  node.querySelector('.row-year').textContent = (m.seasonYear || m.year) || '';
 
   const badge = maybeBestBadge(m);
   if (badge) node.querySelector('.row-head').appendChild(badge);
@@ -989,7 +994,8 @@ function openModal(m, opts = {}) {
   modalState.surprise = !!opts.surprise;
 
   els.modalTitle.textContent = m.title;
-  const yearStr = m.year ? ` · ${m.year}` : '';
+  const seasonYearStr = (m.seasonYear || m.year);
+  const yearStr = seasonYearStr ? ` · ${seasonYearStr}` : '';
   els.modalSubtitle.textContent = `Season ${m.season} · ${m.episodes.length} episodes${yearStr} · ${m.genres.join(', ') || 'No genre listed'}`;
 
   fillShapeTags(els.modalShapes, m.shapes, { clickable: false });
@@ -1214,7 +1220,8 @@ function buildShowSeasonRow(m, bestSeason) {
   meta.className = 'ss-meta';
   const eps = document.createElement('span');
   eps.className = 'ss-eps';
-  const yearStr = m.year ? ` · ${m.year}` : '';
+  const ssYear = m.seasonYear || m.year;
+  const yearStr = ssYear ? ` · ${ssYear}` : '';
   eps.textContent = `${m.episodes.length} eps${yearStr}`;
   meta.appendChild(eps);
   if (m.shapes.length) {

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -1169,19 +1169,7 @@ function openShowModal(seriesId) {
       }
     }
   }
-  const shapeList = commonShapes ? [...commonShapes] : [];
-  els.showModalShapes.replaceChildren();
-  if (shapeList.length > 0) {
-    fillShapeTags(els.showModalShapes, shapeList, { clickable: false });
-  } else if (seasons.length > 1) {
-    // No single shape applies to every season — render a muted hint so the
-    // header doesn't read as "no shape information" (which would be wrong).
-    const hint = document.createElement('span');
-    hint.className = 'shape-tag varied-hint';
-    hint.textContent = 'Varied across seasons';
-    hint.title = 'Each season has its own pattern — see per-season chips below';
-    els.showModalShapes.appendChild(hint);
-  }
+  fillShapeTags(els.showModalShapes, commonShapes ? [...commonShapes] : [], { clickable: false });
 
   els.showModalOverview.textContent = meta.overview || '';
 

--- a/apps/rising-seasons/scripts/build-data.js
+++ b/apps/rising-seasons/scripts/build-data.js
@@ -68,12 +68,13 @@ async function loadRatings() {
 }
 
 async function loadSeries(ratings) {
-  // Single pass: collect series basics AND episode titles. We skip
-  // unrated episodes because they can never appear in our matches —
-  // that keeps the episodeTitles map roughly bounded to the size of the
-  // ratings map (~1.5M entries) instead of every tvEpisode ever (~6M+).
+  // Single pass: collect series basics AND episode titles + air years.
+  // We skip unrated episodes because they can never appear in our matches —
+  // that keeps the maps roughly bounded to the size of the ratings map
+  // (~1.5M entries) instead of every tvEpisode ever (~6M+).
   const series = new Map();
   const episodeTitles = new Map();
+  const episodeYears = new Map();
   const rl = openTsv('title.basics.tsv.gz');
   let header = true;
   for await (const line of rl) {
@@ -89,6 +90,11 @@ async function loadSeries(ratings) {
       if (primaryTitle && primaryTitle !== '\\N') {
         episodeTitles.set(tconst, primaryTitle);
       }
+      const startYear = cols[5];
+      if (startYear && startYear !== '\\N') {
+        const y = parseInt(startYear, 10);
+        if (Number.isFinite(y)) episodeYears.set(tconst, y);
+      }
       continue;
     }
 
@@ -103,10 +109,10 @@ async function loadSeries(ratings) {
       genres,
     });
   }
-  return { series, episodeTitles };
+  return { series, episodeTitles, episodeYears };
 }
 
-async function loadEpisodes(series, ratings, episodeTitles) {
+async function loadEpisodes(series, ratings, episodeTitles, episodeYears) {
   // Map<seriesId, Map<seasonNumber, Array<{episode, tconst, rating, votes, name}>>>
   const result = new Map();
   const rl = openTsv('title.episode.tsv.gz');
@@ -138,6 +144,10 @@ async function loadEpisodes(series, ratings, episodeTitles) {
     const ep = { episode, tconst, rating: r.rating, votes: r.votes };
     const name = episodeTitles && episodeTitles.get(tconst);
     if (name) ep.name = name;
+    const year = episodeYears && episodeYears.get(tconst);
+    // Year is build-internal — match.js consumes it to compute the
+    // per-season `seasonYear` and then drops it from the projection.
+    if (year) ep.year = year;
     arr.push(ep);
   }
   return result;
@@ -160,15 +170,16 @@ function loadTmdbCache() {
   const ratings = await loadRatings();
   console.log(`${ratings.size.toLocaleString()} rated titles`);
 
-  process.stdout.write('Loading series basics + episode titles... ');
-  const { series, episodeTitles } = await loadSeries(ratings);
+  process.stdout.write('Loading series basics + episode titles + air years... ');
+  const { series, episodeTitles, episodeYears } = await loadSeries(ratings);
   console.log(
     `${series.size.toLocaleString()} TV series + mini-series, ` +
-    `${episodeTitles.size.toLocaleString()} episode titles`,
+    `${episodeTitles.size.toLocaleString()} episode titles, ` +
+    `${episodeYears.size.toLocaleString()} episode air years`,
   );
 
   process.stdout.write('Loading episodes... ');
-  const episodes = await loadEpisodes(series, ratings, episodeTitles);
+  const episodes = await loadEpisodes(series, ratings, episodeTitles, episodeYears);
   console.log(`${episodes.size.toLocaleString()} series have rated episodes`);
 
   process.stdout.write('Detecting shape matches... ');

--- a/apps/rising-seasons/scripts/build-data.js
+++ b/apps/rising-seasons/scripts/build-data.js
@@ -32,7 +32,11 @@ const DATA_DIR = path.join(__dirname, '..', 'data');
 const OUT_FILE = path.join(__dirname, '..', 'data.json');
 const TMDB_CACHE = path.join(DATA_DIR, 'tmdb-cache.json');
 
-const MIN_EPISODES = parseInt(process.env.MIN_EPISODES || '4', 10);
+// Default 3 (was 4) so short-season formats like BBC Sherlock (3 eps/season)
+// are included. Most shape detectors require >= 4 episodes internally, so
+// short seasons will be emitted as shape-less rows under the parent show
+// rather than appearing as their own pattern hits.
+const MIN_EPISODES = parseInt(process.env.MIN_EPISODES || '3', 10);
 const MIN_VOTES = parseInt(process.env.MIN_VOTES || '100', 10);
 const SERIES_TYPES = new Set(['tvSeries', 'tvMiniSeries']);
 

--- a/apps/rising-seasons/scripts/match.js
+++ b/apps/rising-seasons/scripts/match.js
@@ -234,10 +234,23 @@ function findMatches(seriesById, episodesBySeries, opts = {}) {
     const ratings = eps.map((e) => e.rating);
     const seasonAvg = ratings.reduce((s, r) => s + r, 0) / ratings.length;
 
+    // seasonYear = earliest air year across the season's episodes. We use
+    // min (rather than the first episode's year) so an out-of-order ep
+    // doesn't pull the year forward; if no episode carries a year, we
+    // fall back to null and the UI uses the show's start year (`year`).
+    let seasonYear = null;
+    for (const e of eps) {
+      if (e.year && (!seasonYear || e.year < seasonYear)) seasonYear = e.year;
+    }
+
     matches.push({
       seriesId,
       title: meta.title,
       year: meta.year,
+      // Per-season air year — distinct from `year` (show start year). The
+      // UI prefers seasonYear everywhere a single season is displayed and
+      // falls back to `year` when the build pipeline didn't supply one.
+      seasonYear,
       type: meta.type,
       genres: meta.genres || [],
       season,
@@ -245,6 +258,8 @@ function findMatches(seriesById, episodesBySeries, opts = {}) {
       // drop `tconst` — it's the IMDb episode ID we used to join the ratings
       // and titles tables during build, but the front-end never reads it,
       // so shipping it inflates data.json by ~1.5MB across ~126K episodes.
+      // We also drop the per-episode `year` because seasonYear above
+      // captures the only year the UI needs.
       episodes: eps.map(({ episode, rating, votes, name }) => {
         const ep = { episode, rating, votes };
         if (name) ep.name = name;


### PR DESCRIPTION
Follow-ups to #64 (which shipped the mobile redesign + episode names).

## Summary
- **Per-season year, not show start year.** Each match now carries `seasonYear` (computed at build time from the earliest air year across the season's episodes in `title.basics.tsv.gz`). The card/list/season-modal/show-modal year, the year-range filter, and the "Most recent" sort all use it; search suggestions keep the show-level `year` (suggestions point at a series, not a season). Breaking Bad now reads S1=2008 / S2=2009 / S3=2010 / S4=2011 / S5=2012 instead of "2008" everywhere.
- **Include short-season shows (Sherlock S2 was missing).** `MIN_EPISODES` default lowered from 4 to 3 so BBC-style 3-episode seasons aren't dropped at the build floor. Sherlock now shows all 4 seasons. data.json: 8,646 → 8,975 matches (+329). Most shape detectors still require ≥4 eps internally, so 3-ep seasons emit with `shapes: []` under the parent show and don't pollute the pattern tabs.
- **Search-suggestion fix: picking "Sherlock" no longer surfaces "Sherlock Holmes".** The suggestion handler was setting the search input to the picked series' title, and the downstream filter then substring-matched that against every other show. Added `state.lockedSeriesId` — when a suggestion is picked, the result filter exact-matches that ID and ignores the (display-only) search text. Auto-released the moment the user edits the input, hits Reset, or ESC-clears the search.
- **Cleaner show-modal header.** When no shape applies to every season of a show, the header is now simply empty (was previously a dashed "Varied across seasons" hint). Per-season chips still convey per-season patterns.

## Files changed
- `apps/rising-seasons/scripts/build-data.js` — collect episode air years; default `MIN_EPISODES` 4 → 3
- `apps/rising-seasons/scripts/match.js` — compute `seasonYear` per match
- `apps/rising-seasons/js/app.js` — UI uses `seasonYear`; `lockedSeriesId` flow; remove "Varied" hint
- `apps/rising-seasons/css/styles.css` — remove orphaned `.shape-tag.varied-hint` rule
- `apps/rising-seasons/data.json` — rebuilt (per-season years, +329 short seasons)

## Test plan
- [x] `npm test` — 272/272 pass
- [ ] Open Breaking Bad → show modal shows S1-S5 each with its own year
- [ ] Open Sherlock → all 4 seasons visible (S1 2010, S2 2012, S3 2013, S4 2016)
- [ ] Type `Sherlock` in search → pick BBC Sherlock from the suggestion dropdown → results show only BBC Sherlock (not "Sherlock Holmes" or "The Case-Book of Sherlock Holmes"); editing the search field releases the lock
- [ ] Year filter `>= 2020` returns seasons that actually aired in 2020+, not shows that premiered before then
- [ ] "Most recent" sort orders by season year, not show year
- [ ] Show modal: shows whose seasons share no shape no longer show the dashed "Varied across seasons" pill