### PR TITLE
Escape user-typed strings before innerHTML interpolation

### DIFF
--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -410,6 +410,7 @@
     
     <!-- Include Scripts -->
     <script src="../../assets/js/passive-events-fix.js"></script>
+    <script src="../../assets/js/escape-html.js"></script>
     <script src="../../assets/js/jquery.min.js"></script>
     <script src="../../assets/js/global-icons.js"></script>
     <script src="../../assets/js/browser.min.js"></script>

--- a/apps/football-h2h/js/football-h2h.js
+++ b/apps/football-h2h/js/football-h2h.js
@@ -224,14 +224,14 @@ function applyPlayerNameChanges(newPlayer1Name, newPlayer2Name) {
     
     if (player1Header) {
         const player1IconDisplay = playerIcons.player1 || '⚽';
-        player1Header.innerHTML = `<span class="player-header-icon">${player1IconDisplay}</span> ${player1Name}`;
+        player1Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player1IconDisplay)}</span> ${escapeHtml(player1Name)}`;
     }
-    
+
     if (player2Header) {
         const player2IconDisplay = playerIcons.player2 || '⚽';
-        player2Header.innerHTML = `<span class="player-header-icon">${player2IconDisplay}</span> ${player2Name}`;
+        player2Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player2IconDisplay)}</span> ${escapeHtml(player2Name)}`;
     }
-    
+
     // Update modal labels (if they exist)
     const modalPlayer1Name = document.getElementById('modalPlayer1Name');
     const modalPlayer2Name = document.getElementById('modalPlayer2Name');
