### PR TITLE
sync hardening + a11y/SEO/SRI sweep

### DIFF
--- a/about.html
+++ b/about.html
@@ -31,6 +31,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://shevato.com/about.html" />
   <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta property="og:image:type" content="image/svg+xml" />
+  <meta property="og:image:alt" content="Shevato logo" />
   <meta property="og:site_name" content="Shevato" />
   <meta property="og:locale" content="en_US" />
 

--- a/apps.html
+++ b/apps.html
@@ -43,6 +43,7 @@
   <meta name="twitter:title" content="Free Apps | Games, Fitness, Sports and TV Trackers from Shevato" />
   <meta name="twitter:description" content="Free web apps for racing, gym, football, TV episode-rating analytics, and MapTap.gg head-to-head tracking." />
   <meta name="twitter:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta name="twitter:image:alt" content="Shevato apps including Mario Kart, Gym Tracker, Football H2H, Rising Seasons, MapTap Rivals" />
   <meta name="twitter:site" content="@shevato" />
   
   <!-- Breadcrumbs -->

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -282,19 +282,19 @@
             <!-- Statistics Tabs -->
             <div class="stats-tabs-section">
                 <div class="stats-tabs" role="tablist">
-                    <button class="stats-tab active" onclick="switchStatsTab('h2h')" role="tab" aria-selected="true" aria-controls="h2h-stats">
+                    <button id="tab-h2h" class="stats-tab active" onclick="switchStatsTab('h2h')" role="tab" aria-selected="true" aria-controls="h2h-stats">
                         ⚔️ H2H Stats
                     </button>
-                    <button class="stats-tab" onclick="switchStatsTab('general')" role="tab" aria-selected="false" aria-controls="general-stats">
+                    <button id="tab-general" class="stats-tab" onclick="switchStatsTab('general')" role="tab" aria-selected="false" aria-controls="general-stats">
                         📊 General Stats
                     </button>
-                    <button class="stats-tab" onclick="switchStatsTab('player')" role="tab" aria-selected="false" aria-controls="player-stats">
+                    <button id="tab-player" class="stats-tab" onclick="switchStatsTab('player')" role="tab" aria-selected="false" aria-controls="player-stats">
                         👤 Player Stats
                     </button>
                 </div>
 
                 <!-- H2H Stats Tab Content -->
-                <section class="stats-overview stats-tab-content active" id="h2h-stats" role="tabpanel">
+                <section class="stats-overview stats-tab-content active" id="h2h-stats" role="tabpanel" aria-labelledby="tab-h2h">
                     <!-- Total Wins Row -->
                     <h3 class="h2h-section-title">Total Wins</h3>
                     <div class="stats-grid h2h-row">
@@ -340,7 +340,7 @@
                 </section>
 
                 <!-- General Stats Tab Content -->
-                <section class="stats-overview stats-tab-content" id="general-stats" role="tabpanel" style="display: none;">
+                <section class="stats-overview stats-tab-content" id="general-stats" role="tabpanel" aria-labelledby="tab-general" style="display: none;">
                     <div class="stats-grid">
                         <div class="stat-card">
                             <div class="stat-label">Total Games</div>
@@ -358,7 +358,7 @@
                 </section>
 
                 <!-- Player Stats Tab Content -->
-                <section class="stats-overview stats-tab-content" id="player-stats" role="tabpanel" style="display: none;">
+                <section class="stats-overview stats-tab-content" id="player-stats" role="tabpanel" aria-labelledby="tab-player" style="display: none;">
                     <div class="player-comparison-wrap">
                         <table class="player-comparison-table">
                             <thead>

--- a/apps/football-h2h/js/modalUtils.js
+++ b/apps/football-h2h/js/modalUtils.js
@@ -32,35 +32,29 @@ function createModal({ icon, title, content, buttons = [] }) {
     modal.appendChild(dialog);
     document.body.appendChild(modal);
 
-    // Add event listeners for buttons
+    // Single teardown so every close path (button, background, Escape)
+    // removes the document-level keydown listener. The previous version
+    // only removed the listener on the Escape path, so opening +
+    // dismissing modals via background-click or any button stacked
+    // listeners that fired forever.
+    const closeModal = () => {
+        if (modal.parentNode) modal.parentNode.removeChild(modal);
+        document.removeEventListener('keydown', escapeHandler);
+    };
+    const escapeHandler = (e) => { if (e.key === 'Escape') closeModal(); };
+    document.addEventListener('keydown', escapeHandler);
+
     buttons.forEach(btn => {
         const buttonEl = document.getElementById(btn.id);
         if (buttonEl && btn.onClick) {
             buttonEl.onclick = () => {
                 const result = btn.onClick();
-                // Only close if onClick doesn't return false and closeOnClick is not false
-                if (result !== false && btn.closeOnClick !== false) {
-                    document.body.removeChild(modal);
-                }
+                if (result !== false && btn.closeOnClick !== false) closeModal();
             };
         }
     });
 
-    // Close on background click
-    modal.onclick = (e) => {
-        if (e.target === modal) {
-            document.body.removeChild(modal);
-        }
-    };
-
-    // Close on Escape key
-    const escapeHandler = (e) => {
-        if (e.key === 'Escape') {
-            document.body.removeChild(modal);
-            document.removeEventListener('keydown', escapeHandler);
-        }
-    };
-    document.addEventListener('keydown', escapeHandler);
+    modal.onclick = (e) => { if (e.target === modal) closeModal(); };
 
     return modal;
 }

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -91,7 +91,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💪</text></svg>">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous" referrerpolicy="no-referrer">
 
     <!-- Import shared CSS modules -->
     <link rel="stylesheet" href="../mario-kart/css/utilities.css">

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -83,7 +83,7 @@
 
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🗺️</text></svg>">
 
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">
@@ -552,7 +552,7 @@
   <script src="../../assets/js/main.js"></script>
 
   <!-- Charts -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
   <!-- App -->
   <script src="js/app.js" defer></script>

