### PR TITLE
Rising Seasons: discovery features (compare, filters, search, polish)

### DIFF
--- a/.github/workflows/refresh-rising-seasons.yml
+++ b/.github/workflows/refresh-rising-seasons.yml
@@ -67,7 +67,11 @@ jobs:
             echo "::warning::TMDB_TOKEN secret not configured — skipping enrichment."
             exit 0
           fi
+          # Step 1: posters / overviews / original language.
           node apps/rising-seasons/scripts/enrich-tmdb.js
+          # Step 2: US watch providers (separate call per series; incremental).
+          node apps/rising-seasons/scripts/enrich-providers.js
+          # Merge both into data.json.
           node --max-old-space-size=4096 apps/rising-seasons/scripts/build-data.js
 
       # Persist the cache for the next run regardless of whether the

--- a/apps/rising-seasons/DATA_README.md
+++ b/apps/rising-seasons/DATA_README.md
@@ -2,8 +2,9 @@
 
 The Rising Seasons app is powered by `apps/rising-seasons/data.json`, a build
 artifact regenerated from IMDb's daily TSV dumps (and optionally enriched
-with TMDB posters + overviews). The data file is committed to the repo
-so the static site has zero runtime dependencies.
+with TMDB posters, plot overviews, original language, and US watch
+providers). The data file is committed to the repo so the static site
+has zero runtime dependencies.
 
 ## Automated weekly refresh
 
@@ -13,10 +14,12 @@ The workflow `.github/workflows/refresh-imdb.yml` runs every **Monday at
 1. Downloads the three IMDb gzipped TSV dumps.
 2. Runs `node apps/rising-seasons/scripts/build-data.js` to regenerate
    `data.json`.
-3. If the `TMDB_TOKEN` secret is set, runs the TMDB enrichment script
-   and rebuilds so posters and overviews are merged in. The TMDB cache
-   is persisted between runs via `actions/cache` so each refresh only
-   fetches metadata for newly-discovered series.
+3. If the `TMDB_TOKEN` secret is set, runs both TMDB enrichment scripts
+   in sequence — `enrich-tmdb.js` (posters / overviews / language) then
+   `enrich-providers.js` (US watch providers) — and rebuilds so the new
+   fields are merged in. The TMDB cache is persisted between runs via
+   `actions/cache` so each refresh only fetches metadata for newly-
+   discovered series.
 4. Runs the test suite.
 5. Commits `data.json` back to the branch the workflow ran on, but
    *only if it actually changed*.
@@ -52,8 +55,10 @@ cd ../../..
 # 2. Build data.json from the dumps.
 npm run build:rising-seasons
 
-# 3. (Optional) Enrich with posters + overviews.
-TMDB_TOKEN='eyJh...' npm run enrich:rising-seasons
+# 3. (Optional) Enrich with TMDB metadata. Both scripts are incremental —
+#    they only fetch series missing the data each one provides.
+TMDB_TOKEN='eyJh...' npm run enrich:rising-seasons             # posters / overviews / language
+TMDB_TOKEN='eyJh...' npm run enrich:rising-seasons:providers   # US watch providers
 npm run build:rising-seasons   # re-run to merge the cache into data.json
 
 # 4. Commit if anything changed.
@@ -75,31 +80,49 @@ gh run watch
 
 ```jsonc
 {
-  "builtAt": "2026-05-08T18:15:23.000Z",
-  "minEpisodes": 4,         // build-time threshold
-  "minVotes": 100,          // build-time threshold
-  "count": 4230,            // total matching seasons
+  "builtAt": "2026-05-11T18:24:00.000Z",
+  "minEpisodes": 3,                                       // build-time threshold
+  "minVotes": 100,                                        // build-time threshold
+  "relaxedGenres": ["Reality-TV", "Game-Show", "Talk-Show"], // genres that get the lower floor below
+  "relaxedMinVotes": 10,                                  // per-episode vote floor for relaxed-genre series
+  "count": 16510,                                         // total matching seasons
   "shapeCounts": {
-    "rising": 356, "consistent": 253, "slow-burn": 622,
-    "big-finale": 2490, "rebound": 2088
+    "rollercoaster": 3551, "big-finale": 2999, "rebound": 2783,
+    "mid-peak": 1105, "bad-finale": 1041, "slow-burn": 873,
+    "rising": 603, "front-loaded": 540, "consistent": 461, "declining": 211
   },
-  "genres": [{"name": "Drama", "count": 2637}, ...],
+  "genres": [{"name": "Drama", "count": 6880}, ...],
+  "languages": [{"code": "en", "count": 5015}, {"code": "ja", "count": 455}, ...],
+  "providers": [{"name": "Netflix", "count": 1566}, {"name": "Hulu", "count": 735}, ...],
   "matches": [
     {
       "seriesId": "tt...",
-      "title": "...", "year": 2020, "type": "tvSeries",
+      "title": "...", "year": 2020, "seasonYear": 2021, "type": "tvSeries",
       "genres": ["Drama", "Crime"],
       "season": 1,
-      "episodes": [{"episode": 1, "rating": 7.4, "votes": 1234, "tconst": "tt..."}, ...],
+      "episodes": [{"episode": 1, "rating": 7.4, "votes": 1234, "name": "Pilot"}, ...],
       "firstRating": 7.4, "lastRating": 9.1, "avgRating": 8.2,
       "minVotes": 1234,
       "shapes": ["rising", "slow-burn"],
-      // present when TMDB enrichment ran:
-      "poster": "/abc.jpg", "overview": "...", "tmdbId": 12345
+      "seriesRating": 8.6, "seriesVotes": 124500,
+      // present when TMDB enrich-tmdb.js ran:
+      "poster": "/abc.jpg", "overview": "...", "tmdbId": 12345,
+      "language": "en",
+      // present when TMDB enrich-providers.js ran AND the series has US streaming:
+      "providers": ["Netflix", "Hulu"]
     }
   ]
 }
 ```
+
+Notes on individual fields:
+
+- `year` is the show's start year; `seasonYear` is the air year of the earliest-aired episode in this specific season. The UI prefers `seasonYear` everywhere a single season is rendered and falls back to `year` if absent.
+- `episodes[].name` is present when IMDb has an episode title for it. Per-episode `tconst` and `year` are intentionally dropped from the projection to keep `data.json` small — the UI doesn't read them.
+- `seriesRating` / `seriesVotes` are the show-level IMDb score (not the average of episode ratings).
+- `language` is a TMDB-supplied ISO 639-1 code (e.g. `en`, `ja`, `ko`). Missing for series TMDB couldn't match.
+- `providers` is a deduped, brand-normalized list of US streaming providers (Netflix Standard with Ads → "Netflix", Peacock Premium Plus → "Peacock", etc.). Missing for series with no US streaming availability or before `enrich-providers.js` has run.
+- `languages` and `providers` aggregates at the root are popularity-ranked vocabularies built per unique series (not per season) so a long-running show doesn't dominate the count.
 
 The browser app reads `builtAt` to display "Built [date]" and to flag
 the data as stale (with a `console.warn` and UI badge) if it's older
@@ -107,21 +130,24 @@ than 30 days.
 
 ## Tunables
 
-`build-data.js` accepts two env vars:
+`build-data.js` accepts these env vars:
 
-| Var            | Default | Effect                                          |
-| -------------- | ------- | ----------------------------------------------- |
-| `MIN_EPISODES` | `4`     | Skip seasons with fewer rated episodes          |
-| `MIN_VOTES`    | `100`   | Every episode must have ≥ this many votes       |
+| Var               | Default                              | Effect                                                                                            |
+| ----------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `MIN_EPISODES`    | `3`                                  | Skip seasons with fewer rated episodes                                                            |
+| `MIN_VOTES`       | `100`                                | Every episode must have ≥ this many votes                                                         |
+| `RELAX_GENRES`    | `Reality-TV,Game-Show,Talk-Show`     | Series tagged with any of these IMDb genres use the relaxed floor below                           |
+| `RELAX_MIN_VOTES` | `10`                                 | Per-episode vote floor for relaxed-genre series (reality episodes rarely clear 100 votes on IMDb) |
 
 The browser UI applies its own (typically stricter) defaults on top, so
 build wide and let users narrow in the UI.
 
 ## Repo size considerations
 