@@ -488,8 +488,8 @@ function renderGamesTableLegacy() {
                 <td>${dateTimeDisplay}</td>
                 <td><span class="goal-circle ${player1Class}">${game.player1Goals}</span></td>
                 <td><span class="goal-circle ${player2Class}">${game.player2Goals}</span></td>
-                <td>${game.player1Team || game.team || 'Ultimate Team'}</td>
-                <td>${game.player2Team || game.team || 'Ultimate Team'}</td>
+                <td>${escapeHtml(game.player1Team || game.team || 'Ultimate Team')}</td>
+                <td>${escapeHtml(game.player2Team || game.team || 'Ultimate Team')}</td>
                 <td>
                     <div class="action-buttons">
                         <button class="btn-icon edit" onclick="editGame(${game.id})" title="Edit">
@@ -1194,8 +1194,8 @@ function updatePlayerIconDisplays() {
     const player1IconDisplay = document.getElementById('player1IconDisplay');
     const player2IconDisplay = document.getElementById('player2IconDisplay');
     
-    if (player1IconDisplay) player1IconDisplay.innerHTML = `<span class="team-logo">${playerIcons.player1}</span>`;
-    if (player2IconDisplay) player2IconDisplay.innerHTML = `<span class="team-logo">${playerIcons.player2}</span>`;
+    if (player1IconDisplay) player1IconDisplay.innerHTML = `<span class="team-logo">${escapeHtml(playerIcons.player1)}</span>`;
+    if (player2IconDisplay) player2IconDisplay.innerHTML = `<span class="team-logo">${escapeHtml(playerIcons.player2)}</span>`;
     
     // Update display names (if elements exist)
     const player1DisplayName = document.getElementById('player1DisplayName');
@@ -1209,14 +1209,14 @@ function updatePlayerIconDisplays() {
     
     if (player1Header) {
         const player1IconDisplay = playerIcons.player1 || '⚽';
-        player1Header.innerHTML = `<span class="player-header-icon">${player1IconDisplay}</span> ${player1Name}`;
+        player1Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player1IconDisplay)}</span> ${escapeHtml(player1Name)}`;
     }
-    
+
     if (player2Header) {
         const player2IconDisplay = playerIcons.player2 || '⚽';
-        player2Header.innerHTML = `<span class="player-header-icon">${player2IconDisplay}</span> ${player2Name}`;
+        player2Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player2IconDisplay)}</span> ${escapeHtml(player2Name)}`;
     }
-    
+
     // Update player management modal if it's open
     const playerModal = document.getElementById('playerManagementModal');
     if (playerModal && playerModal.classList.contains('active')) {
@@ -1614,8 +1614,8 @@ function renderGamesTableWithData(gamesData) {
             <td class="player-score player2-score ${player2ScoreClass}">
                 <span class="score-number">${game.player2Goals}</span>${player2PenaltyText}
             </td>
-            <td class="team-name">${game.player1Team}</td>
-            <td class="team-name">${game.player2Team}</td>
+            <td class="team-name">${escapeHtml(game.player1Team)}</td>
+            <td class="team-name">${escapeHtml(game.player2Team)}</td>
             <td class="actions">
                 <button class="edit-btn" onclick="editGame(${game.id})" title="Edit game">✏️</button>
                 <button class="delete-btn" onclick="deleteGame(${game.id})" title="Delete game">🗑️</button>

--- a/apps/football-h2h/js/sidebar.js
+++ b/apps/football-h2h/js/sidebar.js
@@ -586,32 +586,32 @@ function generateSidebarPlayerSettings() {
                 <h4 class="section-title">Player Names</h4>
                 <div class="player-input-group">
                     <label for="sidebar-player1-name">Player 1</label>
-                    <input type="text" id="sidebar-player1-name" class="sidebar-player-input" 
-                           placeholder="Enter player 1 name" value="${currentPlayer1Name}" 
+                    <input type="text" id="sidebar-player1-name" class="sidebar-player-input"
+                           placeholder="Enter player 1 name" value="${escapeHtml(currentPlayer1Name)}"
                            onchange="updatePlayerName(1, this.value)">
                 </div>
                 <div class="player-input-group">
                     <label for="sidebar-player2-name">Player 2</label>
-                    <input type="text" id="sidebar-player2-name" class="sidebar-player-input" 
-                           placeholder="Enter player 2 name" value="${currentPlayer2Name}" 
+                    <input type="text" id="sidebar-player2-name" class="sidebar-player-input"
+                           placeholder="Enter player 2 name" value="${escapeHtml(currentPlayer2Name)}"
                            onchange="updatePlayerName(2, this.value)">
                 </div>
             </div>
-            
+
             <div class="player-settings-section">
                 <h4 class="section-title">Player Icons</h4>
                 <div class="player-icon-row">
                     <div class="player-icon-item">
                         <div class="player-icon-display clickable-icon" onclick="openIconSelector(1)">
-                            <span class="team-logo">${currentPlayer1Icon}</span>
+                            <span class="team-logo">${escapeHtml(currentPlayer1Icon)}</span>
                         </div>
-                        <span class="player-label">${currentPlayer1Name}</span>
+                        <span class="player-label">${escapeHtml(currentPlayer1Name)}</span>
                     </div>
                     <div class="player-icon-item">
                         <div class="player-icon-display clickable-icon" onclick="openIconSelector(2)">
-                            <span class="team-logo">${currentPlayer2Icon}</span>
+                            <span class="team-logo">${escapeHtml(currentPlayer2Icon)}</span>
                         </div>
-                        <span class="player-label">${currentPlayer2Name}</span>
+                        <span class="player-label">${escapeHtml(currentPlayer2Name)}</span>
                     </div>
                 </div>
             </div>
@@ -643,28 +643,28 @@ function generateSidebarGameInputs() {
     container.innerHTML = `
         <div class="sidebar-game-goals">
             <div class="sidebar-player-input">
-                <label for="sidebar-player1-goals">${currentPlayer1Name} Goals:</label>
-                <input type="number" id="sidebar-player1-goals" class="sidebar-goals-input" 
+                <label for="sidebar-player1-goals">${escapeHtml(currentPlayer1Name)} Goals:</label>
+                <input type="number" id="sidebar-player1-goals" class="sidebar-goals-input"
                        min="0" max="99" placeholder="" onchange="checkSidebarForDraw()">
             </div>
             <div class="sidebar-player-input">
-                <label for="sidebar-player2-goals">${currentPlayer2Name} Goals:</label>
-                <input type="number" id="sidebar-player2-goals" class="sidebar-goals-input" 
+                <label for="sidebar-player2-goals">${escapeHtml(currentPlayer2Name)} Goals:</label>
+                <input type="number" id="sidebar-player2-goals" class="sidebar-goals-input"
                        min="0" max="99" placeholder="" onchange="checkSidebarForDraw()">
             </div>
             <div class="sidebar-penalty-section" id="sidebar-penalty-section" style="display: none;">
                 <label for="sidebar-penalty-winner">Penalty Result:</label>
                 <select id="sidebar-penalty-winner" class="sidebar-team-select">
                     <option value="">Select Result</option>
-                    <option value="1">${currentPlayer1Name} Won</option>
-                    <option value="2">${currentPlayer2Name} Won</option>
+                    <option value="1">${escapeHtml(currentPlayer1Name)} Won</option>
+                    <option value="2">${escapeHtml(currentPlayer2Name)} Won</option>
                     <option value="draw">No Winner (Draw)</option>
                 </select>
             </div>
         </div>
         <div class="sidebar-game-teams">
             <div class="sidebar-player-input">
-                <label for="sidebar-player1-team-type">${currentPlayer1Name} Team Type:</label>
+                <label for="sidebar-player1-team-type">${escapeHtml(currentPlayer1Name)} Team Type:</label>
                 <select id="sidebar-player1-team-type" class="sidebar-team-select" onchange="updateSidebarTeamOptions(1)">
                     <option value="Ultimate Team">Ultimate Team</option>
                     <option value="Premier League">Premier League</option>
@@ -688,7 +688,7 @@ function generateSidebarGameInputs() {
                 </div>
             </div>
             <div class="sidebar-player-input">
-                <label for="sidebar-player2-team-type">${currentPlayer2Name} Team Type:</label>
+                <label for="sidebar-player2-team-type">${escapeHtml(currentPlayer2Name)} Team Type:</label>
                 <select id="sidebar-player2-team-type" class="sidebar-team-select" onchange="updateSidebarTeamOptions(2)">
                     <option value="Ultimate Team">Ultimate Team</option>
                     <option value="Premier League">Premier League</option>

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1441,11 +1441,12 @@
 
     // callouts
     calloutsHost.innerHTML = '';
-    if (s.hot) calloutsHost.appendChild(callout('good', '🔥', `Hot streak: <strong>${s.streak.curMine} wins in a row</strong> against ${rival.name}.`));
-    if (s.onColdStreak) calloutsHost.appendChild(callout('bad', '❄️', `${rival.name} has won the last <strong>${s.streak.curTheirs} games</strong>. Time to bounce back.`));
+    const rivalNameSafe = escapeHtml(rival.name);
+    if (s.hot) calloutsHost.appendChild(callout('good', '🔥', `Hot streak: <strong>${s.streak.curMine} wins in a row</strong> against ${rivalNameSafe}.`));
+    if (s.onColdStreak) calloutsHost.appendChild(callout('bad', '❄️', `${rivalNameSafe} has won the last <strong>${s.streak.curTheirs} games</strong>. Time to bounce back.`));
     if (s.total >= 3) {
       const pb = s.games.find(g => getMyTotal(g) === s.bestMine);
-      if (pb) calloutsHost.appendChild(callout('good', '⭐', `Personal best <strong>${s.bestMine}</strong> set vs ${rival.name} on ${fmtDateShort(pb.date)}.`));
+      if (pb) calloutsHost.appendChild(callout('good', '⭐', `Personal best <strong>${s.bestMine}</strong> set vs ${rivalNameSafe} on ${fmtDateShort(pb.date)}.`));
     }
     // games table (most recent first), paginated
     tableBody.innerHTML = '';
@@ -1616,7 +1617,7 @@
     }
     if (s.myTotalPerfects > 0 || s.theirTotalPerfects > 0) {
       cWrap.appendChild(callout('', '💯',
-        `Perfect 100s — <strong>you ${s.myTotalPerfects}</strong>, ${s.rival.name} ${s.theirTotalPerfects}.`));
+        `Perfect 100s — <strong>you ${s.myTotalPerfects}</strong>, ${escapeHtml(s.rival.name)} ${s.theirTotalPerfects}.`));
     }
     if (s.mostVolatile && s.mostVolatile.total >= 3) {
       cWrap.appendChild(callout('', '🎲',

--- a/apps/mario-kart/js/charts.js
+++ b/apps/mario-kart/js/charts.js
@@ -203,7 +203,7 @@ function createHeatmapView(raceData = null) {
                             <tr>
                                 <th>Day</th>
                                 <th>Activity</th>
-                                ${players.map(player => `<th>${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}<span class="subtitle">Avg Pos</span></th>`).join('')}
+                                ${players.map(player => `<th>${escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player))}<span class="subtitle">Avg Pos</span></th>`).join('')}
                             </tr>
                         </thead>
                         <tbody id="weekly-breakdown-body">
@@ -495,7 +495,7 @@ function createAnalysisView(raceData = null) {
                         if (!data.date || data.averagePosition === null) {
                             return `
                                 <div class="worst-day-item">
-                                    <span>${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}</span>
+                                    <span>${escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player))}</span>
                                     <div>
                                         <div class="worst-day-score">—</div>
                                     </div>
@@ -511,7 +511,7 @@ function createAnalysisView(raceData = null) {
                         
                         return `
                             <div class="worst-day-item">
-                                <span>${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}</span>
+                                <span>${escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player))}</span>
                                 <div>
                                     <div class="worst-day-score">Avg ${formatDecimal(data.averagePosition)}</div>
                                     <small>${formattedDate} (${data.raceCount} races)</small>
@@ -532,7 +532,7 @@ function createAnalysisView(raceData = null) {
                         if (!data.date || data.averagePosition === null) {
                             return `
                                 <div class="best-day-item">
-                                    <span>${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}</span>
+                                    <span>${escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player))}</span>
                                     <div>
                                         <div class="best-day-score">—</div>
                                     </div>
