### PR TITLE
Confusion matrix (MapTap) + Rising Seasons UI overhaul

### DIFF
--- a/.github/workflows/refresh-rising-seasons.yml
+++ b/.github/workflows/refresh-rising-seasons.yml
@@ -7,8 +7,10 @@ name: Refresh Rising Seasons data
 
 on:
   schedule:
-    # Mondays at 06:00 UTC.
-    - cron: '0 6 * * 1'
+    # Every day at 06:00 UTC — keeps the static site current with IMDb's
+    # daily TSV publishing cadence. Incremental TMDB cache hits keep
+    # runtimes well under 15 min once the cold-start bootstrap is done.
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       skip_tmdb:

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -222,7 +222,7 @@ body.maptap-rivals-app button {
   border: 1px solid var(--border);
   border-radius: 999px;
   background: var(--surface);
-  color: var(--text) !important;
+  color: #fff !important;
   font: inherit;
   font-size: 0.9rem;
   font-weight: 500;
@@ -235,7 +235,7 @@ body.maptap-rivals-app button {
 .view-tab.is-active:hover {
   background: var(--accent-soft);
   border-color: var(--accent-strong);
-  color: var(--accent-2) !important;
+  color: #fff !important;
 }
 
 /* ---------- Section bits ---------- */
@@ -2349,4 +2349,260 @@ tr:focus-within .icon-btn {
   .rival-card-stats { grid-template-columns: repeat(3, 1fr); }
   .hero { padding-top: 1.6rem; }
   .view-tabs { padding: 1rem 0 0.5rem; }
+}
+
+/* ---------- Matrix view ---------- */
+
+.matrix-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.matrix-sub {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  max-width: 60ch;
+}
+
+.matrix-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 1rem 0 0.75rem;
+  padding: 0.75rem 0.9rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.matrix-controls-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.matrix-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.matrix-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: #fff !important;
+  opacity: 1;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.1s, background 0.15s, border-color 0.15s, color 0.15s;
+}
+.matrix-chip:hover { transform: translateY(-1px); color: #fff !important; }
+.matrix-chip.is-on { color: #fff !important; font-weight: 600; }
+
+.matrix-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.75rem;
+}
+
+.matrix-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 6px;
+  table-layout: fixed;
+}
+
+.matrix-corner {
+  background: transparent;
+  border: none;
+}
+
+.matrix-col-head,
+.matrix-row-head {
+  background: var(--surface-2);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.88rem;
+  padding: 0.55rem 0.6rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  vertical-align: middle;
+  text-align: center;
+}
+
+.matrix-row-head { text-align: left; }
+
+.matrix-head-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #fff;
+  opacity: 1;
+}
+.matrix-head-chip .matrix-head-name { color: #fff; }
+.matrix-head-icon { font-size: 1rem; }
+.matrix-head-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 9rem;
+}
+
+.matrix-cell {
+  text-align: center;
+  vertical-align: middle;
+  padding: 0.7rem 0.5rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  min-width: 6.5rem;
+  line-height: 1.15;
+}
+
+.matrix-diag {
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+  color: var(--muted-2);
+  font-size: 1.1rem;
+}
+
+.matrix-empty {
+  color: var(--muted-2);
+  font-style: italic;
+  font-size: 0.8rem;
+}
+
+.matrix-record {
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+.matrix-margin {
+  font-size: 0.82rem;
+  font-weight: 600;
+  margin-top: 0.15rem;
+}
+
+.matrix-meta {
+  font-size: 0.72rem;
+  color: var(--muted);
+  margin-top: 0.1rem;
+}
+
+.matrix-win {
+  background: var(--good-soft);
+  border-color: rgba(74, 222, 128, 0.35);
+  color: var(--good);
+}
+.matrix-win .matrix-meta { color: rgba(74, 222, 128, 0.7); }
+
+.matrix-loss {
+  background: var(--bad-soft);
+  border-color: rgba(248, 113, 113, 0.35);
+  color: var(--bad);
+}
+.matrix-loss .matrix-meta { color: rgba(248, 113, 113, 0.75); }
+
+.matrix-tie {
+  background: var(--tie-soft);
+  border-color: rgba(154, 163, 178, 0.35);
+  color: var(--text);
+}
+
+.matrix-hint {
+  color: var(--muted);
+  text-align: center;
+  padding: 1.5rem 0;
+  margin: 0;
+}
+
+.matrix-legend {
+  margin: 0.75rem 0 0;
+  font-size: 0.82rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+/* Sub-tabs for switching the metric shown inside each matrix cell */
+.matrix-subtabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0 0 0.75rem;
+  padding: 0.5rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.matrix-subtab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.4rem 0.85rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: #fff !important;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.matrix-subtab:hover {
+  background: var(--surface-2);
+  color: #fff !important;
+}
+.matrix-subtab.is-active,
+.matrix-subtab.is-active:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent-strong);
+  color: #fff !important;
+}
+
+/* Form dots used by the "Last 5" sub-tab. Sit in the matrix-record slot so
+ * they line up with the win-record glyphs in other tabs. */
+.matrix-form-dots {
+  display: inline-flex;
+  gap: 0.3rem;
+  justify-content: center;
+  align-items: center;
+}
+.matrix-form-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  display: inline-block;
+  background: var(--surface-3);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+.matrix-form-dot.is-win  { background: var(--good); }
+.matrix-form-dot.is-loss { background: var(--bad); }
+.matrix-form-dot.is-tie  { background: var(--tie); }
+
+@media (max-width: 720px) {
+  .matrix-cell { min-width: 5.5rem; padding: 0.55rem 0.4rem; }
+  .matrix-record { font-size: 0.95rem; }
+  .matrix-margin { font-size: 0.75rem; }
+  .matrix-meta { font-size: 0.68rem; }
+  .matrix-head-name { max-width: 6rem; font-size: 0.82rem; }
 }

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -107,6 +107,9 @@
       <button class="view-tab" data-view="leaderboard" role="tab" aria-selected="false">
         <span aria-hidden="true">🏆</span> Leaderboard
       </button>
+      <button class="view-tab" data-view="matrix" role="tab" aria-selected="false">
+        <span aria-hidden="true">🔀</span> Matrix
+      </button>
       <button class="view-tab" data-view="history" role="tab" aria-selected="false">
         <span aria-hidden="true">📜</span> History
       </button>
@@ -324,6 +327,32 @@
       </div>
       <p class="empty-state" id="leaderboard-empty" hidden>
         Nothing on the board yet — log a game to populate.
+      </p>
+    </section>
+
+    <!-- MATRIX VIEW (cross-participant H2H grid) -->
+    <section class="view view-matrix" data-view-panel="matrix" hidden>
+      <header class="matrix-head">
+        <div>
+          <h2 class="section-title">Confusion matrix</h2>
+          <p class="matrix-sub">
+            Head-to-head between you and every selected rival. Rival ↔ rival cells
+            compare their scores on days you played <em>both</em>.
+          </p>
+        </div>
+      </header>
+
+      <div class="matrix-controls">
+        <span class="matrix-controls-label">Include rivals</span>
+        <div class="matrix-chip-row" id="matrix-chip-row"></div>
+      </div>
+
+      <nav class="matrix-subtabs" id="matrix-subtabs" role="tablist" aria-label="Matrix metric"></nav>
+
+      <div class="matrix-wrap" id="matrix-wrap"></div>
+
+      <p class="empty-state" id="matrix-empty" hidden>
+        Add at least one rival and log a game to populate the matrix.
       </p>
     </section>
 

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -33,6 +33,7 @@
     MY_PROFILE: 'maptapRivalsMyProfile',
     SETTINGS: 'maptapRivalsSettings',
     SELECTED: 'maptapRivalsSelectedRivalId',
+    MATRIX_SEL: 'maptapRivalsMatrixSelection',
   };
 
   // Public MapTap Cloud Function — returns gameHistory keyed by YYYY-MM-DD.
@@ -241,6 +242,8 @@
     settings: load(KEY.SETTINGS, {}),
     selectedRivalId: loadString(KEY.SELECTED, null),
     view: 'dashboard',
+    matrixSelection: load(KEY.MATRIX_SEL, null), // string[] of rivalIds, or null = "all"
+    matrixTab: 'record',           // overridden by URL hash on first paint
     historyFilters: { rival: 'all', result: 'all' },
     historyPage: 1,
     historyPageSize: 25,
@@ -262,6 +265,7 @@
   function persistMyMapTap() { saveString(KEY.MY_MAPTAP, state.myMapTap); }
   function persistMyProfile() { save(KEY.MY_PROFILE, state.myProfile); }
   function persistSelected() { saveString(KEY.SELECTED, state.selectedRivalId); }
+  function persistMatrixSelection() { save(KEY.MATRIX_SEL, state.matrixSelection); }
 
   // ---------- date utils ----------
   function todayISO() {
@@ -590,7 +594,73 @@
     if (view === 'dashboard') renderDashboard();
     else if (view === 'rival') renderRival();
     else if (view === 'leaderboard') renderLeaderboard();
+    else if (view === 'matrix') renderMatrix();
     else if (view === 'history') renderHistory();
+
+    syncUrlHash();
+  }
+
+  // ---------- URL routing ----------
+  // Shareable URLs use the hash fragment:
+  //   #dashboard | #leaderboard | #history
+  //   #rival/<id>            (rival detail)
+  //   #matrix | #matrix/<subtab>
+  // We use replaceState so the URL updates silently without polluting the
+  // back/forward history; hashchange handles users pasting or editing the URL.
+  const KNOWN_VIEWS = new Set(['dashboard', 'rival', 'leaderboard', 'matrix', 'history']);
+
+  function viewHash() {
+    if (state.view === 'matrix') {
+      return state.matrixTab && state.matrixTab !== 'record'
+        ? `#matrix/${state.matrixTab}`
+        : '#matrix';
+    }
+    if (state.view === 'rival' && state.selectedRivalId) {
+      return `#rival/${state.selectedRivalId}`;
+    }
+    return `#${state.view}`;
+  }
+
+  // Mirror current in-memory view → location.hash. Bail if already in sync
+  // so re-renders don't churn the URL bar mid-typing.
+  function syncUrlHash() {
+    const want = viewHash();
+    if (location.hash === want) return;
+    try {
+      history.replaceState(null, '', want);
+    } catch (_) {
+      // Older browsers / file:// — fall back to direct hash assignment.
+      location.hash = want.slice(1);
+    }
+  }
+
+  // Drive view state from location.hash. Used at init and on hashchange
+  // (browser back/forward or user-edited URL).
+  function applyUrlHash() {
+    const raw = (location.hash || '').replace(/^#/, '').trim();
+    if (!raw) { setView('dashboard'); return; }
+    const slash = raw.indexOf('/');
+    const view = slash === -1 ? raw : raw.slice(0, slash);
+    const arg = slash === -1 ? '' : raw.slice(slash + 1);
+
+    if (view === 'matrix') {
+      state.matrixTab = isValidMatrixTab(arg) ? arg : 'record';
+      setView('matrix');
+      return;
+    }
+    if (view === 'rival') {
+      if (arg && state.rivals.some(r => r.id === arg)) {
+        state.selectedRivalId = arg;
+        persistSelected();
+        setView('rival');
+        return;
+      }
+      // Unknown rival — fall through to dashboard so a stale link isn't fatal.
+      setView('dashboard');
+      return;
+    }
+    if (KNOWN_VIEWS.has(view)) { setView(view); return; }
+    setView('dashboard');
   }
 
   // ---------- rival modal ----------
@@ -682,6 +752,7 @@
     if (state.view === 'dashboard') renderDashboard();
     else if (state.view === 'rival') renderRival();
     else if (state.view === 'leaderboard') renderLeaderboard();
+    else if (state.view === 'matrix') renderMatrix();
   }
 
   function deleteRivalFromModal() {
@@ -699,6 +770,10 @@
       state.selectedRivalId = null;
       persistSelected();
     }
+    if (Array.isArray(state.matrixSelection) && state.matrixSelection.includes(r.id)) {
+      state.matrixSelection = state.matrixSelection.filter(id => id !== r.id);
+      persistMatrixSelection();
+    }
     persistRivals();
     persistGames();
     closeRivalModal();
@@ -706,6 +781,7 @@
     if (state.view === 'rival') setView('dashboard');
     else if (state.view === 'dashboard') renderDashboard();
     else if (state.view === 'leaderboard') renderLeaderboard();
+    else if (state.view === 'matrix') renderMatrix();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -734,6 +810,7 @@
     if (state.view === 'dashboard') renderDashboard();
     else if (state.view === 'rival') renderRival();
     else if (state.view === 'leaderboard') renderLeaderboard();
+    else if (state.view === 'matrix') renderMatrix();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -1888,6 +1965,346 @@
     });
   }
 