-`data.json` is ~6 MB after enrichment. Weekly commits will grow git
-history by roughly a few MB/week (most fields are stable; only ratings,
-votes, and counts change). If history bloat becomes an issue, options:
+`data.json` is ~26 MB after both enrichment passes (posters + providers).
+Weekly commits will grow git history by roughly a few MB/week (most fields
+are stable; only ratings, votes, and counts change). If history bloat
+becomes an issue, options:
 
 - Move to a `data` orphan branch the site fetches from.
 - Build at deploy time on Netlify (would need to download IMDb dumps

--- a/apps/rising-seasons/README.md
+++ b/apps/rising-seasons/README.md
@@ -4,23 +4,44 @@ Find TV shows by the **shape** of their IMDb episode ratings, not the average. B
 
 ## How it works
 
-1. A Node script (`scripts/build-data.js`) streams three gzipped TSV dumps from IMDb, joins episodes with their ratings, runs each season through five shape detectors, and writes `data.json` with all matching seasons (tagged with every shape they fit).
-2. An optional second script (`scripts/enrich-tmdb.js`) fetches posters + plot overviews from TMDB and caches them so they survive rebuilds.
+1. A Node script (`scripts/build-data.js`) streams three gzipped TSV dumps from IMDb, joins episodes with their ratings, runs each season through ten shape detectors, and writes `data.json` with every season that passes the vote/episode floor (tagged with every shape it fits — seasons matching no shape are still included with `shapes: []`).
+2. Two optional enrichment scripts pull TMDB metadata: `scripts/enrich-tmdb.js` for posters, overviews, and language; `scripts/enrich-providers.js` for US streaming providers (Netflix / Max / Prime / …). Both cache to `data/tmdb-cache.json` so they survive rebuilds.
 3. `index.html` loads `data.json` in the browser and renders shape chips, filters, an SVG curve per season, and a per-season detail modal. The browser app supports grid + list views, watched tracking (localStorage), pagination via IntersectionObserver, and shareable URL state.
 
 `data.json` is committed to the repo and refreshed weekly by GitHub Actions — no manual updates needed. See [`DATA_README.md`](DATA_README.md) for the auto-refresh details.
 
 ## Shapes
 
-| Shape       | Rule                                                                |
-| ----------- | ------------------------------------------------------------------- |
-| Rising      | Each episode's rating ≥ the previous one (non-decreasing).          |
-| Consistent  | All episodes ≥ 8.0 with a spread of ≤ 0.5.                          |
-| Slow burn   | Second-half average ≥ first-half average + 0.6.                     |
-| Big finale  | Finale is the season's peak AND ≥ season average + 0.5.             |
-| Rebound     | A real interior dip (≥ 0.4 below the start/end), recovers above the start. |
+| Shape          | Rule                                                                          |
+| -------------- | ----------------------------------------------------------------------------- |
+| Rising         | Each episode's rating ≥ the previous one (non-decreasing).                    |
+| Consistent     | All episodes ≥ 8.0 with a spread of ≤ 0.5.                                    |
+| Slow burn      | Second-half average ≥ first-half average + 0.6.                               |
+| Big finale     | Finale is the season's peak AND ≥ season average + 0.5.                       |
+| Rebound        | A real interior dip (≥ 0.4 below the start/end), recovers above the start.    |
+| Front-loaded   | First-half average ≥ second-half average + 0.6 (mirror of slow burn).         |
+| Declining      | Each episode's rating ≤ the previous one, with first strictly > last.         |
+| Bad finale     | Finale is the season's trough AND ≤ season average − 0.5.                     |
+| Rollercoaster  | Many large adjacent direction-flips with a wide range (chaotic seasons).      |
+| Mid-peak       | Peak sits in the middle half of the season, well above both edges.            |
 
 A season can match more than one shape — the card shows all of them.
+
+## Browser app features
+
+| Feature                  | What it does                                                                                       |
+| ------------------------ | -------------------------------------------------------------------------------------------------- |
+| Shape filter             | Toggle one or more shape chips; AND across selected shapes.                                        |
+| Genre filter (tri-state) | Click a chip to **require** that genre; click again to **exclude** it (red strike); third click clears. AND across required genres. |
+| Language filter          | Multi-select chips for the top original languages (TMDB `original_language`).                      |
+| Streaming filter         | Multi-select chips for top US watch providers (Netflix, HBO Max, Prime …).                         |
+| Hidden gems toggle       | Surfaces seasons with avg ≥ 8.0 *and* fewer than 1,000 votes per episode.                          |
+| Episode-title search     | Searching ≥3 chars also matches against episode names — "Gray Matter" → Breaking Bad.              |
+| Compare shows            | "+ Add to compare" on each show, then a floating button opens an overlay chart of season-trajectories for up to 5 series (persisted in localStorage). |
+| Season overlay           | In the show modal, all seasons drawn together on one chart with a legend.                          |
+| Best / worst badges      | Inline pill on the highest- and lowest-rated season of each series (skipped when all seasons tie). |
+| Watched tracking         | Per-season toggle; persists in localStorage; "watched / unwatched" filters and stats.              |
+| Above-IMDb badge         | Marks seasons whose average episode rating beats the show's overall IMDb score.                    |
 
 ## One-time setup
 
@@ -43,31 +64,42 @@ A season can match more than one shape — the card shows all of them.
 
    ~20 seconds. Writes `apps/rising-seasons/data.json` (also git-ignored — it's a build artifact). IMDb republishes the dumps daily, so re-running picks up new ratings.
 
-## Optional: poster + overview enrichment
+## Optional: TMDB enrichment
 
-To add posters and plot summaries to each card, get a free TMDB v4 read access token:
+The app uses TMDB for posters, plot summaries, original language, and US streaming providers. All of it is optional — `data.json` is valid without any of it.
 
 1. Sign up at <https://www.themoviedb.org/signup>.
 2. Generate a v4 read access token at <https://www.themoviedb.org/settings/api>.
-3. Run the enrichment, then rebuild so `data.json` picks up the cache:
+3. Run the two enrichment scripts in order, then rebuild so `data.json` picks up the cache:
 
    ```sh
+   # Posters + overviews + original_language (one /find call per series).
    TMDB_TOKEN=eyJh...your_token... npm run enrich:rising-seasons
+
+   # US watch providers (one /tv/{id}/watch/providers call per series).
+   TMDB_TOKEN=eyJh...your_token... npm run enrich:rising-seasons:providers
+
+   # Merge both into data.json.
    npm run build:rising-seasons
    ```
 
-   First run takes a few minutes (one HTTP request per unique series, throttled to ~10/s). Subsequent runs reuse `data/tmdb-cache.json` and only fetch new series.
+   Both scripts are incremental: they skip cache entries that already have the data they fetch, so re-runs only hit TMDB for new or previously-failed series. First-run cost is ~15-20 minutes for posters and another ~25-30 for providers (both throttled to ~6 req/s).
 
-The app degrades gracefully without the cache — cards just show a gradient placeholder instead of a poster.
+The app degrades gracefully without each layer:
+- No posters → cards show a gradient placeholder.
+- No language → language filter chips just don't render.
+- No providers → streaming filter and show-modal badges don't render.
 
 ## Build tunables
 
 Pass via env vars to `build-data.js`:
 
-| Var            | Default | Meaning                                           |
-| -------------- | ------- | ------------------------------------------------- |
-| `MIN_EPISODES` | `4`     | Skip seasons with fewer rated episodes            |
-| `MIN_VOTES`    | `100`   | Every episode must have at least this many votes  |
+| Var               | Default                              | Meaning                                                                                            |
+| ----------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `MIN_EPISODES`    | `3`                                  | Skip seasons with fewer rated episodes                                                             |
+| `MIN_VOTES`       | `100`                                | Every episode must have at least this many votes                                                   |
+| `RELAX_GENRES`    | `Reality-TV,Game-Show,Talk-Show`     | Series tagged with any of these genres use the lower floor below                                   |
+| `RELAX_MIN_VOTES` | `10`                                 | Per-episode vote floor for relaxed-genre series (reality episodes rarely clear 100 votes on IMDb)  |
 
 The browser UI applies its own (stricter) defaults on top, so building wide and filtering narrow in the UI is the easy path.
 

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -80,6 +80,18 @@ html {
   background-attachment: fixed;
   background-color: var(--bg);
   min-height: 100%;
+  /* Hide the vertical scrollbar visually so the .page content box is
+     always at full viewport width — opening / closing the More-filters
+     panel (or the mobile drawer's body scroll-lock) can't shift the
+     layout horizontally because there's no scrollbar gutter to gain
+     or lose. Vertical scrolling still works via wheel / keyboard /
+     touch; only the scrollbar's visible track is suppressed. */
+  scrollbar-width: none;          /* Firefox */
+}
+html::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;                  /* Chromium / WebKit */
 }
 
 body.rising-seasons-app {
@@ -679,6 +691,17 @@ body.rising-seasons-app button {
   text-overflow: ellipsis;
 }
 
+.search-suggestion .ss-ep-hint {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--accent);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 0.1rem;
+}
+
 .search-suggestion mark {
   background: transparent;
   color: var(--accent);
@@ -757,7 +780,21 @@ body.rising-seasons-app button {
    inputs, soft hairline-divided sub-sections, integrated Reset link.
    Surface is just a hint above the page bg, not a strong card. */
 
-.advanced { margin-top: 0.5rem; }
+/* Always-on panel chrome — keeps the section the same outer width whether
+   the user has expanded the additional filters or not. Previously the
+   background/border/padding only applied with [open], so opening the
+   section made it appear to widen. */
+.advanced {
+  margin-top: 0.6rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.018));
+  border: 1px solid rgba(255, 255, 255, 0.085);
+  border-radius: 12px;
+  padding: 0.9rem 1.1rem;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    var(--shadow-lift);
+}
 
 /* Trigger: small, quiet, refined. A "+" rotates to "×" when open. */
 .advanced summary {
@@ -800,20 +837,6 @@ body.rising-seasons-app button {
   color: var(--accent);
 }
 
-/* Panel: a real (but quiet) editorial surface — subtle top-down
-   gradient + soft inset highlight + hairline border. Sits clearly on
-   the page without feeling like a heavy card. */
-.advanced[open] {
-  margin-top: 0.6rem;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.018));
-  border: 1px solid rgba(255, 255, 255, 0.085);
-  border-radius: 12px;
-  padding: 0.9rem 1.1rem 0.9rem;
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.04) inset,
-    var(--shadow-lift);
-}
 
 /* Numeric inputs + Sort: 4-column grid for an even rhythm, caption
    labels above slim 32 px controls. */