--- a/apps/mario-kart/js/backup.js
+++ b/apps/mario-kart/js/backup.js
@@ -79,14 +79,23 @@ function restoreFromBackup() {
         modal.appendChild(dialog);
         document.body.appendChild(modal);
 
-        // Add event listeners
-        document.getElementById('cancel-restore').onclick = () => {
-            document.body.removeChild(modal);
+        // Single teardown path so cancel/confirm/background-click/Escape
+        // all converge on the same cleanup. Older code called
+        // removeChild from each handler independently and never removed
+        // the document-level keydown listener except on the Escape path,
+        // so opening + cancelling the modal repeatedly stacked listeners.
+        const closeModal = () => {
+            if (modal.parentNode) modal.parentNode.removeChild(modal);
+            document.removeEventListener('keydown', escapeHandler);
         };
+        const escapeHandler = (e) => { if (e.key === 'Escape') closeModal(); };
+        document.addEventListener('keydown', escapeHandler);
+
+        document.getElementById('cancel-restore').onclick = closeModal;
 
         document.getElementById('confirm-restore').onclick = () => {
-            document.body.removeChild(modal);
-            
+            closeModal();
+
             // Perform the restore
             races = backupData.races || [];
             
@@ -147,20 +156,7 @@ function restoreFromBackup() {
         };
 
         // Close on background click
-        modal.onclick = (e) => {
-            if (e.target === modal) {
-                document.body.removeChild(modal);
-            }
-        };
-
-        // Close on Escape key
-        const escapeHandler = (e) => {
-            if (e.key === 'Escape') {
-                document.body.removeChild(modal);
-                document.removeEventListener('keydown', escapeHandler);
-            }
-        };
-        document.addEventListener('keydown', escapeHandler);
+        modal.onclick = (e) => { if (e.target === modal) closeModal(); };
 
     } catch (e) {
         showMessage('Failed to restore backup', true);

--- a/apps/mario-kart/js/main.js
+++ b/apps/mario-kart/js/main.js
@@ -307,7 +307,7 @@ function generateSidebarRaceInputs() {
         
         html += `
             <div class="sidebar-player-input" data-player="${player}">
-                <label for="sidebar-${player}">${playerName}</label>
+                <label for="sidebar-${player}">${window.escapeHtml ? window.escapeHtml(playerName) : playerName}</label>
                 <div class="position-input-group">
                     <input 
                         type="number" 
@@ -1063,12 +1063,21 @@ function updateRaceHistoryTable(filteredRaces) {
         ? window.GlobalPaginationManager.getPaginatedItems('mario-kart-races', reversedRaces)
         : reversedRaces;
 
+    // Pre-index both source arrays so lookups inside the row map are O(1)
+    // instead of O(n) per row. With heavy users (1k+ races) the previous
+    // indexOf-per-row pattern made the history tab visibly hitch on
+    // every render.
+    const filteredIndexMap = new Map();
+    for (let i = 0; i < filteredRaces.length; i++) filteredIndexMap.set(filteredRaces[i], i);
+    const racesIndexMap = new Map();
+    for (let i = 0; i < races.length; i++) racesIndexMap.set(races[i], i);
+
     // Update history table
     const historyHtml = racesToDisplay.map((race) => {
         const positions = players.map(player => race[player]).filter(pos => pos !== null);
-        // Calculate race number based on original position in filtered races
-        const originalIndex = filteredRaces.indexOf(race);
+        const originalIndex = filteredIndexMap.get(race) ?? -1;
         const raceNumber = originalIndex + 1;
+        const globalIndex = racesIndexMap.get(race) ?? -1;
         const playerCells = players.map(player => {
             const position = race[player];
             return position !== null
@@ -1082,8 +1091,8 @@ function updateRaceHistoryTable(filteredRaces) {
             <td>${race.date}${race.timestamp ? '<br><small>' + race.timestamp + '</small>' : ''}</td>
             ${playerCells}
             <td>
-                <button class="edit-btn" onclick="editRace(${races.indexOf(race)})" title="Edit race">✏️</button>
-                <button class="delete-btn" onclick="deleteRace(${races.indexOf(race)})" title="Delete race">🗑️</button>
+                <button class="edit-btn" onclick="editRace(${globalIndex})" title="Edit race">✏️</button>
+                <button class="delete-btn" onclick="deleteRace(${globalIndex})" title="Delete race">🗑️</button>
             </td>
         </tr>
     `;

--- a/apps/mario-kart/tests/core.test.js
+++ b/apps/mario-kart/tests/core.test.js
@@ -1,0 +1,320 @@
+'use strict';
+
+// Pin timezone so date-based filter assertions stay deterministic.
+process.env.TZ = 'UTC';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const JS_DIR = path.join(__dirname, '..', 'js');
+
+// Mario-kart's scripts use the classic globals pattern (no module.exports).
+// Each test loads the relevant file into a fresh vm context with the
+// runtime globals it expects (window, document, races, players, etc.) stubbed.
+function makeContext(extra = {}) {
+  const noopFn = () => null;
+  const sandbox = {
+    console,
+    Date,
+    Intl,
+    JSON,
+    Math,
+    Array,
+    Object,
+    Number,
+    String,
+    Boolean,
+    setTimeout, clearTimeout, setInterval, clearInterval,
+    window: {},
+    document: {
+      getElementById: noopFn,
+      querySelector: noopFn,
+      querySelectorAll: () => [],
+      createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} }, appendChild() {} }),
+      body: { appendChild() {}, removeChild() {} },
+      addEventListener() {},
+      removeEventListener() {},
+    },
+    localStorage: (() => {
+      const map = new Map();
+      return {
+        getItem: (k) => (map.has(k) ? map.get(k) : null),
+        setItem: (k, v) => map.set(k, String(v)),
+        removeItem: (k) => map.delete(k),
+        clear: () => map.clear(),
+      };
+    })(),
+    showMessage: () => {},
+    updateDisplay: () => {},
+    updateAchievements: () => {},
+    ...extra,
+  };
+  sandbox.window = sandbox.window || {};
+  sandbox.window.localStorage = sandbox.localStorage;
+  return vm.createContext(sandbox);
+}
+
+function loadInto(ctx, file) {
+  const src = fs.readFileSync(path.join(JS_DIR, file), 'utf8');
+  vm.runInContext(src, ctx, { filename: file });
+}
+
+// --- detectActivePlayersFromRaces -----------------------------------------
+
+test('detectActivePlayersFromRaces: empty/missing input defaults to 3', () => {
+  const ctx = makeContext();
+  loadInto(ctx, 'dataManager.js');
+  const fn = ctx.detectActivePlayersFromRaces;
+  assert.equal(fn([]), 3);
+  assert.equal(fn(null), 3);
+  assert.equal(fn(undefined), 3);
+});
+
+test('detectActivePlayersFromRaces: returns highest active player number', () => {
+  const ctx = makeContext();
+  loadInto(ctx, 'dataManager.js');
+  const fn = ctx.detectActivePlayersFromRaces;
+  assert.equal(fn([{ player1: 1, player2: 2, player3: null, player4: null }]), 2);
+  assert.equal(fn([{ player1: 1, player2: null, player3: 3, player4: null }]), 3);
+  assert.equal(fn([{ player1: 1, player2: 2, player3: 3, player4: 4 }]), 4);
+});
+
+test('detectActivePlayersFromRaces: clamps between 1 and 4', () => {
+  const ctx = makeContext();
+  loadInto(ctx, 'dataManager.js');
+  const fn = ctx.detectActivePlayersFromRaces;
+  assert.equal(fn([{ player1: null, player2: null, player3: null, player4: null }]), 1);
+});
+
+// --- getFilteredRaces ------------------------------------------------------
+
+test('getFilteredRaces: "all" returns every race', () => {
+  const today = new Date().toISOString().slice(0, 10);
+  const races = [
+    { date: '2020-01-01' },
+    { date: today },
+  ];
+  const ctx = makeContext({ races, currentView: 'stats' });
+  loadInto(ctx, 'dateFilter.js');
+  ctx.currentDateFilter = 'all';
+  assert.equal(ctx.getFilteredRaces().length, 2);
+});
+
+test('getFilteredRaces: "today" returns only races dated today', () => {
+  const today = new Date().toLocaleDateString('en-CA');
+  const races = [
+    { date: '2020-01-01' },
+    { date: today },
+    { date: today },
+  ];
+  const ctx = makeContext({ races, currentView: 'stats' });
+  loadInto(ctx, 'dateFilter.js');
+  // Top-level `let` bindings in dateFilter.js aren't exposed on the
+  // vm context (vm only exposes `var`/function/class), so flip the
+  // filter through the public API instead of touching ctx.* directly.
+  ctx.setDateFilter('today');
+  assert.equal(ctx.getFilteredRaces().length, 2);
+});
+
+test('getFilteredRaces: "custom" range filters inclusively', () => {
+  const races = [
+    { date: '2026-01-01' },
+    { date: '2026-02-15' },
+    { date: '2026-03-30' },
+  ];
+  // Stub the two inputs applyCustomDateFilter() reads so we can drive
+  // it through the public API rather than poking module-local `let` vars.
+  const inputs = {
+    'filter-start-date': { value: '2026-02-01' },
+    'filter-end-date': { value: '2026-03-01' },
+  };
+  const ctx = makeContext({
+    races,
+    currentView: 'stats',
+    document: {
+      getElementById: (id) => inputs[id] || null,
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      createElement: () => ({ style: {}, classList: { add() {}, remove() {} }, appendChild() {}, insertAdjacentElement() {}, remove() {} }),
+      body: { appendChild() {}, removeChild() {} },
+      addEventListener() {},
+      removeEventListener() {},
+    },
+  });
+  loadInto(ctx, 'dateFilter.js');
+  ctx.setDateFilter('custom');
+  ctx.applyCustomDateFilter();
+  const filtered = ctx.getFilteredRaces();
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0].date, '2026-02-15');
+});
+
+// --- saveAction / undoLastAction / redoLastAction -------------------------
+
+test('undoRedo: ADD_RACE then undo pops the last race', () => {
+  const ctx = makeContext({
+    races: [{ player1: 1, player2: 2, date: '2026-01-01' }],
+  });
+  loadInto(ctx, 'undoRedo.js');
+  ctx.saveAction('ADD_RACE', { race: ctx.races[0] });
+  ctx.undoLastAction();
+  assert.equal(ctx.races.length, 0);
+});
+
+test('undoRedo: DELETE_RACE then undo restores at original index', () => {
+  const original = { player1: 3, player2: 4, date: '2026-01-02' };
+  const ctx = makeContext({
+    races: [{ player1: 1, player2: 2, date: '2026-01-01' }],
+  });
+  loadInto(ctx, 'undoRedo.js');
+  ctx.saveAction('DELETE_RACE', { race: original, index: 1 });
+  ctx.undoLastAction();
+  assert.equal(ctx.races.length, 2);
+  assert.deepEqual(ctx.races[1], original);
+});
+
+test('undoRedo: history is bounded by MAX_HISTORY (oldest evicted)', () => {
+  // actionHistory and historyPosition are module-local `let` bindings, so
+  // we observe boundedness via behaviour: push 60 ADD_RACE actions, undo
+  // them all, then verify only 50 races were popped (the buffer evicted
+  // the first 10).
+  const ctx = makeContext({ races: [] });
+  loadInto(ctx, 'undoRedo.js');
+  for (let i = 0; i < 60; i++) {
+    ctx.races.push({ player1: i, date: '2026-01-01' });
+    ctx.saveAction('ADD_RACE', { race: { player1: i, date: '2026-01-01' } });
+  }
+  let undoCount = 0;
+  // Undo until no further effect; cap iterations to avoid runaway loops
+  // if MAX_HISTORY ever changes upward.
+  for (let i = 0; i < 200; i++) {
+    const before = ctx.races.length;
+    ctx.undoLastAction();
+    if (ctx.races.length === before) break;
+    undoCount++;
+  }
+  assert.equal(undoCount, 50);
+});
+
+test('undoRedo: redo after undo replays the action', () => {
+  const ctx = makeContext({
+    races: [{ player1: 1, player2: 2, date: '2026-01-01' }],
+  });
+  loadInto(ctx, 'undoRedo.js');
+  const newRace = { player1: 5, player2: 6, date: '2026-01-02' };
+  ctx.races.push(newRace);
+  ctx.saveAction('ADD_RACE', { race: newRace });
+  ctx.undoLastAction();
+  assert.equal(ctx.races.length, 1);
+  ctx.redoLastAction();
+  assert.equal(ctx.races.length, 2);
+  assert.deepEqual(ctx.races[1], newRace);
+});
+
+// --- calculateStats: H2H winner determination -----------------------------
+// Loaded against a stubbed `players` global so the dynamic loops over
+// player pairs see the fixture set instead of whatever the production
+// code would have configured at runtime.
+
+function loadStats(players, races) {
+  const ctx = makeContext({
+    players,
+    races,
+    getFilteredRaces: () => races,
+  });
+  // statistics.js calls formatDecimal from utils.js — load it first.
+  loadInto(ctx, 'utils.js');
+  loadInto(ctx, 'statistics.js');
+  return ctx;
+}
+
+test('calculateStats: empty race data returns zeroed structure', () => {
+  const ctx = loadStats(['player1', 'player2'], []);
+  const stats = ctx.calculateStats([]);
+  assert.equal(stats.totalRaces, 0);
+  assert.equal(stats.firstPlace.player1, 0);
+  assert.equal(stats.h2h.player1.player2, 0);
+});
+
+test('calculateStats: H2H increments only for the lower (better) position', () => {
+  const races = [
+    { date: '2026-01-01', player1: 1, player2: 2 },
+    { date: '2026-01-01', player1: 3, player2: 1 },
+    { date: '2026-01-01', player1: 2, player2: 4 },
+  ];
+  const ctx = loadStats(['player1', 'player2'], races);
+  const stats = ctx.calculateStats(races);
+  // player1 beat player2 on race 1 and 3 => 2; player2 beat player1 on race 2 => 1
+  assert.equal(stats.h2h.player1.player2, 2);
+  assert.equal(stats.h2h.player2.player1, 1);
+});
+
+test('calculateStats: skips races where one player did not finish', () => {
+  const races = [
+    { date: '2026-01-01', player1: 1, player2: 2 },
+    { date: '2026-01-01', player1: null, player2: 1 },
+    { date: '2026-01-01', player1: 3, player2: null },
+  ];
+  const ctx = loadStats(['player1', 'player2'], races);
+  const stats = ctx.calculateStats(races);
+  // Only race 1 contributes; player1 wins.
+  assert.equal(stats.h2h.player1.player2, 1);
+  assert.equal(stats.h2h.player2.player1, 0);
+});
+
+test('calculateStats: tracks first-place and podium finishes', () => {
+  const races = [
+    { date: '2026-01-01', player1: 1, player2: 4 },
+    { date: '2026-01-02', player1: 3, player2: 1 },
+    { date: '2026-01-03', player1: 2, player2: 5 },
+  ];
+  const ctx = loadStats(['player1', 'player2'], races);
+  const stats = ctx.calculateStats(races);
+  assert.equal(stats.firstPlace.player1, 1);
+  assert.equal(stats.firstPlace.player2, 1);
+  assert.equal(stats.podiumFinish.player1, 3); // 1, 3, 2 — all <= 3
+  assert.equal(stats.podiumFinish.player2, 1); // only the 1
+  assert.equal(stats.racesPlayed.player1, 3);
+  assert.equal(stats.racesPlayed.player2, 3);
+});
+
+test('calculateStats: equal positions count as no win for either', () => {
+  const races = [
+    { date: '2026-01-01', player1: 2, player2: 2 },
+  ];
+  const ctx = loadStats(['player1', 'player2'], races);
+  const stats = ctx.calculateStats(races);
+  assert.equal(stats.h2h.player1.player2, 0);
+  assert.equal(stats.h2h.player2.player1, 0);
+});
+
+test('calculateStats: 4-player H2H pairs are tracked independently', () => {
+  const races = [
+    { date: '2026-01-01', player1: 1, player2: 2, player3: 3, player4: 4 },
+    { date: '2026-01-01', player1: 4, player2: 3, player3: 2, player4: 1 },
+  ];
+  const ctx = loadStats(['player1', 'player2', 'player3', 'player4'], races);
+  const stats = ctx.calculateStats(races);
+  // Race 1: p1 < p2,p3,p4 ; p2 < p3,p4 ; p3 < p4
+  // Race 2: p4 < p3,p2,p1 ; p3 < p2,p1 ; p2 < p1
+  // Net: each pair wins once.
+  assert.equal(stats.h2h.player1.player2, 1);
+  assert.equal(stats.h2h.player2.player1, 1);
+  assert.equal(stats.h2h.player3.player4, 1);
+  assert.equal(stats.h2h.player4.player3, 1);
+});
+
+test('calculateStats: h2hByDay buckets by date', () => {
+  const races = [
+    { date: '2026-01-01', player1: 1, player2: 2 },
+    { date: '2026-01-01', player1: 1, player2: 2 },
+    { date: '2026-01-02', player1: 3, player2: 1 },
+  ];
+  const ctx = loadStats(['player1', 'player2'], races);
+  const stats = ctx.calculateStats(races);
+  assert.equal(stats.h2hByDay['2026-01-01'].player1.player2, 2);
+  assert.equal(stats.h2hByDay['2026-01-02'].player2.player1, 1);
+});

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -88,7 +88,7 @@
 
   <!-- Site chrome: main.css for #header / #footer / #menu styling, font-awesome
        for footer icons. App styles override what they need to. -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">

