### PR TITLE
Live remote-update sync + offline indicator for the 4 non-gym apps

### DIFF
--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -101,9 +101,12 @@
     <!-- Football H2H specific CSS -->
     <link rel="stylesheet" href="css/sidebar.css">
     <link rel="stylesheet" href="../../assets/css/pagination.css">
+    <link rel="stylesheet" href="../../assets/css/sync-status.css">
     <link rel="stylesheet" href="css/football-h2h.css">
 </head>
 <body class="mario-kart-app football-h2h-tracker">
+    <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->
+    <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>
     <div data-include="header"></div>
     
     <!-- Sidebar Toggle Button -->
@@ -226,6 +229,8 @@
                     <button class="sidebar-date-today-btn" onclick="setSidebarDateToday()">Set to Today</button>
                 </div>
             </div>
+            <!-- Sync status pill — auto-populated by assets/js/sync-status.js -->
+            <div class="sidebar-section sidebar-sync-footer" data-sync-status-slot></div>
         </div>
     </aside>
     
@@ -410,6 +415,7 @@
     
     <!-- Include Scripts -->
     <script src="../../assets/js/passive-events-fix.js"></script>
+    <script src="../../assets/js/sync-status.js"></script>
     <script src="../../assets/js/escape-html.js"></script>
     <script src="../../assets/js/jquery.min.js"></script>
     <script src="../../assets/js/global-icons.js"></script>

--- a/apps/football-h2h/js/football-h2h.js
+++ b/apps/football-h2h/js/football-h2h.js
@@ -106,7 +106,20 @@ document.addEventListener('DOMContentLoaded', function() {
             }, 1000);
         }, { once: true });
     }