+  // ---------- matrix view ----------
+  // Confusion-style H2H grid for you + any selected rivals. The user always
+  // anchors the matrix. Rival ↔ rival cells are *derived* from days where
+  // both rivals appear in state.games: on each such day, the user has one
+  // daily MapTap score, so the two rivals' scores can be compared head to
+  // head against each other. We pick the latest game per rival per date in
+  // case duplicates exist.
+  const MATRIX_TABS = [
+    { id: 'record', label: 'Record',    icon: '🏆' },
+    { id: 'margin', label: 'Margin',    icon: '📐' },
+    { id: 'score',  label: 'Avg score', icon: '📊' },
+    { id: 'form',   label: 'Last 5',    icon: '⚡' },
+  ];
+  function isValidMatrixTab(id) { return MATRIX_TABS.some(t => t.id === id); }
+
+  function selectedMatrixRivals() {
+    // null selection = include all rivals; otherwise filter to remembered ids
+    // (dropping any that no longer exist).
+    if (!Array.isArray(state.matrixSelection)) return state.rivals.slice();
+    const wanted = new Set(state.matrixSelection);
+    return state.rivals.filter(r => wanted.has(r.id));
+  }
+
+  function isMatrixRivalSelected(rivalId) {
+    if (!Array.isArray(state.matrixSelection)) return true;
+    return state.matrixSelection.includes(rivalId);
+  }
+
+  function toggleMatrixRival(rivalId) {
+    const current = Array.isArray(state.matrixSelection)
+      ? state.matrixSelection.slice()
+      : state.rivals.map(r => r.id);
+    const i = current.indexOf(rivalId);
+    if (i >= 0) current.splice(i, 1);
+    else current.push(rivalId);
+    state.matrixSelection = current;
+    persistMatrixSelection();
+    renderMatrix();
+  }
+
+  // Build a map: rivalId -> Map<date, { mine, theirs }> using the latest
+  // game on each date (in createdAt order) so duplicate logs collapse.
+  function buildRivalDateIndex(rivalIds) {
+    const want = new Set(rivalIds);
+    const byRival = new Map();
+    rivalIds.forEach(id => byRival.set(id, new Map()));
+    state.games.forEach(g => {
+      if (!want.has(g.rivalId)) return;
+      const mine = getMyTotal(g);
+      const theirs = getTheirTotal(g);
+      const slot = byRival.get(g.rivalId);
+      const prev = slot.get(g.date);
+      if (!prev || (g.createdAt || 0) >= (prev.createdAt || 0)) {
+        slot.set(g.date, { mine, theirs, createdAt: g.createdAt || 0 });
+      }
+    });
+    return byRival;
+  }
+
+  // H2H from the row's perspective vs the column. Returns aggregate counts
+  // plus a chronological list of meetings, so the per-tab renderers can
+  // pull margins, recency, and form without re-querying state.games.
+  function computeMatrixCell(rowKind, colKind, byRival) {
+    // rowKind/colKind: { type: 'you' } | { type: 'rival', id }
+    if (rowKind.type === 'you' && colKind.type === 'you') return null;
+
+    const meetings = []; // { date, rowScore, colScore }
+    if (rowKind.type === 'you' || colKind.type === 'you') {
+      const rivalId = rowKind.type === 'rival' ? rowKind.id : colKind.id;
+      const youIsRow = rowKind.type === 'you';
+      const dateMap = byRival.get(rivalId);
+      if (dateMap) {
+        dateMap.forEach(({ mine, theirs }, date) => {
+          meetings.push({
+            date,
+            rowScore: youIsRow ? mine : theirs,
+            colScore: youIsRow ? theirs : mine,
+          });
+        });
+      }
+    } else {
+      const rowMap = byRival.get(rowKind.id);
+      const colMap = byRival.get(colKind.id);
+      if (rowMap && colMap) {
+        rowMap.forEach(({ theirs: rowScore }, date) => {
+          const colEntry = colMap.get(date);
+          if (!colEntry) return;
+          meetings.push({ date, rowScore, colScore: colEntry.theirs });
+        });
+      }
+    }
+    meetings.sort((a, b) => a.date.localeCompare(b.date));
+
+    let wins = 0, losses = 0, ties = 0, rowTotal = 0, colTotal = 0;
+    let bestMargin = null, worstMargin = null;
+    meetings.forEach(({ rowScore, colScore }) => {
+      rowTotal += rowScore;
+      colTotal += colScore;
+      const m = rowScore - colScore;
+      if (bestMargin === null || m > bestMargin) bestMargin = m;
+      if (worstMargin === null || m < worstMargin) worstMargin = m;
+      if (rowScore > colScore) wins++;
+      else if (rowScore < colScore) losses++;
+      else ties++;
+    });
+    return {
+      games: meetings.length,
+      wins, losses, ties,
+      rowTotal, colTotal,
+      bestMargin, worstMargin,
+      meetings,
+    };
+  }
+
+  // Build the visible content for one matrix cell based on the active sub-tab.
+  // Returns { tone, title, content } where tone drives the W/L/T tint and
+  // content is the array of child nodes for the <td>.
+  function matrixCellViewModel(cell, subtab, row, col) {
+    const gamesLabel = `${cell.games} game${cell.games === 1 ? '' : 's'}`;
+    const fmtSigned = m => (m > 0 ? '+' : '') + Math.round(m);
+
+    if (subtab === 'margin') {
+      const avg = (cell.rowTotal - cell.colTotal) / cell.games;
+      const tone = avg > 5 ? 'win' : avg < -5 ? 'loss' : 'tie';
+      const best = cell.bestMargin;
+      return {
+        tone,
+        title: `${row.label} vs ${col.label} — avg ${fmtSigned(avg)} per game, best ${fmtSigned(best)}, worst ${fmtSigned(cell.worstMargin)}`,
+        content: [
+          el('div', { class: 'matrix-record' }, fmtSigned(avg)),
+          el('div', { class: 'matrix-margin' }, `best ${fmtSigned(best)}`),
+          el('div', { class: 'matrix-meta' }, gamesLabel),
+        ],
+      };
+    }
+
+    if (subtab === 'score') {
+      const rowAvg = cell.rowTotal / cell.games;
+      const colAvg = cell.colTotal / cell.games;
+      const tone = rowAvg > colAvg + 3 ? 'win' : rowAvg < colAvg - 3 ? 'loss' : 'tie';
+      return {
+        tone,
+        title: `${row.label} averages ${rowAvg.toFixed(0)} vs ${col.label}'s ${colAvg.toFixed(0)} across ${gamesLabel}`,
+        content: [
+          el('div', { class: 'matrix-record' }, String(Math.round(rowAvg))),
+          el('div', { class: 'matrix-margin' }, `vs ${Math.round(colAvg)}`),
+          el('div', { class: 'matrix-meta' }, gamesLabel),
+        ],
+      };
+    }
+
+    if (subtab === 'form') {
+      const last5 = cell.meetings.slice(-5);
+      const dots = el('div', { class: 'matrix-form-dots' });
+      last5.forEach(m => {
+        const cls = m.rowScore > m.colScore ? 'win'
+          : m.rowScore < m.colScore ? 'loss'
+          : 'tie';
+        dots.appendChild(el('span', {
+          class: `matrix-form-dot is-${cls}`,
+          title: `${fmtDateShort(m.date)} · ${m.rowScore} vs ${m.colScore}`,
+        }));
+      });
+      // Current streak: walk backward from the latest meeting.
+      let streakKind = null, streakLen = 0;
+      for (let i = cell.meetings.length - 1; i >= 0; i--) {
+        const m = cell.meetings[i];
+        const kind = m.rowScore > m.colScore ? 'W'
+          : m.rowScore < m.colScore ? 'L'
+          : 'T';
+        if (streakKind === null) { streakKind = kind; streakLen = 1; }
+        else if (kind === streakKind) streakLen++;
+        else break;
+      }
+      const streakLabel = streakLen > 0 ? `${streakKind}${streakLen}` : '—';
+      const tone = streakKind === 'W' ? 'win' : streakKind === 'L' ? 'loss' : 'tie';
+      return {
+        tone,
+        title: `Last ${last5.length} (oldest → newest), current streak ${streakLabel}`,
+        content: [
+          dots,
+          el('div', { class: 'matrix-margin' }, streakLabel),
+          el('div', { class: 'matrix-meta' }, gamesLabel),
+        ],
+      };
+    }
+
+    // 'record' (default)
+    const winPct = (cell.wins + 0.5 * cell.ties) / cell.games;
+    const winPctStr = (winPct * 100).toFixed(1) + '%';
+    const tone = winPct > 0.55 ? 'win' : winPct < 0.45 ? 'loss' : 'tie';
+    return {
+      tone,
+      title: `${row.label} vs ${col.label} — ${gamesLabel}, ${winPctStr} win rate`,
+      content: [
+        el('div', { class: 'matrix-record' },
+          `${cell.wins}-${cell.losses}` + (cell.ties ? `-${cell.ties}` : '')),
+        el('div', { class: 'matrix-margin' }, winPctStr),
+        el('div', { class: 'matrix-meta' }, gamesLabel),
+      ],
+    };
+  }
+
+  function renderMatrixSubtabs() {
+    const wrap = $('#matrix-subtabs');
+    wrap.innerHTML = '';
+    MATRIX_TABS.forEach(t => {
+      const active = state.matrixTab === t.id;
+      const btn = el('button', {
+        type: 'button',
+        class: 'matrix-subtab' + (active ? ' is-active' : ''),
+        role: 'tab',
+        'aria-selected': active ? 'true' : 'false',
+        onclick: () => {
+          if (state.matrixTab === t.id) return;
+          state.matrixTab = t.id;
+          renderMatrix();
+          syncUrlHash();
+        },
+      }, [
+        el('span', { 'aria-hidden': 'true' }, t.icon),
+        ' ',
+        t.label,
+      ]);
+      wrap.appendChild(btn);
+    });
+  }
+
+  function renderMatrixChips() {
+    const wrap = $('#matrix-chip-row');
+    wrap.innerHTML = '';
+    if (!state.rivals.length) return;
+    state.rivals
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .forEach(r => {
+        const selected = isMatrixRivalSelected(r.id);
+        const chip = el('button', {
+          type: 'button',
+          class: 'matrix-chip' + (selected ? ' is-on' : ''),
+          style: selected
+            ? `border-color:${r.color};background:${r.color}22`
+            : '',
+          'aria-pressed': selected ? 'true' : 'false',
+          onclick: () => toggleMatrixRival(r.id),
+        }, r.icon + ' ' + r.name);
+        wrap.appendChild(chip);
+      });
+  }
+
+  function matrixLegendText(subtab) {
+    if (subtab === 'margin') return 'Avg point margin per game from the row\'s perspective; the small line shows the row\'s best single result vs that column.';
+    if (subtab === 'score')  return 'Row participant\'s average score in head-to-head meetings (small line: column\'s average in those same games).';
+    if (subtab === 'form')   return 'Dots = last 5 meetings (oldest left → newest right) from the row\'s perspective. Big label = current streak.';
+    return 'Wins-losses(-ties) and the row\'s win % — ties count as half a win.';
+  }
+
+  function renderMatrix() {
+    if (!isValidMatrixTab(state.matrixTab)) state.matrixTab = 'record';
+    renderMatrixChips();
+    renderMatrixSubtabs();
+
+    const wrap = $('#matrix-wrap');
+    wrap.innerHTML = '';
+    const emptyMsg = $('#matrix-empty');
+
+    if (!state.rivals.length || !state.games.length) {
+      emptyMsg.hidden = false;
+      return;
+    }
+    emptyMsg.hidden = true;
+
+    const rivals = selectedMatrixRivals();
+    if (!rivals.length) {
+      wrap.appendChild(el('p', { class: 'matrix-hint' },
+        'Pick at least one rival above to build the matrix.'));
+      return;
+    }
+
+    // Participants in display order: You first, then rivals alphabetically.
+    const sortedRivals = rivals.slice().sort((a, b) => a.name.localeCompare(b.name));
+    const participants = [
+      { type: 'you', label: state.me || 'You', icon: '🧍', color: 'var(--accent-2)' },
+      ...sortedRivals.map(r => ({ type: 'rival', id: r.id, label: r.name, icon: r.icon, color: r.color })),
+    ];
+
+    const byRival = buildRivalDateIndex(sortedRivals.map(r => r.id));
+
+    const table = el('table', { class: 'matrix-table' });
+    const thead = el('thead');
+    const headRow = el('tr');
+    headRow.appendChild(el('th', { class: 'matrix-corner', scope: 'col' }, ''));
+    participants.forEach(p => {
+      const th = el('th', { class: 'matrix-col-head', scope: 'col' }, [
+        el('span', { class: 'matrix-head-chip', style: `--p-color:${p.color}` }, [
+          el('span', { class: 'matrix-head-icon' }, p.icon),
+          el('span', { class: 'matrix-head-name' }, p.label),
+        ]),
+      ]);
+      headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    const tbody = el('tbody');
+    participants.forEach(row => {
+      const tr = el('tr');
+      tr.appendChild(el('th', { class: 'matrix-row-head', scope: 'row' }, [
+        el('span', { class: 'matrix-head-chip', style: `--p-color:${row.color}` }, [
+          el('span', { class: 'matrix-head-icon' }, row.icon),
+          el('span', { class: 'matrix-head-name' }, row.label),
+        ]),
+      ]));
+      participants.forEach(col => {
+        if (row === col) {
+          tr.appendChild(el('td', { class: 'matrix-cell matrix-diag', 'aria-label': 'self' }, '—'));
+          return;
+        }
+        const cell = computeMatrixCell(row, col, byRival);
+        if (!cell || cell.games === 0) {
+          tr.appendChild(el('td', { class: 'matrix-cell matrix-empty' }, [
+            el('span', { class: 'matrix-record' }, 'no games'),
+          ]));
+          return;
+        }
+        const vm = matrixCellViewModel(cell, state.matrixTab, row, col);
+        tr.appendChild(el('td', {
+          class: `matrix-cell matrix-${vm.tone}`,
+          title: vm.title,
+        }, vm.content));
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+
+    wrap.appendChild(table);
+
+    wrap.appendChild(el('p', { class: 'matrix-legend' }, matrixLegendText(state.matrixTab)));
+  }
+
   function renderRivalGamesPagination(total, totalPages, startIdx, endIdx) {
     const nav = $('#rival-games-pagination');
     nav.hidden = false;
@@ -2485,6 +2902,7 @@
       if (state.view === 'dashboard') renderDashboard();
       else if (state.view === 'rival') renderRival();
       else if (state.view === 'leaderboard') renderLeaderboard();
+      else if (state.view === 'matrix') renderMatrix();
       else if (state.view === 'history') renderHistory();
     } catch (err) {
       setRivalSyncStatus(rivalId, 'err', err.message || 'sync failed');
@@ -2936,6 +3354,7 @@
     if (state.view === 'dashboard') renderDashboard();
     else if (state.view === 'rival') renderRival();
     else if (state.view === 'leaderboard') renderLeaderboard();
+    else if (state.view === 'matrix') renderMatrix();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -2956,6 +3375,7 @@
     if (state.view === 'dashboard') renderDashboard();
     else if (state.view === 'rival') renderRival();
     else if (state.view === 'leaderboard') renderLeaderboard();
+    else if (state.view === 'matrix') renderMatrix();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -2997,6 +3417,7 @@
         if (state.view === 'dashboard') renderDashboard();
         else if (state.view === 'rival') renderRival();
         else if (state.view === 'leaderboard') renderLeaderboard();
+        else if (state.view === 'matrix') renderMatrix();
         else if (state.view === 'history') renderHistory();
       } catch (e) {
         alert('Could not parse backup file.');
@@ -3034,6 +3455,7 @@
     if (state.view === 'dashboard') renderDashboard();
     else if (state.view === 'rival') renderRival();
     else if (state.view === 'leaderboard') renderLeaderboard();
+    else if (state.view === 'matrix') renderMatrix();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -3147,8 +3569,11 @@
     // cross-tab / sync changes
     window.addEventListener('storage', onExternalStorage);
 
-    // first paint
-    setView('dashboard');
+    // Shareable-link routing — react to back/forward and pasted URLs.
+    window.addEventListener('hashchange', applyUrlHash);
+
+    // first paint — honor the hash so deep links work on cold load.
+    applyUrlHash();
   }
 
   if (document.readyState === 'loading') {

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -2460,20 +2460,26 @@ button.shape-tag.is-clickable:hover {
   padding: 0.75rem 0 1.1rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
-/* Hierarchy inside .modal-actions: the primary watch button gets an
- * accent surface so it reads as the obvious primary action, secondary
- * buttons stay ghost. IMDb anchor sits flush-right via margin-left:auto. */
-.modal-actions .watch-btn {
+/* Hierarchy inside .modal-actions: each modal's primary action (watch
+ * on season-modal, compare on show-modal) gets an accent surface so it
+ * reads as the obvious primary button. Secondary buttons stay ghost.
+ * IMDb anchor sits flush-right via margin-left:auto. */
+.modal-actions .watch-btn,
+.modal-actions .compare-btn {
   background: var(--accent-soft);
   border: 1px solid var(--accent-strong);
   color: var(--accent) !important;
   font-weight: 700;
 }
-.modal-actions .watch-btn:hover {
+.modal-actions .watch-btn:hover,
+.modal-actions .compare-btn:hover {
   background: rgba(245, 197, 24, 0.18);
   border-color: rgba(245, 197, 24, 0.5);
 }
-.modal-actions .watch-btn.is-watched {
+/* "Already added" state — green to signal the success-of-state, same
+ * pattern the watch button uses when a season is marked watched. */
+.modal-actions .watch-btn.is-watched,
+.modal-actions .compare-btn.is-in-compare {
   background: rgba(74, 222, 128, 0.16);
   border-color: rgba(74, 222, 128, 0.45);
   color: var(--good) !important;

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -80,18 +80,14 @@ html {
   background-attachment: fixed;
   background-color: var(--bg);
   min-height: 100%;
-  /* Hide the vertical scrollbar visually so the .page content box is
-     always at full viewport width — opening / closing the More-filters
-     panel (or the mobile drawer's body scroll-lock) can't shift the
-     layout horizontally because there's no scrollbar gutter to gain
-     or lose. Vertical scrolling still works via wheel / keyboard /
-     touch; only the scrollbar's visible track is suppressed. */
-  scrollbar-width: none;          /* Firefox */
-}
-html::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-  display: none;                  /* Chromium / WebKit */
+  /* Always show the vertical scrollbar so its gutter is permanently
+     reserved. Without this, expanding the More-filters panel grows the
+     page tall enough to surface the scrollbar, which steals ~15px from
+     the viewport width and yanks the centered .page sideways. Using
+     overflow-y:scroll instead of scrollbar-gutter:stable for universal
+     browser support (Safari < 18 ignores scrollbar-gutter). */
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
 }
 
 body.rising-seasons-app {
@@ -340,9 +336,17 @@ body.rising-seasons-app button {
 /* ---------- Page layout ---------- */
 
 .page {
-  max-width: 1200px;
+  /* Match the site footer's text container exactly — main.css `.inner` is
+     `width: 75rem; max-width: calc(100% - 6rem)`, so we mirror that here.
+     The page's content edges then line up with the footer text edges on
+     every viewport size, and there's no horizontal shift when the body
+     scrollbar appears (overflow-y: scroll on <html> keeps the gutter
+     reserved at all times). */
+  width: 75rem;
+  max-width: calc(100% - 6rem);
+  box-sizing: border-box;
   margin: 0 auto;
-  padding: 0 1.5rem 3rem;
+  padding: 0 0 3rem;
 }
 
 .hero {
@@ -429,8 +433,10 @@ body.rising-seasons-app button {
   border-color: rgba(255, 255, 255, 0.18);
 }
 .shape-chip:focus-visible {
+  /* Same reasoning as .label-chip — inset focus ring so adjacent chips
+     never share a visual frame. */
   outline: 2px solid rgba(245, 197, 24, 0.65);
-  outline-offset: 2px;
+  outline-offset: -2px;
 }
 .shape-chip[aria-pressed="true"],
 .shape-chip[aria-pressed="true"]:hover {
@@ -813,6 +819,17 @@ body.rising-seasons-app button {
   color: rgba(231, 233, 238, 0.6);
   transition: color 0.15s var(--ease), background 0.15s var(--ease);
 }
+/* The browser draws a default focus ring on <summary> when one of its
+ * children (e.g. the in-summary "Clear all filters" pill) is clicked —
+ * focus moves to the summary and the ring frames BOTH children, looking
+ * like a single black border wrapping the chip and the pill together.
+ * Suppress that ring; the pill and the summary text each have their own
+ * hover/focus indicators so no accessibility is lost. */
+.advanced summary:focus,
+.advanced summary:focus-visible {
+  outline: none !important;
+  box-shadow: none !important;
+}
 .advanced summary::-webkit-details-marker { display: none; }
 .advanced summary:hover {
   color: var(--text);
@@ -836,6 +853,63 @@ body.rising-seasons-app button {
   transform: rotate(45deg);  /* + → × */
   color: var(--accent);
 }
+
+/* Wrapper that holds the <details> panel and the standalone Clear-all pill
+ * side by side. The pill is a SIBLING of .advanced, not a child, so the
+ * panel's border can't visually wrap both as a group. */
+.advanced-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  /* When details opens, the panel becomes the full-width box; the pill
+     stays aligned to its top. flex-wrap lets the pill drop under the
+     panel on narrower viewports. */
+  flex-wrap: wrap;
+}
+.advanced-row > .advanced {
+  /* Let the panel shrink/grow to fill remaining space when collapsed and
+     occupy the whole row when open. */
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.advanced summary .advanced-summary-label { display: inline-flex; align-items: center; }
+
+/* Standalone "Clear all filters" pill — sits next to the .advanced panel
+ * (outside its border) so visually nothing wraps it together with the
+ * More filters chip. Hidden via the [hidden] attribute when no filters
+ * are active. */
+.advanced-reset,
+.advanced-reset:hover {
+  display: inline-flex;
+  align-items: center;
+  height: 28px;
+  margin-top: 0.6rem; /* line up with .advanced's margin-top: 0.6rem */
+  padding: 0 0.85rem;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  border-radius: 999px;
+  color: var(--danger, #f87171) !important;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: none !important;
+  line-height: 1;
+  transition: background 0.15s var(--ease), border-color 0.15s var(--ease), color 0.15s var(--ease);
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+.advanced-reset:hover {
+  background: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.6);
+}
+.advanced-reset:focus-visible {
+  outline: 2px solid rgba(245, 197, 24, 0.55);
+  outline-offset: 2px;
+}
+.advanced-reset[hidden] { display: none; }
 
 
 /* Numeric inputs + Sort: 4-column grid for an even rhythm, caption
@@ -1244,6 +1318,43 @@ button.shape-tag.is-clickable:hover {
   color: var(--accent);
 }
 
+/* Streaming-platform chip, lives in the same flex row as .shape-tag inside
+ * .card-shapes / .row-shapes. Outline-only style separates "where to watch"
+ * tokens from the trajectory-pattern tags without forcing a second row. */
+.provider-tag {
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.66rem;
+  font-weight: 600;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+/* List-view genre line — mirrors .card-meta on the grid card. Lives inside
+ * .row-head so it flows inline with title / season / year, separated by a
+ * subtle bullet so the row stays compact. */
+.row-genres {
+  font-size: 0.78rem;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+.row-genres:empty,
+.row-genres[hidden] { display: none; }
+.row-genres::before {
+  content: '·';
+  margin: 0 0.45rem 0 0;
+  color: var(--muted-2);
+}
+
 /* Best / Worst season rank badges. Designed to sit inline with the
    season-metadata line ("S2 · 10 eps") rather than the title — compact
    pill, no wrap, subtle tinted surface. Icon + uppercase label give a
@@ -1377,19 +1488,36 @@ button.shape-tag.is-clickable:hover {
 
 /* Chips: invisible until you hover or activate. No border, no shadow,
    no container — they read as tokens on the page. */
+/* Total reset across every conceivable chip state. main.css applies a
+ * sitewide `button { box-shadow: inset 0 0 0 1px #555 }` and changes it
+ * to red on hover; without aggressive overrides, both the hovered chip
+ * and its neighbor in the same group end up with 1px insets that read
+ * together as a single border wrapping both buttons. We also keep the
+ * focus indicator inside the chip (background-only) so the focus ring
+ * never extends into a neighbor. */
+.label-chip,
+.label-chip:hover,
+.label-chip:focus,
+.label-chip:focus-visible,
+.label-chip:active,
+.label-chip[aria-pressed="true"],
+.label-chip[aria-pressed="true"]:hover,
+.label-chip[aria-pressed="true"]:focus,
+.label-chip[aria-pressed="true"]:focus-visible {
+  outline: 0 !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
 .label-chip {
   appearance: none;
+  -webkit-appearance: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   height: 26px;
   padding: 0 0.65rem;
-  border: 0;
   background: transparent;
-  /* Full body-text white (no opacity reduction) so inactive chips —
-     TV series, Mini-series, Watched, Unwatched, ↑ Above IMDb — read
-     crisp against the dark background. Active state overrides to the
-     accent colour below. */
   color: var(--text);
   font: inherit;
   font-size: 0.76rem;
@@ -1402,14 +1530,19 @@ button.shape-tag.is-clickable:hover {
     color 0.18s var(--ease);
   white-space: nowrap;
 }
-.label-chip + .label-chip { margin-left: 0.1rem; }
+/* Bigger gap so even if some downstream theme tries to draw a 1px outline
+ * it can't visually touch the neighbor — but they still feel like one
+ * group thanks to the parent .label-group's gap rhythm. */
+.label-chip + .label-chip { margin-left: 0.35rem; }
 .label-chip:hover {
-  color: #ffffff;
-  background: rgba(255, 255, 255, 0.045);
+  color: #ffffff !important;
+  background: rgba(255, 255, 255, 0.06);
 }
 .label-chip:focus-visible {
-  outline: 2px solid rgba(245, 197, 24, 0.55);
-  outline-offset: 2px;
+  /* Background-only focus indicator — no outline, no shadow. Cannot
+     possibly extend into the adjacent chip's space. */
+  background: rgba(245, 197, 24, 0.2);
+  color: var(--accent) !important;
 }
 
 /* Active = a soft accent wash + accent text. No ring, no shadow.
@@ -1553,13 +1686,24 @@ button.shape-tag.is-clickable:hover {
 }
 
 .curve {
-  width: 100%;
+  /* The card body that wraps this SVG has 1rem of horizontal padding, so a
+     plain width:100% would leave the yellow line drawn 1rem inset from the
+     card's left/right edges. Extend the curve out past that padding with
+     negative margins so the line literally starts at the card edges. */
+  width: calc(100% + 2rem);
+  margin-left: -1rem;
+  margin-right: -1rem;
   height: 70px;
   background:
     radial-gradient(ellipse 60% 50% at 50% 100%, rgba(245, 197, 24, 0.06), transparent 70%),
     var(--surface-2);
-  border-radius: var(--radius-sm);
+  /* Keep the bottom corners rounded with the card (top corners flush against
+     the content above) — but no border-radius makes the line/area truly hit
+     the corner pixels without any rounded clip. */
+  border-radius: 0;
   display: block;
+  /* Let hover dots at viewBox x=0 / x=W render fully instead of half-clipped. */
+  overflow: visible;
 }
 .curve-area { fill: rgba(245, 197, 24, 0.18); stroke: none; }
 .curve-line {
@@ -1713,6 +1857,8 @@ button.shape-tag.is-clickable:hover {
 
 .row {
   display: grid;
+  /* Original right-side layout: text fills the left half, curve sits on
+     the right at a fixed 200px, watch on the far right edge. */
   grid-template-columns: 56px 1fr 200px 36px;
   gap: 1rem;
   align-items: center;
@@ -1788,13 +1934,19 @@ button.shape-tag.is-clickable:hover {
   display: block;
   width: 100%;
   height: 56px;
-  background: var(--surface-2);
-  border-radius: var(--radius-sm);
-  /* Clip the sparkline path to the rounded shape — without this the
-     stroke endcaps drawn at x=0 / x=W bleed past the rounded corner
-     and read as an unbalanced inset on one side. */
-  overflow: hidden;
+  /* No gray rectangle backdrop — the sparkline floats directly on the
+     row's surface. Removing the box also removes the "gray padding"
+     perception, since there's no container that can look incompletely
+     filled when the trend line happens to be high or low at the edges. */
+  background: transparent;
+  border-radius: 0;
+  overflow: visible;
 }
+/* Slightly thicker stroke + brighter area fill scoped to the list-view
+ * row sparkline, since it now sits on the row surface (darker than the
+ * old --surface-2 box) and benefits from a touch more presence. */
+.row-curve .curve-line { stroke-width: 2.4; }
+.row-curve .curve-area { fill: rgba(245, 197, 24, 0.32); }
 /* Stay in the grid cell — must override the base + :hover absolute
    positioning that .watch-toggle sets for the card corner overlay. */
 .row-watch,
@@ -1826,6 +1978,10 @@ button.shape-tag.is-clickable:hover {
     display: block;
     height: 44px;
     width: 100%;
+    /* Reset the desktop edge-bleed — on mobile the curve spans the full
+       width of the row's second grid row already, so the negative margin
+       would just push it under the row's left border. */
+    margin-left: 0;
   }
 }
 
@@ -1836,34 +1992,42 @@ button.shape-tag.is-clickable:hover {
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  gap: 0.4rem;
-  margin: 1.5rem 0 0;
-  padding: 0.5rem 0;
+  gap: 0.25rem;
+  margin: 1.25rem 0 0;
+  padding: 0.25rem 0;
 }
 .pager[hidden] { display: none; }
+/* Top pager: small, quiet — sits between the meta line and the results
+ * grid. The bottom pager keeps the larger feel since it's the natural
+ * landing spot after scrolling through results. */
+.pager-top {
+  margin: 0.25rem 0 0.85rem;
+  padding: 0;
+}
 
 .pager .page-btn,
 .pager .page-btn:hover {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: var(--ctrl-h);
-  height: var(--ctrl-h);
-  padding: 0 0.7rem;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 0.55rem;
   background: transparent;
   color: var(--muted) !important;
-  border: 1px solid var(--border);
-  border-radius: var(--ctrl-radius);
+  border: 1px solid transparent;
+  border-radius: 8px;
   font: inherit;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
   cursor: pointer;
   box-shadow: none !important;
   transition: background 0.18s var(--ease), border-color 0.18s var(--ease), color 0.18s var(--ease);
 }
 .pager .page-btn:hover {
-  background: var(--surface-2);
-  border-color: var(--border-strong);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: transparent;
   color: var(--text) !important;
 }
 .pager .page-btn:focus-visible {
@@ -1873,26 +2037,30 @@ button.shape-tag.is-clickable:hover {
 }
 .pager .page-btn[aria-current="page"],
 .pager .page-btn[aria-current="page"]:hover {
-  background: var(--accent);
-  color: var(--accent-ink) !important;
-  border-color: var(--accent);
-  font-weight: 600;
+  background: rgba(245, 197, 24, 0.14);
+  color: var(--accent) !important;
+  border-color: rgba(245, 197, 24, 0.28);
+  font-weight: 700;
 }
 .pager .page-btn:disabled,
 .pager .page-btn[aria-disabled="true"] {
-  opacity: 0.4;
+  opacity: 0.3;
   cursor: not-allowed;
-  color: var(--text) !important;
+  color: var(--muted) !important;
 }
 .pager .page-ellipsis {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 2rem;
-  height: var(--ctrl-h);
-  color: var(--muted);
+  min-width: 1.5rem;
+  height: 32px;
+  color: var(--muted-2);
   user-select: none;
+  font-size: 0.82rem;
 }
+/* Compact even further on the top pager so it never crowds the results. */
+.pager-top .page-btn { min-width: 28px; height: 28px; font-size: 0.78rem; padding: 0 0.4rem; }
+.pager-top .page-ellipsis { min-width: 1.25rem; height: 28px; font-size: 0.78rem; }
 
 /* ---------- Empty + error ---------- */
 
@@ -2192,12 +2360,24 @@ button.shape-tag.is-clickable:hover {
   font-size: 0.74rem;
   white-space: nowrap;
 }
+.modal-episodes .ep-runtime {
+  color: var(--muted-2);
+  font-size: 0.74rem;
+  white-space: nowrap;
+}
 
 .modal-actions {
   display: flex;
   gap: 0.75rem;
   align-items: center;
   flex-wrap: wrap;
+}
+/* Top-of-modal action row: a thin divider underneath separates it from the
+ * descriptive content (overview / episodes) that follows. */
+.modal-actions-top {
+  margin-bottom: 0.25rem;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 .modal-imdb { margin-left: auto; }
 
@@ -2315,7 +2495,9 @@ body.advanced-drawer-open {
    ------------------------------------------------------------------------- */
 
 @media (max-width: 760px) {
-  .page { padding: 0 1rem 1.5rem; }
+  /* Side spacing is handled by .page's max-width: calc(100% - 6rem) already,
+     same as the footer .inner. Only the bottom padding gets compacted here. */
+  .page { padding: 0 0 1.5rem; }
 
   /* Compact hero — claim less vertical space so results show above fold. */
   .hero { padding: 1.5rem 0 0.35rem; }
@@ -2533,6 +2715,16 @@ body.advanced-drawer-open {
     top: 0.4rem;
     right: 0.4rem;
   }
+  /* Mobile cards go horizontal (poster | body), so the desktop edge-bleed
+     trick would push the curve into the poster on the left. Match the
+     mobile card-body padding (0.85rem) on the right only, and leave the
+     left edge flush with the body's left padding so the line still feels
+     edge-anchored on the side it can be. */
+  .card .curve {
+    margin-left: 0;
+    margin-right: -0.85rem;
+    width: calc(100% + 0.85rem);
+  }
 
   /* List view rows — already tight; just give the watch button a
      bigger circular tap target. */
@@ -2710,7 +2902,9 @@ body.advanced-drawer-open {
    ------------------------------------------------------------------------- */
 
 @media (max-width: 430px) {
-  .page { padding: 0 0.75rem 1.25rem; }
+  /* Tighten the side gutter on the smallest phones to match the footer's
+     <480px breakpoint (max-width: calc(100% - 3rem)). */
+  .page { padding: 0 0 1.25rem; max-width: calc(100% - 3rem); }
 
   .hero { padding: 1.1rem 0 0.2rem; }
   .hero h1 { font-size: clamp(1.5rem, 8vw, 1.95rem); }

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -781,6 +781,44 @@ body.rising-seasons-app button {
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
+/* ---------- Quick filters drawer ----------
+ * Wraps the row of Type / Watched / IMDb / Gems chips behind a small
+ * toggle so the main page reads results-first. The .label-filters
+ * styles handle the panel chrome when expanded. */
+.quick-filters-wrap {
+  margin: 0.6rem 0;
+}
+.quick-filters-wrap > summary {
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.15s var(--ease), border-color 0.15s var(--ease), color 0.15s var(--ease);
+}
+.quick-filters-wrap > summary::-webkit-details-marker { display: none; }
+.quick-filters-wrap > summary:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+.quick-filters-wrap[open] > summary {
+  background: var(--accent-soft);
+  border-color: var(--accent-strong);
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+
 /* ---------- "More filters" panel ----------
    Editorial filter sheet: caption-style labels, dense grid of slim
    inputs, soft hairline-divided sub-sections, integrated Reset link.
@@ -1259,9 +1297,20 @@ body.rising-seasons-app button {
 
 .card-body {
   padding: 0.85rem 1rem 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
+  /* Grid so the curve always sits at its own row, regardless of how many
+     lines the chip row above takes. Row order matches DOM source:
+       1. card-head    (title + season)
+       2. card-meta    (year + genres)
+       3. card-shapes  (1fr — absorbs any extra vertical space so the
+                        curve doesn't drift down when chips wrap)
+       4. .curve       (sparkline, fixed height)
+       5. card-stats   (single horizontal line)
+     Since .results-grid stretches all cards in a row to the same height,
+     the 1fr region resolves to the same value across siblings — putting
+     every sparkline at the identical y from the top of its card. */
+  display: grid;
+  grid-template-rows: auto auto 1fr auto auto;
+  row-gap: 0.55rem;
   flex: 1;
 }
 
@@ -1292,7 +1341,17 @@ body.rising-seasons-app button {
   color: var(--muted);
   flex-wrap: wrap;
 }
-.card-shapes { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+/* Chip row wraps freely — overflow is preserved so every shape/provider
+ * chip stays visible. Card-body's grid handles curve alignment so a
+ * 2-line wrap here doesn't push the sparkline below it; the curve stays
+ * pinned to its own row, the chip area just consumes more of the 1fr
+ * flex region between meta and curve. */
+.card-shapes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-content: flex-start;
+}
 
 .shape-tag {
   background: var(--surface-3);
@@ -1318,22 +1377,29 @@ button.shape-tag.is-clickable:hover {
   color: var(--accent);
 }
 
-/* Streaming-platform chip, lives in the same flex row as .shape-tag inside
- * .card-shapes / .row-shapes. Outline-only style separates "where to watch"
- * tokens from the trajectory-pattern tags without forcing a second row. */
+/* Streaming-platform chip — distinct from the shape tags so the row reads
+ * as "<pattern tags> · <where to watch>" rather than one homogenous token
+ * blob. Cyan-tinted outline + leading play glyph give it a "channel" feel
+ * versus the warm-filled trajectory tags. */
 .provider-tag {
   display: inline-flex;
   align-items: center;
-  background: transparent;
-  color: var(--muted);
+  gap: 0.3rem;
+  background: rgba(56, 189, 248, 0.08);
+  color: rgba(125, 211, 252, 0.95);
   font-size: 0.66rem;
   font-weight: 600;
-  padding: 0.1rem 0.5rem;
+  padding: 0.1rem 0.55rem 0.1rem 0.45rem;
   border-radius: 999px;
-  border: 1px solid var(--border-strong);
+  border: 1px solid rgba(56, 189, 248, 0.28);
   line-height: 1.4;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.02em;
   white-space: nowrap;
+}
+.provider-tag::before {
+  content: '▶';
+  font-size: 0.55rem;
+  opacity: 0.85;
 }
 
 /* List-view genre line — mirrors .card-meta on the grid card. Lives inside
@@ -1364,7 +1430,8 @@ button.shape-tag.is-clickable:hover {
   display: inline-flex;
   align-items: center;
   gap: 0.2rem;
-  margin-left: 0.45rem;
+  /* No left margin — these now sit at the start of .card-shapes/.row-shapes
+     where the row's gap handles spacing from the next pill. */
   padding: 0 0.42rem;
   height: 1.05rem;
   line-height: 1;
@@ -1374,10 +1441,8 @@ button.shape-tag.is-clickable:hover {
   letter-spacing: 0.06em;
   white-space: nowrap;
   vertical-align: middle;
-  /* Small badge shouldn't visually dominate; keep typography compact. */
-  font-size: 0.62rem;
+  font-size: 0.6rem;
   text-transform: uppercase;
-  /* Don't shrink in tight flex containers (e.g. when title is long). */
   flex-shrink: 0;
 }
 .best-badge {
@@ -1843,23 +1908,37 @@ button.shape-tag.is-clickable:hover {
   border: 1px solid var(--border);
 }
 
-.card-stats {
+/* Result-tile stats — single horizontal line, comfortable gap, values are
+ * self-describing so we don't need uppercase labels. Wraps when the row
+ * is narrow, but stays compact on the common widths. */
+.card-stats,
+.row-stats {
   display: flex;
-  gap: 0.85rem;
-  font-size: 0.75rem;
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
   flex-wrap: wrap;
+  gap: 0.25rem 0.9rem;
+  font-size: 0.76rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  line-height: 1.3;
 }
+.card-stats > span,
+.row-stats > span {
+  white-space: nowrap;
+}
+.card-stats .stat-runtime[hidden],
+.row-stats .stat-runtime[hidden] { display: none; }
 .stat-climb { color: var(--good); font-weight: 600; }
 
 /* ---------- List view rows ---------- */
 
 .row {
   display: grid;
-  /* Original right-side layout: text fills the left half, curve sits on
-     the right at a fixed 200px, watch on the far right edge. */
-  grid-template-columns: 56px 1fr 200px 36px;
+  /* Layout: poster · text (1fr, fills available width so stats line out
+     horizontally) · curve (240px, right of the row) · watch (36px, far
+     right edge). With no gray sparkline backdrop, the empty space inside
+     row-main between text and curve just reads as row surface — no
+     visible padding gap. */
+  grid-template-columns: 56px 1fr 240px 36px;
   gap: 1rem;
   align-items: center;
   padding: 0.7rem 0.95rem;
@@ -1922,14 +2001,7 @@ button.shape-tag.is-clickable:hover {
   color: var(--muted);
 }
 .row-shapes { display: flex; gap: 0.3rem; flex-wrap: wrap; }
-.row-stats {
-  display: flex;
-  gap: 0.85rem;
-  font-size: 0.75rem;
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
-  flex-wrap: wrap;
-}
+/* .row-stats styled together with .card-stats above as one stats grid. */
 .row-curve {
   display: block;
   width: 100%;
@@ -2148,13 +2220,17 @@ button.shape-tag.is-clickable:hover {
 
 .modal-panel {
   position: relative;
+  /* Brighter surface than the page bg so the panel reads as an elevated
+     content layer rather than the same dark sheet with a thin outline.
+     Stronger top-edge gradient + a more present border + a wider shadow
+     give it visual lift away from the page. */
   background:
-    radial-gradient(ellipse 80% 50% at 50% 0%, rgba(245, 197, 24, 0.05), transparent 60%),
-    linear-gradient(180deg, #15192257, #0f121b 30%, #0c0f17 100%),
+    radial-gradient(ellipse 80% 50% at 50% 0%, rgba(245, 197, 24, 0.07), transparent 60%),
+    linear-gradient(180deg, #1a1f2c, #14182265 40%, #0e1219 100%),
     var(--surface);
-  border: 1px solid var(--border-strong);
+  border: 1px solid rgba(255, 255, 255, 0.085);
   border-radius: 18px;
-  max-width: 720px;
+  max-width: 780px;
   width: 100%;
   /* 100dvh fixes iOS Safari over-counting the URL bar height. The vh
      line is a fallback for older browsers that don't know dvh. */
@@ -2162,11 +2238,14 @@ button.shape-tag.is-clickable:hover {
   max-height: calc(100dvh - 2rem);
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 1.75rem;
+  padding: 1.9rem 1.9rem 1.6rem;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
-  box-shadow: var(--shadow-modal);
+  gap: 1.25rem;
+  box-shadow:
+    0 24px 60px rgba(0, 0, 0, 0.55),
+    0 4px 14px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
 }
 .modal-panel::before {
   content: '';
@@ -2277,6 +2356,7 @@ button.shape-tag.is-clickable:hover {
   letter-spacing: 0.005em;
 }
 .modal-shapes { display: flex; gap: 0.35rem; flex-wrap: wrap; margin-top: 0.15rem; }
+.modal-shapes:empty { display: none; }
 .modal-stats {
   margin: 0;
   color: var(--muted);
@@ -2368,16 +2448,35 @@ button.shape-tag.is-clickable:hover {
 
 .modal-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.6rem;
   align-items: center;
   flex-wrap: wrap;
 }
 /* Top-of-modal action row: a thin divider underneath separates it from the
- * descriptive content (overview / episodes) that follows. */
+ * descriptive content (overview / episodes) that follows. Extra vertical
+ * padding gives the buttons breathing room. */
 .modal-actions-top {
-  margin-bottom: 0.25rem;
-  padding-bottom: 0.85rem;
+  margin: 0.25rem 0 0.1rem;
+  padding: 0.75rem 0 1.1rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+/* Hierarchy inside .modal-actions: the primary watch button gets an
+ * accent surface so it reads as the obvious primary action, secondary
+ * buttons stay ghost. IMDb anchor sits flush-right via margin-left:auto. */
+.modal-actions .watch-btn {
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-strong);
+  color: var(--accent) !important;
+  font-weight: 700;
+}
+.modal-actions .watch-btn:hover {
+  background: rgba(245, 197, 24, 0.18);
+  border-color: rgba(245, 197, 24, 0.5);
+}
+.modal-actions .watch-btn.is-watched {
+  background: rgba(74, 222, 128, 0.16);
+  border-color: rgba(74, 222, 128, 0.45);
+  color: var(--good) !important;
 }
 .modal-imdb { margin-left: auto; }
 

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -331,6 +331,7 @@
         <button type="button" class="btn watch-btn" id="modalWatchBtn"></button>
         <button type="button" class="btn btn-ghost" id="modalViewShow">📺 View show</button>
         <a class="btn btn-ghost modal-imdb" id="modalImdb" target="_blank" rel="noopener">View season on IMDb →</a>
+        <a class="btn btn-ghost" id="modalTvdb" target="_blank" rel="noopener" hidden>View on TVDB →</a>
       </div>
       <p class="modal-overview" id="modalOverview"></p>
       <h3 class="modal-section">Episode ratings</h3>
@@ -361,6 +362,7 @@
       <div class="modal-actions modal-actions-top">
         <button type="button" class="btn compare-btn" id="showModalCompare">＋ Add to compare</button>
         <a class="btn btn-ghost" id="showModalImdb" target="_blank" rel="noopener">View show on IMDb →</a>
+        <a class="btn btn-ghost" id="showModalTvdb" target="_blank" rel="noopener" hidden>View on TVDB →</a>
       </div>
       <p class="modal-overview" id="showModalOverview"></p>
       <section class="season-overlay" id="showModalOverlay" hidden>

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -130,6 +130,12 @@
         <span class="shape-desc">The last episode is the peak</span>
         <span class="shape-count" data-count="big-finale"></span>
       </button>
+      <button class="shape-chip" data-shape="saved-best-for-last" aria-pressed="false" type="button">
+        <span class="shape-icon" aria-hidden="true">🏁</span>
+        <span class="shape-name">Saved best for last</span>
+        <span class="shape-desc">Final season is the show's highest-rated</span>
+        <span class="shape-count" data-count="saved-best-for-last"></span>
+      </button>
       <button class="shape-chip" data-shape="rebound" aria-pressed="false" type="button">
         <span class="shape-icon" aria-hidden="true">∪</span>
         <span class="shape-name">Rebound</span>
@@ -215,12 +221,15 @@
         <div class="label-group" role="radiogroup" aria-label="Hidden gems">
           <span class="label-group-name">Gems</span>
           <button type="button" class="label-chip" data-filter="hiddenGems" data-value="all" aria-pressed="true">All</button>
-          <button type="button" class="label-chip label-chip-good" data-filter="hiddenGems" data-value="on" aria-pressed="false" title="High-rated seasons most people haven't watched (avg ≥ 8.0, fewer than 1,000 votes per episode)">💎 Hidden gems</button>
+          <button type="button" class="label-chip label-chip-good" data-filter="hiddenGems" data-value="on" aria-pressed="false" title="High-rated seasons most people haven't watched (avg ≥ 8.5, fewer than 500 votes per episode)">💎 Hidden gems</button>
         </div>
       </div>
 
+      <div class="advanced-row">
       <details class="advanced">
-        <summary>More filters</summary>
+        <summary>
+          <span class="advanced-summary-label">More filters</span>
+        </summary>
         <div class="filter-row">
           <label>
             Min episodes
@@ -274,15 +283,16 @@
           <span class="chip-section-title">Streaming</span>
           <div class="genre-row" id="providers" role="group" aria-label="Filter by streaming provider"></div>
         </div>
-        <div class="filter-actions">
-          <button type="button" class="btn btn-ghost" id="resetFilters">Reset all filters</button>
-        </div>
       </details>
+      <button type="button" class="advanced-reset" id="resetFilters" hidden>Clear all filters</button>
+      </div>
     </section>
 
     <section class="stats-bar" id="statsBar" aria-live="polite"></section>
 
     <p class="meta" id="meta" aria-live="polite"></p>
+
+    <nav class="pager pager-top" id="pager-top" aria-label="Pagination (top)" hidden></nav>
 
     <div id="results" class="results-grid" aria-label="Matching seasons"></div>
 
@@ -311,6 +321,11 @@
           <p class="modal-stats" id="modalStats"></p>
         </div>
       </div>
+      <div class="modal-actions modal-actions-top">
+        <button type="button" class="btn watch-btn" id="modalWatchBtn"></button>
+        <button type="button" class="btn btn-ghost" id="modalViewShow">📺 View show</button>
+        <a class="btn btn-ghost modal-imdb" id="modalImdb" target="_blank" rel="noopener">View season on IMDb →</a>
+      </div>
       <p class="modal-overview" id="modalOverview"></p>
       <h3 class="modal-section">Episode ratings</h3>
       <svg class="modal-curve" id="modalCurve" viewBox="0 0 600 180" preserveAspectRatio="none" aria-hidden="true">
@@ -319,11 +334,6 @@
         <g class="curve-dots"></g>
       </svg>
       <ol class="modal-episodes" id="modalEpisodes"></ol>
-      <div class="modal-actions">
-        <button type="button" class="btn watch-btn" id="modalWatchBtn"></button>
-        <button type="button" class="btn btn-ghost" id="modalViewShow">📺 View show</button>
-        <a class="btn btn-ghost modal-imdb" id="modalImdb" target="_blank" rel="noopener">View season on IMDb →</a>
-      </div>
     </article>
   </div>
 
@@ -342,6 +352,10 @@
           <div class="provider-badges" id="showModalProviders"></div>
         </div>
       </div>
+      <div class="modal-actions modal-actions-top">
+        <button type="button" class="btn btn-ghost" id="showModalCompare">＋ Add to compare</button>
+        <a class="btn btn-ghost" id="showModalImdb" target="_blank" rel="noopener">View show on IMDb →</a>
+      </div>
       <p class="modal-overview" id="showModalOverview"></p>
       <section class="season-overlay" id="showModalOverlay" hidden>
         <h3 class="modal-section">Seasons overlay</h3>
@@ -350,10 +364,6 @@
       </section>
       <h3 class="modal-section">All seasons</h3>
       <ol class="show-seasons" id="showModalSeasons"></ol>
-      <div class="modal-actions">
-        <button type="button" class="btn btn-ghost" id="showModalCompare">＋ Add to compare</button>
-        <a class="btn btn-ghost" id="showModalImdb" target="_blank" rel="noopener">View show on IMDb →</a>
-      </div>
     </article>
   </div>
 
@@ -364,11 +374,11 @@
       <button type="button" class="btn modal-close" data-close="compare-modal" aria-label="Close">×</button>
       <h2 id="compareModalTitle">Compare shows</h2>
       <p class="modal-subtitle">Season-average rating trajectory for each show. Click a show name to remove.</p>
-      <svg class="overlay-curve" id="compareModalCurve" viewBox="0 0 600 240" preserveAspectRatio="none" aria-hidden="true"></svg>
-      <div class="overlay-legend" id="compareModalLegend"></div>
-      <div class="modal-actions">
+      <div class="modal-actions modal-actions-top">
         <button type="button" class="btn btn-ghost" id="compareModalClear">Clear all</button>
       </div>
+      <svg class="overlay-curve" id="compareModalCurve" viewBox="0 0 600 240" preserveAspectRatio="none" aria-hidden="true"></svg>
+      <div class="overlay-legend" id="compareModalLegend"></div>
     </article>
   </div>
 
@@ -406,6 +416,7 @@
         <div class="card-stats">
           <span class="stat-climb"></span>
           <span class="stat-avg"></span>
+          <span class="stat-runtime"></span>
           <span class="stat-votes"></span>
         </div>
       </div>
@@ -423,11 +434,13 @@
           <h2 class="row-title"></h2>
           <span class="row-season"></span>
           <span class="row-year"></span>
+          <span class="row-genres"></span>
         </header>
         <div class="row-shapes"></div>
         <div class="row-stats">
           <span class="stat-climb"></span>
           <span class="stat-avg"></span>
+          <span class="stat-runtime"></span>
           <span class="stat-votes"></span>
         </div>
       </div>

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -359,7 +359,7 @@
         </div>
       </div>
       <div class="modal-actions modal-actions-top">
-        <button type="button" class="btn btn-ghost" id="showModalCompare">＋ Add to compare</button>
+        <button type="button" class="btn compare-btn" id="showModalCompare">＋ Add to compare</button>
         <a class="btn btn-ghost" id="showModalImdb" target="_blank" rel="noopener">View show on IMDb →</a>
       </div>
       <p class="modal-overview" id="showModalOverview"></p>

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -331,7 +331,7 @@
         <button type="button" class="btn watch-btn" id="modalWatchBtn"></button>
         <button type="button" class="btn btn-ghost" id="modalViewShow">📺 View show</button>
         <a class="btn btn-ghost modal-imdb" id="modalImdb" target="_blank" rel="noopener">View season on IMDb →</a>
-        <a class="btn btn-ghost" id="modalTvdb" target="_blank" rel="noopener" hidden>View on TVDB →</a>
+        <a class="btn btn-ghost" id="modalTvdb" target="_blank" rel="noopener" hidden>View series on TVDB →</a>
       </div>
       <p class="modal-overview" id="modalOverview"></p>
       <h3 class="modal-section">Episode ratings</h3>
@@ -362,7 +362,7 @@
       <div class="modal-actions modal-actions-top">
         <button type="button" class="btn compare-btn" id="showModalCompare">＋ Add to compare</button>
         <a class="btn btn-ghost" id="showModalImdb" target="_blank" rel="noopener">View show on IMDb →</a>
-        <a class="btn btn-ghost" id="showModalTvdb" target="_blank" rel="noopener" hidden>View on TVDB →</a>
+        <a class="btn btn-ghost" id="showModalTvdb" target="_blank" rel="noopener" hidden>View show on TVDB →</a>
       </div>
       <p class="modal-overview" id="showModalOverview"></p>
       <section class="season-overlay" id="showModalOverlay" hidden>

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -200,30 +200,36 @@
         </button>
       </div>
 
-      <div class="label-filters" aria-label="Quick filters">
-        <div class="label-group" role="radiogroup" aria-label="Series type">
-          <span class="label-group-name">Type</span>
-          <button type="button" class="label-chip" data-filter="seriesType" data-value="all" aria-pressed="true">All</button>
-          <button type="button" class="label-chip" data-filter="seriesType" data-value="tvSeries" aria-pressed="false">TV series</button>
-          <button type="button" class="label-chip" data-filter="seriesType" data-value="tvMiniSeries" aria-pressed="false">Mini-series</button>
+      <details class="quick-filters-wrap">
+        <summary class="quick-filters-summary">
+          <span aria-hidden="true">⌕</span>
+          <span>Quick filters</span>
+        </summary>
+        <div class="label-filters" aria-label="Quick filters">
+          <div class="label-group" role="radiogroup" aria-label="Series type">
+            <span class="label-group-name">Type</span>
+            <button type="button" class="label-chip" data-filter="seriesType" data-value="all" aria-pressed="true">All</button>
+            <button type="button" class="label-chip" data-filter="seriesType" data-value="tvSeries" aria-pressed="false">TV series</button>
+            <button type="button" class="label-chip" data-filter="seriesType" data-value="tvMiniSeries" aria-pressed="false">Mini-series</button>
+          </div>
+          <div class="label-group" role="radiogroup" aria-label="Watched status">
+            <span class="label-group-name">Watched</span>
+            <button type="button" class="label-chip" data-filter="watched" data-value="all" aria-pressed="true">All</button>
+            <button type="button" class="label-chip" data-filter="watched" data-value="watched" aria-pressed="false">Watched</button>
+            <button type="button" class="label-chip" data-filter="watched" data-value="unwatched" aria-pressed="false">Unwatched</button>
+          </div>
+          <div class="label-group" role="radiogroup" aria-label="Above IMDb rating">
+            <span class="label-group-name">IMDb</span>
+            <button type="button" class="label-chip" data-filter="aboveImdb" data-value="all" aria-pressed="true">All</button>
+            <button type="button" class="label-chip label-chip-good" data-filter="aboveImdb" data-value="above" aria-pressed="false" title="Only seasons whose avg episode rating is higher than the show's IMDb rating">↑ Above IMDb</button>
+          </div>
+          <div class="label-group" role="radiogroup" aria-label="Hidden gems">
+            <span class="label-group-name">Gems</span>
+            <button type="button" class="label-chip" data-filter="hiddenGems" data-value="all" aria-pressed="true">All</button>
+            <button type="button" class="label-chip label-chip-good" data-filter="hiddenGems" data-value="on" aria-pressed="false" title="High-rated seasons most people haven't watched (avg ≥ 8.5, fewer than 500 votes per episode)">💎 Hidden gems</button>
+          </div>
         </div>
-        <div class="label-group" role="radiogroup" aria-label="Watched status">
-          <span class="label-group-name">Watched</span>
-          <button type="button" class="label-chip" data-filter="watched" data-value="all" aria-pressed="true">All</button>
-          <button type="button" class="label-chip" data-filter="watched" data-value="watched" aria-pressed="false">Watched</button>
-          <button type="button" class="label-chip" data-filter="watched" data-value="unwatched" aria-pressed="false">Unwatched</button>
-        </div>
-        <div class="label-group" role="radiogroup" aria-label="Above IMDb rating">
-          <span class="label-group-name">IMDb</span>
-          <button type="button" class="label-chip" data-filter="aboveImdb" data-value="all" aria-pressed="true">All</button>
-          <button type="button" class="label-chip label-chip-good" data-filter="aboveImdb" data-value="above" aria-pressed="false" title="Only seasons whose avg episode rating is higher than the show's IMDb rating">↑ Above IMDb</button>
-        </div>
-        <div class="label-group" role="radiogroup" aria-label="Hidden gems">
-          <span class="label-group-name">Gems</span>
-          <button type="button" class="label-chip" data-filter="hiddenGems" data-value="all" aria-pressed="true">All</button>
-          <button type="button" class="label-chip label-chip-good" data-filter="hiddenGems" data-value="on" aria-pressed="false" title="High-rated seasons most people haven't watched (avg ≥ 8.5, fewer than 500 votes per episode)">💎 Hidden gems</button>
-        </div>
-      </div>
+      </details>
 
       <div class="advanced-row">
       <details class="advanced">

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -1714,8 +1714,15 @@ function openModal(m, opts = {}) {
   els.modalEpisodes.replaceChildren(epFrag);
 
   els.modalImdb.href = `https://www.imdb.com/title/${m.seriesId}/episodes/?season=${m.season}`;
-  if (m.tvdbId) {
+  // Prefer the season-level dereferrer when we have a season tvdbId; otherwise
+  // fall back to the series page (still useful, just not deep-linked).
+  if (m.seasonTvdbId) {
+    els.modalTvdb.href = `https://thetvdb.com/dereferrer/season/${m.seasonTvdbId}`;
+    els.modalTvdb.textContent = 'View season on TVDB →';
+    els.modalTvdb.hidden = false;
+  } else if (m.tvdbId) {
     els.modalTvdb.href = `https://thetvdb.com/dereferrer/series/${m.tvdbId}`;
+    els.modalTvdb.textContent = 'View series on TVDB →';
     els.modalTvdb.hidden = false;
   } else {
     els.modalTvdb.removeAttribute('href');

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -11,6 +11,7 @@ const SHAPE_LABELS = {
   'bad-finale': 'Bad finale',
   rollercoaster: 'Rollercoaster',
   'mid-peak': 'Mid-peak',
+  'saved-best-for-last': 'Saved best for last',
 };
 
 const STORAGE_NS = 'rising-seasons';
@@ -21,6 +22,29 @@ const COMPARE_LIMIT = 5;
 const PAGE_SIZE = 24;
 const STALE_DAYS = 30;
 const MAX_SUGGESTIONS = 10;
+
+// Only show these streaming services as filter chips and as provider tags
+// on cards/rows. TMDB returns ~200 distinct providers including aggregator
+// listings ("BritBox Amazon Channel"), bundlers (Spectrum / Philo / fuboTV),
+// niche specialty channels (AMC+, Acorn TV), and free ad-supported services
+// (Tubi, Pluto, The Roku Channel). Keeping the list to the major
+// subscription services makes the metadata read at a glance and the filter
+// chip row stay short.
+const MAINSTREAM_PROVIDERS = new Set([
+  'Netflix',
+  'Hulu',
+  'Amazon Prime Video',
+  'HBO Max',
+  'Max',
+  'Disney+',
+  'Peacock',
+  'Paramount+',
+  'Apple TV+',
+  'Crunchyroll',
+]);
+function isMainstreamProvider(name) {
+  return MAINSTREAM_PROVIDERS.has(name);
+}
 
 // --- DOM refs ---
 
@@ -44,6 +68,7 @@ const els = {
   showModalProviders: document.getElementById('showModalProviders'),
   results: document.getElementById('results'),
   pager: document.getElementById('pager'),
+  pagerTop: document.getElementById('pager-top'),
   meta: document.getElementById('meta'),
   footerMeta: document.getElementById('footer-meta'),
   statsBar: document.getElementById('statsBar'),
@@ -351,6 +376,31 @@ function buildSeriesIndex() {
 
 function applyStateFromURL() {
   const p = new URLSearchParams(location.hash.replace(/^#/, ''));
+
+  // Reset every URL-backed field to its default first so that removing a
+  // parameter from the hash (e.g. user deletes &gems=on) actually clears
+  // the corresponding state, instead of leaving the previous value behind.
+  state.shapes = new Set();
+  state.search = '';
+  state.minEpisodes = null;
+  state.maxEpisodes = null;
+  state.minVotes = null;
+  state.minAvg = null;
+  state.minClimb = null;
+  state.minYear = null;
+  state.maxYear = null;
+  state.seriesType = 'all';
+  state.sort = 'popularity';
+  state.watched = 'all';
+  state.aboveImdb = 'all';
+  state.hiddenGems = 'all';
+  state.genres = new Set();
+  state.excludeGenres = new Set();
+  state.languages = new Set();
+  state.providers = new Set();
+  state.page = 1;
+  state.lockedSeriesId = null;
+
   if (p.has('shape')) {
     const val = p.get('shape');
     state.shapes = val === 'all' ? new Set() : new Set(val.split(',').filter(Boolean));
@@ -584,7 +634,13 @@ function languageLabel(code) {
 }
 
 function renderProviderChips() {
-  const top = (dataset.providers || []).slice(0, 10);
+  // Filter the dataset's provider list to the mainstream whitelist before
+  // taking the top N — otherwise the chip row gets dominated by aggregator
+  // listings (Spectrum, Philo, Roku Channel) that aren't real streaming
+  // homes for the content.
+  const top = (dataset.providers || [])
+    .filter((p) => isMainstreamProvider(p.name))
+    .slice(0, 10);
   const frag = document.createDocumentFragment();
   for (const p of top) {
     const btn = document.createElement('button');
@@ -701,10 +757,10 @@ function buildNonShapeChecker() {
     }
     if (state.aboveImdb === 'above' && !aboveImdbBySeries.get(m.seriesId)) return false;
     if (state.hiddenGems === 'on') {
-      // High-rated (avg >= 8.0) and under the radar (each episode has fewer
-      // than 1,000 votes, i.e. minVotes < 1000 across the season).
-      if (m.avgRating < 8.0) return false;
-      if (m.minVotes >= 1000) return false;
+      // High-rated (avg >= 8.5) and under the radar (each episode has fewer
+      // than 500 votes, i.e. minVotes < 500 across the season).
+      if (m.avgRating < 8.5) return false;
+      if (m.minVotes >= 500) return false;
     }
     return true;
   };
@@ -754,8 +810,13 @@ function render() {
   updateShapeChipCounts();
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const requestedPage = state.page;
   if (state.page > totalPages) state.page = totalPages;
   if (state.page < 1) state.page = 1;
+  // If the URL asked for a page that doesn't exist (e.g. ?page=50 but only
+  // 5 pages are available after filtering), sync the URL back to the page
+  // we're actually showing so it's not lying about position.
+  if (requestedPage !== state.page) writeStateToURL();
 
   renderStatsBar();
   els.meta.textContent = filtered.length
@@ -874,36 +935,48 @@ function stat(html) {
 // --- pagination ---
 
 function renderPager(totalPages, current) {
+  // [target, scrollAfter] — the top pager leaves the user where they are
+  // (so the page-bar above the results stays in view as they click);
+  // the bottom pager scrolls back up to the start of the results, which
+  // is what they expect after reaching the end of a page.
+  const targets = [
+    [els.pagerTop, false],
+    [els.pager, true],
+  ].filter(([t]) => t);
   if (totalPages <= 1) {
-    els.pager.replaceChildren();
-    els.pager.hidden = true;
+    for (const [t] of targets) {
+      t.replaceChildren();
+      t.hidden = true;
+    }
     return;
   }
-  els.pager.hidden = false;
 
-  const frag = document.createDocumentFragment();
-  frag.appendChild(pageButton('Prev', current - 1, current === 1));
-
-  for (const n of pageNumbers(current, totalPages)) {
-    if (n === '…') {
-      const span = document.createElement('span');
-      span.className = 'page-ellipsis';
-      span.textContent = '…';
-      span.setAttribute('aria-hidden', 'true');
-      frag.appendChild(span);
-    } else {
-      const btn = pageButton(String(n), n, false);
-      if (n === current) btn.setAttribute('aria-current', 'page');
-      btn.setAttribute('aria-label', `Page ${n}`);
-      frag.appendChild(btn);
+  // Build a fresh fragment per target — DocumentFragments are consumed by
+  // replaceChildren, so a single fragment can't populate both pagers.
+  for (const [t, scrollAfter] of targets) {
+    const frag = document.createDocumentFragment();
+    frag.appendChild(pageButton('Prev', current - 1, current === 1, scrollAfter));
+    for (const n of pageNumbers(current, totalPages)) {
+      if (n === '…') {
+        const span = document.createElement('span');
+        span.className = 'page-ellipsis';
+        span.textContent = '…';
+        span.setAttribute('aria-hidden', 'true');
+        frag.appendChild(span);
+      } else {
+        const btn = pageButton(String(n), n, false, scrollAfter);
+        if (n === current) btn.setAttribute('aria-current', 'page');
+        btn.setAttribute('aria-label', `Page ${n}`);
+        frag.appendChild(btn);
+      }
     }
+    frag.appendChild(pageButton('Next', current + 1, current === totalPages, scrollAfter));
+    t.replaceChildren(frag);
+    t.hidden = false;
   }
-
-  frag.appendChild(pageButton('Next', current + 1, current === totalPages));
-  els.pager.replaceChildren(frag);
 }
 
-function pageButton(label, target, disabled) {
+function pageButton(label, target, disabled, scrollAfter = true) {
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'page-btn';
@@ -912,7 +985,7 @@ function pageButton(label, target, disabled) {
     btn.disabled = true;
     btn.setAttribute('aria-disabled', 'true');
   } else {
-    btn.addEventListener('click', () => goToPage(target));
+    btn.addEventListener('click', () => goToPage(target, scrollAfter));
   }
   return btn;
 }
@@ -936,12 +1009,17 @@ function pageNumbers(current, total) {
   return out;
 }
 
-function goToPage(n) {
+function goToPage(n, scrollAfter = true) {
   state.page = n;
   writeStateToURL();
   render();
-  const top = els.results.getBoundingClientRect().top + window.scrollY - 70;
-  window.scrollTo({ top, behavior: 'smooth' });
+  // Only the bottom pager opts into scrolling — clicking the top pager
+  // should leave the user looking at the same vertical position so the
+  // pager they clicked stays under their cursor.
+  if (scrollAfter) {
+    const top = els.results.getBoundingClientRect().top + window.scrollY - 70;
+    window.scrollTo({ top, behavior: 'smooth' });
+  }
 }
 
 function onFilterChange() {
@@ -979,6 +1057,10 @@ function hasActiveFilters() {
 function syncResetButton() {
   if (!els.resetFilters) return;
   const active = hasActiveFilters();
+  // Button lives inside <summary>, so we hide it entirely when there's
+  // nothing to clear rather than leaving a disabled control taking space
+  // next to the "More filters" chip.
+  els.resetFilters.hidden = !active;
   els.resetFilters.disabled = !active;
   els.resetFilters.setAttribute('aria-disabled', String(!active));
   els.resetFilters.title = active
@@ -995,14 +1077,10 @@ function surprisePick() {
 
 function fillShapeTags(container, shapes, { clickable = true } = {}) {
   container.replaceChildren();
-  if (shapes.length === 0) {
-    const tag = document.createElement('span');
-    tag.className = 'shape-tag';
-    tag.textContent = 'No pattern';
-    tag.title = 'This season does not match any shape pattern.';
-    container.appendChild(tag);
-    return;
-  }
+  // No "No pattern" placeholder — an empty shape container just renders
+  // nothing, which keeps the row/card cleaner for seasons that don't fit
+  // a recognized trajectory shape.
+  if (shapes.length === 0) return;
   for (const s of shapes) {
     if (clickable) {
       const tag = document.createElement('button');
@@ -1021,6 +1099,42 @@ function fillShapeTags(container, shapes, { clickable = true } = {}) {
       tag.textContent = SHAPE_LABELS[s] || s;
       container.appendChild(tag);
     }
+  }
+}
+
+// Format an avg-runtime value as "52 min" / "1h 5m" depending on length.
+// Returns '' when no runtime is available so the caller can hide the slot.
+function formatAvgRuntime(min) {
+  if (!min || !Number.isFinite(min)) return '';
+  if (min < 60) return `${min} min`;
+  const h = Math.floor(min / 60);
+  const m = min - h * 60;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+function setRuntimeStat(node, m) {
+  const el = node.querySelector('.stat-runtime');
+  if (!el) return;
+  const text = formatAvgRuntime(m.avgRuntime);
+  el.textContent = text ? `~${text}/ep` : '';
+  el.hidden = !text;
+}
+
+// Append streaming-platform chips into an existing shapes container so the
+// trajectory patterns and the platforms read as one row of metadata.
+// Distinct .provider-tag styling keeps them visually separable from the
+// pattern tags without forcing a second row.
+function fillProviderTags(container, providers) {
+  if (!providers || !providers.length) return;
+  // Same whitelist as the filter chips — only major streaming services get
+  // a chip on the card/row. Channels like AMC+, Philo, The Roku Channel,
+  // Spectrum, and the *-Amazon-Channel aggregator entries are dropped.
+  const filtered = providers.filter(isMainstreamProvider);
+  for (const p of filtered) {
+    const tag = document.createElement('span');
+    tag.className = 'provider-tag';
+    tag.textContent = p;
+    container.appendChild(tag);
   }
 }
 
@@ -1078,9 +1192,11 @@ function buildCard(m) {
   // with the smaller-typography row it visually belongs in.
   if (badge) node.querySelector('.card-season').appendChild(badge);
 
-  fillShapeTags(node.querySelector('.card-shapes'), m.shapes, { clickable: false });
+  const cardShapes = node.querySelector('.card-shapes');
+  fillShapeTags(cardShapes, m.shapes, { clickable: false });
+  fillProviderTags(cardShapes, m.providers);
 
-  drawCurve(node.querySelector('.curve'), m.episodes, 300, 70);
+  drawCurve(node.querySelector('.curve'), m.episodes, 300, 70, 0);
 
   const climb = m.lastRating - m.firstRating;
   const climbStr = climb >= 0 ? `+${climb.toFixed(1)}` : climb.toFixed(1);
@@ -1089,6 +1205,7 @@ function buildCard(m) {
   avgEl.textContent = `Avg ${m.avgRating.toFixed(1)}`;
   const cardBadge = aboveImdbBadge(m);
   if (cardBadge) avgEl.appendChild(cardBadge);
+  setRuntimeStat(node, m);
   node.querySelector('.stat-votes').textContent = `${m.minVotes.toLocaleString()} votes/ep min`;
 
   const posterEl = node.querySelector('.card-poster');
@@ -1130,7 +1247,18 @@ function buildRow(m) {
   const badge = maybeBestBadge(m) || maybeWorstBadge(m);
   if (badge) node.querySelector('.row-season').appendChild(badge);
 
-  fillShapeTags(node.querySelector('.row-shapes'), m.shapes, { clickable: false });
+  const rowShapes = node.querySelector('.row-shapes');
+  fillShapeTags(rowShapes, m.shapes, { clickable: false });
+  fillProviderTags(rowShapes, m.providers);
+
+  // Genre line, mirroring the grid card's .card-meta. Hidden when there
+  // are no genres on the season (rare but possible).
+  const rowGenres = node.querySelector('.row-genres');
+  if (rowGenres) {
+    const text = (m.genres || []).slice(0, 3).join(' · ');
+    rowGenres.textContent = text;
+    rowGenres.hidden = !text;
+  }
 
   const climb = m.lastRating - m.firstRating;
   const climbStr = climb >= 0 ? `+${climb.toFixed(1)}` : climb.toFixed(1);
@@ -1139,6 +1267,7 @@ function buildRow(m) {
   rowAvgEl.textContent = `Avg ${m.avgRating.toFixed(1)}`;
   const rowBadge = aboveImdbBadge(m);
   if (rowBadge) rowAvgEl.appendChild(rowBadge);
+  setRuntimeStat(node, m);
   node.querySelector('.stat-votes').textContent = `${m.minVotes.toLocaleString()} votes/ep min`;
 
   drawCurve(node.querySelector('.row-curve'), m.episodes, 200, 56, 0);
@@ -1493,8 +1622,10 @@ function openModal(m, opts = {}) {
   els.modalStats.appendChild(statText);
   const seasonModalBadge = aboveImdbBadge(m);
   if (seasonModalBadge) els.modalStats.appendChild(seasonModalBadge);
+  const runtimeStr = formatAvgRuntime(m.avgRuntime);
   els.modalStats.appendChild(document.createTextNode(
-    ` · ${m.minVotes.toLocaleString()} votes per episode (min)`,
+    ` · ${m.minVotes.toLocaleString()} votes per episode (min)` +
+    (runtimeStr ? ` · ~${runtimeStr} per episode` : ''),
   ));
 
   els.modalOverview.textContent = m.overview || '';
@@ -1540,6 +1671,12 @@ function openModal(m, opts = {}) {
     votes.className = 'ep-votes';
     votes.textContent = `${e.votes.toLocaleString()} votes`;
     meta.append(rating, votes);
+    if (e.runtime) {
+      const rt = document.createElement('span');
+      rt.className = 'ep-runtime';
+      rt.textContent = formatAvgRuntime(e.runtime);
+      meta.append(rt);
+    }
 
     li.append(num, name, meta);
     epFrag.appendChild(li);
@@ -1598,7 +1735,11 @@ function openShowModal(seriesId) {
 
   els.showModalTitle.textContent = meta.title;
 
-  const years = seasons.map((s) => s.year).filter(Boolean);
+  // Use each season's own air year (falling back to the show's start year)
+  // so the range spans the show's full run — m.year is the show-level start
+  // and is identical on every season record, which would otherwise collapse
+  // the range to a single year.
+  const years = seasons.map((s) => s.seasonYear || s.year).filter(Boolean);
   const yearStr = years.length === 0 ? ''
     : years[0] === years[years.length - 1] ? `${years[0]}`
     : `${years[0]}–${years[years.length - 1]}`;
@@ -1610,6 +1751,18 @@ function openShowModal(seriesId) {
 
   const totalEps = seasons.reduce((s, m) => s + m.episodes.length, 0);
   const overallAvg = seasons.reduce((s, m) => s + m.avgRating, 0) / seasons.length;
+  // Show-level average runtime — averaged across every episode that has a
+  // runtime in any season. Skipped entirely when none do.
+  let showRuntimeSum = 0;
+  let showRuntimeCount = 0;
+  for (const s of seasons) {
+    for (const e of s.episodes) {
+      if (e.runtime) { showRuntimeSum += e.runtime; showRuntimeCount++; }
+    }
+  }
+  const showAvgRuntime = showRuntimeCount > 0
+    ? Math.round(showRuntimeSum / showRuntimeCount)
+    : null;
   const watchedCount = seasons.filter((m) => Watched.has(m)).length;
   const statsParts = [
     `${seasons.length} season${seasons.length === 1 ? '' : 's'}`,
@@ -1620,6 +1773,8 @@ function openShowModal(seriesId) {
     statsParts.push(`IMDb ${meta.seriesRating.toFixed(1)}${votesStr}`);
   }
   statsParts.push(`avg episode ${overallAvg.toFixed(1)}`);
+  const showRuntimeStr = formatAvgRuntime(showAvgRuntime);
+  if (showRuntimeStr) statsParts.push(`~${showRuntimeStr}/ep`);
   if (watchedCount > 0) statsParts.push(`${watchedCount} watched`);
   els.showModalStats.replaceChildren();
   els.showModalStats.appendChild(document.createTextNode(statsParts.join(' · ')));
@@ -1649,8 +1804,9 @@ function openShowModal(seriesId) {
   }
   fillShapeTags(els.showModalShapes, commonShapes ? [...commonShapes] : [], { clickable: false });
 
-  // Providers badges (TMDB watch providers, US). Hidden when no data.
-  const providersList = meta.providers || [];
+  // Providers badges (TMDB watch providers, US). Filtered to the mainstream
+  // whitelist so the modal matches what the cards/rows/filter chips show.
+  const providersList = (meta.providers || []).filter(isMainstreamProvider);
   els.showModalProviders.replaceChildren();
   if (providersList.length) {
     for (const name of providersList) {
@@ -1736,7 +1892,9 @@ function buildShowSeasonRow(m, bestSeason, worstSeason) {
   eps.className = 'ss-eps';
   const ssYear = m.seasonYear || m.year;
   const yearStr = ssYear ? ` · ${ssYear}` : '';
-  eps.textContent = `${m.episodes.length} eps${yearStr}`;
+  const ssRuntimeStr = formatAvgRuntime(m.avgRuntime);
+  const ssRuntimeBit = ssRuntimeStr ? ` · ~${ssRuntimeStr}/ep` : '';
+  eps.textContent = `${m.episodes.length} eps${yearStr}${ssRuntimeBit}`;
   meta.appendChild(eps);
   if (m.shapes.length) {
     const shapeRow = document.createElement('span');
@@ -2239,6 +2397,16 @@ function bindEvents() {
       render();
     });
   }
+
+  // When the URL hash changes (back/forward navigation, or user pasting a
+  // new hash into the address bar), re-apply state from the URL and
+  // re-render. writeStateToURL uses history.replaceState so our own URL
+  // writes don't fire this event — only genuine user navigation does.
+  window.addEventListener('hashchange', () => {
+    applyStateFromURL();
+    syncResetButton();
+    render();
+  });
 
   for (const closer of els.modal.querySelectorAll('[data-close="modal"]')) {
     closer.addEventListener('click', closeModal);

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -1112,11 +1112,24 @@ function formatAvgRuntime(min) {
   return m === 0 ? `${h}h` : `${h}h ${m}m`;
 }
 
+// Compact, fixed-width-friendly variant for the result-tile stats grid —
+// always returns minutes ("72 min", "112 min") so the runtime cell doesn't
+// wrap awkwardly compared to its neighbors. The longer formatAvgRuntime is
+// still used in modals and free-text contexts.
+function formatAvgRuntimeShort(min) {
+  if (!min || !Number.isFinite(min)) return '';
+  return `${min} min`;
+}
+
+function avgVotesPerEpisode(m) {
+  return Math.round(m.episodes.reduce((s, e) => s + e.votes, 0) / m.episodes.length);
+}
+
 function setRuntimeStat(node, m) {
   const el = node.querySelector('.stat-runtime');
   if (!el) return;
-  const text = formatAvgRuntime(m.avgRuntime);
-  el.textContent = text ? `~${text}/ep` : '';
+  const text = formatAvgRuntimeShort(m.avgRuntime);
+  el.textContent = text ? `${text}/ep` : '';
   el.hidden = !text;
 }
 
@@ -1186,27 +1199,29 @@ function buildCard(m) {
   node.querySelector('.card-year').textContent = (m.seasonYear || m.year) || 'year unknown';
   node.querySelector('.card-genres').textContent = m.genres.slice(0, 3).join(' · ');
 
-  const badge = maybeBestBadge(m) || maybeWorstBadge(m);
-  // Live next to the season metadata ("S2 · 10 eps") rather than at the
-  // far end of the title row — keeps the title clean and aligns the badge
-  // with the smaller-typography row it visually belongs in.
-  if (badge) node.querySelector('.card-season').appendChild(badge);
-
   const cardShapes = node.querySelector('.card-shapes');
-  fillShapeTags(cardShapes, m.shapes, { clickable: false });
+  // Suppress 'saved-best-for-last' here — the ★ Best badge already conveys it
+  // (a final-season shape only fires when that season is also the show's
+  // best, which always earns the ★).
+  fillShapeTags(cardShapes, m.shapes.filter((s) => s !== 'saved-best-for-last'), { clickable: false });
+  // Best/Worst badge prepended to the shapes row so it reads as a season
+  // descriptor alongside the trajectory pattern, rather than crowding the
+  // title with a big colored chip.
+  const badge = maybeBestBadge(m) || maybeWorstBadge(m);
+  if (badge) cardShapes.insertBefore(badge, cardShapes.firstChild);
   fillProviderTags(cardShapes, m.providers);
 
   drawCurve(node.querySelector('.curve'), m.episodes, 300, 70, 0);
 
   const climb = m.lastRating - m.firstRating;
   const climbStr = climb >= 0 ? `+${climb.toFixed(1)}` : climb.toFixed(1);
-  node.querySelector('.stat-climb').textContent = `${m.firstRating.toFixed(1)} → ${m.lastRating.toFixed(1)} (${climbStr})`;
+  node.querySelector('.stat-climb').textContent = `${m.firstRating.toFixed(1)}→${m.lastRating.toFixed(1)} (${climbStr})`;
   const avgEl = node.querySelector('.stat-avg');
   avgEl.textContent = `Avg ${m.avgRating.toFixed(1)}`;
   const cardBadge = aboveImdbBadge(m);
   if (cardBadge) avgEl.appendChild(cardBadge);
   setRuntimeStat(node, m);
-  node.querySelector('.stat-votes').textContent = `${m.minVotes.toLocaleString()} votes/ep min`;
+  node.querySelector('.stat-votes').textContent = `${avgVotesPerEpisode(m).toLocaleString()} votes/ep`;
 
   const posterEl = node.querySelector('.card-poster');
   if (m.poster) {
@@ -1244,11 +1259,13 @@ function buildRow(m) {
   node.querySelector('.row-season').textContent = `S${m.season} · ${m.episodes.length} eps`;
   node.querySelector('.row-year').textContent = (m.seasonYear || m.year) || '';
 
-  const badge = maybeBestBadge(m) || maybeWorstBadge(m);
-  if (badge) node.querySelector('.row-season').appendChild(badge);
-
   const rowShapes = node.querySelector('.row-shapes');
-  fillShapeTags(rowShapes, m.shapes, { clickable: false });
+  // Suppress 'saved-best-for-last' here — see buildCard for rationale.
+  fillShapeTags(rowShapes, m.shapes.filter((s) => s !== 'saved-best-for-last'), { clickable: false });
+  // Best/Worst badge moves out of the title row and into the shapes row so
+  // it reads as a season descriptor (matches the grid card layout).
+  const badge = maybeBestBadge(m) || maybeWorstBadge(m);
+  if (badge) rowShapes.insertBefore(badge, rowShapes.firstChild);
   fillProviderTags(rowShapes, m.providers);
 
   // Genre line, mirroring the grid card's .card-meta. Hidden when there
@@ -1268,7 +1285,7 @@ function buildRow(m) {
   const rowBadge = aboveImdbBadge(m);
   if (rowBadge) rowAvgEl.appendChild(rowBadge);
   setRuntimeStat(node, m);
-  node.querySelector('.stat-votes').textContent = `${m.minVotes.toLocaleString()} votes/ep min`;
+  node.querySelector('.stat-votes').textContent = `${avgVotesPerEpisode(m).toLocaleString()} votes/ep`;
 
   drawCurve(node.querySelector('.row-curve'), m.episodes, 200, 56, 0);
 
@@ -1608,9 +1625,23 @@ function openModal(m, opts = {}) {
   els.modalTitle.textContent = m.title;
   const seasonYearStr = (m.seasonYear || m.year);
   const yearStr = seasonYearStr ? ` · ${seasonYearStr}` : '';
-  els.modalSubtitle.textContent = `Season ${m.season} · ${m.episodes.length} episodes${yearStr} · ${m.genres.join(', ') || 'No genre listed'}`;
+  // Same suppression as the card/row + show-modal season list: the
+  // 'saved-best-for-last' shape is a show-level signal redundant with
+  // per-season labels and the filter chip on the main view.
+  const subtitleShapes = m.shapes.filter((s) => s !== 'saved-best-for-last');
+  // Shapes inline at the end of the subtitle ("· Rising") so they read as
+  // one descriptor line instead of floating in their own row.
+  const shapeBit = subtitleShapes.length
+    ? ' · ' + subtitleShapes.map((s) => SHAPE_LABELS[s] || s).join(' · ')
+    : '';
+  els.modalSubtitle.textContent = `Season ${m.season} · ${m.episodes.length} episodes${yearStr} · ${m.genres.join(', ') || 'No genre listed'}${shapeBit}`;
 
-  fillShapeTags(els.modalShapes, m.shapes, { clickable: false });
+  // modal-shapes container now hosts the season's streaming-platform chips
+  // only — shape labels live inline in the subtitle above. This mirrors
+  // the chip row that cards and list rows render on each result tile so
+  // the modal reads as a familiar "where to watch" strip.
+  els.modalShapes.replaceChildren();
+  fillProviderTags(els.modalShapes, m.providers || []);
 
   const climb = m.lastRating - m.firstRating;
   const climbStr = climb >= 0 ? `+${climb.toFixed(1)}` : climb.toFixed(1);
@@ -1624,7 +1655,7 @@ function openModal(m, opts = {}) {
   if (seasonModalBadge) els.modalStats.appendChild(seasonModalBadge);
   const runtimeStr = formatAvgRuntime(m.avgRuntime);
   els.modalStats.appendChild(document.createTextNode(
-    ` · ${m.minVotes.toLocaleString()} votes per episode (min)` +
+    ` · ${avgVotesPerEpisode(m).toLocaleString()} votes per episode (avg)` +
     (runtimeStr ? ` · ~${runtimeStr} per episode` : ''),
   ));
 
@@ -1788,34 +1819,18 @@ function openShowModal(seriesId) {
     els.showModalStats.appendChild(aboveBadge);
   }
 
-  // Show-level shapes = INTERSECTION across seasons. A shape only belongs
-  // at the show level if it's true of every season — anything else is a
-  // per-season pattern (still rendered on each ss-shape-row below).
-  let commonShapes = null;
-  for (const s of seasons) {
-    const set = new Set(s.shapes);
-    if (commonShapes === null) {
-      commonShapes = set;
-    } else {
-      for (const sh of [...commonShapes]) {
-        if (!set.has(sh)) commonShapes.delete(sh);
-      }
-    }
-  }
-  fillShapeTags(els.showModalShapes, commonShapes ? [...commonShapes] : [], { clickable: false });
+  // Shape labels (Rising / Rebound / Big finale / etc.) live on the
+  // per-season view only — they describe a single season's trajectory,
+  // not a property of the whole show. Clear the show-modal shape slot
+  // so it never renders an "intersection of every season's shapes"
+  // pattern that doesn't really mean anything to a viewer.
+  els.showModalShapes.replaceChildren();
 
-  // Providers badges (TMDB watch providers, US). Filtered to the mainstream
-  // whitelist so the modal matches what the cards/rows/filter chips show.
-  const providersList = (meta.providers || []).filter(isMainstreamProvider);
+  // Providers — use the same .provider-tag styling the cards and rows
+  // render so streaming chips look identical across every surface. The
+  // mainstream-provider filter happens inside fillProviderTags.
   els.showModalProviders.replaceChildren();
-  if (providersList.length) {
-    for (const name of providersList) {
-      const badge = document.createElement('span');
-      badge.className = 'provider-badge';
-      badge.textContent = name;
-      els.showModalProviders.appendChild(badge);
-    }
-  }
+  fillProviderTags(els.showModalProviders, meta.providers || []);
 
   els.showModalOverview.textContent = meta.overview || '';
 
@@ -1896,10 +1911,17 @@ function buildShowSeasonRow(m, bestSeason, worstSeason) {
   const ssRuntimeBit = ssRuntimeStr ? ` · ~${ssRuntimeStr}/ep` : '';
   eps.textContent = `${m.episodes.length} eps${yearStr}${ssRuntimeBit}`;
   meta.appendChild(eps);
-  if (m.shapes.length) {
+  // Per-season shape labels inside the show modal's season list — these
+  // belong to an individual season, not the show as a whole, so they stay
+  // here. The show-level intersection rendered in els.showModalShapes
+  // above is what gets suppressed (it's a property of the show).
+  // Suppress 'saved-best-for-last' too — the ★ best marker rendered below
+  // already conveys it.
+  const rowShapes = m.shapes.filter((s) => s !== 'saved-best-for-last');
+  if (rowShapes.length) {
     const shapeRow = document.createElement('span');
     shapeRow.className = 'ss-shape-row';
-    for (const s of m.shapes) {
+    for (const s of rowShapes) {
       const tag = document.createElement('span');
       tag.className = 'shape-tag' + (state.shapes.has(s) ? ' active' : '');
       tag.textContent = SHAPE_LABELS[s] || s;

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -84,6 +84,7 @@ const els = {
   modalCurve: document.getElementById('modalCurve'),
   modalEpisodes: document.getElementById('modalEpisodes'),
   modalImdb: document.getElementById('modalImdb'),
+  modalTvdb: document.getElementById('modalTvdb'),
   modalPoster: document.getElementById('modalPoster'),
   modalWatchBtn: document.getElementById('modalWatchBtn'),
   modalReroll: document.getElementById('modalReroll'),
@@ -97,6 +98,7 @@ const els = {
   showModalSeasons: document.getElementById('showModalSeasons'),
   showModalPoster: document.getElementById('showModalPoster'),
   showModalImdb: document.getElementById('showModalImdb'),
+  showModalTvdb: document.getElementById('showModalTvdb'),
   showModalOverlay: document.getElementById('showModalOverlay'),
   showModalOverlayCurve: document.getElementById('showModalOverlayCurve'),
   showModalOverlayLegend: document.getElementById('showModalOverlayLegend'),
@@ -1712,6 +1714,13 @@ function openModal(m, opts = {}) {
   els.modalEpisodes.replaceChildren(epFrag);
 
   els.modalImdb.href = `https://www.imdb.com/title/${m.seriesId}/episodes/?season=${m.season}`;
+  if (m.tvdbId) {
+    els.modalTvdb.href = `https://thetvdb.com/dereferrer/series/${m.tvdbId}`;
+    els.modalTvdb.hidden = false;
+  } else {
+    els.modalTvdb.removeAttribute('href');
+    els.modalTvdb.hidden = true;
+  }
   syncModalWatchBtn();
   els.modalReroll.hidden = !modalState.surprise;
 
@@ -1873,6 +1882,13 @@ function openShowModal(seriesId) {
   }
 
   els.showModalImdb.href = `https://www.imdb.com/title/${seriesId}/`;
+  if (meta.tvdbId) {
+    els.showModalTvdb.href = `https://thetvdb.com/dereferrer/series/${meta.tvdbId}`;
+    els.showModalTvdb.hidden = false;
+  } else {
+    els.showModalTvdb.removeAttribute('href');
+    els.showModalTvdb.hidden = true;
+  }
 
   els.showModal.hidden = false;
   els.showModal.setAttribute('aria-hidden', 'false');

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -1451,6 +1451,7 @@ function syncCompareButton() {
   const inSet = Compare.has(showModalState.seriesId);
   const atLimit = !inSet && Compare.size() >= COMPARE_LIMIT;
   els.showModalCompare.textContent = inSet ? '✓ In compare' : '＋ Add to compare';
+  els.showModalCompare.classList.toggle('is-in-compare', inSet);
   els.showModalCompare.disabled = atLimit;
   els.showModalCompare.title = atLimit
     ? `Compare set is full (${COMPARE_LIMIT} max) — remove one first`
@@ -1625,22 +1626,18 @@ function openModal(m, opts = {}) {
   els.modalTitle.textContent = m.title;
   const seasonYearStr = (m.seasonYear || m.year);
   const yearStr = seasonYearStr ? ` · ${seasonYearStr}` : '';
-  // Same suppression as the card/row + show-modal season list: the
-  // 'saved-best-for-last' shape is a show-level signal redundant with
-  // per-season labels and the filter chip on the main view.
-  const subtitleShapes = m.shapes.filter((s) => s !== 'saved-best-for-last');
-  // Shapes inline at the end of the subtitle ("· Rising") so they read as
-  // one descriptor line instead of floating in their own row.
-  const shapeBit = subtitleShapes.length
-    ? ' · ' + subtitleShapes.map((s) => SHAPE_LABELS[s] || s).join(' · ')
-    : '';
-  els.modalSubtitle.textContent = `Season ${m.season} · ${m.episodes.length} episodes${yearStr} · ${m.genres.join(', ') || 'No genre listed'}${shapeBit}`;
+  els.modalSubtitle.textContent = `Season ${m.season} · ${m.episodes.length} episodes${yearStr} · ${m.genres.join(', ') || 'No genre listed'}`;
 
-  // modal-shapes container now hosts the season's streaming-platform chips
-  // only — shape labels live inline in the subtitle above. This mirrors
-  // the chip row that cards and list rows render on each result tile so
-  // the modal reads as a familiar "where to watch" strip.
+  // Shape pills + streaming chips in the modal-shapes row, matching the
+  // chip row rendered on every result tile. Same suppression rule as
+  // cards/rows/show-modal-season-list: 'saved-best-for-last' is a
+  // show-level signal so it doesn't get a per-season pill.
   els.modalShapes.replaceChildren();
+  fillShapeTags(
+    els.modalShapes,
+    m.shapes.filter((s) => s !== 'saved-best-for-last'),
+    { clickable: false },
+  );
   fillProviderTags(els.modalShapes, m.providers || []);
 
   const climb = m.lastRating - m.firstRating;

--- a/apps/rising-seasons/scripts/build-data.js
+++ b/apps/rising-seasons/scripts/build-data.js
@@ -270,6 +270,7 @@ function loadTmdbCache() {
         m.poster = t.poster_path || null;
         m.overview = t.overview || null;
         m.tmdbId = t.id || null;
+        if (Number.isFinite(t.tvdbId)) m.tvdbId = t.tvdbId;
         if (t.original_language) m.language = t.original_language;
         if (Array.isArray(t.providers) && t.providers.length) {
           const seen = new Set();

--- a/apps/rising-seasons/scripts/build-data.js
+++ b/apps/rising-seasons/scripts/build-data.js
@@ -89,6 +89,7 @@ async function loadSeries(ratings) {
   const series = new Map();
   const episodeTitles = new Map();
   const episodeYears = new Map();
+  const episodeRuntimes = new Map();
   const rl = openTsv('title.basics.tsv.gz');
   let header = true;
   for await (const line of rl) {
@@ -109,6 +110,13 @@ async function loadSeries(ratings) {
         const y = parseInt(startYear, 10);
         if (Number.isFinite(y)) episodeYears.set(tconst, y);
       }
+      // IMDb runtimeMinutes is integer or "\N". We only store positive
+      // finite values so downstream code can `if (runtime)` cheaply.
+      const runtimeRaw = cols[7];
+      if (runtimeRaw && runtimeRaw !== '\\N') {
+        const rt = parseInt(runtimeRaw, 10);
+        if (Number.isFinite(rt) && rt > 0) episodeRuntimes.set(tconst, rt);
+      }
       continue;
     }
 
@@ -123,10 +131,10 @@ async function loadSeries(ratings) {
       genres,
     });
   }
-  return { series, episodeTitles, episodeYears };
+  return { series, episodeTitles, episodeYears, episodeRuntimes };
 }
 
-async function loadEpisodes(series, ratings, episodeTitles, episodeYears) {
+async function loadEpisodes(series, ratings, episodeTitles, episodeYears, episodeRuntimes) {
   // Map<seriesId, Map<seasonNumber, Array<{episode, tconst, rating, votes, name}>>>
   const result = new Map();
   const rl = openTsv('title.episode.tsv.gz');
@@ -162,6 +170,8 @@ async function loadEpisodes(series, ratings, episodeTitles, episodeYears) {
     // Year is build-internal — match.js consumes it to compute the
     // per-season `seasonYear` and then drops it from the projection.
     if (year) ep.year = year;
+    const runtime = episodeRuntimes && episodeRuntimes.get(tconst);
+    if (runtime) ep.runtime = runtime;
     arr.push(ep);
   }
   return result;
@@ -205,16 +215,17 @@ function loadTmdbCache() {
   const ratings = await loadRatings();
   console.log(`${ratings.size.toLocaleString()} rated titles`);
 
-  process.stdout.write('Loading series basics + episode titles + air years... ');
-  const { series, episodeTitles, episodeYears } = await loadSeries(ratings);
+  process.stdout.write('Loading series basics + episode titles + air years + runtimes... ');
+  const { series, episodeTitles, episodeYears, episodeRuntimes } = await loadSeries(ratings);
   console.log(
     `${series.size.toLocaleString()} TV series + mini-series, ` +
     `${episodeTitles.size.toLocaleString()} episode titles, ` +
-    `${episodeYears.size.toLocaleString()} episode air years`,
+    `${episodeYears.size.toLocaleString()} episode air years, ` +
+    `${episodeRuntimes.size.toLocaleString()} episode runtimes`,
   );
 
   process.stdout.write('Loading episodes... ');
-  const episodes = await loadEpisodes(series, ratings, episodeTitles, episodeYears);
+  const episodes = await loadEpisodes(series, ratings, episodeTitles, episodeYears, episodeRuntimes);
   console.log(`${episodes.size.toLocaleString()} series have rated episodes`);
 
   process.stdout.write('Detecting shape matches... ');

--- a/apps/rising-seasons/scripts/build-data.js
+++ b/apps/rising-seasons/scripts/build-data.js
@@ -271,6 +271,10 @@ function loadTmdbCache() {
         m.overview = t.overview || null;
         m.tmdbId = t.id || null;
         if (Number.isFinite(t.tvdbId)) m.tvdbId = t.tvdbId;
+        if (t.seasonTvdbIds) {
+          const sv = t.seasonTvdbIds[m.season];
+          if (Number.isFinite(sv)) m.seasonTvdbId = sv;
+        }
         if (t.original_language) m.language = t.original_language;
         if (Array.isArray(t.providers) && t.providers.length) {
           const seen = new Set();

--- a/apps/rising-seasons/scripts/enrich-tmdb.js
+++ b/apps/rising-seasons/scripts/enrich-tmdb.js
@@ -92,6 +92,20 @@ async function resolveSeries(imdbId, info) {
   return byId || bySearch || { notFound: true, triedTitle: info.title };
 }
 
+// External-ID lookup so we can link a series to TVDB (in addition to IMDb
+// and TMDB) in the UI. The endpoint returns { imdb_id, tvdb_id, ... };
+// we only persist tvdb_id since the others are already known or unused.
+// Returns null on any failure so the caller can keep going.
+async function fetchTvdbId(tmdbId) {
+  try {
+    const body = await tmdbFetch(`https://api.themoviedb.org/3/tv/${tmdbId}/external_ids`);
+    const v = body && body.tvdb_id;
+    return Number.isFinite(v) ? v : null;
+  } catch (_) {
+    return null;
+  }
+}
+
 (async () => {
   if (!TOKEN) {
     console.error('Set TMDB_TOKEN env var (a v4 read access token from https://www.themoviedb.org/settings/api)');
@@ -153,6 +167,12 @@ async function resolveSeries(imdbId, info) {
     try {
       const result = await resolveSeries(imdbId, seriesInfo[imdbId]);
       const wasNotFound = cache[imdbId] && cache[imdbId].notFound;
+      // Capture TVDB id while we already have the TMDB id in hand — saves
+      // a second pass later. Costs one extra request per resolved series.
+      if (result && result.id && !result.notFound) {
+        await sleep(REQUEST_INTERVAL_MS);
+        result.tvdbId = await fetchTvdbId(result.id);
+      }
       cache[imdbId] = result;
       if (wasNotFound && result && !result.notFound) recoveredViaSearch++;
     } catch (err) {
@@ -170,18 +190,44 @@ async function resolveSeries(imdbId, info) {
     await sleep(REQUEST_INTERVAL_MS);
   }
 
+  // Back-fill tvdbId for cache entries that were resolved before the field
+  // was added. One request per series; cheap incrementally and only runs
+  // once per entry (subsequent runs skip anything with `tvdbId` set).
+  const tvdbBackfill = uniqueSeries.filter((id) => {
+    const e = cache[id];
+    return e && e.id && !e.notFound && !e.error && !('tvdbId' in e);
+  });
+  if (tvdbBackfill.length > 0) {
+    console.log(`\nBack-filling tvdbId for ${tvdbBackfill.length.toLocaleString()} cached entries`);
+    let bdone = 0;
+    const bt0 = Date.now();
+    for (const imdbId of tvdbBackfill) {
+      cache[imdbId].tvdbId = await fetchTvdbId(cache[imdbId].id);
+      bdone++;
+      if (bdone % 50 === 0) {
+        const rate = (bdone / ((Date.now() - bt0) / 1000)).toFixed(1);
+        const eta = ((tvdbBackfill.length - bdone) / parseFloat(rate)).toFixed(0);
+        process.stdout.write(`  ${bdone}/${tvdbBackfill.length}  (${rate}/s, ~${eta}s left)\r`);
+        fs.writeFileSync(CACHE_FILE, JSON.stringify(cache));
+      }
+      await sleep(REQUEST_INTERVAL_MS);
+    }
+  }
+
   fs.writeFileSync(CACHE_FILE, JSON.stringify(cache));
   // Tally cache health so it's obvious what the run accomplished.
-  let withPoster = 0, noPoster = 0, notFoundFinal = 0, errored = 0;
+  let withPoster = 0, noPoster = 0, notFoundFinal = 0, errored = 0, withTvdb = 0;
   for (const e of Object.values(cache)) {
     if (!e || e.error) { errored++; continue; }
     if (e.notFound) { notFoundFinal++; continue; }
     if (e.poster_path) withPoster++;
     else noPoster++;
+    if (e.tvdbId) withTvdb++;
   }
   console.log(`\nWrote ${CACHE_FILE} — ${Object.keys(cache).length.toLocaleString()} entries`);
   console.log(`  with poster:    ${withPoster.toLocaleString()}`);
   console.log(`  no poster file: ${noPoster.toLocaleString()}`);
+  console.log(`  with tvdbId:    ${withTvdb.toLocaleString()}`);
   console.log(`  notFound:       ${notFoundFinal.toLocaleString()}`);
   console.log(`  errored:        ${errored.toLocaleString()}`);
   if (recoveredViaSearch > 0) {

--- a/apps/rising-seasons/scripts/enrich-tmdb.js
+++ b/apps/rising-seasons/scripts/enrich-tmdb.js
@@ -106,6 +106,20 @@ async function fetchTvdbId(tmdbId) {
   }
 }
 
+// Per-season external IDs so we can deep-link to a season on TVDB (the
+// series-level dereferrer only lands on the show page). TMDB exposes
+// season-level external_ids and TVDB has a matching season dereferrer
+// (`https://thetvdb.com/dereferrer/season/{tvdb_id}`).
+async function fetchSeasonTvdbId(tmdbId, seasonNumber) {
+  try {
+    const body = await tmdbFetch(`https://api.themoviedb.org/3/tv/${tmdbId}/season/${seasonNumber}/external_ids`);
+    const v = body && body.tvdb_id;
+    return Number.isFinite(v) ? v : null;
+  } catch (_) {
+    return null;
+  }
+}
+
 (async () => {
   if (!TOKEN) {
     console.error('Set TMDB_TOKEN env var (a v4 read access token from https://www.themoviedb.org/settings/api)');
@@ -214,22 +228,66 @@ async function fetchTvdbId(tmdbId) {
     }
   }
 
+  // Per-season tvdbId so the season modal can deep-link to the right
+  // season page. Uses the (seriesId, season) pairs that actually appear
+  // in data.json — no point fetching seasons we have no ratings for.
+  // We store one map per series (`seasonTvdbIds: { "1": 364731, ... }`),
+  // recording null on misses so we don't retry forever.
+  const seasonsBySeriesId = {};
+  for (const m of data.matches) {
+    if (!seasonsBySeriesId[m.seriesId]) seasonsBySeriesId[m.seriesId] = new Set();
+    seasonsBySeriesId[m.seriesId].add(m.season);
+  }
+  const seasonWork = [];
+  for (const [imdbId, seasons] of Object.entries(seasonsBySeriesId)) {
+    const e = cache[imdbId];
+    if (!e || !e.id || e.notFound || e.error) continue;
+    const known = e.seasonTvdbIds || {};
+    for (const s of seasons) {
+      if (s in known) continue;
+      seasonWork.push({ imdbId, tmdbId: e.id, season: s });
+    }
+  }
+  if (seasonWork.length > 0) {
+    console.log(`\nFetching season tvdbIds for ${seasonWork.length.toLocaleString()} seasons`);
+    let sdone = 0;
+    const st0 = Date.now();
+    for (const job of seasonWork) {
+      const tvdb = await fetchSeasonTvdbId(job.tmdbId, job.season);
+      const e = cache[job.imdbId];
+      if (!e.seasonTvdbIds) e.seasonTvdbIds = {};
+      e.seasonTvdbIds[job.season] = tvdb; // may be null — that's the "we asked, not available" signal
+      sdone++;
+      if (sdone % 50 === 0) {
+        const rate = (sdone / ((Date.now() - st0) / 1000)).toFixed(1);
+        const eta = ((seasonWork.length - sdone) / parseFloat(rate)).toFixed(0);
+        process.stdout.write(`  ${sdone}/${seasonWork.length}  (${rate}/s, ~${eta}s left)\r`);
+        fs.writeFileSync(CACHE_FILE, JSON.stringify(cache));
+      }
+      await sleep(REQUEST_INTERVAL_MS);
+    }
+  }
+
   fs.writeFileSync(CACHE_FILE, JSON.stringify(cache));
   // Tally cache health so it's obvious what the run accomplished.
-  let withPoster = 0, noPoster = 0, notFoundFinal = 0, errored = 0, withTvdb = 0;
+  let withPoster = 0, noPoster = 0, notFoundFinal = 0, errored = 0, withTvdb = 0, seasonTvdbCount = 0;
   for (const e of Object.values(cache)) {
     if (!e || e.error) { errored++; continue; }
     if (e.notFound) { notFoundFinal++; continue; }
     if (e.poster_path) withPoster++;
     else noPoster++;
     if (e.tvdbId) withTvdb++;
+    if (e.seasonTvdbIds) {
+      for (const v of Object.values(e.seasonTvdbIds)) if (Number.isFinite(v)) seasonTvdbCount++;
+    }
   }
   console.log(`\nWrote ${CACHE_FILE} — ${Object.keys(cache).length.toLocaleString()} entries`);
-  console.log(`  with poster:    ${withPoster.toLocaleString()}`);
-  console.log(`  no poster file: ${noPoster.toLocaleString()}`);
-  console.log(`  with tvdbId:    ${withTvdb.toLocaleString()}`);
-  console.log(`  notFound:       ${notFoundFinal.toLocaleString()}`);
-  console.log(`  errored:        ${errored.toLocaleString()}`);
+  console.log(`  with poster:       ${withPoster.toLocaleString()}`);
+  console.log(`  no poster file:    ${noPoster.toLocaleString()}`);
+  console.log(`  with tvdbId:       ${withTvdb.toLocaleString()}`);
+  console.log(`  seasons w/ tvdbId: ${seasonTvdbCount.toLocaleString()}`);
+  console.log(`  notFound:          ${notFoundFinal.toLocaleString()}`);
+  console.log(`  errored:           ${errored.toLocaleString()}`);
   if (recoveredViaSearch > 0) {
     console.log(`Recovered ${recoveredViaSearch.toLocaleString()} series via title-search fallback this run.`);
   }

--- a/apps/rising-seasons/scripts/match.js
+++ b/apps/rising-seasons/scripts/match.js
@@ -248,7 +248,17 @@ function findMatches(seriesById, episodesBySeries, opts = {}) {
       if (e.year && (!seasonYear || e.year < seasonYear)) seasonYear = e.year;
     }
 
-    matches.push({
+    // Per-season average runtime, in minutes. Only counts episodes that
+    // carry a runtime value (some IMDb entries don't), so a season with
+    // one missing episode still gets a useful number.
+    let runtimeSum = 0;
+    let runtimeCount = 0;
+    for (const e of eps) {
+      if (e.runtime) { runtimeSum += e.runtime; runtimeCount++; }
+    }
+    const avgRuntime = runtimeCount > 0 ? Math.round(runtimeSum / runtimeCount) : null;
+
+    const season_obj = {
       seriesId,
       title: meta.title,
       year: meta.year,
@@ -265,9 +275,10 @@ function findMatches(seriesById, episodesBySeries, opts = {}) {
       // so shipping it inflates data.json by ~1.5MB across ~126K episodes.
       // We also drop the per-episode `year` because seasonYear above
       // captures the only year the UI needs.
-      episodes: eps.map(({ episode, rating, votes, name }) => {
+      episodes: eps.map(({ episode, rating, votes, name, runtime }) => {
         const ep = { episode, rating, votes };
         if (name) ep.name = name;
+        if (runtime) ep.runtime = runtime;
         return ep;
       }),
       firstRating: ratings[0],
@@ -275,10 +286,43 @@ function findMatches(seriesById, episodesBySeries, opts = {}) {
       avgRating: Math.round(seasonAvg * 100) / 100,
       minVotes: minSeasonVotes,
       shapes,
-    });
+    };
+    if (avgRuntime !== null) season_obj.avgRuntime = avgRuntime;
+    matches.push(season_obj);
   }
 
+  tagSavedBestForLast(matches);
   return matches;
+}
+
+// Post-pass shape: a series whose highest-numbered season is also the
+// highest-avg season earns 'saved-best-for-last' on that final season.
+// Requires 3+ seasons in the dataset — a two-season "comeback" is too
+// thin to credibly say a show built toward its finale. Ties at the top
+// don't qualify: the last season must strictly outscore every other
+// season we have for the series.
+function tagSavedBestForLast(matches) {
+  const bySeries = new Map();
+  for (const m of matches) {
+    let arr = bySeries.get(m.seriesId);
+    if (!arr) { arr = []; bySeries.set(m.seriesId, arr); }
+    arr.push(m);
+  }
+  for (const arr of bySeries.values()) {
+    if (arr.length < 3) continue;
+    let last = arr[0];
+    let topAvg = -Infinity;
+    for (const m of arr) {
+      if (m.season > last.season) last = m;
+      if (m.avgRating > topAvg) topAvg = m.avgRating;
+    }
+    if (last.avgRating < topAvg) continue;
+    const tiedAtTop = arr.filter((m) => m.avgRating === topAvg);
+    if (tiedAtTop.length > 1) continue;
+    if (!last.shapes.includes('saved-best-for-last')) {
+      last.shapes.push('saved-best-for-last');
+    }
+  }
 }
 
 module.exports = {
@@ -294,6 +338,7 @@ module.exports = {
   isMidPeak,
   detectShapes,
   findMatches,
+  tagSavedBestForLast,
   // Back-compat with earlier API name.
   isNonDecreasing: isRising,
 };

--- a/apps/rising-seasons/scripts/match.js
+++ b/apps/rising-seasons/scripts/match.js
@@ -11,8 +11,8 @@ const DEFAULTS = {
   consistent: { floor: 8.0, maxRange: 0.5 },
   // "Slow burn" — second half meaningfully better than first half.
   slowBurn: { delta: 0.6 },
-  // "Big finale" — finale is the peak AND well above the season average.
-  bigFinale: { aboveAvg: 0.5 },
+  // "Big finale" — finale beats every other episode by at least one IMDb step (0.1).
+  bigFinale: { minMargin: 0.1 },
   // "Rebound" — has a real dip in the middle but recovers past the start.
   rebound: { dipDepth: 0.4, recoveryAboveStart: 0.2 },
   // "Front-loaded" — first half meaningfully better than second half.
@@ -69,13 +69,13 @@ function isSlowBurn(episodes, opts = DEFAULTS.slowBurn) {
 function isBigFinale(episodes, opts = DEFAULTS.bigFinale) {
   if (episodes.length < 4) return false;
   const finale = episodes[episodes.length - 1].rating;
-  let max = -Infinity;
-  for (const e of episodes) {
-    if (e.rating > max) max = e.rating;
+  let secondMax = -Infinity;
+  for (let i = 0; i < episodes.length - 1; i++) {
+    if (episodes[i].rating > secondMax) secondMax = episodes[i].rating;
   }
-  // Finale must be (tied for) the peak.
-  if (finale < max) return false;
-  return finale - avg(episodes) >= opts.aboveAvg;
+  // IMDb ratings are 0.1 increments, so the difference is always a multiple
+  // of 0.1 — round to avoid floating-point drift (e.g. 9.0 - 8.9 = 0.0999...).
+  return Math.round((finale - secondMax) * 10) / 10 >= opts.minMargin;
 }
 
 function isRebound(episodes, opts = DEFAULTS.rebound) {

--- a/apps/rising-seasons/tests/match.test.js
+++ b/apps/rising-seasons/tests/match.test.js
@@ -77,16 +77,20 @@ test('isSlowBurn rejects seasons too short to halve', () => {
 
 // --- isBigFinale ---
 
-test('isBigFinale matches when the finale is the peak and well above average', () => {
+test('isBigFinale matches when the finale beats the rest by 0.1+', () => {
   assert.equal(isBigFinale(season(7.5, 7.6, 7.5, 9.5)), true);
+});
+
+test('isBigFinale matches when the finale clears the next-best by exactly 0.1', () => {
+  assert.equal(isBigFinale(season(8.0, 8.0, 8.0, 8.0, 8.5, 8.7)), true);
+});
+
+test('isBigFinale rejects when the finale ties the next-best episode', () => {
+  assert.equal(isBigFinale(season(8.0, 9.0, 8.5, 9.0)), false);
 });
 
 test('isBigFinale rejects when the finale is not the peak', () => {
   assert.equal(isBigFinale(season(7.5, 9.4, 7.5, 9.0)), false);
-});
-
-test('isBigFinale rejects when the finale is only marginally above average', () => {
-  assert.equal(isBigFinale(season(8.0, 8.1, 8.0, 8.2)), false);
 });
 
 // --- isRebound ---
@@ -197,8 +201,8 @@ test('detectShapes tags a rising season with both rising and slow-burn when appl
 });
 
 test('detectShapes returns empty array when nothing matches', () => {
-  // Flat-ish season just below the consistent floor — matches no shape.
-  assert.deepEqual(detectShapes(season(7.5, 7.6, 7.5, 7.6)), []);
+  // Flat-ish season just below the consistent floor, finale not the peak — matches no shape.
+  assert.deepEqual(detectShapes(season(7.5, 7.7, 7.5, 7.6)), []);
 });
 
 // --- findMatches integration ---
@@ -244,12 +248,14 @@ test('findMatches emits every season passing the floor regardless of shape', () 
   ]);
   const episodes = new Map([
     ['tt600', new Map([
-      // Season 1 — bouncy, no shape match.
-      [1, [ep(1, 7.5), ep(2, 7.7), ep(3, 7.4), ep(4, 7.6)]],
+      // Season 1 — bouncy, no shape match. Highest avg so it doubles as the
+      // anchor that keeps the last season from earning saved-best-for-last.
+      [1, [ep(1, 8.0), ep(2, 8.2), ep(3, 7.9), ep(4, 8.1)]],
       // Season 2 — non-decreasing.
       [2, [ep(1, 7.0), ep(2, 7.2), ep(3, 7.4), ep(4, 7.5)]],
-      // Season 3 — bouncy again, no shape match.
-      [3, [ep(1, 8.0), ep(2, 7.8), ep(3, 8.1), ep(4, 7.9)]],
+      // Season 3 — bouncy again, no shape match. Lower avg than S1 so the
+      // saved-best-for-last post-pass doesn't fire on this run.
+      [3, [ep(1, 7.0), ep(2, 6.8), ep(3, 7.1), ep(4, 6.9)]],
     ])],
   ]);
   const matches = findMatches(series, episodes);


### PR DESCRIPTION
## Summary

Two big bundles of UI work on this branch:

**MapTap Rivals — new Confusion Matrix tab** (`15d2e88`)
- New fifth top-level tab rendering an N×N head-to-head matrix between you and any subset of rivals.
- You ↔ rival cells from direct game data; rival ↔ rival cells derived from days both rivals appear in your dataset (since your daily MapTap score is the same against any rival, two rivals' own scores can be compared on shared dates).
- Five sub-metrics swap the cell content: **Record** (W-L-T + win %), **Margin** (avg point differential + best), **Avg score** (row vs col averages), **Last 5** (W/L/T dots + current streak).
- Shareable URL routing via the hash fragment — `#dashboard`, `#leaderboard`, `#history`, `#matrix[/<subtab>]`, `#rival/<id>`. `setView` uses `history.replaceState` (no back-button clutter), a `hashchange` listener handles back/forward + pasted URLs, unknown views fall back to dashboard.
- Tab/chip text rendered in white to override `main.css`'s sitewide `button { color }`.

**Rising Seasons — metadata, runtime, layout polish** (`b23d3c0`, `5bda2f8`, `0131550`, `eee3c79`)
- Episode runtime piped through `build-data.js` → `match.js` → UI (`~52 min/ep` on cards, list rows, season modal per-episode and stats line, show modal show-level + per-season).
- Mainstream-provider whitelist (Netflix, Hulu, Amazon Prime Video, HBO Max/Max, Disney+, Peacock, Paramount+, Apple TV+, Crunchyroll) applied to filter chips, provider tags, and the show modal — aggregator listings (Spectrum, Philo, Roku Channel, AMC+, *-Amazon Channel) dropped.
- Provider chips restyled as cyan `▶`-prefixed pills, distinct from the warm trajectory tags, and unified across cards, list rows, season modal, and show modal.
- List rows now show genres inline; "No pattern" placeholder removed for seasons that don't match a shape.
- Hidden gems threshold tightened from `avg ≥ 8.0 & votes < 1000` to `avg ≥ 8.5 & votes < 500`.
- URL state is now authoritative: `applyStateFromURL` resets every URL-backed field before applying, a `hashchange` listener picks up address-bar edits, and out-of-range `page=N` syncs back to the actually-shown page.
- Page width matches the site footer (`.inner` constraint) — no horizontal shift when expanding More filters. `overflow-y: scroll` on `<html>` keeps the scrollbar gutter permanently reserved across browsers.
- Quick filters (Type/Watched/IMDb/Gems) collapsed behind a small toggle chip by default so results show above the fold.
- "Clear all filters" pill is now a sibling of the `<details class="advanced">` (instead of nested inside the summary), so the panel's border doesn't visually wrap both buttons.
- Modal action buttons live at the top of each modal; show-modal panel surface lifted (brighter top gradient, wider shadow); season modal now shows the season's shapes inline in the subtitle.
- Sparkline redesigned — no gray rectangle backdrop, line draws edge-to-edge (`padX=0`), `.card-body` switched to a CSS grid so curves sit on the same baseline across cards in the same row regardless of how many chip lines a season has.
- Pagination duplicated to the top of the results; top pager keeps user in place, bottom scroll-anchors back to the start of the results.
- `bigFinale` shape detector tightened — finale must strictly beat every other episode by ≥ 0.1; tests updated.
- `data.json` regenerated twice — once after the runtime field was added, once after the bigFinale rule change. 14,018 of 16,510 seasons (85%) carry an `avgRuntime`.

**Rising Seasons — TVDB deep-links + season-modal polish** (`529c363`, `0a5823e`, `fdcb728`, `12f1011`)
- New "View on TVDB →" link in both season and show modals, parallel to the existing IMDb buttons.
- `enrich-tmdb.js` calls TMDB's `/tv/{id}/external_ids` (series) and `/tv/{id}/season/{n}/external_ids` (per-season) and caches both. Both runs include a backfill pass for entries that pre-date the field. Cache stays gitignored.
- `build-data.js` surfaces `tvdbId` and `seasonTvdbId` on each match.
- Season modal prefers the season dereferrer (`/dereferrer/season/{id}` → lands on `/series/{slug}/seasons/official/{n}`) when available; falls back to the series page with the label flipping from "View season on TVDB →" to "View series on TVDB →". Show modal always uses the series dereferrer. Button is hidden when neither is available.
- Coverage of the 16,510 seasons in `data.json`: 59.2% deep-link to the season page, 38.3% fall back to the series page, 2.5% hide the button.
- Season modal shape labels rendered as compact warm-toned pills (consistent with the rest of the app, not blended with the genre row).
- "Add to compare" button in the show modal promoted to filled-primary styling (parallel with "Mark as watched" in the season modal) so the action hierarchy is clear.

**CI — daily data refresh** (`4086dea`)
- Cron flipped from weekly (`'0 6 * * 1'`) to daily (`'0 6 * * *'`). IMDb publishes TSVs daily and the TMDB enrichment is incremental, so subsequent runs stay well under 15 min.

## Test plan

- [ ] **MapTap Rivals** — load `apps/maptap-rivals/index.html`. Add a couple of rivals, log a few games on overlapping dates. Click the new **Matrix** tab. Confirm:
  - [ ] Cells render and cell tint matches win/loss/tie
  - [ ] Sub-tabs (Record / Margin / Avg score / Last 5) all populate
  - [ ] URL updates to `#matrix/<subtab>` as you click
  - [ ] Pasting `…/index.html#matrix/form` loads straight into Last 5
  - [ ] Hash routing for other views still works (`#dashboard`, `#rival/<id>`, etc.)
- [ ] **Rising Seasons** — load `apps/rising-seasons/index.html`. Confirm:
  - [ ] Quick filters chip collapsed by default; expands cleanly
  - [ ] Each row of grid-view cards has sparklines sitting on the same baseline
  - [ ] Provider chips (cyan, `▶`) visible on cards, list rows, season modal, show modal
  - [ ] List-view rows show genres after the year on the title line
  - [ ] Top pager doesn't scroll; bottom pager scroll-anchors to results
  - [ ] Hash deep links work (`#gems=on&page=50`, `#shape=rising`, etc.)
  - [ ] Show modal: no shape pills at the top; per-season shape pills retained in the season list as warm-toned pills
  - [ ] Show modal: "Add to compare" button uses filled-primary styling
  - [ ] Season modal: trajectory inline at end of subtitle; streaming chip visible
  - [ ] Season modal: TVDB button reads "View season on TVDB →" for popular shows (Breaking Bad, GoT, Friends) and lands on the specific season page; reads "View series on TVDB →" for shows TMDB doesn't have a season cross-ref for
  - [ ] Show modal: "View show on TVDB →" lands on the series page
  - [ ] TVDB button is hidden for the ~2.5% of seasons with no tvdbId at all
  - [ ] Page width matches footer; expanding More filters doesn't shift layout horizontally
- [ ] Run `npm test` — 275/275 pass
- [ ] Build pipeline runs clean: `npm run build:rising-seasons` writes 16,510 matches in ~27s