--- a/apps/rising-seasons/scripts/build-changelog.js
+++ b/apps/rising-seasons/scripts/build-changelog.js
@@ -45,9 +45,12 @@ function loadJsonFromFile(p) {
 // path doesn't exist in that ref (first-ever build, fresh checkout, etc).
 function loadJsonFromGit(ref, relPath, repoRoot) {
   try {
+    // 64 MiB is well above any plausible JSON we ship (data.json sits at
+     // ~30 MiB) and well below the previous 512 MiB cap that wasted RAM
+     // on memory-constrained CI runners.
     const buf = execFileSync('git', ['show', `${ref}:${relPath}`], {
       cwd: repoRoot,
-      maxBuffer: 512 * 1024 * 1024,
+      maxBuffer: 64 * 1024 * 1024,
     });
     return JSON.parse(buf.toString('utf8'));
   } catch {

--- a/contact.html
+++ b/contact.html
@@ -31,6 +31,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://shevato.com/contact.html" />
   <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta property="og:image:type" content="image/svg+xml" />
+  <meta property="og:image:alt" content="Shevato logo" />
   <meta property="og:site_name" content="Shevato" />
   <meta property="og:locale" content="en_US" />
 
@@ -108,7 +110,7 @@
               </a>
             </li>
             <li>
-              <a href="https://www.linkedin.com/in/nikita-soifer/" rel="noopener" aria-label="LinkedIn profile of Nikita Soifer">
+              <a href="https://www.linkedin.com/in/nikita-soifer/" rel="noopener noreferrer" aria-label="LinkedIn profile of Nikita Soifer">
                 <span class="icon fa-linkedin" aria-hidden="true"></span>
                 <span>
                   <span class="label">LinkedIn</span>
@@ -117,7 +119,7 @@
               </a>
             </li>
             <li>
-              <a href="https://github.com/nsoifer01" rel="noopener" aria-label="GitHub profile">
+              <a href="https://github.com/nsoifer01" rel="noopener noreferrer" aria-label="GitHub profile">
                 <span class="icon fa-github" aria-hidden="true"></span>
                 <span>
                   <span class="label">GitHub</span>

--- a/database.rules.json
+++ b/database.rules.json
@@ -21,7 +21,7 @@
                   ".validate": "newData.isNumber() || newData.val() === '.sv'"
                 },
                 "rev": {
-                  ".validate": "newData.isNumber() && newData.val() >= 0"
+                  ".validate": "newData.isNumber() && newData.val() > 0"
                 }
               }
             },

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,26 +1,29 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Users can only read/write their own data
+    // The user document itself (no subcollections — those are scoped
+    // explicitly below so the granular validation actually applies).
     match /users/{userId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
-      
-      // Recursive rule for all subcollections and documents
-      match /{document=**} {
-        allow read, write: if request.auth != null && request.auth.uid == userId;
-      }
     }
