### PR TITLE
firestore: migrate off deprecated persistence API, fix cross-browser sync race

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -20,7 +20,11 @@
 // adapter below provides the same surface main.js needs.
 
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
-import { getFirestore } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+import {
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager
+} from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
 import { getDatabase } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-database.js";
 import {
   getAuth,
@@ -46,7 +50,15 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
-export const db = getFirestore(app);
+// Firestore with offline persistence configured at init time (modern API).
+// Replaces the deprecated enableMultiTabIndexedDbPersistence() call that used
+// to live in sync-system/firebase-persistence.js. If IndexedDB is unavailable
+// (Safari private mode, etc.), the SDK falls back to in-memory cache itself.
+export const db = initializeFirestore(app, {
+  localCache: persistentLocalCache({
+    tabManager: persistentMultipleTabManager()
+  })
+});
 export const rtdb = getDatabase(app);
 export { app };
 

--- a/sync-system/firebase-persistence.js
+++ b/sync-system/firebase-persistence.js
@@ -1,67 +1,22 @@
 // Firebase offline persistence module
-// Enables IndexedDB caching for Firestore with graceful fallbacks
+// Persistence is now configured at Firestore init time in firebase-config.js
+// using the modern persistentLocalCache + persistentMultipleTabManager API.
+// This module's enablePersistence() is kept as a no-op so existing callers
+// (sync-system/app-sync-init.js, the per-app preload <script> tags) continue
+// to work without changes.
 
-import { 
-  enableIndexedDbPersistence,
-  enableMultiTabIndexedDbPersistence,
+import {
   disableNetwork,
   enableNetwork
 } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
 
 /**
- * Enable offline persistence for Firestore
- * @param {Firestore} db - Firestore instance
- * @param {boolean} multiTab - Enable multi-tab support (default: true)
+ * No-op shim: persistence is configured at initializeFirestore() time now.
+ * Kept for backwards compatibility with existing call sites.
  * @returns {Promise<{success: boolean, message: string}>}
  */
-export async function enablePersistence(db, multiTab = true) {
-  try {
-    // Check if persistence is already enabled
-    if (window._firestorePersistenceEnabled) {
-      return { success: true, message: 'Persistence already enabled' };
-    }
-
-    // Try multi-tab persistence first (recommended)
-    if (multiTab) {
-      try {
-        // Note: Using deprecated API temporarily - modern API caused connection issues
-        await enableMultiTabIndexedDbPersistence(db);
-        window._firestorePersistenceEnabled = true;
-        return { success: true, message: 'Multi-tab persistence enabled (deprecated API)' };
-      } catch (err) {
-        // Fall back to single-tab if multi-tab fails
-        console.warn('Multi-tab persistence failed, trying single-tab:', err.message);
-      }
-    }
-
-    // Single-tab persistence
-    await enableIndexedDbPersistence(db);
-    window._firestorePersistenceEnabled = true;
-    return { success: true, message: 'Single-tab persistence enabled (deprecated API)' };
-
-  } catch (err) {
-    // Handle common errors
-    let message = 'Persistence not available: ';
-    
-    if (err.code === 'failed-precondition') {
-      // Multiple tabs open
-      message += 'Multiple tabs open. Close other tabs and reload.';
-    } else if (err.code === 'unimplemented') {
-      // Browser doesn't support persistence
-      message += 'Browser doesn\'t support offline persistence.';
-    } else if (err.name === 'QuotaExceededError') {
-      // Storage quota exceeded
-      message += 'Storage quota exceeded. Clear browser data.';
-    } else if (window.location.protocol === 'file:') {
-      // File protocol doesn't support IndexedDB
-      message += 'File protocol detected. Use HTTP(S) server.';
-    } else {
-      message += err.message;
-    }
-
-    console.warn(message);
-    return { success: false, message };
-  }
+export async function enablePersistence() {
+  return { success: true, message: 'Persistence configured at init (modern cache API)' };
 }
 
 /**

--- a/sync-system/storage-sync-robust.js
+++ b/sync-system/storage-sync-robust.js
@@ -291,6 +291,7 @@ class StorageSyncManager {
       if (state.stopped) return;
 
       const unsubscribe = onSnapshot(docRef,
+        { includeMetadataChanges: true },
         (snapshot) => {
           if (state.stopped) return;
 
@@ -302,12 +303,17 @@ class StorageSyncManager {
             this.applyRemoteChange(key, info);
           }
 
-          // First snapshot doubles as the initial merge: any keys we
-          // have locally but Firestore doesn't are queued for upload.
-          // This replaces the old separate `getDoc` round-trip in
-          // `performInitialMerge`, which was the chief contributor to
-          // the 429s under auth-state churn.
-          if (!state.initialMergeDone) {
+          // Initial merge: queue any keys we have locally but Firestore
+          // doesn't. Gate on !fromCache because persistent IndexedDB
+          // cache means the first snapshot can come from an empty/stale
+          // local cache; uploading local-only keys against that view
+          // silently overwrites whatever a different browser already
+          // wrote to the same keys (the "sometimes data is kept,
+          // sometimes not" cross-browser bug). includeMetadataChanges
+          // guarantees we get a callback when the snapshot transitions
+          // from cached to server-confirmed even if the data is
+          // unchanged.
+          if (!state.initialMergeDone && !snapshot.metadata.fromCache) {
             state.initialMergeDone = true;
             this.uploadLocalOnlyKeys(state, remoteData);
           }


### PR DESCRIPTION
## Summary

Two related fixes for the Firestore sync layer.

1. **Migrate to the modern persistent-cache API.** Configure persistence at `initializeFirestore()` time in `firebase-config.js` using `persistentLocalCache` + `persistentMultipleTabManager`. Replaces the deprecated `enableMultiTabIndexedDbPersistence()` call in `sync-system/firebase-persistence.js`, which produced this console warning on every signed-in app page:

   > `@firebase/firestore: Firestore (10.7.1): enableMultiTabIndexedDbPersistence() will be deprecated in the future, you can use FirestoreSettings.cache instead.`

   `firebase-persistence.js`'s `enablePersistence()` export is kept as a no-op shim so existing callers (`app-sync-init.js`, per-app preload `<script>` tags) don't need touching. `toggleNetwork()` and `PERSISTENCE_CAVEATS` are preserved.

2. **Fix the "sometimes data is kept between browsers, sometimes not" bug.** With persistent cache, `onSnapshot()` may deliver a *cached* snapshot first (empty for fresh browsers, stale on re-login) and the *server* snapshot second. `storage-sync-robust.js` was treating the first snapshot as authoritative and uploading any locally-present keys that were "missing from remote." Against an empty/stale cache view, that silently overwrote whatever a different browser had written to the same keys on the server.

   Fix: pass `{ includeMetadataChanges: true }` to `onSnapshot` and gate the `uploadLocalOnlyKeys()` call on `!snapshot.metadata.fromCache`, so the initial upload only runs once we have actually seen the server's view. Remote-key application still runs on every snapshot (cached snapshots are still useful for fast local restore).

## Files changed

- `firebase-config.js` — switch from `getFirestore(app)` to `initializeFirestore(app, { localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() }) })`
- `sync-system/firebase-persistence.js` — drop deprecated `enableIndexedDbPersistence` / `enableMultiTabIndexedDbPersistence` imports; `enablePersistence()` is now a no-op shim
- `sync-system/storage-sync-robust.js` — `onSnapshot` now takes `{ includeMetadataChanges: true }` and the initial-merge upload is gated on `!snapshot.metadata.fromCache`

## Test plan

Automated (already verified locally):
- [x] All three of `initializeFirestore`, `persistentLocalCache`, `persistentMultipleTabManager` exist as exports on the Firebase 10.7.1 CDN bundle
- [x] `firebase-config.js` evaluates cleanly: `db` is a `Firestore` instance, no deprecation warnings, no thrown errors
- [x] football-h2h app page loads with no console errors after both changes
- [x] No remaining call sites for `enableMultiTabIndexedDbPersistence` / `enableIndexedDbPersistence` in the repo

Manual (needs reviewer):
- [ ] Hard-refresh any signed-in app page, open DevTools Console, filter for `deprecat` — should show zero matches
- [ ] Cross-browser sync regression test: in Browser A signed in, write data; in Browser B add **different** local data before sign-in, then sign in to the same account. Browser B should converge to Browser A's data, and Browser A should be **unchanged** when you reload it (pre-fix, Browser B's stale local data would have clobbered Browser A's data on the server)
- [ ] Bidirectional smoke test: add an entry in Browser A, reload Browser B → appears within a few seconds; reverse direction same
- [ ] Offline write test: DevTools → Network → Offline, add an entry, switch online → entry syncs to Firestore