### PR TITLE
fix(csp): allow Google Analytics + migrate UA-140119780-1 to GA4

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,7 +17,7 @@
     <link rel="dns-prefetch" href="https://www.google-analytics.com">
 
     <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
     <script defer src="/assets/js/analytics.js"></script>
 
     <link rel="stylesheet" href="/assets/css/main.css" />

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
 
   <link rel="stylesheet" href="assets/css/main.css" />

--- a/apps.html
+++ b/apps.html
@@ -19,7 +19,7 @@
   <link rel="dns-prefetch" href="https://www.google-analytics.com">
 
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
 
   <link rel="stylesheet" href="assets/css/main.css" />

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,4 +1,4 @@
 window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
-gtag('config', 'UA-140119780-1');
+gtag('config', 'G-GEQGY35JJN');

--- a/contact.html
+++ b/contact.html
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
 
   <link rel="stylesheet" href="assets/css/main.css" />

--- a/home.html
+++ b/home.html
@@ -20,7 +20,7 @@
   <link rel="dns-prefetch" href="https://www.google-analytics.com">
 
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
 
   <link rel="stylesheet" href="assets/css/main.css" />

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -14,7 +14,7 @@
   <link rel="dns-prefetch" href="https://www.google-analytics.com">
 
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
 
   <title>מועדון אלף - רופא עד הבית 24/7 | שירות רפואי מקצועי בישראל</title>

--- a/netlify.toml
+++ b/netlify.toml
@@ -34,7 +34,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "geolocation=(), microphone=(), camera=(), interest-cohort=()"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.firebasedatabase.app https://*.firebaseapp.com wss://*.firebaseio.com; frame-src 'self' https://*.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'"
+    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://cdnjs.cloudflare.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.firebasedatabase.app https://*.firebaseapp.com https://www.google-analytics.com https://*.analytics.google.com wss://*.firebaseio.com; frame-src 'self' https://*.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'"
 
 # Long-cache static asset families. The exercise DB is content-addressed
 # only by name today; if we add hashed bundles later, bump these and

--- a/work.html
+++ b/work.html
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140119780-1"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
 
   <link rel="stylesheet" href="assets/css/main.css" />


### PR DESCRIPTION
## Summary
- The report-only CSP doesn't allow `googletagmanager.com` in `script-src`, so every marketing page logs a violation when loading `gtag/js`. Once the directive graduates from Report-Only to enforced (per the comment in `netlify.toml:23-28`), GA stops loading.
- The tag in use, `UA-140119780-1`, is a Universal Analytics property — Google sunset UA on July 1, 2024, so it loads but no longer collects data.

## Changes
- `netlify.toml` — add `https://www.googletagmanager.com` to `script-src` and `https://www.google-analytics.com https://*.analytics.google.com` to `connect-src` so GA4's loader script and beacon endpoints are both allowed.
- Swap `UA-140119780-1` → `G-GEQGY35JJN` in seven HTML pages (`404`, `home`, `about`, `apps`, `work`, `contact`, `moadon-alef`) and `assets/js/analytics.js`.

## Test plan
- [ ] Deploy to Netlify (preview or prod) and reload any marketing page.
- [ ] DevTools console: confirm the `googletagmanager.com` CSP-violation message is gone.
- [ ] DevTools network tab: confirm `gtag/js?id=G-GEQGY35JJN` returns 200 and the GA collect requests fire to `*.analytics.google.com` / `www.google-analytics.com`.
- [ ] GA4 → Reports → Realtime: confirm the visit shows up in the new property.
- [ ] Watch console for any new CSP violations over the next few days before flipping `Content-Security-Policy-Report-Only` → `Content-Security-Policy`.