-    
-    // Alternative: More granular control per namespace
+
+    // Per-app sync documents written by storage-sync-robust.js. The shape
+    // check is the *only* reason the granular rule existed; the broader
+    // recursive rule that used to live above this one bypassed it
+    // entirely (Firestore unions allow rules — any matching allow grants
+    // access — so a permissive parent rule disables narrower validation
+    // on the same path).
     match /users/{userId}/apps/{namespace} {
       allow read: if request.auth != null && request.auth.uid == userId;
-      
-      allow write: if request.auth != null 
+
+      allow write: if request.auth != null
         && request.auth.uid == userId
-        && request.resource.data.keys().hasAll(['data', 'meta'])
+        && request.resource.data.keys().hasOnly(['data', 'meta'])
+        && request.resource.data.data is map
+        && request.resource.data.meta is map
         && request.resource.data.meta.keys().hasAll(['lastUpdated']);
     }
-    
+
     // Deny all other access
     match /{document=**} {
       allow read, write: if false;

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Shevato - Software Engineering Services</title>
-  <meta name="description" content="Shevato LLC - software engineering services and free web apps. Redirecting to the home page." />
+  <meta name="description" content="Shevato LLC delivers Spring Boot microservices, REST APIs, and full stack web applications for client teams, plus a handful of free web apps." />
   <meta name="robots" content="noindex, follow" />
   <meta name="google-site-verification" content="IbbJIj83Wn2D-MXH6-ZVYbknM_R1Nst4Z1IAqdEJH_o" />
   <link rel="canonical" href="https://shevato.com/home.html" />

--- a/netlify.toml
+++ b/netlify.toml
@@ -34,7 +34,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "geolocation=(), microphone=(), camera=(), interest-cohort=()"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://cdnjs.cloudflare.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.firebasedatabase.app https://*.firebaseapp.com https://www.google-analytics.com https://*.analytics.google.com wss://*.firebaseio.com; frame-src 'self' https://*.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'"
+    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://cdnjs.cloudflare.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; font-src 'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.firebasedatabase.app https://*.firebaseapp.com https://www.google-analytics.com https://*.analytics.google.com wss://*.firebaseio.com; frame-src 'self' https://shevato-site.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'"
 
 # Long-cache static asset families. The exercise DB is content-addressed
 # only by name today; if we add hashed bundles later, bump these and

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "test": "node --test apps/gym-tracker/tests/ apps/football-h2h/tests/ apps/rising-seasons/tests/",
+    "test": "node --test apps/gym-tracker/tests/ apps/football-h2h/tests/ apps/rising-seasons/tests/ apps/mario-kart/tests/",
     "test:gym": "node --test apps/gym-tracker/tests/",
     "test:football": "node --test apps/football-h2h/tests/",
     "test:rising-seasons": "node --test apps/rising-seasons/tests/",
+    "test:mario-kart": "node --test apps/mario-kart/tests/",
     "build:rising-seasons": "node apps/rising-seasons/scripts/build-data.js",
     "enrich:rising-seasons": "node apps/rising-seasons/scripts/enrich-tmdb.js",
     "enrich:rising-seasons:providers": "node apps/rising-seasons/scripts/enrich-providers.js"

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -6,7 +6,7 @@
         <ul class="plain">
           <li><a href="mailto:nikita@shevato.com"><i class="icon fa-envelope" aria-hidden="true">&nbsp;</i>nikita@shevato.com</a></li>
           <li><a href="tel:+1504-638-3370"><i class="icon fa-phone" aria-hidden="true">&nbsp;</i>+1 (504) 638-3370</a></li>
-          <li><a href="https://www.linkedin.com/in/nikita-soifer/" rel="noopener" aria-label="Shevato on LinkedIn"><i class="icon fa-linkedin" aria-hidden="true">&nbsp;</i>LinkedIn</a></li>
+          <li><a href="https://www.linkedin.com/in/nikita-soifer/" rel="noopener noreferrer" aria-label="Shevato on LinkedIn"><i class="icon fa-linkedin" aria-hidden="true">&nbsp;</i>LinkedIn</a></li>
         </ul>
       </section>
     </div>

--- a/sync-system/app-sync-init.js
+++ b/sync-system/app-sync-init.js
@@ -185,6 +185,12 @@ export function setupAppSyncIntegration() {
         if (user) {
           initAppSync().catch(error => {
             console.error('❌ App sync initialization failed:', error);
+            // Broadcast so per-app UI (sync-status pill, banner) can show
+            // "sync offline" instead of silently letting writes accumulate
+            // in localStorage with no path to Firestore.
+            window.dispatchEvent(new CustomEvent('appSyncFailed', {
+              detail: { message: error?.message || String(error) }
+            }));
           });
         } else {
           stopAppSync();

--- a/sync-system/storage-sync-robust.js
+++ b/sync-system/storage-sync-robust.js
@@ -20,10 +20,13 @@ import {
 import { db, rtdb, auth } from '../firebase-config.js';
 
 // Configuration
-const DEBOUNCE_MS = 300; // Reduced for faster sync
+const DEBOUNCE_MS = 500; // Balanced: catches keystroke bursts without thrashing Firestore quota
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 1000;
 const USE_FIRESTORE = true;
+// Firestore rejects documents > 1 MiB. We refuse to flush above 700 KB so a
+// single namespace can't silently lose writes once payloads grow.
+const MAX_FLUSH_BYTES = 700 * 1024;
 
 // Global state management (singleton pattern)
 class StorageSyncManager {
@@ -423,39 +426,42 @@ class StorageSyncManager {
     }
     
     if (shouldApply) {
-      // Set sync lock to prevent echo
+      // Echo-prevention lock. Held only across the synchronous body below
+      // so that any forward through the immediate-sync override (which
+      // runs synchronously inside setItem) sees the lock and skips. Older
+      // versions cleared this via setTimeout(..., 100) which silently
+      // dropped any local user write that happened during that window.
       this.syncLocks.set(key, true);
-      
+
       try {
         // Use original methods if available, otherwise fall back to localStorage directly
         const setItem = this.originalMethods?.setItem || localStorage.setItem.bind(localStorage);
         const removeItem = this.originalMethods?.removeItem || localStorage.removeItem.bind(localStorage);
-        
+
         if (remoteInfo.deleted || remoteInfo.value === undefined || remoteInfo.value === null) {
           removeItem(key);
         } else {
-          const value = typeof remoteInfo.value === 'object' ? 
+          const value = typeof remoteInfo.value === 'object' ?
             JSON.stringify(remoteInfo.value) : String(remoteInfo.value);
           setItem(key, value);
         }
-        
+
         // Update local tracking
         this.localRevisions.set(key, {
           rev: remoteInfo.rev || 0,
           updatedAt: remoteTimestamp,
           hash: this.hashValue(remoteInfo.value)
         });
-        
+
         this.lastRemoteUpdates.set(key, remoteTimestamp);
-        
+
         // Dispatch custom event for apps that want to listen
         window.dispatchEvent(new CustomEvent('localStorageSync', {
           detail: { key, value: remoteInfo.value, source: 'remote' }
         }));
-        
+
       } finally {
-        // Clear sync lock after a brief delay
-        setTimeout(() => this.syncLocks.delete(key), 100);
+        this.syncLocks.delete(key);
       }
     }
   }
@@ -594,10 +600,40 @@ class StorageSyncManager {
       }
     }
 
+    // Refuse to ship a payload that would breach Firestore's 1 MiB doc
+    // ceiling. Surface as a real error so the retry path requeues and the
+    // user sees something instead of a silent drop.
+    const approxBytes = this.estimatePayloadBytes(dataPayload);
+    if (approxBytes > MAX_FLUSH_BYTES) {
+      throw new Error(
+        `Refusing to flush ${state.namespace}: payload ~${approxBytes}B exceeds ${MAX_FLUSH_BYTES}B`
+      );
+    }
+
     await setDoc(docRef, {
       data: dataPayload,
       meta: { lastUpdated: serverTimestamp() }
     }, { merge: true });
+  }
+
+  /**
+   * Cheap upper-bound estimate of a payload's serialised size. Sentinels
+   * like serverTimestamp() are not JSON-serialisable, so we substitute a
+   * stand-in before measuring. Order-of-magnitude accurate, which is all
+   * the size guard needs.
+   */
+  estimatePayloadBytes(payload) {
+    try {
+      const probe = JSON.stringify(payload, (_, v) => {
+        if (v && typeof v === 'object' && typeof v.toJSON !== 'function' && v.constructor && v.constructor.name && v.constructor.name.includes('FieldValue')) {
+          return '__SENTINEL__';
+        }
+        return v;
+      });
+      return probe ? probe.length : 0;
+    } catch {
+      return 0;
+    }
   }
 
   /**
@@ -835,15 +871,19 @@ window._debugSync = {
   locks: () => Array.from(syncManager.syncLocks.keys()),
   revisions: () => Object.fromEntries(syncManager.localRevisions),
   
-  // Manual initial merge trigger
+  // Manual re-upload of any keys present locally but missing remotely.
+  // The initial merge no longer has a dedicated method (the snapshot
+  // listener covers it on attach); this debug entry just re-runs the
+  // local-only-keys upload against an empty remote snapshot.
   async triggerInitialMerge(namespace) {
     const state = syncManager.syncStates.get(namespace);
     if (!state) {
       console.error(`❌ Namespace "${namespace}" not found`);
       return;
     }
-
-    await syncManager.performInitialMerge(state);
+    state.initialMergeDone = false;
+    syncManager.uploadLocalOnlyKeys(state, {});
+    state.initialMergeDone = true;
   },
   
   // Get all available namespaces

--- a/sync-system/sync-modal-integration.js
+++ b/sync-system/sync-modal-integration.js
@@ -88,6 +88,7 @@
         userJustSignedIn = false;
         awaitingInitialSync = false;
         lastKnownUserId = null;
+        tearDownSyncWatch();
         hideSyncModal();
       }
 
@@ -97,68 +98,82 @@
     });
   }
   
+  // Single owner of the in-flight sync watch. Holding it on the IIFE
+  // scope (not inside checkForSyncCompletion) lets every exit path —
+  // first-change, timeout, sign-out, manual mark-complete — share one
+  // teardown so we never leak the setItem override or the
+  // localStorageSync listener across sign-in cycles.
+  let activeSyncWatch = null;
+
+  function tearDownSyncWatch() {
+    const watch = activeSyncWatch;
+    if (!watch) return;
+    activeSyncWatch = null;
+
+    // Restore setItem only if no other code has wrapped it in the
+    // meantime; otherwise leave the chain intact so we don't clobber a
+    // newer override.
+    if (watch.installedSetItem && localStorage.setItem === watch.installedSetItem) {
+      localStorage.setItem = watch.originalSetItem;
+    }
+    window.removeEventListener('localStorageSync', watch.eventListener);
+    if (watch.timeoutId) clearTimeout(watch.timeoutId);
+  }
+
   // Check if sync has completed by monitoring localStorage changes
   function checkForSyncCompletion() {
     if (!awaitingInitialSync) return;
-    
-    let changeCount = 0;
+    if (activeSyncWatch) tearDownSyncWatch();
+
     const maxWaitTime = 8000; // 8 seconds max wait
-    const startTime = Date.now();
-    
-    // Monitor localStorage for sync-related changes
-    const originalSetItem = localStorage.setItem;
-    
-    function monitorChanges(key, value) {
-      // Count meaningful changes (not just auth tokens or UI state)
+    let changeCount = 0;
+
+    const watch = {
+      originalSetItem: localStorage.setItem,
+      installedSetItem: null,
+      eventListener: null,
+      timeoutId: null
+    };
+
+    function monitorChanges(key) {
+      if (!awaitingInitialSync) return;
       if (key && !key.includes('firebase:') && !key.includes('Auth') &&
           !key.includes('Welcome') && !key.includes('theme')) {
         changeCount++;
-
-        // If we've seen some changes, consider sync complete
-        if (changeCount >= 1) {
-          completeSyncProcess();
-        }
+        if (changeCount >= 1) completeSyncProcess();
       }
     }
-    
-    // Override setItem temporarily
-    localStorage.setItem = function(key, value) {
-      originalSetItem.call(this, key, value);
-      monitorChanges(key, value);
+
+    watch.installedSetItem = function(key, value) {
+      watch.originalSetItem.call(this, key, value);
+      try { monitorChanges(key); } catch (_) { /* never break the write */ }
     };
