### PR TITLE
ci: bump GitHub Actions off the deprecated Node 20 majors

### DIFF
--- a/.github/workflows/refresh-rising-seasons.yml
+++ b/.github/workflows/refresh-rising-seasons.yml
@@ -33,10 +33,10 @@ jobs:
     timeout-minutes: 75
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -51,7 +51,7 @@ jobs:
       # Restore the TMDB cache from the most recent successful run so we
       # only fetch newly-discovered series, not the whole catalogue.
       - name: Restore TMDB cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: apps/rising-seasons/data/tmdb-cache.json
           key: tmdb-cache-${{ github.run_id }}
@@ -81,7 +81,7 @@ jobs:
       # enrichment step ran (we still want to keep what we had).
       - name: Save TMDB cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: apps/rising-seasons/data/tmdb-cache.json
           key: tmdb-cache-${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 


### PR DESCRIPTION
## Summary

GitHub announced that Node 20 actions will be force-switched to Node 24 on June 2nd, 2026 and removed entirely on September 16th, 2026. The deprecation warning was firing on every recent workflow run. Bumping to the current majors clears it.

- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/cache/restore` v4 → v5
- `actions/cache/save` v4 → v5

Touched both workflow files (`refresh-rising-seasons.yml`, `test.yml`).

## Verification

Triggered the rising-seasons refresh workflow on this branch with `gh workflow run refresh-rising-seasons.yml --ref rising-seasons-actions-v6`:

- Run #25742792301 — completed in 2m20s, all steps ✓.
- Zero annotations returned from the check-runs API (the Node 20 deprecation message that previously appeared on every run is gone).
- `data.json` rebuilt successfully with cache restore + save working on the new versions.

These are all first-party actions with backwards-compatible inputs across this major bump, so no behavior change is expected and none was observed.

## Test plan

- [x] Trigger `refresh-rising-seasons.yml` on branch → green.
- [ ] After merge: the `tests` workflow (push trigger on master) will also exercise the bumped checkout / setup-node actions.