### PR TITLE
chore: simplify marketing site (dead-code, token, font, bugfixes)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,5 +1,5 @@
 @import url(font-awesome.min.css);
-@import url("https://fonts.googleapis.com/css?family=Raleway:200,300,400,500,600");
+@import url("https://fonts.googleapis.com/css?family=Raleway:200,300,400,500,600&display=swap");
 @import url(firebase-auth.css);
 /* Basic */
 body {

--- a/assets/css/moadon-alef-theme.css
+++ b/assets/css/moadon-alef-theme.css
@@ -1,5 +1,10 @@
 /* Override some styles for medical theme */
 
+:root {
+  --medical-blue: #0066cc;
+  --medical-blue-hover: #0044aa;
+  --medical-blue-icon-hover: #004499;
+}
 
 .highlights section {
   transition: all 0.3s ease;
@@ -7,13 +12,13 @@
 }
 
 .highlights section:hover {
-  border-color: #0066cc;
+  border-color: var(--medical-blue);
   transform: translateY(-5px);
 }
 
 /* Medical theme colors */
 .icon.medical {
-  color: #0066cc !important;
+  color: var(--medical-blue) !important;
 }
 
 /* Language switcher styles */
@@ -28,9 +33,9 @@
 
 .lang-btn {
   padding: 12px 24px;
-  border: 2px solid #0066cc;
+  border: 2px solid var(--medical-blue);
   background: white;
-  color: #0066cc;
+  color: var(--medical-blue);
   border-radius: 25px;
   cursor: pointer;
   font-weight: 600;
@@ -64,7 +69,7 @@
 .brand-title {
   font-size: 3rem;
   font-weight: bold;
-  color: #0066cc;
+  color: var(--medical-blue);
   margin-bottom: 20px;
   letter-spacing: -1px;
 }
@@ -72,7 +77,7 @@
 .main-phone {
   font-size: 2.5rem;
   font-weight: bold;
-  color: #0066cc;
+  color: var(--medical-blue);
   text-decoration: none;
   display: inline-block;
   margin: 20px 0;
@@ -80,7 +85,7 @@
 }
 
 .main-phone:hover {
-  color: #0044aa;
+  color: var(--medical-blue-hover);
   transform: scale(1.05);
 }
 
@@ -127,13 +132,13 @@
   display: block;
   margin-bottom: 1rem;
   font-size: 4rem !important;
-  color: #0066cc;
+  color: var(--medical-blue);
   transition: transform 0.3s ease, color 0.3s ease;
 }
 
 .highlights .content header .icon:hover {
   transform: scale(1.1);
-  color: #004499;
+  color: var(--medical-blue-icon-hover);
 }
 
 .highlights .content header h2 {

--- a/assets/js/global-icons.js
+++ b/assets/js/global-icons.js
@@ -25,8 +25,3 @@ window.GlobalIcons = {
         return [...this.SPORTS, ...this.ANIMALS, ...this.GENERAL];
     }
 };
-
-// Export for CommonJS environments if needed
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = window.GlobalIcons;
-}

--- a/assets/js/language-switcher.js
+++ b/assets/js/language-switcher.js
@@ -5,16 +5,20 @@
  * attribute, which keeps the markup compatible with strict CSPs that
  * disallow inline event handlers.
  *