@@ -548,7 +548,7 @@ function createAnalysisView(raceData = null) {
                         
                         return `
                             <div class="best-day-item">
-                                <span>${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}</span>
+                                <span>${escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player))}</span>
                                 <div>
                                     <div class="best-day-score">Avg ${formatDecimal(data.averagePosition)}</div>
                                     <small>${formattedDate} (${data.raceCount} races)</small>

--- a/apps/mario-kart/js/main.js
+++ b/apps/mario-kart/js/main.js
@@ -1025,9 +1025,10 @@ function updateHistoryTableHeaders() {
     if (!headerRow) return;
 
     // Generate dynamic headers
-    const playerHeaders = players.map(player =>
-        `<th style="cursor: pointer;" onclick="sortTable('${player}')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('${player}')" aria-label="Sort by ${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}'s position">${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)} ↕</th>`
-    ).join('');
+    const playerHeaders = players.map(player => {
+        const name = escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player));
+        return `<th style="cursor: pointer;" onclick="sortTable('${player}')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('${player}')" aria-label="Sort by ${name}'s position">${name} ↕</th>`;
+    }).join('');
 
     headerRow.innerHTML = `
         <th>Race #</th>
@@ -1143,7 +1144,7 @@ function updateMobileRaceCards(filteredRaces) {
             return position !== null
                 ? `
                     <div class="position-item">
-                        <span class="player-label">${playerName}:</span>
+                        <span class="player-label">${escapeHtml(playerName)}:</span>
                         <span class="position-cell ${getRelativePositionClass(position, positions)}">${position}</span>
                     </div>
                 `
@@ -1273,7 +1274,7 @@ function updateDisplay() {
                         const avgs = players.map(p => parseFloat(stats.averageFinish[p]) || '-');
                         return `
                             <div class="stat-item ${getStatClass(avg || '-', avgs)}">
-                                <div class="player-name">${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}</div>
+                                <div class="player-name">${escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player))}</div>
                                 <div class="player-value">${avg || '-'}</div>
                             </div>
                         `;
@@ -1296,7 +1297,7 @@ function updateDisplay() {
                         });
                         return `
                             <div class="stat-item ${getStatClass(played > 0 ? winRate : '-', allWinRates, true)}">
-                                <div class="player-name">${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}</div>
+                                <div class="player-name">${escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player))}</div>
                                 <div class="player-value">${played > 0 ? winRateDisplay + '%' : '-'}</div>
                                 ${played > 0 ? `<div class="stat-count">${wins}</div>` : ''}
                             </div>
@@ -1320,7 +1321,7 @@ function updateDisplay() {
                         });
                         return `
                             <div class="stat-item ${getStatClass(played > 0 ? podiumRate : '-', allPodiumRates, true)}">
-                                <div class="player-name">${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}</div>
+                                <div class="player-name">${escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player))}</div>
                                 <div class="player-value">${played > 0 ? podiumRateDisplay + '%' : '-'}</div>
                                 ${played > 0 ? `<div class="stat-count">${podiums}</div>` : ''}
                             </div>