-    
-    // Also listen for custom sync events if available
-    window.addEventListener('localStorageSync', (event) => {
-      if (event.detail && event.detail.key) {
-        monitorChanges(event.detail.key, event.detail.value);
-      }
-    });
-    
-    // Timeout fallback
-    setTimeout(() => {
-      if (awaitingInitialSync) {
-        completeSyncProcess();
-      }
+    localStorage.setItem = watch.installedSetItem;
+
+    watch.eventListener = (event) => {
+      if (event.detail && event.detail.key) monitorChanges(event.detail.key);
+    };
+    window.addEventListener('localStorageSync', watch.eventListener);
+
+    watch.timeoutId = setTimeout(() => {
+      if (awaitingInitialSync) completeSyncProcess();
     }, maxWaitTime);
+
+    activeSyncWatch = watch;
 
     function completeSyncProcess() {
       if (!awaitingInitialSync) return;
 
       awaitingInitialSync = false;
       syncCompleted = true;
+      tearDownSyncWatch();
 
-      // Restore original setItem
-      localStorage.setItem = originalSetItem;
-      
-      // Show completion message briefly, then refresh
       if (window.SyncLoadingModal) {
         window.SyncLoadingModal.updateMessage('Sync Complete!', 'Refreshing page...');
-        
+
         setTimeout(() => {
           hideSyncModal();
-          // Mark that we're about to refresh due to sync completion
           sessionStorage.setItem(SYNC_REFRESH_KEY, 'true');
-          // Refresh the page to show synced data
           window.location.reload();
         }, 1000);
       }
@@ -187,6 +202,7 @@
     markSyncComplete: () => {
       if (awaitingInitialSync) {
         awaitingInitialSync = false;
+        tearDownSyncWatch();
         hideSyncModal();
         setTimeout(() => window.location.reload(), 500);
       }

--- a/work.html
+++ b/work.html
@@ -31,6 +31,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://shevato.com/work.html" />
   <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
+  <meta property="og:image:type" content="image/svg+xml" />
+  <meta property="og:image:alt" content="Shevato logo" />
   <meta property="og:site_name" content="Shevato" />
   <meta property="og:locale" content="en_US" />
 


### PR DESCRIPTION
## Summary

Round of fixes following a multi-agent code review of the entire site. Scope: real bugs and concrete a11y/SEO/security gaps. No code-splitting, no git-history rewrite.

### Sync system (highest blast radius)
- **`storage-sync-robust.js`**: drop the 100 ms async hole in the echo-lock that silently dropped local writes landing in the post-apply window; clear synchronously in `finally`. Add `MAX_FLUSH_BYTES=700 KB` guard so a namespace can't quietly breach Firestore's 1 MiB doc limit. Bump `DEBOUNCE_MS` 300 → 500. Fix dead `_debugSync.triggerInitialMerge` (the `performInitialMerge` it called never existed).
- **`sync-modal-integration.js`**: single shared teardown for `setItem` restore + `localStorageSync` listener removal across every close path (timeout, sign-out, manual mark-complete). Was leaking on every sign-in cycle that didn't end normally.
- **`app-sync-init.js`**: surface `initAppSync` failures via `appSyncFailed` CustomEvent so per-app UI can show "sync offline" instead of accumulating writes that never reach Firestore.
- **`firestore.rules`**: drop the broad recursive rule that bypassed the granular shape validation. Per-app docs now must match `data:map + meta.lastUpdated` shape on write.
- **`database.rules.json`**: `rev` validation tightened from `>= 0` to `> 0` to match the increment-from-1 contract.

### Apps
- **mario-kart `main.js`**: escape player-name interpolation in the sidebar input label (the only remaining unescaped site after #73). Race-history render now uses pre-built O(1) index `Map`s instead of `indexOf` per row.
- **mario-kart `backup.js`** + **football-h2h `modalUtils.js`**: single `closeModal()` teardown so background-click and button paths also remove the document-level keydown listener (was only removed on Escape).
- **football-h2h `index.html`**: tabs given IDs, panels given matching `aria-labelledby` for bidirectional ARIA wiring.
- **rising-seasons / maptap-rivals / gym-tracker `index.html`**: SRI `integrity` + `crossorigin` + `referrerpolicy` on Font-Awesome 6.4.0 from cdnjs; same for Chart.js 4.4.1 from jsDelivr in maptap-rivals.
- **rising-seasons `build-changelog.js`**: `maxBuffer` 512 MiB → 64 MiB.

### Root site
- **`index.html`**: real meta description (was "Redirecting to the home page").
- **`{about,work,contact,apps}.html`**: `og:image:alt`, `og:image:type`, `twitter:image:alt` for parity with `home.html`.
- **`contact.html`** + **`partials/footer.html`**: `rel="noopener noreferrer"` on every external `https://` link.
- **`netlify.toml`**: `frame-src` narrowed from `*.firebaseapp.com` to `shevato-site.firebaseapp.com`.

### Tests
- **`apps/mario-kart/tests/core.test.js`** — 17 new tests covering `detectActivePlayersFromRaces`, `getFilteredRaces`, undo/redo with `MAX_HISTORY` boundedness, and `calculateStats` H2H winner determination across 2- and 4-player fixtures. Loads classic-script files into stubbed `node:vm` contexts because the sources have no `module.exports`.
- `package.json`: `npm test` picks up the new suite; new `test:mario-kart` script.
- **304 tests total, all passing.**

### Explicitly skipped
- main.css `@import` → `<link>` conversion (12 HTML files, fragile cascade order, ~15 ms gain)
- Lazy-load `firebase-auth.css` (44 KB, marginal)
- 29 MB `data.json` lazy-load (would require code-splitting)
- mario-kart shape-selector ARIA `role="radio"` refactor (LOW finding, would touch JS too)
- Several agent findings turned out to be false positives — Chart.js fallback was already implemented, gym-tracker SW behaviour was correct stale-while-revalidate, etc.

## Test plan

### Automated
- [x] `npm test` — 304 tests pass

### Headless verification (already run)
- [x] Mario-kart player-name XSS escape: payload renders as literal text
- [x] Football-h2h tab/panel `aria-labelledby` wired bidirectionally
- [x] Football-h2h modal listener cleanup: 5 opens / 5 removes / 0 leaked
- [x] SRI on Font-Awesome accepted by browser on rising-seasons / maptap-rivals / gym-tracker

### Manual (requires real browser + Firebase auth)
- [ ] **Echo-lock race**: open mario-kart in two tabs (same user), add a race in tab 2, watch tab 1's `marioKartRaces` update without console errors
- [ ] **Sync-modal listener leak**: sign-in/sign-out/sign-in/sign-out 3 cycles; no JS errors, sync resumes each time
- [ ] **Backup modal escape leak**: open mario-kart "Restore from Backup" 5×, mix Escape/Cancel/background-click closes; `getEventListeners(document).keydown.length` returns `0` after each close
- [ ] **Firestore size guard**: `localStorage.setItem('marioKartRaces', JSON.stringify([{date:'2026-05-15', player1:1, player2:2, blob:'x'.repeat(800*1024)}]))` produces a `Refusing to flush ... exceeds 716800B` console error within ~500 ms
- [ ] **Race-history perf**: seed 500 races via console; pagination feels instant; Edit/Delete buttons reference correct race
- [ ] **Football-h2h background-click cleanup**: open Add Game modal 5×, dismiss via background each time, then press Escape — no-op
- [ ] **CSP** (after deploy): no new violations except known jQuery `unsafe-inline` ones; Sign In modal still works