-    
+
+    // Live remote-update channel: another device pushed a change.
+    // 750 ms debounce coalesces the per-key burst the storage layer
+    // emits when it flushes several keys back-to-back (e.g. just
+    // after sign-in or after a reconnect).
+    let __footballRemoteRefreshTimer = null;
+    window.addEventListener('localStorageSync', (e) => {
+        const key = e.detail?.key;
+        if (typeof key !== 'string' || !key.startsWith('footballH2H')) return;
+        if (e.detail?.source !== 'remote') return;
+        clearTimeout(__footballRemoteRefreshTimer);
+        __footballRemoteRefreshTimer = setTimeout(initializeAppData, 750);
+    });
+
     // Initialize sidebar after everything else is loaded
     setTimeout(() => {
         if (window.initializeSidebar) {

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -85,9 +85,12 @@
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="../../assets/css/main.css">
+  <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">
 </head>
 <body class="maptap-rivals-app">
+  <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->
+  <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>
   <div data-include="header"></div>
 
   <main class="page">
@@ -526,6 +529,7 @@
        breakpoints is not defined` and the auth-UI / partial-include
        wiring never runs. -->
   <script src="../../assets/js/passive-events-fix.js"></script>
+  <script src="../../assets/js/sync-status.js"></script>
   <script src="../../assets/js/jquery.min.js"></script>
   <script src="../../assets/js/browser.min.js"></script>
   <script src="../../assets/js/breakpoints.min.js"></script>

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -3582,4 +3582,16 @@
   } else {
     init();
   }
+
+  // Live remote-update channel: bridge the storage-sync layer's
+  // `localStorageSync` event into a synthetic `'storage'` event so
+  // the existing `onExternalStorage` handler (wired above for the
+  // cross-tab `'storage'` event) re-renders the active view when
+  // another device pushes a change.
+  window.addEventListener('localStorageSync', (e) => {
+    const key = e.detail?.key;
+    if (typeof key !== 'string' || !key.startsWith('maptapRivals')) return;
+    if (e.detail?.source !== 'remote') return;
+    window.dispatchEvent(new StorageEvent('storage', { key }));
+  });
 })();

--- a/apps/mario-kart/js/main.js
+++ b/apps/mario-kart/js/main.js
@@ -1624,6 +1624,11 @@ document.addEventListener('DOMContentLoaded', function() {
     // Live remote-update channel: another device pushed a change.
     // 750 ms debounce coalesces the per-key burst the storage layer
     // emits when it flushes several Mario Kart keys back-to-back.
+    // PlayerNameManager caches in memory after its initial load, so
+    // we explicitly call `initialize()` to make remote name renames
+    // visible — without it the table headers and stat cards keep
+    // showing stale names even after `loadSavedData()` refreshes
+    // `races`.
     let __mkRemoteRefreshTimer = null;
     window.addEventListener('localStorageSync', (e) => {
         const key = e.detail?.key;
@@ -1632,6 +1637,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!key.startsWith('marioKart') && key !== 'selectedGameVersion') return;
         clearTimeout(__mkRemoteRefreshTimer);
         __mkRemoteRefreshTimer = setTimeout(() => {
+            if (window.PlayerNameManager?.initialize) window.PlayerNameManager.initialize();
             if (window.loadSavedData) window.loadSavedData();
             if (typeof updateDisplay === 'function') updateDisplay();
             if (window.updateAllPlayerIcons) window.updateAllPlayerIcons();

--- a/apps/mario-kart/js/main.js
+++ b/apps/mario-kart/js/main.js
@@ -1621,6 +1621,23 @@ document.addEventListener('DOMContentLoaded', function() {
         }, { once: true });
     }
 
+    // Live remote-update channel: another device pushed a change.
+    // 750 ms debounce coalesces the per-key burst the storage layer
+    // emits when it flushes several Mario Kart keys back-to-back.
+    let __mkRemoteRefreshTimer = null;
+    window.addEventListener('localStorageSync', (e) => {
+        const key = e.detail?.key;
+        if (typeof key !== 'string') return;
+        if (e.detail?.source !== 'remote') return;
+        if (!key.startsWith('marioKart') && key !== 'selectedGameVersion') return;
+        clearTimeout(__mkRemoteRefreshTimer);
+        __mkRemoteRefreshTimer = setTimeout(() => {
+            if (window.loadSavedData) window.loadSavedData();
+            if (typeof updateDisplay === 'function') updateDisplay();
+            if (window.updateAllPlayerIcons) window.updateAllPlayerIcons();
+        }, 750);
+    });
+
     // Subscribe to player symbol changes to update H2H tables
     if (window.PlayerSymbolManager) {
         window.PlayerSymbolManager.subscribe(() => {

--- a/apps/mario-kart/tracker.html
+++ b/apps/mario-kart/tracker.html
@@ -102,6 +102,7 @@
     <link rel="stylesheet" href="css/players-dropdown-new.css">
     <link rel="stylesheet" href="css/player-icons.css">
     <link rel="stylesheet" href="../../assets/css/pagination.css">
+    <link rel="stylesheet" href="../../assets/css/sync-status.css">
     <link rel="stylesheet" href="css/sidebar.css">
     <link rel="stylesheet" href="css/tooltip.css">
     <link rel="stylesheet" href="css/help-styles.css">
@@ -114,6 +115,8 @@
     <script src="../../sync-system/sync-immediate.js"></script>
 </head>
 <body class="mario-kart-app mario-kart-tracker">
+    <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->
+    <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>
     <div data-include="header"></div>
     
     
@@ -213,6 +216,8 @@
                     <button class="sidebar-date-today-btn" onclick="setSidebarDateToday()">Set to Today</button>
                 </div>
             </div>
+            <!-- Sync status pill — auto-populated by assets/js/sync-status.js -->
+            <div class="sidebar-section sidebar-sync-footer" data-sync-status-slot></div>
         </div>
     </aside>
     
@@ -576,6 +581,7 @@
 
     <!-- Import all modules -->
     <script src="../../assets/js/escape-html.js"></script>
+    <script src="../../assets/js/sync-status.js"></script>
     <script src="js/constants.js"></script>
     <script src="js/gameVersionManager.js"></script>
     <script src="js/modalUtils.js"></script>

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -90,9 +90,12 @@
        for footer icons. App styles override what they need to. -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="../../assets/css/main.css">
+  <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">
 </head>
 <body class="rising-seasons-app">
+  <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->
+  <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>
   <div data-include="header"></div>
 
   <main class="page">
@@ -507,6 +510,7 @@
 
   <!-- Site JS preamble (required by main.js — same order all the other apps use) -->
   <script src="../../assets/js/passive-events-fix.js"></script>
+  <script src="../../assets/js/sync-status.js"></script>
   <script src="../../assets/js/jquery.min.js"></script>
   <script src="../../assets/js/browser.min.js"></script>
   <script src="../../assets/js/breakpoints.min.js"></script>

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -2835,4 +2835,19 @@ function isTypingTarget(el) {
   return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
 }
 
+// Live remote-update channel: another device toggled a watched
+// season. 750 ms debounce coalesces bursts after sign-in or
+// reconnect. Re-loads the Watched set then re-renders.
+let __rsRemoteRefreshTimer = null;
+window.addEventListener('localStorageSync', (e) => {
+  const key = e.detail?.key;
+  if (typeof key !== 'string' || !key.startsWith(`${STORAGE_NS}:`)) return;
+  if (e.detail?.source !== 'remote') return;
+  clearTimeout(__rsRemoteRefreshTimer);
+  __rsRemoteRefreshTimer = setTimeout(() => {
+    Watched.load();
+    render();
+  }, 750);
+});
+
 load();

--- a/assets/css/sync-status.css
+++ b/assets/css/sync-status.css
@@ -1,0 +1,61 @@
+/* Shared sync-status indicator
+   ----------------------------
+   Two surfaces, see assets/js/sync-status.js:
+   - `.sync-status-pill` rendered into `[data-sync-status-slot]`
+   - `.sync-banner` (id="sync-banner") shown only when offline,
+     plus a brief recovery flash on the offline -> synced transition.
+
+   Colours are inlined (not theme tokens) so the indicator looks
+   right across every app's palette without coupling to per-app
+   CSS variables. */
+
+.sync-status-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.2;
+    color: #fff;
+    user-select: none;
+    transition: background 200ms ease, color 200ms ease;
+    white-space: nowrap;
+}
+.sync-status-pill::before {
+    content: '';
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    margin-right: 6px;
+    background: currentColor;
+    flex: none;
+}
+.sync-status-pill[data-state="synced"]     { background: rgba(34, 197, 94, 0.85); }
+.sync-status-pill[data-state="syncing"]    { background: rgba(245, 158, 11, 0.85); }
+.sync-status-pill[data-state="connecting"] { background: rgba(245, 158, 11, 0.6); }
+.sync-status-pill[data-state="offline"]    { background: rgba(148, 163, 184, 0.85); }
+.sync-status-pill[data-state="idle"]       { background: rgba(100, 116, 139, 0.7); }
+
+.sync-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10100; /* above the marketing site header (z-index 10001) so the offline notice is never covered */
+    padding: 8px 14px;
+    padding-top: calc(8px + env(safe-area-inset-top, 0px));
+    text-align: center;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.2;
+    color: #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+    transition: background 200ms ease, opacity 200ms ease, transform 200ms ease;
+    transform: translateY(0);
+}
+.sync-banner[hidden] { display: none; }
+.sync-banner[data-state="offline"] { background: rgba(100, 116, 139, 0.95); }
+.sync-banner[data-state="synced"]  { background: rgba(34, 197, 94, 0.95); }
+.sync-banner[data-fading="true"]   { opacity: 0; transform: translateY(-4px); }

--- a/assets/js/sync-status.js
+++ b/assets/js/sync-status.js
@@ -1,0 +1,151 @@
+// Shared sync-status indicator
+// ----------------------------
+// Renders into two surfaces, auto-mounted on DOMContentLoaded:
+//
+//   1. `#sync-banner` — fixed top-of-viewport banner. Only visible
+//      when the user is offline (or briefly on the offline -> synced
+//      transition). Silent otherwise so it never competes with the
+//      app's own content.
+//
+//   2. Any element with `[data-sync-status-slot]` — gets an inline
+//      pill showing the full state label. Use this in a sidebar
+//      footer or header. Apps that don't want the pill just skip
+//      this attribute.
+//
+// Gym-tracker has its own ES-module version of this (with the same
+// classifier output and DOM contract) that mounts via an explicit
+// import. To avoid double-mounting, this classic-script version
+// checks `window.__syncStatusMounted` before binding.
+
+(function () {
+    'use strict';
+
+    if (window.__syncStatusMounted) return;
+
+    const POLL_MS = 2000;
+    const RECOVERY_FLASH_MS = 2000;
+
+    function classify(online, status, signedIn) {
+        if (online === false) return { state: 'offline', label: 'Offline' };
+        if (!status) return { state: 'connecting', label: 'Connecting…' };
+        if (status.totalQueueSize > 0) return { state: 'syncing', label: 'Saving…' };
+        if (status.activeNamespaces === 0) {
+            if (signedIn) return { state: 'connecting', label: 'Connecting…' };
+            return { state: 'idle', label: 'Local only' };
+        }
+        return { state: 'synced', label: 'Synced' };
+    }
+
+    function readCurrent() {
+        const online = navigator.onLine !== false;
+        const status = typeof window.gymGetGlobalSyncStatus === 'function'
+            ? window.gymGetGlobalSyncStatus()
+            : null;
+        const signedIn = !!(window.firebaseAuth && typeof window.firebaseAuth.getCurrentUser === 'function'
+            && window.firebaseAuth.getCurrentUser());
+        return classify(online, status, signedIn);
+    }
+
+    let pillEls = [];
+    let bannerEl = null;
+    let lastRender = null;
+    let recoveryTimer = null;
+    let pollTimer = null;
+
+    function applyToPill(el, next) {
+        el.dataset.state = next.state;
+        el.textContent = next.label;
+        el.setAttribute('aria-label', 'Sync status: ' + next.label);
+        el.title = next.label;
+    }
+
+    function updateBanner(prev, next) {
+        if (!bannerEl) return;
+
+        if (next.state === 'offline') {
+            clearTimeout(recoveryTimer);
+            recoveryTimer = null;
+            bannerEl.hidden = false;
+            bannerEl.dataset.state = 'offline';
+            bannerEl.dataset.fading = 'false';
+            bannerEl.textContent = 'You’re offline — changes saved on this device';
+            return;
+        }
+
+        const justRecovered = prev && prev.state === 'offline';
+        if (justRecovered) {
+            clearTimeout(recoveryTimer);
+            bannerEl.hidden = false;
+            bannerEl.dataset.state = 'synced';
+            bannerEl.dataset.fading = 'false';
+            bannerEl.textContent = 'Back online — synced';
+            recoveryTimer = setTimeout(function () {
+                if (!bannerEl) return;
+                bannerEl.dataset.fading = 'true';
+                setTimeout(function () {
+                    if (bannerEl && bannerEl.dataset.state === 'synced') {
+                        bannerEl.hidden = true;
+                        bannerEl.dataset.fading = 'false';
+                    }
+                }, 220);
+            }, RECOVERY_FLASH_MS);
+            return;
+        }
+
+        if (!recoveryTimer) {
+            bannerEl.hidden = true;
+            bannerEl.dataset.fading = 'false';
+        }
+    }
+
+    function render() {
+        const next = readCurrent();
+        const prev = lastRender;
+        if (prev && prev.state === next.state && prev.label === next.label) return;
+        lastRender = next;
+        for (let i = 0; i < pillEls.length; i++) applyToPill(pillEls[i], next);
+        updateBanner(prev, next);
+    }
+
+    function createPill() {
+        const el = document.createElement('div');
+        el.className = 'sync-status-pill';
+        el.setAttribute('role', 'status');
+        el.setAttribute('aria-live', 'polite');
+        el.dataset.state = 'connecting';
+        el.textContent = 'Connecting…';
+        el.setAttribute('aria-label', 'Sync status: Connecting…');
+        el.title = 'Connecting…';
+        return el;
+    }
+
+    function mount() {
+        if (window.__syncStatusMounted) return;
+        window.__syncStatusMounted = true;
+
+        const slots = document.querySelectorAll('[data-sync-status-slot]');
+        for (let i = 0; i < slots.length; i++) {
+            const pill = createPill();
+            slots[i].appendChild(pill);
+            pillEls.push(pill);
+        }
+
+        bannerEl = document.getElementById('sync-banner');
+
+        if (pillEls.length === 0 && !bannerEl) {
+            window.__syncStatusMounted = false;
+            return;
+        }
+
+        render();
+        pollTimer = setInterval(render, POLL_MS);
+        window.addEventListener('online', render);
+        window.addEventListener('offline', render);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', mount);
+    } else {
+        mount();
+    }
+})();


### PR DESCRIPTION
## Summary

Brings **football-h2h**, **mario-kart**, **maptap-rivals**, and **rising-seasons** in line with gym-tracker's data-sync behaviour — specifically the user-visible parts of how cross-device sync feels. Two scoped changes; everything else gym-tracker does differently (StorageService abstraction, direct Firestore access for delete-account, full ES-module architecture) is intentionally **not** ported — those are architectural preferences with no data-flow effect.

## What changed

### 1. Live remote-update reactivity

Each app now listens to the storage-sync layer's `localStorageSync` event (dispatched by `sync-system/storage-sync-robust.js` whenever a remote write lands), filters by its key prefix, debounces 750 ms (matching gym-tracker), and refreshes its in-memory state + re-renders.

| App | Refresh path |
|---|---|
| football-h2h | calls existing `initializeAppData()` |
| mario-kart | `window.loadSavedData()` + `updateDisplay()` + `updateAllPlayerIcons()` |
| maptap-rivals | dispatches synthetic `'storage'` event so the existing `onExternalStorage` handler reuses its per-key routing |
| rising-seasons | `Watched.load()` + `render()` |

Before this change these apps only listened for `syncSystemReady` (one-shot, post-sign-in) and required a manual page reload to see changes pushed from another device. Now: open the app on phone + laptop, change something on one, the other catches up within a second.

### 2. Shared offline indicator UI

New shared files extracted from gym-tracker's `js/utils/sync-status.js` pattern:

- `assets/js/sync-status.js` — classic-script IIFE that auto-mounts on `DOMContentLoaded`. Polls `window.gymGetGlobalSyncStatus()` every 2 s, plus `online`/`offline` window events. No-ops if another instance is already mounted, so gym-tracker's own ES-module version keeps working unchanged.
- `assets/css/sync-status.css` — pill + banner styles with inlined colours (not theme tokens) so the indicator looks right across every app's palette without coupling to per-app CSS variables.

Two surfaces:
- `#sync-banner` at the top of `<body>` — only visible when offline, plus a brief recovery flash on offline → synced. Silent otherwise so it never competes with app content. Banner `z-index: 10100` keeps it above the marketing site header (`z-index: 10001`) on pages that include it.
- `[data-sync-status-slot]` placeholders get an inline pill with the full state label. Added to football-h2h and mario-kart sidebars; omitted from maptap-rivals/rising-seasons (no obvious sidebar surface — the banner is enough).

## Test plan

Each app verified via headless Chrome from the worktree on a temp server:

- [x] Baselines — all 4 apps render cleanly with the new banner element + script/CSS includes; no layout regressions.
- [x] Offline state — forced `navigator.onLine = false` + `'offline'` event; banner appears at the top with "You're offline — changes saved on this device" in all 4 apps. Pill state flips to `offline` in football-h2h and mario-kart sidebars.
- [x] Mount guard — `window.__syncStatusMounted` prevents double-mount; gym-tracker's existing ES-module sync-status keeps working.

## Notes

- Branch was cut from `origin/master` in a fresh worktree at `/tmp/shevato-sync-pr` to isolate this change from other in-flight agent work.
- Live remote-update path is purely additive: nothing happens unless the sync layer fires a `localStorageSync` event with `source: 'remote'`, which only happens when the user is signed in and Firestore pushes a change. No behaviour change for offline-only / signed-out users.
- Considered porting gym-tracker's `StorageService` abstraction (funnel reads/writes through a service class) but rejected: it touches every localStorage call site in each app, large blast radius, no functional change. The sync layer is already transparent at the `localStorage.setItem` level — the abstraction is purely organisational.