@@ -894,25 +917,29 @@ body.rising-seasons-app button {
    divider above. Chips are bigger and brighter than the inputs so
    the section reads as "tap a chip" rather than another row of
    form fields. */
-.genre-row {
+.chip-section {
   position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem 0.4rem;
   margin-top: 1.15rem;
   padding-top: 1rem;
   border-top: 1px solid rgba(255, 255, 255, 0.075);
 }
-.genre-row::before {
-  content: 'Genres';
+.chip-section-title {
   display: block;
-  flex: 1 0 100%;
   font-size: 0.62rem;
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: rgba(231, 233, 238, 0.85);
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+/* Hide the whole section when its chip row is empty (e.g. providers
+   before the cache has been populated). :has() saves a JS toggle. */
+.chip-section:has(.genre-row:empty) { display: none; }
+
+.genre-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.4rem;
 }
 .genre-row:empty { display: none; }
 
@@ -947,6 +974,16 @@ body.rising-seasons-app button {
   background: rgba(245, 197, 24, 0.13);
   border-color: rgba(245, 197, 24, 0.5);
   color: var(--accent) !important;
+}
+/* Tri-state for genre chips only — clicking a green chip again flips it to
+   "exclude" (red). Click once more to clear. */
+.genre-chip[data-exclude="true"],
+.genre-chip[data-exclude="true"]:hover {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.55);
+  color: var(--danger) !important;
+  text-decoration: line-through;
+  text-decoration-thickness: 1.5px;
 }
 .genre-chip:focus-visible {
   outline: none;
@@ -988,9 +1025,9 @@ body.rising-seasons-app button {
 
 /* Mobile: collapse the 4-up grid to 2 so inputs don't get squished. */
 @media (max-width: 540px) {
-  .advanced[open] { padding: 0.75rem 0.85rem; }
+  .advanced { padding: 0.75rem 0.85rem; }
   .advanced .filter-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .genre-row { margin-top: 0.9rem; padding-top: 0.8rem; }
+  .chip-section { margin-top: 0.9rem; padding-top: 0.8rem; }
   .filter-actions { margin-top: 0.85rem; padding-top: 0.7rem; }
 }
 
@@ -1207,17 +1244,53 @@ button.shape-tag.is-clickable:hover {
   color: var(--accent);
 }
 
-.best-badge {
-  display: inline-block;
-  margin-left: 0.4rem;
-  padding: 0.05rem 0.4rem;
-  font-size: 0.7rem;
-  color: var(--accent);
-  background: var(--accent-soft);
+/* Best / Worst season rank badges. Designed to sit inline with the
+   season-metadata line ("S2 · 10 eps") rather than the title — compact
+   pill, no wrap, subtle tinted surface. Icon + uppercase label give a
+   premium streaming-app feel without competing with the title. */
+.best-badge,
+.worst-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  margin-left: 0.45rem;
+  padding: 0 0.42rem;
+  height: 1.05rem;
+  line-height: 1;
   border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
   vertical-align: middle;
-  font-weight: 600;
+  /* Small badge shouldn't visually dominate; keep typography compact. */
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  /* Don't shrink in tight flex containers (e.g. when title is long). */
+  flex-shrink: 0;
 }
+.best-badge {
+  color: var(--accent);
+  background: rgba(245, 197, 24, 0.12);
+  border-color: rgba(245, 197, 24, 0.28);
+}
+.worst-badge {
+  color: var(--danger);
+  background: rgba(248, 113, 113, 0.10);
+  border-color: rgba(248, 113, 113, 0.28);
+}
+.rank-badge-icon {
+  font-size: 0.72rem;
+  line-height: 1;
+  /* Slight optical lift — symbols sit lower than baseline. */
+  transform: translateY(-0.04em);
+}
+.worst-badge .rank-badge-icon {
+  /* The ▼ symbol is bottom-heavy; shift the opposite way. */
+  transform: translateY(0.02em);
+  font-size: 0.58rem;
+}
+.rank-badge-label { line-height: 1; }
 
 .above-imdb {
   display: inline-block;
@@ -1506,11 +1579,124 @@ button.shape-tag.is-clickable:hover {
 .modal-curve {
   width: 100%;
   height: 180px;
+  /* Modal-panel is a flex column with overflow-y: auto. Without flex-shrink: 0,
+     the SVG (which has no intrinsic content height) collapses when the modal's
+     other content pushes the panel past its max-height, squashing the curve
+     into a thin strip even though the viewBox math is correct. */
+  flex-shrink: 0;
   background:
     radial-gradient(ellipse 60% 50% at 50% 100%, rgba(245, 197, 24, 0.08), transparent 70%),
     var(--surface-2);
   border-radius: 12px;
   padding: 0.5rem;
+}
+
+.season-overlay {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  flex-shrink: 0;
+}
+.season-overlay[hidden] { display: none; }
+.overlay-curve {
+  width: 100%;
+  height: 200px;
+  flex-shrink: 0;
+  background: var(--surface-2);
+  border-radius: 12px;
+  padding: 0.5rem;
+}
+.overlay-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.8rem;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+.overlay-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.overlay-legend-swatch {
+  display: inline-block;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 2px;
+}
+
+.compare-fab {
+  position: fixed;
+  bottom: 1.25rem;
+  right: 1.25rem;
+  z-index: 9000;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #1a1300;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  box-shadow:
+    0 10px 24px rgba(0, 0, 0, 0.45),
+    0 2px 8px rgba(245, 197, 24, 0.35);
+  transition: transform 0.12s var(--ease), box-shadow 0.2s var(--ease);
+}
+.compare-fab[hidden] { display: none; }
+.compare-fab:hover { transform: translateY(-1px); }
+.compare-fab-icon { font-size: 1.05rem; }
+.compare-fab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.35rem;
+  height: 1.35rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  background: rgba(26, 19, 0, 0.18);
+  font-size: 0.8rem;
+}
+
+.compare-legend-remove {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.78rem;
+  transition: border-color 0.15s, background 0.15s;
+}
+.compare-legend-remove:hover {
+  border-color: var(--danger);
+  background: rgba(248, 113, 113, 0.08);
+}
+.compare-legend-x {
+  margin-left: 0.15rem;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.provider-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.35rem;
+}
+.provider-badges:empty { display: none; }
+.provider-badge {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border-radius: 999px;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border);
 }
 
 .card-stats {
@@ -1599,13 +1785,23 @@ button.shape-tag.is-clickable:hover {
   flex-wrap: wrap;
 }
 .row-curve {
+  display: block;
   width: 100%;
   height: 56px;
   background: var(--surface-2);
   border-radius: var(--radius-sm);
+  /* Clip the sparkline path to the rounded shape — without this the
+     stroke endcaps drawn at x=0 / x=W bleed past the rounded corner
+     and read as an unbalanced inset on one side. */
+  overflow: hidden;
 }
-.row-watch {
+/* Stay in the grid cell — must override the base + :hover absolute
+   positioning that .watch-toggle sets for the card corner overlay. */
+.row-watch,
+.row-watch:hover {
   position: static;
+  top: auto;
+  right: auto;
   width: 2rem;
   height: 2rem;
 }
@@ -1797,6 +1993,7 @@ button.shape-tag.is-clickable:hover {
   max-height: calc(100vh - 2rem);
   max-height: calc(100dvh - 2rem);
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 1.75rem;
   display: flex;
   flex-direction: column;
@@ -2013,6 +2210,46 @@ button.shape-tag.is-clickable:hover {
      for motion-sensitive users — disable both and just show/hide. */
   .advanced-backdrop,
   details.advanced[open] { animation: none; }
+}
+
+/* ---------- Content-width alignment guard ----------
+   Every top-level block under <main class="page"> — the unified toolbar,
+   the expanded More-filters panel, the stats bar, the results count, and
+   the list/grid of results — has to share the same horizontal box so the
+   left/right border edges stack vertically. Without this, intrinsic
+   sizing from a <select>'s longest option, a long row title, or the
+   advanced-panel's grid can grow a single block past .page's content
+   area and the page reads as misaligned.
+
+   The fix has three parts:
+   1. Lock each block to width:100% inside .page's content box with
+      box-sizing:border-box so border+padding live INSIDE the width.
+   2. Set min-width:0 so flex/grid intrinsic minimums don't expand the
+      box (default min-width:auto would let a wide <select> push a track
+      out, even with minmax(0, 1fr) on the column).
+   3. Belt-and-braces on the advanced-panel form controls themselves —
+      their label parents already have min-width:0, but locking the
+      input/select to min-width:0 guarantees they can't drag the 4-up
+      grid wider than its container on any browser. */
+.filter-row.primary,
+.label-filters,
+.advanced,
+.advanced[open],
+.stats-bar,
+.meta,
+.results-grid,
+.row {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.advanced .filter-row input,
+.advanced .filter-row select {
+  min-width: 0;
 }
 
 /* ============================================================================

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -212,6 +212,11 @@
           <button type="button" class="label-chip" data-filter="aboveImdb" data-value="all" aria-pressed="true">All</button>
           <button type="button" class="label-chip label-chip-good" data-filter="aboveImdb" data-value="above" aria-pressed="false" title="Only seasons whose avg episode rating is higher than the show's IMDb rating">↑ Above IMDb</button>
         </div>
+        <div class="label-group" role="radiogroup" aria-label="Hidden gems">
+          <span class="label-group-name">Gems</span>
+          <button type="button" class="label-chip" data-filter="hiddenGems" data-value="all" aria-pressed="true">All</button>
+          <button type="button" class="label-chip label-chip-good" data-filter="hiddenGems" data-value="on" aria-pressed="false" title="High-rated seasons most people haven't watched (avg ≥ 8.0, fewer than 1,000 votes per episode)">💎 Hidden gems</button>
+        </div>
       </div>
 
       <details class="advanced">
@@ -257,7 +262,18 @@
             </select>
           </label>
         </div>
-        <div class="genre-row" id="genres" role="group" aria-label="Filter by genre"></div>
+        <div class="chip-section">
+          <span class="chip-section-title">Genres</span>
+          <div class="genre-row" id="genres" role="group" aria-label="Filter by genre"></div>
+        </div>
+        <div class="chip-section">
+          <span class="chip-section-title">Language</span>
+          <div class="genre-row" id="languages" role="group" aria-label="Filter by language"></div>
+        </div>
+        <div class="chip-section">
+          <span class="chip-section-title">Streaming</span>
+          <div class="genre-row" id="providers" role="group" aria-label="Filter by streaming provider"></div>
+        </div>
         <div class="filter-actions">
           <button type="button" class="btn btn-ghost" id="resetFilters">Reset all filters</button>
         </div>
@@ -323,16 +339,45 @@
           <p class="modal-subtitle" id="showModalSubtitle"></p>
           <p class="modal-stats" id="showModalStats"></p>
           <div class="modal-shapes" id="showModalShapes"></div>
+          <div class="provider-badges" id="showModalProviders"></div>
         </div>
       </div>
       <p class="modal-overview" id="showModalOverview"></p>
+      <section class="season-overlay" id="showModalOverlay" hidden>
+        <h3 class="modal-section">Seasons overlay</h3>
+        <svg class="overlay-curve" id="showModalOverlayCurve" viewBox="0 0 600 200" preserveAspectRatio="none" aria-hidden="true"></svg>
+        <div class="overlay-legend" id="showModalOverlayLegend"></div>
+      </section>
       <h3 class="modal-section">All seasons</h3>
       <ol class="show-seasons" id="showModalSeasons"></ol>
       <div class="modal-actions">
+        <button type="button" class="btn btn-ghost" id="showModalCompare">＋ Add to compare</button>
         <a class="btn btn-ghost" id="showModalImdb" target="_blank" rel="noopener">View show on IMDb →</a>
       </div>
     </article>
   </div>
+
+  <!-- Compare modal (overlay trajectory across multiple series) -->
+  <div class="modal" id="compareModal" role="dialog" aria-modal="true" aria-labelledby="compareModalTitle" aria-hidden="true" hidden>
+    <div class="modal-backdrop" data-close="compare-modal"></div>
+    <article class="modal-panel">
+      <button type="button" class="btn modal-close" data-close="compare-modal" aria-label="Close">×</button>
+      <h2 id="compareModalTitle">Compare shows</h2>
+      <p class="modal-subtitle">Season-average rating trajectory for each show. Click a show name to remove.</p>
+      <svg class="overlay-curve" id="compareModalCurve" viewBox="0 0 600 240" preserveAspectRatio="none" aria-hidden="true"></svg>
+      <div class="overlay-legend" id="compareModalLegend"></div>
+      <div class="modal-actions">
+        <button type="button" class="btn btn-ghost" id="compareModalClear">Clear all</button>
+      </div>
+    </article>
+  </div>
+
+  <!-- Floating button: opens compare modal when compareSet has entries -->
+  <button type="button" class="compare-fab" id="compareFab" hidden aria-label="Open compare modal">
+    <span class="compare-fab-icon" aria-hidden="true">⇄</span>
+    <span class="compare-fab-label">Compare</span>
+    <span class="compare-fab-count" id="compareFabCount">0</span>
+  </button>
 
   <!-- Card template (grid view) -->
   <template id="card-template">

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -16,6 +16,8 @@ const SHAPE_LABELS = {
 const STORAGE_NS = 'rising-seasons';
 const KEY_WATCHED = `${STORAGE_NS}:watched`;
 const KEY_VIEW = `${STORAGE_NS}:view`;
+const KEY_COMPARE = `${STORAGE_NS}:compare`;
+const COMPARE_LIMIT = 5;
 const PAGE_SIZE = 24;
 const STALE_DAYS = 30;
 const MAX_SUGGESTIONS = 10;
@@ -37,6 +39,9 @@ const els = {
   surprise: document.getElementById('surprise'),
   resetFilters: document.getElementById('resetFilters'),
   genres: document.getElementById('genres'),
+  languages: document.getElementById('languages'),
+  providers: document.getElementById('providers'),
+  showModalProviders: document.getElementById('showModalProviders'),
   results: document.getElementById('results'),
   pager: document.getElementById('pager'),
   meta: document.getElementById('meta'),
@@ -67,6 +72,16 @@ const els = {
   showModalSeasons: document.getElementById('showModalSeasons'),
   showModalPoster: document.getElementById('showModalPoster'),
   showModalImdb: document.getElementById('showModalImdb'),
+  showModalOverlay: document.getElementById('showModalOverlay'),
+  showModalOverlayCurve: document.getElementById('showModalOverlayCurve'),
+  showModalOverlayLegend: document.getElementById('showModalOverlayLegend'),
+  showModalCompare: document.getElementById('showModalCompare'),
+  compareModal: document.getElementById('compareModal'),
+  compareModalCurve: document.getElementById('compareModalCurve'),
+  compareModalLegend: document.getElementById('compareModalLegend'),
+  compareModalClear: document.getElementById('compareModalClear'),
+  compareFab: document.getElementById('compareFab'),
+  compareFabCount: document.getElementById('compareFabCount'),
   viewToggle: document.querySelector('.view-toggle'),
   suggestions: document.getElementById('searchSuggestions'),
 };
@@ -93,8 +108,12 @@ const state = {
   seriesType: 'all',
   watched: 'all',
   aboveImdb: 'all',
+  hiddenGems: 'all',
   sort: 'popularity',
   genres: new Set(),
+  excludeGenres: new Set(),
+  languages: new Set(),
+  providers: new Set(),
   view: 'grid',
   page: 1,
 };
@@ -103,6 +122,7 @@ let dataset = null;
 let filtered = [];
 let seriesIndex = [];
 let bestSeasonBySeries = new Map();
+let worstSeasonBySeries = new Map();
 let aboveImdbBySeries = new Map();
 let pendingModalKey = null;
 let pendingShowKey = null;
@@ -157,6 +177,42 @@ const ViewPref = {
   },
 };
 
+// Selected series for the "Compare" overlay. Stored as an array (preserves
+// insertion order so the legend reads in the order the user added shows).
+const Compare = {
+  ids: [],
+  load() {
+    try {
+      const raw = localStorage.getItem(KEY_COMPARE);
+      if (raw) this.ids = JSON.parse(raw).slice(0, COMPARE_LIMIT);
+    } catch { /* corrupt or unavailable — start empty */ }
+  },
+  save() {
+    try { localStorage.setItem(KEY_COMPARE, JSON.stringify(this.ids)); }
+    catch { /* quota or disabled — silent */ }
+  },
+  has(seriesId) { return this.ids.includes(seriesId); },
+  size() { return this.ids.length; },
+  add(seriesId) {
+    if (this.ids.includes(seriesId)) return false;
+    if (this.ids.length >= COMPARE_LIMIT) return false;
+    this.ids.push(seriesId);
+    this.save();
+    return true;
+  },
+  remove(seriesId) {
+    const i = this.ids.indexOf(seriesId);
+    if (i < 0) return false;
+    this.ids.splice(i, 1);
+    this.save();
+    return true;
+  },
+  clear() {
+    this.ids = [];
+    this.save();
+  },
+};
+
 // Chrome (header / footer / menu / auth UI) is loaded by
 // ../../assets/js/main.js — see the script block in index.html. We
 // deliberately do not run a second include loader here: parallel AJAX
@@ -175,6 +231,7 @@ async function load() {
     return;
   }
   Watched.load();
+  Compare.load();
   state.view = ViewPref.load();
   applyViewClasses();
   applyStateFromURL();
@@ -183,6 +240,9 @@ async function load() {
   buildBestSeasonMap();
   buildAboveImdbMap();
   renderGenreChips();
+  renderLanguageChips();
+  renderProviderChips();
+  syncCompareFab();
   bindEvents();
   bindKeyboard();
   bindAdvancedDrawer();
@@ -230,13 +290,18 @@ function buildAboveImdbMap() {
 }
 
 function buildBestSeasonMap() {
-  // For each series with 2+ qualifying seasons, identify the highest-avg one.
-  // Single-season series get no badge — there's no "best" without a contest.
+  // For each series with 2+ qualifying seasons, identify the highest- and
+  // lowest-avg one. Single-season series get no badge — there's no "best" or
+  // "worst" without a contest.
   const byId = new Map();
   for (const m of dataset.matches) {
     let entry = byId.get(m.seriesId);
     if (!entry) {
-      entry = { count: 0, bestSeason: m.season, bestAvg: m.avgRating };
+      entry = {
+        count: 0,
+        bestSeason: m.season, bestAvg: m.avgRating,
+        worstSeason: m.season, worstAvg: m.avgRating,
+      };
       byId.set(m.seriesId, entry);
     }
     entry.count++;
@@ -244,10 +309,21 @@ function buildBestSeasonMap() {
       entry.bestAvg = m.avgRating;
       entry.bestSeason = m.season;
     }
+    if (m.avgRating < entry.worstAvg) {
+      entry.worstAvg = m.avgRating;
+      entry.worstSeason = m.season;
+    }
   }
   bestSeasonBySeries = new Map();
+  worstSeasonBySeries = new Map();
   for (const [seriesId, info] of byId) {
-    if (info.count >= 2) bestSeasonBySeries.set(seriesId, info.bestSeason);
+    if (info.count < 2) continue;
+    bestSeasonBySeries.set(seriesId, info.bestSeason);
+    // Skip when best === worst (all seasons tied on avg) — single badge is
+    // meaningless in that case.
+    if (info.bestSeason !== info.worstSeason) {
+      worstSeasonBySeries.set(seriesId, info.worstSeason);
+    }
   }
 }
 
@@ -293,7 +369,11 @@ function applyStateFromURL() {
   if (p.has('sort'))      state.sort = p.get('sort');
   if (p.has('watched'))   state.watched = p.get('watched');
   if (p.has('above'))     state.aboveImdb = p.get('above');
+  if (p.has('gems'))      state.hiddenGems = p.get('gems');
   if (p.has('g'))         state.genres = new Set(p.get('g').split(',').filter(Boolean));
+  if (p.has('xg'))        state.excludeGenres = new Set(p.get('xg').split(',').filter(Boolean));
+  if (p.has('l'))         state.languages = new Set(p.get('l').split(',').filter(Boolean));
+  if (p.has('p'))         state.providers = new Set(p.get('p').split(',').filter(Boolean));
   if (p.has('page'))      state.page = Math.max(1, parseInt(p.get('page'), 10) || 1);
 
   els.search.value = state.search;
@@ -308,7 +388,13 @@ function applyStateFromURL() {
   syncLabelFiltersAria();
   syncShapeChipsAria();
   for (const chip of els.genres.querySelectorAll('.genre-chip')) {
-    chip.setAttribute('aria-pressed', state.genres.has(chip.dataset.genre) ? 'true' : 'false');
+    syncGenreChipTriState(chip);
+  }
+  for (const chip of els.languages.querySelectorAll('.genre-chip')) {
+    chip.setAttribute('aria-pressed', state.languages.has(chip.dataset.language) ? 'true' : 'false');
+  }
+  for (const chip of els.providers.querySelectorAll('.genre-chip')) {
+    chip.setAttribute('aria-pressed', state.providers.has(chip.dataset.provider) ? 'true' : 'false');
   }
 }
 
@@ -318,6 +404,7 @@ function syncLabelFiltersAria() {
     seriesType: state.seriesType,
     watched: state.watched,
     aboveImdb: state.aboveImdb,
+    hiddenGems: state.hiddenGems,
   };
   for (const btn of els.labelFilters.querySelectorAll('.label-chip')) {
     const filter = btn.dataset.filter;
@@ -361,7 +448,11 @@ function writeStateToURL() {
   if (state.sort !== 'popularity') p.set('sort', state.sort);
   if (state.watched !== 'all') p.set('watched', state.watched);
   if (state.aboveImdb !== 'all') p.set('above', state.aboveImdb);
+  if (state.hiddenGems !== 'all') p.set('gems', state.hiddenGems);
   if (state.genres.size) p.set('g', [...state.genres].join(','));
+  if (state.excludeGenres.size) p.set('xg', [...state.excludeGenres].join(','));
+  if (state.languages.size) p.set('l', [...state.languages].join(','));
+  if (state.providers.size) p.set('p', [...state.providers].join(','));
   if (state.page > 1) p.set('page', state.page);
   if (els.modal && !els.modal.hidden && modalState.season) {
     p.set('season', `${modalState.season.seriesId}:${modalState.season.season}`);
@@ -422,6 +513,37 @@ function updateShapeChipCounts() {
   }
 }
 
+// Three click states per genre chip: off → include → exclude → off. The
+// "exclude" state hides any series carrying that genre, which is useful
+// for filters like "Crime AND NOT Reality-TV".
+function syncGenreChipTriState(btn) {
+  const name = btn.dataset.genre;
+  if (state.excludeGenres.has(name)) {
+    btn.setAttribute('aria-pressed', 'false');
+    btn.dataset.exclude = 'true';
+    btn.title = `Excluded — click to clear (currently hiding ${name})`;
+  } else if (state.genres.has(name)) {
+    btn.setAttribute('aria-pressed', 'true');
+    btn.dataset.exclude = 'false';
+    btn.title = `Required — click again to exclude ${name}`;
+  } else {
+    btn.setAttribute('aria-pressed', 'false');
+    btn.dataset.exclude = 'false';
+    btn.title = `Click to require ${name}; click again to exclude it`;
+  }
+}
+
+function cycleGenreState(name) {
+  if (!state.genres.has(name) && !state.excludeGenres.has(name)) {
+    state.genres.add(name);
+  } else if (state.genres.has(name)) {
+    state.genres.delete(name);
+    state.excludeGenres.add(name);
+  } else {
+    state.excludeGenres.delete(name);
+  }
+}
+
 function renderGenreChips() {
   const top = (dataset.genres || []).slice(0, 14);
   const frag = document.createDocumentFragment();
@@ -430,17 +552,77 @@ function renderGenreChips() {
     btn.type = 'button';
     btn.className = 'genre-chip';
     btn.dataset.genre = g.name;
-    btn.setAttribute('aria-pressed', state.genres.has(g.name) ? 'true' : 'false');
     btn.textContent = g.name;
+    syncGenreChipTriState(btn);
     btn.addEventListener('click', () => {
-      if (state.genres.has(g.name)) state.genres.delete(g.name);
-      else state.genres.add(g.name);
-      btn.setAttribute('aria-pressed', state.genres.has(g.name) ? 'true' : 'false');
+      cycleGenreState(g.name);
+      syncGenreChipTriState(btn);
       onFilterChange();
     });
     frag.appendChild(btn);
   }
   els.genres.replaceChildren(frag);
+}
+
+// TMDB stores `original_language` as ISO 639-1 codes (en, ja, ko, ...).
+// The UI shows the English name so users don't need to know codes.
+const LANGUAGE_NAMES = {
+  en: 'English', ja: 'Japanese', ko: 'Korean', es: 'Spanish', zh: 'Chinese',
+  fr: 'French', de: 'German', it: 'Italian', pt: 'Portuguese', ru: 'Russian',
+  tr: 'Turkish', hi: 'Hindi', ar: 'Arabic', th: 'Thai', id: 'Indonesian',
+  pl: 'Polish', nl: 'Dutch', sv: 'Swedish', da: 'Danish', no: 'Norwegian',
+  fi: 'Finnish', he: 'Hebrew', cs: 'Czech', el: 'Greek', hu: 'Hungarian',
+  ro: 'Romanian', uk: 'Ukrainian', vi: 'Vietnamese', tl: 'Filipino',
+  ms: 'Malay', fa: 'Persian', bn: 'Bengali', ta: 'Tamil', te: 'Telugu',
+  ur: 'Urdu', ml: 'Malayalam', mr: 'Marathi', is: 'Icelandic', sk: 'Slovak',
+  bg: 'Bulgarian', hr: 'Croatian', sr: 'Serbian', sl: 'Slovenian',
+  ca: 'Catalan', et: 'Estonian', lv: 'Latvian', lt: 'Lithuanian', ga: 'Irish',
+  cy: 'Welsh', mt: 'Maltese', sq: 'Albanian',
+};
+function languageLabel(code) {
+  return LANGUAGE_NAMES[code] || code.toUpperCase();
+}
+
+function renderProviderChips() {
+  const top = (dataset.providers || []).slice(0, 10);
+  const frag = document.createDocumentFragment();
+  for (const p of top) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'genre-chip';
+    btn.dataset.provider = p.name;
+    btn.setAttribute('aria-pressed', state.providers.has(p.name) ? 'true' : 'false');
+    btn.textContent = p.name;
+    btn.addEventListener('click', () => {
+      if (state.providers.has(p.name)) state.providers.delete(p.name);
+      else state.providers.add(p.name);
+      btn.setAttribute('aria-pressed', state.providers.has(p.name) ? 'true' : 'false');
+      onFilterChange();
+    });
+    frag.appendChild(btn);
+  }
+  els.providers.replaceChildren(frag);
+}
+
+function renderLanguageChips() {
+  const top = (dataset.languages || []).slice(0, 12);
+  const frag = document.createDocumentFragment();
+  for (const l of top) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'genre-chip';
+    btn.dataset.language = l.code;
+    btn.setAttribute('aria-pressed', state.languages.has(l.code) ? 'true' : 'false');
+    btn.textContent = languageLabel(l.code);
+    btn.addEventListener('click', () => {
+      if (state.languages.has(l.code)) state.languages.delete(l.code);
+      else state.languages.add(l.code);
+      btn.setAttribute('aria-pressed', state.languages.has(l.code) ? 'true' : 'false');
+      onFilterChange();
+    });
+    frag.appendChild(btn);
+  }
+  els.languages.replaceChildren(frag);
 }
 
 // --- filter + sort ---
@@ -454,6 +636,9 @@ function buildNonShapeChecker() {
   const minClimb = state.minClimb;
   const { minYear, maxYear, seriesType, watched: watchedFilter } = state;
   const wantGenres = state.genres;
+  const excludeGenres = state.excludeGenres;
+  const wantLanguages = state.languages;
+  const wantProviders = state.providers;
 
   return function (m) {
     if (minEps && m.episodes.length < minEps) return false;
@@ -477,12 +662,37 @@ function buildNonShapeChecker() {
     } else if (q) {
       const titleHit = m.title.toLowerCase().includes(q);
       const idHit = m.seriesId.toLowerCase().includes(q);
-      if (!titleHit && !idHit) return false;
+      let epHit = false;
+      // Episode-title fallback — only run when the cheaper title/id checks
+      // missed, since this scans every episode in the season.
+      if (!titleHit && !idHit && q.length >= 3) {
+        for (const ep of m.episodes) {
+          if (ep.name && ep.name.toLowerCase().includes(q)) { epHit = true; break; }
+        }
+      }
+      if (!titleHit && !idHit && !epHit) return false;
+    }
+    if (wantLanguages.size && (!m.language || !wantLanguages.has(m.language))) {
+      return false;
+    }
+    if (wantProviders.size) {
+      if (!m.providers || m.providers.length === 0) return false;
+      let ok = false;
+      for (const p of m.providers) if (wantProviders.has(p)) { ok = true; break; }
+      if (!ok) return false;
     }
     if (wantGenres.size) {
-      let ok = false;
-      for (const g of m.genres) if (wantGenres.has(g)) { ok = true; break; }
-      if (!ok) return false;
+      // AND across selected genres: the season's series must carry every
+      // selected genre (e.g. "Drama" + "Crime" returns only crime-dramas,
+      // not anything that's just one or the other).
+      for (const g of wantGenres) {
+        if (!m.genres.includes(g)) return false;
+      }
+    }
+    if (excludeGenres.size) {
+      for (const g of m.genres) {
+        if (excludeGenres.has(g)) return false;
+      }
     }
     if (watchedFilter !== 'all') {
       const isWatched = Watched.has(m);
@@ -490,6 +700,12 @@ function buildNonShapeChecker() {
       if (watchedFilter === 'unwatched' && isWatched) return false;
     }
     if (state.aboveImdb === 'above' && !aboveImdbBySeries.get(m.seriesId)) return false;
+    if (state.hiddenGems === 'on') {
+      // High-rated (avg >= 8.0) and under the radar (each episode has fewer
+      // than 1,000 votes, i.e. minVotes < 1000 across the season).
+      if (m.avgRating < 8.0) return false;
+      if (m.minVotes >= 1000) return false;
+    }
     return true;
   };
 }
@@ -751,8 +967,12 @@ function hasActiveFilters() {
   if (state.seriesType && state.seriesType !== 'all') return true;
   if (state.watched && state.watched !== 'all') return true;
   if (state.aboveImdb && state.aboveImdb !== 'all') return true;
+  if (state.hiddenGems && state.hiddenGems !== 'all') return true;
   if (state.sort && state.sort !== 'popularity') return true;
   if (state.genres && state.genres.size > 0) return true;
+  if (state.excludeGenres && state.excludeGenres.size > 0) return true;
+  if (state.languages && state.languages.size > 0) return true;
+  if (state.providers && state.providers.size > 0) return true;
   return false;
 }
 
@@ -804,13 +1024,31 @@ function fillShapeTags(container, shapes, { clickable = true } = {}) {
   }
 }
 
+function buildRankBadge(className, glyph, label, title) {
+  const badge = document.createElement('span');
+  badge.className = className;
+  badge.title = title;
+  const icon = document.createElement('span');
+  icon.className = 'rank-badge-icon';
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = glyph;
+  const text = document.createElement('span');
+  text.className = 'rank-badge-label';
+  text.textContent = label;
+  badge.append(icon, text);
+  return badge;
+}
+
 function maybeBestBadge(m) {
   if (bestSeasonBySeries.get(m.seriesId) !== m.season) return null;
-  const badge = document.createElement('span');
-  badge.className = 'best-badge';
-  badge.textContent = '★ best';
-  badge.title = "Highest-rated season of this series in our dataset";
-  return badge;
+  return buildRankBadge('best-badge', '★', 'Best',
+    "Highest-rated season of this series in our dataset");
+}
+
+function maybeWorstBadge(m) {
+  if (worstSeasonBySeries.get(m.seriesId) !== m.season) return null;
+  return buildRankBadge('worst-badge', '▼', 'Worst',
+    'Lowest-rated season of this series in our dataset');
 }
 
 function aboveImdbBadge(m) {
@@ -834,8 +1072,11 @@ function buildCard(m) {
   node.querySelector('.card-year').textContent = (m.seasonYear || m.year) || 'year unknown';
   node.querySelector('.card-genres').textContent = m.genres.slice(0, 3).join(' · ');
 
-  const badge = maybeBestBadge(m);
-  if (badge) node.querySelector('.card-head').appendChild(badge);
+  const badge = maybeBestBadge(m) || maybeWorstBadge(m);
+  // Live next to the season metadata ("S2 · 10 eps") rather than at the
+  // far end of the title row — keeps the title clean and aligns the badge
+  // with the smaller-typography row it visually belongs in.
+  if (badge) node.querySelector('.card-season').appendChild(badge);
 
   fillShapeTags(node.querySelector('.card-shapes'), m.shapes, { clickable: false });
 
@@ -886,8 +1127,8 @@ function buildRow(m) {
   node.querySelector('.row-season').textContent = `S${m.season} · ${m.episodes.length} eps`;
   node.querySelector('.row-year').textContent = (m.seasonYear || m.year) || '';
 
-  const badge = maybeBestBadge(m);
-  if (badge) node.querySelector('.row-head').appendChild(badge);
+  const badge = maybeBestBadge(m) || maybeWorstBadge(m);
+  if (badge) node.querySelector('.row-season').appendChild(badge);
 
   fillShapeTags(node.querySelector('.row-shapes'), m.shapes, { clickable: false });
 
@@ -900,7 +1141,7 @@ function buildRow(m) {
   if (rowBadge) rowAvgEl.appendChild(rowBadge);
   node.querySelector('.stat-votes').textContent = `${m.minVotes.toLocaleString()} votes/ep min`;
 
-  drawCurve(node.querySelector('.row-curve'), m.episodes, 200, 56);
+  drawCurve(node.querySelector('.row-curve'), m.episodes, 200, 56, 0);
 
   const posterEl = node.querySelector('.row-poster');
   if (m.poster) {
@@ -949,18 +1190,24 @@ function onToggleWatched(m, cardOrRow) {
 
 // --- curve drawing (shared) ---
 
-function drawCurve(svg, episodes, W, H) {
-  const pad = 6;
+function drawCurve(svg, episodes, W, H, padXOverride) {
+  // Charts with hover dots need a small inset so the dots don't get
+  // clipped at the viewport edge. Sparklines without dots (the list-view
+  // row and the show-modal per-season mini-spark) pass padX=0 so the
+  // line/fill plot literally edge-to-edge — symmetric by construction,
+  // no perceived left-bias from a 2-6 px gap on the left.
+  const padX = typeof padXOverride === 'number' ? padXOverride : 4;
+  const padY = 6;
   const ratings = episodes.map((e) => e.rating);
   const lo = Math.max(0, Math.min(...ratings) - 0.3);
   const hi = Math.min(10, Math.max(...ratings) + 0.3);
   const span = Math.max(0.1, hi - lo);
   const n = episodes.length;
-  const xStep = n > 1 ? (W - pad * 2) / (n - 1) : 0;
+  const xStep = n > 1 ? (W - padX * 2) / (n - 1) : 0;
 
   const points = episodes.map((e, i) => {
-    const x = pad + (n > 1 ? i * xStep : (W - pad * 2) / 2);
-    const y = pad + (1 - (e.rating - lo) / span) * (H - pad * 2);
+    const x = padX + (n > 1 ? i * xStep : (W - padX * 2) / 2);
+    const y = padY + (1 - (e.rating - lo) / span) * (H - padY * 2);
     return [x, y];
   });
 
@@ -984,6 +1231,230 @@ function drawCurve(svg, episodes, W, H) {
       dots.appendChild(c);
     }
   }
+}
+
+// Picks a visually distinct stroke color per season. HSL spread across the
+// hue wheel keeps adjacent seasons easy to tell apart even at 10+ seasons.
+function seasonColor(i, total) {
+  const hue = (i * 360) / Math.max(total, 1);
+  return `hsl(${hue.toFixed(0)} 80% 62%)`;
+}
+
+// Draw every season's curve on a shared chart so the user can visually
+// compare per-season shape, slope, and absolute rating. X is normalized to
+// 0..1 (episode index / season length) so seasons of different lengths align.
+// Y range spans the global min/max across all seasons (slightly padded).
+function drawSeasonOverlay(svg, seasons, W, H) {
+  const padX = 10;
+  const padY = 12;
+  // Wipe previous content — this SVG is reused across openShowModal calls.
+  while (svg.firstChild) svg.removeChild(svg.firstChild);
+  if (!seasons.length) return [];
+
+  let lo = Infinity, hi = -Infinity;
+  for (const s of seasons) for (const e of s.episodes) {
+    if (e.rating < lo) lo = e.rating;
+    if (e.rating > hi) hi = e.rating;
+  }
+  lo = Math.max(0, lo - 0.3);
+  hi = Math.min(10, hi + 0.3);
+  const span = Math.max(0.1, hi - lo);
+
+  const NS = 'http://www.w3.org/2000/svg';
+  const colors = [];
+  seasons.forEach((s, idx) => {
+    const color = seasonColor(idx, seasons.length);
+    colors.push({ season: s.season, color });
+    const n = s.episodes.length;
+    const xStep = n > 1 ? (W - padX * 2) / (n - 1) : 0;
+    const points = s.episodes.map((e, i) => {
+      const x = padX + (n > 1 ? i * xStep : (W - padX * 2) / 2);
+      const y = padY + (1 - (e.rating - lo) / span) * (H - padY * 2);
+      return [x, y];
+    });
+    const d = points.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
+    const path = document.createElementNS(NS, 'path');
+    path.setAttribute('d', d);
+    path.setAttribute('fill', 'none');
+    path.setAttribute('stroke', color);
+    path.setAttribute('stroke-width', '2');
+    path.setAttribute('stroke-linecap', 'round');
+    path.setAttribute('stroke-linejoin', 'round');
+    path.setAttribute('vector-effect', 'non-scaling-stroke');
+    path.setAttribute('opacity', '0.85');
+    const title = document.createElementNS(NS, 'title');
+    title.textContent = `Season ${s.season} — avg ${s.avgRating.toFixed(1)}`;
+    path.appendChild(title);
+    svg.appendChild(path);
+  });
+  return colors;
+}
+
+// --- compare set ---
+
+function syncCompareFab() {
+  if (!els.compareFab) return;
+  const n = Compare.size();
+  els.compareFab.hidden = n === 0;
+  els.compareFabCount.textContent = String(n);
+  els.compareFab.setAttribute('aria-label', `Compare ${n} show${n === 1 ? '' : 's'}`);
+}
+
+function syncCompareButton() {
+  if (!els.showModalCompare || !showModalState.seriesId) return;
+  const inSet = Compare.has(showModalState.seriesId);
+  const atLimit = !inSet && Compare.size() >= COMPARE_LIMIT;
+  els.showModalCompare.textContent = inSet ? '✓ In compare' : '＋ Add to compare';
+  els.showModalCompare.disabled = atLimit;
+  els.showModalCompare.title = atLimit
+    ? `Compare set is full (${COMPARE_LIMIT} max) — remove one first`
+    : inSet ? 'Remove this show from the compare set' : 'Add this show to the compare set';
+}
+
+// Trajectory chart: for each selected series, plot one polyline whose x is
+// the season index (1..N for that show) and y is that season's avg rating.
+// Series with different season counts share a normalized x so they overlay
+// cleanly. Hover the line for series + season detail.
+function drawCompareChart(svg, seriesEntries, W, H) {
+  while (svg.firstChild) svg.removeChild(svg.firstChild);
+  if (!seriesEntries.length) return;
+
+  const padX = 14;
+  const padY = 16;
+  const NS = 'http://www.w3.org/2000/svg';
+
+  let lo = Infinity, hi = -Infinity;
+  for (const { seasons } of seriesEntries) {
+    for (const s of seasons) {
+      if (s.avgRating < lo) lo = s.avgRating;
+      if (s.avgRating > hi) hi = s.avgRating;
+    }
+  }
+  lo = Math.max(0, lo - 0.3);
+  hi = Math.min(10, hi + 0.3);
+  const span = Math.max(0.1, hi - lo);
+
+  seriesEntries.forEach(({ title, seasons }, idx) => {
+    const color = seasonColor(idx, seriesEntries.length);
+    const n = seasons.length;
+    const xStep = n > 1 ? (W - padX * 2) / (n - 1) : 0;
+    const points = seasons.map((s, i) => {
+      const x = padX + (n > 1 ? i * xStep : (W - padX * 2) / 2);
+      const y = padY + (1 - (s.avgRating - lo) / span) * (H - padY * 2);
+      return [x, y, s];
+    });
+    const d = points.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
+    const path = document.createElementNS(NS, 'path');
+    path.setAttribute('d', d);
+    path.setAttribute('fill', 'none');
+    path.setAttribute('stroke', color);
+    path.setAttribute('stroke-width', '2.5');
+    path.setAttribute('stroke-linecap', 'round');
+    path.setAttribute('stroke-linejoin', 'round');
+    path.setAttribute('vector-effect', 'non-scaling-stroke');
+    path.setAttribute('opacity', '0.9');
+    const title2 = document.createElementNS(NS, 'title');
+    title2.textContent = title;
+    path.appendChild(title2);
+    svg.appendChild(path);
+    for (const [x, y, s] of points) {
+      const dot = document.createElementNS(NS, 'circle');
+      dot.setAttribute('cx', x.toFixed(1));
+      dot.setAttribute('cy', y.toFixed(1));
+      dot.setAttribute('r', '3.5');
+      dot.setAttribute('fill', color);
+      const dotTitle = document.createElementNS(NS, 'title');
+      dotTitle.textContent = `${title} — S${s.season}: avg ${s.avgRating.toFixed(1)}`;
+      dot.appendChild(dotTitle);
+      svg.appendChild(dot);
+    }
+  });
+}
+
+function buildCompareEntries() {
+  const out = [];
+  for (const id of Compare.ids) {
+    const seasons = dataset.matches
+      .filter((m) => m.seriesId === id)
+      .sort((a, b) => a.season - b.season);
+    if (!seasons.length) continue;
+    out.push({ seriesId: id, title: seasons[0].title, seasons });
+  }
+  return out;
+}
+
+function renderCompareLegend(entries) {
+  const colors = entries.map((_, i) => seasonColor(i, entries.length));
+  const frag = document.createDocumentFragment();
+  entries.forEach((e, i) => {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'overlay-legend-item compare-legend-remove';
+    item.title = 'Remove from compare';
+    const swatch = document.createElement('span');
+    swatch.className = 'overlay-legend-swatch';
+    swatch.style.background = colors[i];
+    const label = document.createElement('span');
+    label.textContent = e.title;
+    const x = document.createElement('span');
+    x.className = 'compare-legend-x';
+    x.textContent = '×';
+    item.append(swatch, label, x);
+    item.addEventListener('click', () => {
+      Compare.remove(e.seriesId);
+      syncCompareFab();
+      if (Compare.size() === 0) {
+        closeCompareModal();
+      } else {
+        renderCompareModal();
+      }
+    });
+    frag.appendChild(item);
+  });
+  els.compareModalLegend.replaceChildren(frag);
+}
+
+function renderCompareModal() {
+  const entries = buildCompareEntries();
+  if (entries.length === 0) {
+    closeCompareModal();
+    return;
+  }
+  drawCompareChart(els.compareModalCurve, entries, 600, 240);
+  renderCompareLegend(entries);
+}
+
+let compareModalState = { lastFocus: null };
+
+function openCompareModal() {
+  if (!els.compareModal.hidden) return;
+  if (Compare.size() === 0) return;
+  compareModalState.lastFocus = document.activeElement;
+  renderCompareModal();
+  els.compareModal.hidden = false;
+  els.compareModal.setAttribute('aria-hidden', 'false');
+  document.documentElement.style.overflow = 'hidden';
+  document.body.style.overflow = 'hidden';
+  syncModalInert();
+  requestAnimationFrame(() => {
+    const close = els.compareModal.querySelector('.modal-close');
+    if (close) close.focus();
+  });
+}
+
+function closeCompareModal() {
+  if (els.compareModal.hidden) return;
+  els.compareModal.hidden = true;
+  els.compareModal.setAttribute('aria-hidden', 'true');
+  if (els.modal.hidden && els.showModal.hidden) {
+    document.documentElement.style.overflow = '';
+    document.body.style.overflow = '';
+  }
+  syncModalInert();
+  if (compareModalState.lastFocus && typeof compareModalState.lastFocus.focus === 'function') {
+    compareModalState.lastFocus.focus();
+  }
+  compareModalState.lastFocus = null;
 }
 
 // --- modal ---
@@ -1081,7 +1552,9 @@ function openModal(m, opts = {}) {
 
   els.modal.hidden = false;
   els.modal.setAttribute('aria-hidden', 'false');
+  document.documentElement.style.overflow = 'hidden';
   document.body.style.overflow = 'hidden';
+  syncModalInert();
   writeStateToURL();
   if (!wasOpen) {
     requestAnimationFrame(() => {
@@ -1095,7 +1568,11 @@ function closeModal() {
   if (els.modal.hidden) return;
   els.modal.hidden = true;
   els.modal.setAttribute('aria-hidden', 'true');
-  document.body.style.overflow = '';
+  if (els.showModal.hidden) {
+    document.documentElement.style.overflow = '';
+    document.body.style.overflow = '';
+  }
+  syncModalInert();
   if (modalState.lastFocus && typeof modalState.lastFocus.focus === 'function') {
     modalState.lastFocus.focus();
   }
@@ -1117,6 +1594,7 @@ function openShowModal(seriesId) {
   const meta = seasons[0];
   showModalState.seriesId = seriesId;
   if (els.showModal.hidden) showModalState.lastFocus = document.activeElement;
+  syncCompareButton();
 
   els.showModalTitle.textContent = meta.title;
 
@@ -1171,6 +1649,18 @@ function openShowModal(seriesId) {
   }
   fillShapeTags(els.showModalShapes, commonShapes ? [...commonShapes] : [], { clickable: false });
 
+  // Providers badges (TMDB watch providers, US). Hidden when no data.
+  const providersList = meta.providers || [];
+  els.showModalProviders.replaceChildren();
+  if (providersList.length) {
+    for (const name of providersList) {
+      const badge = document.createElement('span');
+      badge.className = 'provider-badge';
+      badge.textContent = name;
+      els.showModalProviders.appendChild(badge);
+    }
+  }
+
   els.showModalOverview.textContent = meta.overview || '';
 
   els.showModalPoster.replaceChildren();
@@ -1186,17 +1676,41 @@ function openShowModal(seriesId) {
   }
 
   const bestSeason = bestSeasonBySeries.get(seriesId);
+  const worstSeason = worstSeasonBySeries.get(seriesId);
   const seasonsFrag = document.createDocumentFragment();
   for (const s of seasons) {
-    seasonsFrag.appendChild(buildShowSeasonRow(s, bestSeason));
+    seasonsFrag.appendChild(buildShowSeasonRow(s, bestSeason, worstSeason));
   }
   els.showModalSeasons.replaceChildren(seasonsFrag);
+
+  // Overlay chart: only useful when there's >1 season to compare.
+  if (seasons.length > 1) {
+    els.showModalOverlay.hidden = false;
+    const colors = drawSeasonOverlay(els.showModalOverlayCurve, seasons, 600, 200);
+    const legendFrag = document.createDocumentFragment();
+    for (const { season, color } of colors) {
+      const item = document.createElement('span');
+      item.className = 'overlay-legend-item';
+      const swatch = document.createElement('span');
+      swatch.className = 'overlay-legend-swatch';
+      swatch.style.background = color;
+      const label = document.createElement('span');
+      label.textContent = `S${season}`;
+      item.append(swatch, label);
+      legendFrag.appendChild(item);
+    }
+    els.showModalOverlayLegend.replaceChildren(legendFrag);
+  } else {
+    els.showModalOverlay.hidden = true;
+  }
 
   els.showModalImdb.href = `https://www.imdb.com/title/${seriesId}/`;
 
   els.showModal.hidden = false;
   els.showModal.setAttribute('aria-hidden', 'false');
+  document.documentElement.style.overflow = 'hidden';
   document.body.style.overflow = 'hidden';
+  syncModalInert();
   writeStateToURL();
   requestAnimationFrame(() => {
     const close = els.showModal.querySelector('.modal-close');
@@ -1204,7 +1718,7 @@ function openShowModal(seriesId) {
   });
 }
 
-function buildShowSeasonRow(m, bestSeason) {
+function buildShowSeasonRow(m, bestSeason, worstSeason) {
   const li = document.createElement('li');
   li.className = 'show-season';
   if (Watched.has(m)) li.classList.add('is-watched');
@@ -1245,7 +1759,7 @@ function buildShowSeasonRow(m, bestSeason) {
     path.setAttribute('class', cls);
     sparkSvg.appendChild(path);
   }
-  drawCurve(sparkSvg, m.episodes, 200, 36);
+  drawCurve(sparkSvg, m.episodes, 200, 36, 0);
 
   const stats = document.createElement('div');
   stats.className = 'ss-stats';
@@ -1261,6 +1775,12 @@ function buildShowSeasonRow(m, bestSeason) {
     best.style.color = 'var(--accent)';
     best.textContent = '★ best';
     stats.appendChild(best);
+  } else if (worstSeason === m.season) {
+    const worst = document.createElement('span');
+    worst.className = 'ss-watched-tag';
+    worst.style.color = 'var(--danger)';
+    worst.textContent = '▼ worst';
+    stats.appendChild(worst);
   }
   if (Watched.has(m)) {
     const w = document.createElement('span');
@@ -1284,7 +1804,11 @@ function closeShowModal() {
   if (els.showModal.hidden) return;
   els.showModal.hidden = true;
   els.showModal.setAttribute('aria-hidden', 'true');
-  if (els.modal.hidden) document.body.style.overflow = '';
+  if (els.modal.hidden) {
+    document.documentElement.style.overflow = '';
+    document.body.style.overflow = '';
+  }
+  syncModalInert();
   if (showModalState.lastFocus && typeof showModalState.lastFocus.focus === 'function') {
     showModalState.lastFocus.focus();
   }
@@ -1300,20 +1824,21 @@ function syncModalWatchBtn() {
   els.modalWatchBtn.textContent = isWatched ? 'Watched ✓' : 'Mark as watched';
 }
 
-function trapModalFocus(e) {
-  if (els.modal.hidden || e.key !== 'Tab') return;
-  const focusable = els.modal.querySelectorAll(
-    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-  );
-  if (focusable.length === 0) return;
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
-  if (e.shiftKey && document.activeElement === first) {
-    last.focus();
-    e.preventDefault();
-  } else if (!e.shiftKey && document.activeElement === last) {
-    first.focus();
-    e.preventDefault();
+// Mark everything outside the open modal as `inert` so Tab can't reach
+// background controls (and assistive tech / pointer events are blocked too).
+// When both modals are closed, clears inert from all body children.
+function syncModalInert() {
+  const openModal = !els.compareModal.hidden
+    ? els.compareModal
+    : !els.modal.hidden
+      ? els.modal
+      : !els.showModal.hidden
+        ? els.showModal
+        : null;
+  for (const node of document.body.children) {
+    if (node.tagName === 'TEMPLATE' || node.tagName === 'SCRIPT') continue;
+    if (openModal && node !== openModal) node.setAttribute('inert', '');
+    else node.removeAttribute('inert');
   }
 }
 
@@ -1354,23 +1879,52 @@ function computeSuggestions(rawQuery) {
   const titleStarts = [];
   const titleContains = [];
   const idMatches = [];
+  const matchedIds = new Set();
   for (const s of seriesIndex) {
     const titleL = s.title.toLowerCase();
     const idL = s.seriesId.toLowerCase();
     if (titleL === q || idL === q || idL === `tt${q}`) {
-      exact.push(s);
+      exact.push(s); matchedIds.add(s.seriesId);
     } else if (titleL.startsWith(q)) {
-      titleStarts.push(s);
+      titleStarts.push(s); matchedIds.add(s.seriesId);
     } else if (titleL.includes(q)) {
-      titleContains.push(s);
+      titleContains.push(s); matchedIds.add(s.seriesId);
     } else if (idL.includes(q)) {
-      idMatches.push(s);
+      idMatches.push(s); matchedIds.add(s.seriesId);
     }
     if (exact.length + titleStarts.length + titleContains.length + idMatches.length >= MAX_SUGGESTIONS * 4) {
       break;
     }
   }
-  return [...exact, ...titleStarts, ...titleContains, ...idMatches].slice(0, MAX_SUGGESTIONS);
+  // Episode-name fallback: if the title pass didn't fill the dropdown and
+  // the query is specific (>= 3 chars), surface series whose episode list
+  // contains the query (e.g. "Gray Matter" → Breaking Bad).
+  const epHits = [];
+  const titleHits = exact.length + titleStarts.length + titleContains.length + idMatches.length;
+  if (q.length >= 3 && titleHits < MAX_SUGGESTIONS) {
+    const seriesById = new Map(seriesIndex.map((s) => [s.seriesId, s]));
+    const seen = new Set();
+    for (const m of dataset.matches) {
+      if (matchedIds.has(m.seriesId) || seen.has(m.seriesId)) continue;
+      for (const ep of m.episodes) {
+        if (ep.name && ep.name.toLowerCase().includes(q)) {
+          seen.add(m.seriesId);
+          const base = seriesById.get(m.seriesId);
+          if (base) {
+            epHits.push({
+              ...base,
+              episodeMatch: ep.name,
+              episodeSeason: m.season,
+              episodeNumber: ep.episode,
+            });
+          }
+          break;
+        }
+      }
+      if (epHits.length + titleHits >= MAX_SUGGESTIONS * 2) break;
+    }
+  }
+  return [...exact, ...titleStarts, ...titleContains, ...idMatches, ...epHits].slice(0, MAX_SUGGESTIONS);
 }
 
 function highlightFragment(text, q) {
@@ -1427,6 +1981,17 @@ function renderSuggestionItems() {
     for (const node of highlightFragment(s.seriesId, q)) meta.appendChild(node);
 
     text.append(title, meta);
+
+    // If this match came from an episode-name hit, append a small line
+    // explaining which episode caused the match — so the user understands
+    // why Breaking Bad shows up when they typed "Gray Matter".
+    if (s.episodeMatch) {
+      const epHint = document.createElement('span');
+      epHint.className = 'ss-ep-hint';
+      epHint.appendChild(document.createTextNode(`S${s.episodeSeason}E${s.episodeNumber} · `));
+      for (const node of highlightFragment(s.episodeMatch, q)) epHint.appendChild(node);
+      text.appendChild(epHint);
+    }
     li.append(poster, text);
 
     li.addEventListener('mousedown', (e) => e.preventDefault());
@@ -1520,9 +2085,11 @@ function selectSuggestion(i) {
   state.lockedSeriesId = s.seriesId;
   closeSuggestions();
   state.page = 1;
-  writeStateToURL();
   render();
-  els.search.focus();
+  // Open the show modal directly — the user picked a specific series, so
+  // they want to see it. openShowModal calls writeStateToURL itself and
+  // grabs focus, so we skip both here.
+  openShowModal(s.seriesId);
 }
 
 function readToolbarInputs() {
@@ -1574,6 +2141,7 @@ function bindEvents() {
         if (filter === 'seriesType') state.seriesType = val;
         else if (filter === 'watched') state.watched = val;
         else if (filter === 'aboveImdb') state.aboveImdb = val;
+        else if (filter === 'hiddenGems') state.hiddenGems = val;
         syncLabelFiltersAria();
         onFilterChange();
       });
@@ -1630,7 +2198,11 @@ function bindEvents() {
     state.sort = 'popularity';
     state.watched = 'all';
     state.aboveImdb = 'all';
+    state.hiddenGems = 'all';
     state.genres = new Set();
+    state.excludeGenres = new Set();
+    state.languages = new Set();
+    state.providers = new Set();
     state.page = 1;
     els.search.value = '';
     els.minEpisodes.value = '';
@@ -1644,6 +2216,13 @@ function bindEvents() {
     syncLabelFiltersAria();
     syncShapeChipsAria();
     for (const c of els.genres.querySelectorAll('.genre-chip')) {
+      c.setAttribute('aria-pressed', 'false');
+      c.dataset.exclude = 'false';
+    }
+    for (const c of els.languages.querySelectorAll('.genre-chip')) {
+      c.setAttribute('aria-pressed', 'false');
+    }
+    for (const c of els.providers.querySelectorAll('.genre-chip')) {
       c.setAttribute('aria-pressed', 'false');
     }
     closeSuggestions();
@@ -1667,6 +2246,22 @@ function bindEvents() {
   for (const closer of els.showModal.querySelectorAll('[data-close="show-modal"]')) {
     closer.addEventListener('click', closeShowModal);
   }
+  for (const closer of els.compareModal.querySelectorAll('[data-close="compare-modal"]')) {
+    closer.addEventListener('click', closeCompareModal);
+  }
+  els.showModalCompare.addEventListener('click', () => {
+    if (!showModalState.seriesId) return;
+    if (Compare.has(showModalState.seriesId)) Compare.remove(showModalState.seriesId);
+    else Compare.add(showModalState.seriesId);
+    syncCompareButton();
+    syncCompareFab();
+  });
+  els.compareFab.addEventListener('click', openCompareModal);
+  els.compareModalClear.addEventListener('click', () => {
+    Compare.clear();
+    syncCompareFab();
+    closeCompareModal();
+  });
   els.modalViewShow.addEventListener('click', () => {
     if (!modalState.season) return;
     openShowModal(modalState.season.seriesId);
@@ -1690,7 +2285,9 @@ function bindKeyboard() {
       return;
     }
     if (e.key === 'Escape') {
-      if (!els.modal.hidden) {
+      if (!els.compareModal.hidden) {
+        closeCompareModal();
+      } else if (!els.modal.hidden) {
         closeModal();
       } else if (!els.showModal.hidden) {
         closeShowModal();
@@ -1705,7 +2302,6 @@ function bindKeyboard() {
       }
       return;
     }
-    if (!els.modal.hidden) trapModalFocus(e);
   });
 }
 

--- a/apps/rising-seasons/scripts/build-data.js
+++ b/apps/rising-seasons/scripts/build-data.js
@@ -18,8 +18,13 @@
 // Output: apps/rising-seasons/data.json
 //
 // Tunables (env vars):
-//   MIN_EPISODES (default 4)   — minimum rated episodes per season
-//   MIN_VOTES    (default 100) — every episode must have at least this many votes
+//   MIN_EPISODES     (default 4)   — minimum rated episodes per season
+//   MIN_VOTES        (default 100) — every episode must have at least this many votes
+//   RELAX_GENRES     (default "Reality-TV,Game-Show,Talk-Show") — comma-list of
+//                                    IMDb genres whose series get the lower floor below
+//   RELAX_MIN_VOTES  (default 10)  — per-episode vote floor for the relaxed-genre series.
+//                                    Reality/competition episodes typically draw 10-50
+//                                    IMDb votes, so the standard 100 wipes them out.
 
 const fs = require('fs');
 const path = require('path');
@@ -38,6 +43,11 @@ const TMDB_CACHE = path.join(DATA_DIR, 'tmdb-cache.json');
 // rather than appearing as their own pattern hits.
 const MIN_EPISODES = parseInt(process.env.MIN_EPISODES || '3', 10);
 const MIN_VOTES = parseInt(process.env.MIN_VOTES || '100', 10);
+const RELAX_GENRES = (process.env.RELAX_GENRES ?? 'Reality-TV,Game-Show,Talk-Show')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+const RELAX_MIN_VOTES = parseInt(process.env.RELAX_MIN_VOTES || '10', 10);
 const SERIES_TYPES = new Set(['tvSeries', 'tvMiniSeries']);
 
 function openTsv(filename) {
@@ -157,6 +167,27 @@ async function loadEpisodes(series, ratings, episodeTitles, episodeYears) {
   return result;
 }
 
+// TMDB returns each plan as a separate provider ("Netflix" / "Netflix
+// Standard with Ads", "Peacock Premium" / "Peacock Premium Plus", channel
+// variants like "HBO Max Amazon Channel"). Users care about the brand, so
+// collapse to the parent. Anything we don't recognize passes through.
+function normalizeProvider(name) {
+  if (/^Netflix/i.test(name)) return 'Netflix';
+  if (/^Amazon Prime Video/i.test(name)) return 'Amazon Prime Video';
+  if (/^HBO Max/i.test(name)) return 'HBO Max';
+  if (/^Max\b/i.test(name)) return 'HBO Max';
+  if (/^Peacock/i.test(name)) return 'Peacock';
+  if (/^Hulu/i.test(name)) return 'Hulu';
+  if (/^Disney( Plus|\+)/i.test(name)) return 'Disney+';
+  if (/^Apple TV/i.test(name)) return 'Apple TV+';
+  if (/^Paramount( Plus|\+)/i.test(name)) return 'Paramount+';
+  if (/^Crunchyroll/i.test(name)) return 'Crunchyroll';
+  if (/^Starz/i.test(name)) return 'Starz';
+  if (/^Showtime/i.test(name)) return 'Showtime';
+  if (/^AMC\+/i.test(name) || /^AMC Plus/i.test(name)) return 'AMC+';
+  return name;
+}
+
 function loadTmdbCache() {
   if (!fs.existsSync(TMDB_CACHE)) return null;
   try {
@@ -190,8 +221,11 @@ function loadTmdbCache() {
   const matches = findMatches(series, episodes, {
     minEpisodes: MIN_EPISODES,
     minVotes: MIN_VOTES,
+    relaxedGenres: new Set(RELAX_GENRES),
+    relaxedMinVotes: RELAX_MIN_VOTES,
   });
-  console.log(`${matches.length.toLocaleString()} matching seasons`);
+  const shapedCount = matches.reduce((n, m) => n + (m.shapes.length > 0 ? 1 : 0), 0);
+  console.log(`${matches.length.toLocaleString()} seasons (${shapedCount.toLocaleString()} with at least one shape)`);
 
   // Tally per-shape counts for the build summary.
   const shapeCounts = {};
@@ -225,6 +259,18 @@ function loadTmdbCache() {
         m.poster = t.poster_path || null;
         m.overview = t.overview || null;
         m.tmdbId = t.id || null;
+        if (t.original_language) m.language = t.original_language;
+        if (Array.isArray(t.providers) && t.providers.length) {
+          const seen = new Set();
+          const norm = [];
+          for (const p of t.providers) {
+            const key = normalizeProvider(p.name);
+            if (seen.has(key)) continue;
+            seen.add(key);
+            norm.push(key);
+          }
+          if (norm.length) m.providers = norm;
+        }
         enriched++;
       }
     }
@@ -247,13 +293,48 @@ function loadTmdbCache() {
     .sort((a, b) => b[1] - a[1])
     .map(([name, count]) => ({ name, count }));
 
+  // Same for languages — counted per unique series (not per season) so a
+  // long-running English show doesn't dominate the chip count by virtue of
+  // having more seasons than a foreign-language show.
+  const languageCounts = new Map();
+  const seenSeries = new Set();
+  for (const m of matches) {
+    if (seenSeries.has(m.seriesId)) continue;
+    seenSeries.add(m.seriesId);
+    if (!m.language) continue;
+    languageCounts.set(m.language, (languageCounts.get(m.language) || 0) + 1);
+  }
+  const languages = [...languageCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([code, count]) => ({ code, count }));
+
+  // Same: providers counted per unique series. A series streamed on Netflix +
+  // Hulu contributes one count to each. Skip series with no provider info.
+  const providerCounts = new Map();
+  const seenForProviders = new Set();
+  for (const m of matches) {
+    if (seenForProviders.has(m.seriesId)) continue;
+    seenForProviders.add(m.seriesId);
+    if (!m.providers) continue;
+    for (const p of m.providers) {
+      providerCounts.set(p, (providerCounts.get(p) || 0) + 1);
+    }
+  }
+  const providers = [...providerCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, count]) => ({ name, count }));
+
   fs.writeFileSync(OUT_FILE, JSON.stringify({
     builtAt: new Date().toISOString(),
     minEpisodes: MIN_EPISODES,
     minVotes: MIN_VOTES,
+    relaxedGenres: RELAX_GENRES,
+    relaxedMinVotes: RELAX_MIN_VOTES,
     count: matches.length,
     shapeCounts,
     genres,
+    languages,
+    providers,
     matches,
   }));
   const seconds = ((Date.now() - t0) / 1000).toFixed(1);

--- a/apps/rising-seasons/scripts/enrich-providers.js
+++ b/apps/rising-seasons/scripts/enrich-providers.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+'use strict';
+
+// Adds US watch-provider info (Netflix / Max / Prime / Hulu / ...) to the
+// TMDB cache. Separate from enrich-tmdb.js so it can run incrementally and
+// only touches the `providers` field of each cache entry.
+//
+//   TMDB_TOKEN=... npm run enrich:rising-seasons:providers
+//
+// Reads/writes apps/rising-seasons/data/tmdb-cache.json. Requires that
+// enrich-tmdb.js has already populated each entry with a tmdbId.
+
+const fs = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const CACHE_FILE = path.join(DATA_DIR, 'tmdb-cache.json');
+const REQUEST_INTERVAL_MS = 165;
+const TOKEN = process.env.TMDB_TOKEN || process.env.TMDB_BEARER_TOKEN;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function tmdbFetch(url) {
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${TOKEN}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`TMDB ${res.status} for ${url}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+// Pulls US streaming/ads providers. We deliberately ignore `rent` and `buy`
+// because the UI's "where can I watch this" filter only makes sense for
+// no-extra-cost access.
+async function fetchProviders(tmdbId) {
+  const url = `https://api.themoviedb.org/3/tv/${tmdbId}/watch/providers`;
+  const body = await tmdbFetch(url);
+  const us = body.results && body.results.US;
+  if (!us) return [];
+  const seen = new Set();
+  const out = [];
+  for (const bucket of ['flatrate', 'ads', 'free']) {
+    if (!us[bucket]) continue;
+    for (const p of us[bucket]) {
+      if (seen.has(p.provider_name)) continue;
+      seen.add(p.provider_name);
+      out.push({ name: p.provider_name, logo: p.logo_path || null });
+    }
+  }
+  return out;
+}
+
+(async () => {
+  if (!TOKEN) {
+    console.error('Set TMDB_TOKEN env var (a v4 read access token from https://www.themoviedb.org/settings/api)');
+    process.exit(1);
+  }
+  if (!fs.existsSync(CACHE_FILE)) {
+    console.error(`Missing ${CACHE_FILE} — run enrich-tmdb.js first.`);
+    process.exit(1);
+  }
+  const cache = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8'));
+  // Only fetch providers for entries that have a tmdbId and don't yet
+  // carry a `providers` field. Already-fetched entries are skipped even
+  // when their `providers` list is empty (no US streaming) — we don't want
+  // to refetch on every run for shows that genuinely aren't streamed.
+  const todo = [];
+  for (const [imdbId, entry] of Object.entries(cache)) {
+    if (!entry || entry.notFound || entry.error) continue;
+    if (!entry.id) continue;
+    if ('providers' in entry) continue;
+    todo.push(imdbId);
+  }
+  console.log(`${todo.length.toLocaleString()} entries need provider data`);
+  if (todo.length === 0) return;
+
+  let done = 0;
+  let errored = 0;
+  const t0 = Date.now();
+  for (const imdbId of todo) {
+    const entry = cache[imdbId];
+    try {
+      entry.providers = await fetchProviders(entry.id);
+    } catch (err) {
+      entry.providersError = err.message;
+      errored++;
+    }
+    done++;
+    if (done % 50 === 0) {
+      const rate = (done / ((Date.now() - t0) / 1000)).toFixed(1);
+      const eta = ((todo.length - done) / parseFloat(rate)).toFixed(0);
+      process.stdout.write(`  ${done}/${todo.length}  (${rate}/s, ~${eta}s left)\r`);
+      fs.writeFileSync(CACHE_FILE, JSON.stringify(cache));
+    }
+    await sleep(REQUEST_INTERVAL_MS);
+  }
+  fs.writeFileSync(CACHE_FILE, JSON.stringify(cache));
+  let withProviders = 0, withoutProviders = 0;
+  for (const e of Object.values(cache)) {
+    if (!e || !('providers' in e)) continue;
+    if (e.providers && e.providers.length) withProviders++;
+    else withoutProviders++;
+  }
+  console.log(`\nWrote ${CACHE_FILE}`);
+  console.log(`  with providers: ${withProviders.toLocaleString()}`);
+  console.log(`  no US providers: ${withoutProviders.toLocaleString()}`);
+  console.log(`  errored: ${errored.toLocaleString()}`);
+  console.log('Re-run `npm run build:rising-seasons` to merge into data.json.');
+})();

--- a/apps/rising-seasons/scripts/enrich-tmdb.js
+++ b/apps/rising-seasons/scripts/enrich-tmdb.js
@@ -47,6 +47,7 @@ async function findByImdbId(imdbId) {
     id: tv.id,
     poster_path: tv.poster_path || null,
     overview: tv.overview || null,
+    original_language: tv.original_language || null,
     name: tv.name,
     via: 'imdb',
   };
@@ -70,6 +71,7 @@ async function searchByTitle(title) {
     id: tv.id,
     poster_path: tv.poster_path || null,
     overview: tv.overview || null,
+    original_language: tv.original_language || null,
     name: tv.name,
     via: 'search',
     searchQuery: title,
@@ -133,6 +135,10 @@ async function resolveSeries(imdbId, info) {
     if (e.notFound) return true;
     if (e.error) return true;
     if (!e.poster_path) return true; // matched but no poster — try harder
+    // Back-fill: cache entries written before the language field was added
+    // lack `original_language`. Force a refetch so the language filter has
+    // data for every series, not just newly-added ones.
+    if (!('original_language' in e)) return true;
     return false;
   });
   const retrying = todo.filter((id) => id in cache).length;

--- a/apps/rising-seasons/scripts/match.js
+++ b/apps/rising-seasons/scripts/match.js
@@ -186,28 +186,38 @@ function detectShapes(episodes) {
 }
 
 // Walk the (series -> season -> episodes) map and return one record per
-// qualifying season. A *series* qualifies if at least one of its seasons
-// matches a shape pattern; once a series qualifies, ALL of its seasons
-// that pass the vote/episode floor are included (even ones with shapes:
-// []). This way searching for "The Office" returns every season, not
-// just the few that fit a curve pattern.
+// season that passes the vote/episode floor. Shape matching is descriptive,
+// not gating — seasons with no shape match are still emitted with shapes: []
+// so the app can search the full IMDb catalog.
 //
 // Filters:
 //   minEpisodes — skip seasons with fewer rated episodes than this.
 //   minVotes    — every episode must have at least this many votes (low-vote
 //                 ratings are noisy and not meaningful).
+//   relaxedGenres / relaxedMinVotes — apply a lower per-episode vote floor
+//                 when the series is tagged with any of these genres.
+//                 Reality/competition shows get a fraction of the per-episode
+//                 votes scripted shows do, so the standard floor wipes them
+//                 out entirely; a relaxed floor lets them surface.
 function findMatches(seriesById, episodesBySeries, opts = {}) {
   const minEpisodes = opts.minEpisodes ?? 4;
   const minVotes = opts.minVotes ?? 100;
+  const relaxedGenres = opts.relaxedGenres instanceof Set
+    ? opts.relaxedGenres
+    : new Set(opts.relaxedGenres || []);
+  const relaxedMinVotes = opts.relaxedMinVotes ?? minVotes;
 
-  // Pass 1: precompute (sorted, voted, shaped) info for every season that
-  // passes the vote/episode floor. Mark which series have at least one
-  // shape-matching season.
   const seasons = []; // { seriesId, season, eps, shapes, minSeasonVotes }
-  const qualifyingSeries = new Set();
 
   for (const [seriesId, bySeason] of episodesBySeries) {
-    if (!seriesById.has(seriesId)) continue;
+    const meta = seriesById.get(seriesId);
+    if (!meta) continue;
+    let floor = minVotes;
+    if (relaxedGenres.size > 0 && meta.genres) {
+      for (const g of meta.genres) {
+        if (relaxedGenres.has(g)) { floor = relaxedMinVotes; break; }
+      }
+    }
     for (const [season, eps] of bySeason) {
       if (eps.length < minEpisodes) continue;
       eps.sort((a, b) => a.episode - b.episode);
@@ -216,20 +226,15 @@ function findMatches(seriesById, episodesBySeries, opts = {}) {
       for (const e of eps) {
         if (e.votes < minSeasonVotes) minSeasonVotes = e.votes;
       }
-      if (minSeasonVotes < minVotes) continue;
+      if (minSeasonVotes < floor) continue;
 
       const shapes = detectShapes(eps);
       seasons.push({ seriesId, season, eps, shapes, minSeasonVotes });
-      if (shapes.length > 0) qualifyingSeries.add(seriesId);
     }
   }
 
-  // Pass 2: emit every season belonging to a qualifying series. Shape-less
-  // seasons get shapes: [] — they're searchable but won't appear under any
-  // specific shape tab.
   const matches = [];
   for (const { seriesId, season, eps, shapes, minSeasonVotes } of seasons) {
-    if (!qualifyingSeries.has(seriesId)) continue;
     const meta = seriesById.get(seriesId);
     const ratings = eps.map((e) => e.rating);
     const seasonAvg = ratings.reduce((s, r) => s + r, 0) / ratings.length;

--- a/apps/rising-seasons/tests/match.test.js
+++ b/apps/rising-seasons/tests/match.test.js
@@ -203,7 +203,7 @@ test('detectShapes returns empty array when nothing matches', () => {
 
 // --- findMatches integration ---
 
-test('findMatches tags shapes and includes one record per qualifying season', () => {
+test('findMatches tags shapes and emits one record per season passing the floor', () => {
   const series = new Map([
     ['tt100', { title: 'Climber', year: 2020, type: 'tvSeries', genres: ['Drama'] }],
   ]);
@@ -222,24 +222,23 @@ test('findMatches tags shapes and includes one record per qualifying season', ()
   assert.deepEqual(s1.genres, ['Drama']);
 });
 
-test('findMatches drops series whose seasons all match no shapes', () => {
+test('findMatches keeps shape-less seasons with shapes: []', () => {
   const series = new Map([
-    ['tt500', { title: 'Choppy', year: 2024, type: 'tvSeries' }],
+    ['tt500', { title: 'Choppy', year: 2024, type: 'tvSeries', genres: [] }],
   ]);
   const episodes = new Map([
     ['tt500', new Map([
       // Bouncy, mid-range, no rebound, no consistent floor — matches nothing.
-      // Series has no shape-matching season, so it's excluded entirely.
+      // Still emitted so the full IMDb catalog is searchable.
       [1, [ep(1, 7.5), ep(2, 7.7), ep(3, 7.4), ep(4, 7.6)]],
     ])],
   ]);
-  assert.equal(findMatches(series, episodes).length, 0);
+  const matches = findMatches(series, episodes);
+  assert.equal(matches.length, 1);
+  assert.deepEqual(matches[0].shapes, []);
 });
 
-test('findMatches includes shape-less seasons of qualifying series', () => {
-  // Real-world example: shows like The Office have some seasons that fit
-  // a shape pattern and some that don't. Once any season qualifies the
-  // series, every season is included so search results are complete.
+test('findMatches emits every season passing the floor regardless of shape', () => {
   const series = new Map([
     ['tt600', { title: 'Mixed Bag', year: 2010, type: 'tvSeries', genres: ['Drama'] }],
   ]);
@@ -247,7 +246,7 @@ test('findMatches includes shape-less seasons of qualifying series', () => {
     ['tt600', new Map([
       // Season 1 — bouncy, no shape match.
       [1, [ep(1, 7.5), ep(2, 7.7), ep(3, 7.4), ep(4, 7.6)]],
-      // Season 2 — non-decreasing, qualifies the series.
+      // Season 2 — non-decreasing.
       [2, [ep(1, 7.0), ep(2, 7.2), ep(3, 7.4), ep(4, 7.5)]],
       // Season 3 — bouncy again, no shape match.
       [3, [ep(1, 8.0), ep(2, 7.8), ep(3, 8.1), ep(4, 7.9)]],
@@ -301,6 +300,40 @@ test('findMatches drops seasons whose lowest-vote episode is under minVotes', ()
   ]);
   assert.equal(findMatches(series, episodes, { minVotes: 100 }).length, 0);
   assert.equal(findMatches(series, episodes, { minVotes: 25 }).length, 1);
+});
+
+test('findMatches applies relaxedMinVotes only to series in relaxedGenres', () => {
+  const series = new Map([
+    ['ttReal',   { title: 'Cook-Off',  year: 2020, type: 'tvSeries', genres: ['Reality-TV'] }],
+    ['ttDrama',  { title: 'Big Drama', year: 2020, type: 'tvSeries', genres: ['Drama'] }],
+  ]);
+  // Both seasons have a low-vote episode (15) — well below the standard 100.
+  const episodes = new Map([
+    ['ttReal',  new Map([[1, [ep(1, 7.0, 15), ep(2, 7.2, 5000), ep(3, 7.4, 5000), ep(4, 7.5, 5000)]]])],
+    ['ttDrama', new Map([[1, [ep(1, 7.0, 15), ep(2, 7.2, 5000), ep(3, 7.4, 5000), ep(4, 7.5, 5000)]]])],
+  ]);
+  const matches = findMatches(series, episodes, {
+    minVotes: 100,
+    relaxedGenres: new Set(['Reality-TV']),
+    relaxedMinVotes: 10,
+  });
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].seriesId, 'ttReal');
+});
+
+test('findMatches accepts relaxedGenres as an array', () => {
+  const series = new Map([
+    ['ttGame', { title: 'Quiz Show', year: 2021, type: 'tvSeries', genres: ['Game-Show'] }],
+  ]);
+  const episodes = new Map([
+    ['ttGame', new Map([[1, [ep(1, 7.0, 20), ep(2, 7.2, 20), ep(3, 7.4, 20), ep(4, 7.5, 20)]]])],
+  ]);
+  const matches = findMatches(series, episodes, {
+    minVotes: 100,
+    relaxedGenres: ['Game-Show'],
+    relaxedMinVotes: 10,
+  });
+  assert.equal(matches.length, 1);
 });
 
 test('findMatches skips series missing from the metadata map', () => {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:football": "node --test apps/football-h2h/tests/",
     "test:rising-seasons": "node --test apps/rising-seasons/tests/",
     "build:rising-seasons": "node apps/rising-seasons/scripts/build-data.js",
-    "enrich:rising-seasons": "node apps/rising-seasons/scripts/enrich-tmdb.js"
+    "enrich:rising-seasons": "node apps/rising-seasons/scripts/enrich-tmdb.js",
+    "enrich:rising-seasons:providers": "node apps/rising-seasons/scripts/enrich-providers.js"
   }
 }


### PR DESCRIPTION
## Summary

Five new discovery features for Rising Seasons, plus a batch of UX fixes that came out of testing them.

### New features

- **Compare shows** — "+ Add to compare" button in the show modal adds the series to a localStorage-backed set (up to 5). A floating "Compare (N)" button opens a dedicated modal that overlays each series' season-average trajectory on one chart.
- **Season overlay** — inside the show modal, every season's curve is drawn on a single normalized chart with a color legend.
- **Hidden gems toggle** — avg ≥ 8.0 AND fewer than 1,000 votes per episode.
- **Episode-title search** — typing "Gray Matter" now surfaces Breaking Bad in the autocomplete (with a small "S1E5 · Gray Matter" hint) and matches it in the card filter.
- **Tri-state genre chips** — click cycles off → include → exclude (red strikethrough) → off.

### Filters added

- **Language** — multi-select chips driven by TMDB `original_language`.
- **Streaming** — multi-select chips for US watch providers (Netflix, HBO Max, Prime, Hulu, Peacock, …), brand-normalized so "Netflix Standard with Ads" / "Peacock Premium Plus" collapse to their parent brand.
- **Worst-season badge** alongside the existing "best" — compact uppercase pills positioned next to "S2 · 10 eps", gold for best, red for worst.

### UX fixes

- Modal scroll-lock now locks `<html>` plus `<body>`, with `overscroll-behavior: contain` on the panel — page no longer scrolls behind the modal.
- Focus trap via `inert` on background siblings when any modal is open — Tab can't escape.
- Search-suggestion click opens the show modal directly (one click, not two).
- List-view watched-checkmark flicker fixed (CSS specificity bug — `:hover` rule was overriding `position: static` and teleporting the button on hover).
- Modal-curve `flex-shrink: 0` so the episode-ratings chart doesn't collapse to a thin strip when the modal content overflows.
- Advanced filters panel keeps its chrome whether collapsed or expanded — opening doesn't visually widen the section.
- Filter section labels (GENRES / LANGUAGE / STREAMING) above each chip row.
- Genres filter switched from OR → AND across selected chips.

### Data pipeline

- New `scripts/enrich-providers.js` script — fetches `/tv/{id}/watch/providers` (US) for every cached TMDB series. Incremental, ~25-30 min first run, throttled to ~6 req/s.
- `enrich-tmdb.js` now captures `original_language` and back-fills cache entries missing it.
- `build-data.js` pipes `language` and brand-normalized `providers` through to each match plus root-level popularity-ranked aggregates (`languages`, `providers`).
- `match.js` shape gate removed — every season passing the vote/episode floor is emitted, even with `shapes: []`. Adds relaxed-genre vote floor for reality / game-show / talk-show series whose episodes rarely clear 100 votes.
- Workflow updated to run both enrichment scripts in sequence.

### Stats

- `data.json` now 26 MB — 16,510 seasons across 6,752 series.
- Language data on 99% of matches; US streaming providers on 80%.
- Top streaming chips: Netflix (1,566), Amazon Prime Video (842), Hulu (735), HBO Max (457), Peacock (360).

### Docs

- `README.md` — added "Browser app features" table, expanded Shapes table to all 10 detectors, updated enrichment section for the second script.
- `DATA_README.md` — schema updated with `language`, `providers`, `languages`, `providers` aggregates; updated workflow description and size note.

## Test plan

- [x] `npm test` — 274/274 passing.
- [ ] Visual: open app locally, verify all five features work end-to-end.
- [ ] Verify language chips populate and filter correctly (English / Japanese / Korean / …).
- [ ] Verify streaming chips populate and filter correctly (Netflix / Prime / HBO Max / …).
- [ ] Verify "Gray Matter" search surfaces Breaking Bad with the episode hint.
- [ ] Verify Compare flow: add 2+ shows, open FAB, see overlay chart, remove via legend, clear all.
- [ ] Verify tri-state genre chips: include → exclude (red strike) → off.
- [ ] Verify hidden gems toggle in the quick-filters bar.
- [ ] Verify modal scroll is locked and Tab can't reach background.
- [ ] Verify list-view checkmark hover no longer flickers.