- * Note: the page's `<html>` element intentionally has NO `lang` attribute.
- * A CSS rule (`[lang]:not([lang="en"]) { display: none; }`) hides per-element
- * lang variants by default; setting `<html lang="he">` would hide the
- * entire page. The chosen language is reflected via `dir` and the
- * Open Graph / hreflang tags in <head> still signal targeting to crawlers.
+ * The CSS rule `[lang]:not([lang="en"]) { display: none; }` hides
+ * per-element lang variants by default; the chosen language is then
+ * revealed by toggling inline display below. The `<html>` and `<body>`
+ * elements are skipped so a root-level `lang` attribute (required for
+ * a11y / SEO) cannot blank the page.
  */
 
 const LANG_BLOCK_ELEMENTS = new Set(['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'DIV', 'SECTION']);
 const SUPPORTED_LANGS = new Set(['en', 'ru', 'he']);
 const STORAGE_KEY = 'moadon-alef-lang';
+
+function isStructuralLangHost(el) {
+  return el === document.documentElement || el === document.body;
+}
 
 function switchLanguage(lang) {
   if (!SUPPORTED_LANGS.has(lang)) return;
@@ -25,14 +29,13 @@ function switchLanguage(lang) {
     btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
   });
 
-  // Hide every per-language element except the buttons themselves.
   document.querySelectorAll('[lang]').forEach(el => {
-    if (el.classList.contains('lang-btn')) return;
+    if (el.classList.contains('lang-btn') || isStructuralLangHost(el)) return;
     el.style.display = 'none';
   });
 
   document.querySelectorAll(`[lang="${lang}"]`).forEach(el => {
-    if (el.classList.contains('lang-btn')) return;
+    if (el.classList.contains('lang-btn') || isStructuralLangHost(el)) return;
     el.style.display = LANG_BLOCK_ELEMENTS.has(el.tagName) ? 'block' : 'inline';
   });
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,14 +1,10 @@
 /**
  * Global Enhanced JavaScript
  * Includes: Firebase Config, Auth, UI, and Main site functionality
- * 
+ *
  * Dependencies: jQuery, Firebase SDK (loaded from CDN)
  */
 
-// Firebase Configuration is now loaded directly from firebase-config.js
-// The config file is included in all HTML pages before main.js
-
-// Main Application JavaScript
 (function($) {
   'use strict';
 
@@ -35,7 +31,8 @@
     tabActive: 'auth-tab--active',
     formActive: 'auth-form--active',
     messageVisible: 'auth-message--visible',
-    inputError: 'auth-form__input--error'
+    inputError: 'auth-form__input--error',
+    errorVisible: 'auth-form__error--visible'
   };
 
   // Firebase config will be loaded from external file (firebase-config-local.js)
@@ -64,24 +61,6 @@
   function isValidEmail(email) {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(email);
-  }
-
-  /**
-   * Debounce function to limit function calls
-   * @param {Function} func - Function to debounce
-   * @param {number} wait - Wait time in milliseconds
-   * @returns {Function} Debounced function
-   */
-  function debounce(func, wait) {
-    let timeout;
-    return function executedFunction(...args) {
-      const later = () => {
-        clearTimeout(timeout);
-        func(...args);
-      };
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
-    };
   }
 
   /* ==========================================================================
@@ -466,9 +445,6 @@
       });
     }
 
-    // ... (Additional methods continue - createAuthModal, bindModalEvents, etc.)
-    // Due to length constraints, I'll continue with the most essential methods
-
     /**
      * Create authentication modal
      * @private
@@ -665,6 +641,28 @@
 
 
     /**
+     * Clear inline error state from all auth form inputs.
+     * The CSS forces `.auth-form__error { display: none !important }`, so
+     * visibility is driven by the `auth-form__error--visible` class — not
+     * jQuery `.show()` / `.hide()`, which can't beat `!important`.
+     * @private
+     */
+    clearAuthFormErrors() {
+      $('.auth-form__input').removeClass(CSS_CLASSES.inputError);
+      $('.auth-form__error').text('').removeClass(CSS_CLASSES.errorVisible);
+    }
+
+    /**
+     * Mark a field as invalid: add error class to the input and reveal the
+     * matching error message element.
+     * @private
+     */
+    showFieldError(inputSelector, errorSelector, message) {
+      $(inputSelector).addClass(CSS_CLASSES.inputError);
+      $(errorSelector).text(message).addClass(CSS_CLASSES.errorVisible);
+    }
+
+    /**
      * Validate sign in form
      * @private
      * @param {string} email - Email address
@@ -673,24 +671,18 @@
      */
     validateSignInForm(email, password) {
       let isValid = true;
-
-      // Clear previous errors
-      $('.auth-form__input').removeClass(CSS_CLASSES.inputError);
-      $('.auth-form__error').text('').hide();
+      this.clearAuthFormErrors();
 
       if (!email) {
-        $('#signin-email').addClass(CSS_CLASSES.inputError);
-        $('#signin-email-error').text('Email is required').show();
+        this.showFieldError('#signin-email', '#signin-email-error', 'Email is required');
         isValid = false;
       } else if (!isValidEmail(email)) {
-        $('#signin-email').addClass(CSS_CLASSES.inputError);
-        $('#signin-email-error').text('Please enter a valid email address').show();
+        this.showFieldError('#signin-email', '#signin-email-error', 'Please enter a valid email address');
         isValid = false;
       }
 
       if (!password) {
-        $('#signin-password').addClass(CSS_CLASSES.inputError);
-        $('#signin-password-error').text('Password is required').show();
+        this.showFieldError('#signin-password', '#signin-password-error', 'Password is required');
         isValid = false;
       }
 
@@ -706,28 +698,21 @@
      */
     validateSignUpForm(email, password) {
       let isValid = true;
-
-      // Clear previous errors
-      $('.auth-form__input').removeClass(CSS_CLASSES.inputError);
-      $('.auth-form__error').text('').hide();
+      this.clearAuthFormErrors();
 
       if (!email) {
-        $('#signup-email').addClass(CSS_CLASSES.inputError);
-        $('#signup-email-error').text('Email is required').show();
+        this.showFieldError('#signup-email', '#signup-email-error', 'Email is required');
         isValid = false;
       } else if (!isValidEmail(email)) {
-        $('#signup-email').addClass(CSS_CLASSES.inputError);
-        $('#signup-email-error').text('Please enter a valid email address').show();
+        this.showFieldError('#signup-email', '#signup-email-error', 'Please enter a valid email address');
         isValid = false;
       }
 
       if (!password) {
-        $('#signup-password').addClass(CSS_CLASSES.inputError);
-        $('#signup-password-error').text('Password is required').show();
+        this.showFieldError('#signup-password', '#signup-password-error', 'Password is required');
         isValid = false;
       } else if (password.length < 6) {
-        $('#signup-password').addClass(CSS_CLASSES.inputError);
-        $('#signup-password-error').text('Password must be at least 6 characters long').show();
+        this.showFieldError('#signup-password', '#signup-password-error', 'Password must be at least 6 characters long');
         isValid = false;
       }
 
@@ -956,16 +941,5 @@
       }
     }, 1000);
   });