@@ -1338,7 +1339,7 @@ function updateDisplay() {
                         const allStreaks = players.map(p => stats.racesPlayed[p] > 0 ? stats.bestStreak[p] : '-');
                         return `
                             <div class="stat-item ${getStatClass(played > 0 ? streak : '-', allStreaks, true)}">
-                                <div class="player-name">${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}</div>
+                                <div class="player-name">${escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player))}</div>
                                 <div class="player-value">${played > 0 ? streak : '-'}</div>
                             </div>
                         `;

--- a/apps/mario-kart/js/playerManager.js
+++ b/apps/mario-kart/js/playerManager.js
@@ -33,9 +33,12 @@ function updatePlayerLabels() {
     // Update table headers
     const headers = document.querySelectorAll('#history-table th');
     if (headers.length >= 5) {
-        headers[2].innerHTML = `<span style="cursor: pointer;" onclick="sortTable('player1')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('player1')" aria-label="Sort by ${playerNames.player1}'s position">${playerNames.player1} ↕</span>`;
-        headers[3].innerHTML = `<span style="cursor: pointer;" onclick="sortTable('player2')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('player2')" aria-label="Sort by ${playerNames.player2}'s position">${playerNames.player2} ↕</span>`;
-        headers[4].innerHTML = `<span style="cursor: pointer;" onclick="sortTable('player3')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('player3')" aria-label="Sort by ${playerNames.player3}'s position">${playerNames.player3} ↕</span>`;
+        const p1 = escapeHtml(playerNames.player1);
+        const p2 = escapeHtml(playerNames.player2);
+        const p3 = escapeHtml(playerNames.player3);
+        headers[2].innerHTML = `<span style="cursor: pointer;" onclick="sortTable('player1')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('player1')" aria-label="Sort by ${p1}'s position">${p1} ↕</span>`;
+        headers[3].innerHTML = `<span style="cursor: pointer;" onclick="sortTable('player2')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('player2')" aria-label="Sort by ${p2}'s position">${p2} ↕</span>`;
+        headers[4].innerHTML = `<span style="cursor: pointer;" onclick="sortTable('player3')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('player3')" aria-label="Sort by ${p3}'s position">${p3} ↕</span>`;
     }
 
     // Update player name inputs if they exist

--- a/apps/mario-kart/js/playersDropdown.js
+++ b/apps/mario-kart/js/playersDropdown.js
@@ -115,19 +115,21 @@
                 symbol = nameToUse.charAt(0).toUpperCase() || 'P';
             }
             
+            const safeName = escapeHtml(playerName);
+            const safeSymbol = escapeHtml(symbol);
             return `
                 <div class="player-item ${!isActive ? 'inactive' : ''}" data-player="${playerKey}">
                     <div class="player-header">
-                        <div class="player-initial ${isActive ? 'clickable' : ''}" 
+                        <div class="player-initial ${isActive ? 'clickable' : ''}"
                              onclick="${isActive ? `openIconPicker('${playerKey}', this)` : ''}"
-                             ${isActive ? `title="Click to change icon" aria-label="Change icon for ${playerName}"` : ''}>
-                            <span class="initial-letter">${symbol}</span>
+                             ${isActive ? `title="Click to change icon" aria-label="Change icon for ${safeName}"` : ''}>
+                            <span class="initial-letter">${safeSymbol}</span>
                         </div>
                         <div class="player-details">
                             <label class="player-label">Player ${playerNum}</label>
-                            <input type="text" 
-                                   class="player-name-input" 
-                                   value="${playerName}"
+                            <input type="text"
+                                   class="player-name-input"
+                                   value="${safeName}"
                                    placeholder="Enter name..."
                                    ${!isActive ? 'disabled' : ''}
                                    data-player="${playerKey}"

--- a/apps/mario-kart/js/quickRace.js
+++ b/apps/mario-kart/js/quickRace.js
@@ -77,13 +77,14 @@ function generateQuickPlayerInputs() {
         const inputDiv = document.createElement('div');
         inputDiv.className = 'quick-player-input';
         
+        const truncated = playerName.length > 8 ? playerName.substring(0, 8) + '...' : playerName;
         inputDiv.innerHTML = `
-            <label class="quick-player-label">${playerName.length > 8 ? playerName.substring(0, 8) + '...' : playerName}:</label>
-            <input type="number" 
-                   class="quick-position-input" 
-                   id="quick-player${i}" 
-                   min="${MIN_POSITIONS}" 
-                   max="${MAX_POSITIONS}" 
+            <label class="quick-player-label">${escapeHtml(truncated)}:</label>
+            <input type="number"
+                   class="quick-position-input"
+                   id="quick-player${i}"
+                   min="${MIN_POSITIONS}"
+                   max="${MAX_POSITIONS}"
                    placeholder="${MIN_POSITIONS}-${MAX_POSITIONS}"
                    onkeypress="handleQuickInputEnter(event, ${i})"
                    oninput="validateQuickInput(this)">

--- a/apps/mario-kart/js/sidebarPlayerSettings.js
+++ b/apps/mario-kart/js/sidebarPlayerSettings.js
@@ -94,19 +94,21 @@
                 symbol = nameToUse.charAt(0).toUpperCase() || 'P';
             }
             
+            const safeName = window.escapeHtml ? window.escapeHtml(playerName) : playerName;
+            const safeSymbol = window.escapeHtml ? window.escapeHtml(symbol) : symbol;
             return `
                 <div class="sidebar-player-item ${!isActive ? 'inactive' : ''}" data-player="${playerKey}">
                     <div class="sidebar-player-header">
-                        <div class="sidebar-player-initial ${isActive ? 'clickable' : ''}" 
+                        <div class="sidebar-player-initial ${isActive ? 'clickable' : ''}"
                              onclick="${isActive ? `openSidebarIconPicker('${playerKey}', this)` : ''}"
                              ${isActive ? 'title="Click to change icon"' : ''}>
-                            <span class="sidebar-initial-letter">${symbol}</span>
+                            <span class="sidebar-initial-letter">${safeSymbol}</span>
                         </div>
                         <div class="sidebar-player-details">
                             <label class="sidebar-player-label">Player ${playerNum}</label>
-                            <input type="text" 
-                                   class="sidebar-player-name-input" 
-                                   value="${playerName}"
+                            <input type="text"
+                                   class="sidebar-player-name-input"
+                                   value="${safeName}"
                                    placeholder="Enter name..."
                                    ${!isActive ? 'disabled' : ''}
                                    data-player="${playerKey}"

--- a/apps/mario-kart/tracker.html
+++ b/apps/mario-kart/tracker.html
@@ -575,6 +575,7 @@
     <div data-include="footer" class="mario-kart-footer"></div>
 
     <!-- Import all modules -->
+    <script src="../../assets/js/escape-html.js"></script>
     <script src="js/constants.js"></script>
     <script src="js/gameVersionManager.js"></script>
     <script src="js/modalUtils.js"></script>

--- a/assets/js/escape-html.js
+++ b/assets/js/escape-html.js
@@ -1,0 +1,22 @@
+// Shared HTML-escape helper. Exposed as window.escapeHtml so non-module
+// app scripts (football-h2h, mario-kart) can sanitize user-typed strings
+// (player names, team names) before interpolating into innerHTML.
+(function () {
+    'use strict';
+
+    function escapeHtml(value) {
+        if (value === null || value === undefined) return '';
+        return String(value).replace(/[&<>"']/g, function (ch) {
+            switch (ch) {
+                case '&': return '&amp;';
+                case '<': return '&lt;';
+                case '>': return '&gt;';
+                case '"': return '&quot;';
+                case "'": return '&#39;';
+                default: return ch;
+            }
+        });
+    }
+
+    window.escapeHtml = escapeHtml;
+})();


### PR DESCRIPTION
## Summary

Adds defense-in-depth HTML escaping for player names, team names, and rival names that flow into `innerHTML` across **football-h2h**, **mario-kart**, and **maptap-rivals**. Several call sites injected names into attribute contexts (`value=\"…\"`, `aria-label=\"…\"`) where breakout via a `\"` in the name was trivial; the rest were tag-context injections.