-
-  // Handle scroll and resize events (debounced for performance)
-  const debouncedResize = debounce(() => {
-    // Handle responsive adjustments
-    if (window.authUI && window.authUI.state.isModalOpen) {
-      // Ensure modal is properly positioned
-      window.authUI.trapFocus = window.authUI.trapFocus.bind(window.authUI);
-    }
-  }, 250);
-
-  $window.on('resize', debouncedResize);
 
 })(jQuery);

--- a/assets/js/passive-events-fix.js
+++ b/assets/js/passive-events-fix.js
@@ -29,20 +29,4 @@
     
     return originalAddEventListener.call(this, type, listener, options);
   };
-
-  // jQuery-specific fix for passive touch events
-  if (typeof jQuery !== 'undefined') {
-    jQuery(document).ready(function($) {
-      // Only add passive listeners for scroll-related events
-      // Don't override jQuery methods as they might break functionality
-      var passiveEvents = ['touchstart', 'touchmove', 'wheel', 'mousewheel'];
-      
-      passiveEvents.forEach(function(eventType) {
-        // Add a passive dummy listener to satisfy browser requirements
-        document.addEventListener(eventType, function() {
-          // Empty function - just to register passive capability
-        }, { passive: true });
-      });
-    });
-  }
 })();

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary

Cleanups and bugfixes uncovered during a /simplify review of the marketing site (root HTML pages + partials + assets/css + assets/js). No app changes, no apps/ touched.

### Cleanups (no behavior change unless noted)
- **passive-events-fix.js** — remove dead jQuery dummy-listener block; the `addEventListener` override above already covers the requirement.
- **global-icons.js** — drop CommonJS `module.exports`; file is loaded via `<script>` tag, no bundler.
- **main.js** — strip narrative + AI-scaffolding comments; remove no-op resize handler (and the now-orphaned `debounce` helper).
- **main.js** — extract `clearAuthFormErrors` and `showFieldError` helpers; previously duplicated across `validateSignInForm` and `validateSignUpForm`.
- **moadon-alef-theme.css** — replace 9 hardcoded `#0066cc` / `#0044aa` / `#004499` hexes with `--medical-blue` / `--medical-blue-hover` / `--medical-blue-icon-hover` tokens. Kept scoped to this theme; intentionally distinct from `--brand-blue` in `brand-colors.css`.
- **main.css** — add `&display=swap` to the Google Fonts Raleway import so text uses a fallback instead of being invisible while the font loads (FOIT → FOUT).

### Bugfixes discovered during review
- **moadon-alef.html** — set `<html lang="en">`. The page had no `lang` on `<html>`, which violates a11y. An earlier attempt to use `lang="he"` triggered the `[lang]:not([lang=\"en\"]) { display: none }` rule on the root element and blanked the page; `lang=\"en\"` satisfies a11y without matching that selector.
- **language-switcher.js** — skip `<html>` / `<body>` in the per-language display toggle so a root `lang` attribute can never blank the page again (defensive).
- **main.js auth form** — error messages never appeared because `firebase-auth.css` forces `.auth-form__error { display:none !important }`, which beats jQuery `.show()`. Switched to toggling the `.auth-form__error--visible` class the CSS already supports (line 733).

## Test plan
- [ ] Open `/moadon-alef.html` — page renders with title, phone, three feature cards (Professional Medical Care / 24/7 Availability / Comfort of Home), and EN/RU/HE language switcher.
- [ ] Click each language button — content swaps, body `dir` flips for Hebrew, root `<html>` stays visible.
- [ ] Open any marketing page → click **Sign In** → auth modal opens.
- [ ] Submit sign-in form with `not-an-email` + empty password → red text appears under each field ("Please enter a valid email address", "Password is required") and inputs get error borders.
- [ ] Switch to **Sign Up** tab, repeat with `foo@bar` + `123` → same error styling fires.
- [ ] Smoke-check `/home.html`, `/about.html`, `/work.html`, `/contact.html`, `/apps.html`, `/404.html` — header + footer load, no visible regressions, no console errors.
- [ ] Hard reload `/home.html` with throttled network — fonts fall back to system fonts then swap to Raleway (no period of invisible text).

## Notes
- Branch is based on `origin/master` (which already had #71's GA4 migration merged), so the moadon-alef.html diff here shows ONLY the `lang` change — no overlap with #71.