The Firebase per-UID security rules already prevent cross-user delivery, so this is **self-XSS only** — but the escaping is cheap, removes a sharp edge if a user ever imports a crafted JSON backup or pastes a hostile string into their own form, and brings the three apps in line with the pattern gym-tracker already uses.

## Changes

- **New shared helper** \`assets/js/escape-html.js\` exposing \`window.escapeHtml\`, loaded in \`apps/football-h2h/index.html\` and \`apps/mario-kart/tracker.html\`.
- Wraps the relevant interpolations with \`escapeHtml(...)\` in 8 JS files (football-h2h.js, sidebar.js, charts.js, main.js, playerManager.js, playersDropdown.js, quickRace.js, sidebarPlayerSettings.js).
- maptap-rivals already had its own \`escapeHtml\` — wires it through the four unescaped callout call sites in \`apps/maptap-rivals/js/app.js\`.

## Test plan

Headless XSS smoke tests run against all three apps with payload \`XSS<img src=x onerror=alert(1)><svg/onload=alert(2)>\"END\` injected via each app's name field / localStorage. All passed:

- [x] **football-h2h**: payload renders as literal text in player headers, stats sections, sidebar inputs. No \`<img>\`/\`<svg>\` elements created, no \`alert()\` fires.
- [x] **mario-kart**: payload renders as literal text in dynamic table headers, mobile cards, stat cards. No \`<img>\`/\`<svg>\` elements created, no \`alert()\` fires.
- [x] **maptap-rivals**: rival with malicious name renders text-only across dashboard, stat cards, chart axis labels. No \`<img>\`/\`<svg>\` elements created, no \`alert()\` fires.

### Manual test

For each app: open it → set a player/rival name to \`XSS<img src=x onerror=alert(1)>\` → save → confirm the literal text appears in headers and no alert pops. DevTools search for \`<img src=\"x\"\` should return zero matches.

## Notes

- No behavior change for normal (non-special-char) names — \`escapeHtml\` is a pure no-op on plain ASCII.
- Branch was cut from \`origin/master\` in a fresh worktree to isolate this change from other in-flight work on the same files.