### PR TITLE
maptap-rivals: link history dates + rival/dashboard visual fixes

### DIFF
--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -1447,6 +1447,18 @@ body.maptap-rivals-app button {
   font-variant-numeric: tabular-nums;
   font-size: 0.825rem;
 }
+.games-table tbody td:first-child .maptap-day-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted currentColor;
+  padding-bottom: 1px;
+}
+.games-table tbody td:first-child .maptap-day-link:hover,
+.games-table tbody td:first-child .maptap-day-link:focus-visible {
+  color: var(--accent-2);
+  border-bottom-style: solid;
+  outline: none;
+}
 
 .rounds-cell { width: 0; }
 .rounds-cell .round-dots { display: inline-flex; }

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -415,6 +415,45 @@ body.maptap-rivals-app button {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
 }
 
+.paste-collapse > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.15rem 0;
+}
+.paste-collapse > summary::-webkit-details-marker { display: none; }
+.paste-collapse > summary::after {
+  content: '';
+  margin-left: auto;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: rotate(45deg);
+  transition: transform 0.18s ease, border-color 0.18s ease;
+}
+.paste-collapse > summary:hover::after { border-color: var(--text); }
+.paste-collapse[open] > summary::after { transform: rotate(-135deg); }
+.paste-collapse > summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  border-radius: var(--radius-sm);
+}
+.paste-collapse-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+.paste-collapse-hint {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+.paste-collapse-body { margin-top: 0.9rem; }
+
 .paste-head {
   display: flex;
   align-items: center;
@@ -1802,6 +1841,15 @@ tr:focus-within .icon-btn {
   background: var(--surface-2);
   color: var(--text);
   font-size: 0.9rem;
+}
+
+/* Native <select> dropdown panels render with the OS theme. Color-scheme
+   plus an explicit option background keeps the open dropdown dark in
+   Chromium and Firefox instead of flashing a white list. */
+body.maptap-rivals-app select { color-scheme: dark; }
+body.maptap-rivals-app select option {
+  background-color: var(--surface-2);
+  color: var(--text);
 }
 
 /* ---------- Settings strip ----------

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -135,40 +135,48 @@
         <div class="profile-card-body" id="profile-card-body"></div>
       </section>
 
-      <!-- Paste-mode entry: paste your daily MapTap share, then paste each
-           rival's share. No rival picker — every rival shows up below as
-           its own row, with a live W/L/T preview against your score. -->
+      <!-- Paste-mode entry, collapsed by default — the MapTap profile
+           card above is the recommended path. Opens to reveal the
+           paste rows: every rival shows up as its own row with a live
+           W/L/T preview against your score. -->
       <section class="paste-section">
-        <div class="paste-head">
-          <h2 class="section-title">Paste daily scores</h2>
-          <label class="paste-date-field">
-            <span>Date</span>
-            <input type="date" id="paste-date">
-          </label>
-        </div>
+        <details class="paste-collapse">
+          <summary class="paste-collapse-summary">
+            <span class="paste-collapse-title">Paste daily scores</span>
+            <span class="paste-collapse-hint">Optional · link your MapTap profile above to auto-sync</span>
+          </summary>
+          <div class="paste-collapse-body">
+            <div class="paste-head">
+              <label class="paste-date-field">
+                <span>Date</span>
+                <input type="date" id="paste-date">
+              </label>
+            </div>
 
-        <div class="paste-mine">
-          <div class="paste-mine-head">
-            <span class="paste-mine-label" id="paste-mine-label">Your score</span>
-            <span class="paste-status" id="paste-mine-status">Paste your MapTap result anywhere on the page</span>
+            <div class="paste-mine">
+              <div class="paste-mine-head">
+                <span class="paste-mine-label" id="paste-mine-label">Your score</span>
+                <span class="paste-status" id="paste-mine-status">Paste your MapTap result anywhere on the page</span>
+              </div>
+              <textarea id="paste-mine-input" rows="3" spellcheck="false" autocomplete="off"
+                placeholder="May 10&#10;95🏅 89✨ 91🎉 9🤢 64🙃&#10;Final score: 585"></textarea>
+              <div class="paste-mine-rounds" id="paste-mine-rounds" hidden></div>
+            </div>
+
+            <div class="paste-rivals" id="paste-rivals"></div>
+
+            <p class="paste-empty" id="paste-empty" hidden>
+              Add at least one rival to use paste mode.
+            </p>
+
+            <div class="paste-actions" id="paste-actions" hidden>
+              <span class="paste-summary" id="paste-summary">Paste your score and at least one rival's to save.</span>
+              <button type="button" class="btn btn-primary paste-save-all" id="paste-save-all" disabled>
+                Save day's games
+              </button>
+            </div>
           </div>
-          <textarea id="paste-mine-input" rows="3" spellcheck="false" autocomplete="off"
-            placeholder="May 10&#10;95🏅 89✨ 91🎉 9🤢 64🙃&#10;Final score: 585"></textarea>
-          <div class="paste-mine-rounds" id="paste-mine-rounds" hidden></div>
-        </div>
-
-        <div class="paste-rivals" id="paste-rivals"></div>
-
-        <p class="paste-empty" id="paste-empty" hidden>
-          Add at least one rival to use paste mode.
-        </p>
-
-        <div class="paste-actions" id="paste-actions" hidden>
-          <span class="paste-summary" id="paste-summary">Paste your score and at least one rival's to save.</span>
-          <button type="button" class="btn btn-primary paste-save-all" id="paste-save-all" disabled>
-            Save day's games
-          </button>
-        </div>
+        </details>
       </section>
 
       <div class="dash-summary" id="dash-summary"></div>

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -283,6 +283,17 @@
     const d = new Date(iso + 'T00:00:00');
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   }
+  // MapTap deep-link for a given ISO date: full English month name + day,
+  // no zero pad, no year, no separator. Hardcoded month names because the
+  // URL is owned by maptap.gg and must not vary with the user's locale.
+  function mapTapHistoryUrl(iso) {
+    if (!iso) return null;
+    const d = new Date(iso + 'T00:00:00');
+    if (Number.isNaN(d.getTime())) return null;
+    const MONTHS = ['January','February','March','April','May','June',
+                    'July','August','September','October','November','December'];
+    return `https://maptap.gg/history/${MONTHS[d.getMonth()]}${d.getDate()}`;
+  }
   function fmtDateLong(iso) {
     if (!iso) return '—';
     const d = new Date(iso + 'T00:00:00');
@@ -2364,8 +2375,18 @@
       const myT = getMyTotal(g);
       const theirT = getTheirTotal(g);
       const diff = myT - theirT;
+      const dayUrl = mapTapHistoryUrl(g.date);
+      const dateCell = dayUrl
+        ? el('td', {}, [el('a', {
+            href: dayUrl,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            class: 'maptap-day-link',
+            title: 'Open this day on maptap.gg',
+          }, fmtDateShort(g.date))])
+        : el('td', {}, fmtDateShort(g.date));
       tbody.appendChild(el('tr', {}, [
-        el('td', {}, fmtDateShort(g.date)),
+        dateCell,
         el('td', {}, rival ? `${rival.icon} ${rival.name}` : '—'),
         el('td', { style: 'font-weight:600', title: hasLocs(g) ? `Rounds: ${g.myScores.join(' / ')}` : '' }, String(myT)),
         el('td', { style: 'font-weight:600', title: hasLocs(g) ? `Rounds: ${g.theirScores.join(' / ')}` : '' }, String(theirT)),

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -475,6 +475,8 @@
     let myCum = 0, theirCum = 0;
     let bestMine = -Infinity, worstMine = Infinity;
     let bestTheirs = -Infinity, worstTheirs = Infinity;
+    let bestMineGame = null, worstMineGame = null;
+    let bestTheirsGame = null, worstTheirsGame = null;
     let biggestWinMargin = 0, biggestLossMargin = 0;
     let biggestWinGame = null, biggestLossGame = null;
 
@@ -487,10 +489,10 @@
       else ties++;
       myCum += myT;
       theirCum += theirT;
-      if (myT > bestMine) bestMine = myT;
-      if (myT < worstMine) worstMine = myT;
-      if (theirT > bestTheirs) bestTheirs = theirT;
-      if (theirT < worstTheirs) worstTheirs = theirT;
+      if (myT > bestMine)   { bestMine   = myT;   bestMineGame   = g; }
+      if (myT < worstMine)  { worstMine  = myT;   worstMineGame  = g; }
+      if (theirT > bestTheirs)  { bestTheirs  = theirT; bestTheirsGame  = g; }
+      if (theirT < worstTheirs) { worstTheirs = theirT; worstTheirsGame = g; }
       const diff = myT - theirT;
       if (diff > biggestWinMargin) { biggestWinMargin = diff; biggestWinGame = g; }
       if (diff < biggestLossMargin) { biggestLossMargin = diff; biggestLossGame = g; }
@@ -544,6 +546,10 @@
       worstMine: total ? worstMine : 0,
       bestTheirs: total ? bestTheirs : 0,
       worstTheirs: total ? worstTheirs : 0,
+      bestMineGame: total ? bestMineGame : null,
+      worstMineGame: total ? worstMineGame : null,
+      bestTheirsGame: total ? bestTheirsGame : null,
+      worstTheirsGame: total ? worstTheirsGame : null,
       biggestWinMargin,
       biggestLossMargin: Math.abs(biggestLossMargin),
       biggestWinGame,
@@ -1437,8 +1443,19 @@
       s.streak.curMine > 0 ? `${s.streak.curMine} W` : s.streak.curTheirs > 0 ? `${s.streak.curTheirs} L` : '—',
       `Longest: ${s.streak.longestMine} W / ${s.streak.longestTheirs} L`,
       s.streak.curMine > 0 ? 'is-good' : s.streak.curTheirs > 0 ? 'is-bad' : ''));
-    cardsHost.appendChild(makeStatCard('Best score (you)', s.bestMine, `Worst: ${s.worstMine}`, 'is-accent'));
-    cardsHost.appendChild(makeStatCard(`Best score (${rival.name})`, s.bestTheirs, `Worst: ${s.worstTheirs}`));
+    const bestMineDate  = s.bestMineGame  ? fmtDateShort(s.bestMineGame.date)  : null;
+    const worstMineDate = s.worstMineGame ? fmtDateShort(s.worstMineGame.date) : null;
+    const bestTheirsDate  = s.bestTheirsGame  ? fmtDateShort(s.bestTheirsGame.date)  : null;
+    const worstTheirsDate = s.worstTheirsGame ? fmtDateShort(s.worstTheirsGame.date) : null;
+    cardsHost.appendChild(makeStatCard('Best score (you)', s.bestMine,
+      bestMineDate
+        ? `${bestMineDate} · Worst ${s.worstMine}${worstMineDate ? ` (${worstMineDate})` : ''}`
+        : `Worst: ${s.worstMine}`,
+      'is-accent'));
+    cardsHost.appendChild(makeStatCard(`Best score (${rival.name})`, s.bestTheirs,
+      bestTheirsDate
+        ? `${bestTheirsDate} · Worst ${s.worstTheirs}${worstTheirsDate ? ` (${worstTheirsDate})` : ''}`
+        : `Worst: ${s.worstTheirs}`));
     cardsHost.appendChild(makeStatCard('Consistency (you)', s.consistencyMine.toFixed(1), 'σ — lower = steadier'));
     cardsHost.appendChild(makeStatCard('Biggest win', s.biggestWinGame ? `+${s.biggestWinMargin}` : '—',
       s.biggestWinGame ? `${s.biggestWinGame.myScore}–${s.biggestWinGame.theirScore} on ${fmtDateShort(s.biggestWinGame.date)}` : '—',
@@ -1765,14 +1782,17 @@
             pointBackgroundColor: '#4ade80',
             pointRadius: 3,
           },
-          {
-            label: s.rival.name,
-            data: s.locStats.map(l => l.theirAvg),
-            borderColor: s.rival.color,
-            backgroundColor: hexToRgba(s.rival.color, 0.18),
-            pointBackgroundColor: s.rival.color,
-            pointRadius: 3,
-          },
+          (() => {
+            const rc = chartRivalColor(s.rival.color);
+            return {
+              label: s.rival.name,
+              data: s.locStats.map(l => l.theirAvg),
+              borderColor: rc,
+              backgroundColor: hexToRgba(rc, 0.18),
+              pointBackgroundColor: rc,
+              pointRadius: 3,
+            };
+          })(),
         ],
       },
       options: chartCommon({
@@ -1816,6 +1836,23 @@
   }
 
   // ---------- charts ----------
+  // The "You" series is pinned to a fixed green across charts. If the
+  // rival's chosen color sits too close to that green in RGB space the
+  // two lines become indistinguishable, so swap to a contrasting orange.
+  const USER_CHART_COLOR = '#4ade80';
+  const RIVAL_FALLBACK_COLOR = '#f97316';
+  function chartRivalColor(rivalColor) {
+    if (!rivalColor || typeof rivalColor !== 'string' || rivalColor[0] !== '#' || rivalColor.length !== 7) {
+      return RIVAL_FALLBACK_COLOR;
+    }
+    const u = parseInt(USER_CHART_COLOR.slice(1), 16);
+    const r = parseInt(rivalColor.slice(1), 16);
+    const dr = ((u >> 16) & 0xff) - ((r >> 16) & 0xff);
+    const dg = ((u >> 8)  & 0xff) - ((r >> 8)  & 0xff);
+    const db =  (u        & 0xff) -  (r        & 0xff);
+    return (dr * dr + dg * dg + db * db) < 6400 ? RIVAL_FALLBACK_COLOR : rivalColor;
+  }
+
   function destroyChart(name) {
     if (state.charts[name]) {
       state.charts[name].destroy();
@@ -1850,15 +1887,18 @@
             fill: true,
             pointRadius: 3,
           },
-          {
-            label: s.rival.name,
-            data: last30.map(getTheirTotal),
-            borderColor: s.rival.color,
-            backgroundColor: hexToRgba(s.rival.color, 0.12),
-            tension: 0.3,
-            fill: true,
-            pointRadius: 3,
-          },
+          (() => {
+            const rc = chartRivalColor(s.rival.color);
+            return {
+              label: s.rival.name,
+              data: last30.map(getTheirTotal),
+              borderColor: rc,
+              backgroundColor: hexToRgba(rc, 0.12),
+              tension: 0.3,
+              fill: true,
+              pointRadius: 3,
+            };
+          })(),
         ],
       },
       options: chartCommon({


### PR DESCRIPTION
## Summary
- **History dates link to MapTap.gg.** Each Date cell in the History tab is a dotted-underlined link that opens `https://maptap.gg/history/<MonthDay>` in a new tab (e.g. `2026-03-31` → `https://maptap.gg/history/March31`).
- **Best/worst score dates on rival cards.** The two "Best score" stat cards in the rival detail now show the date next to the value and the worst-score date in the sub-line (e.g. "May 16 · Worst 412 (May 14)").
- **Distinct user vs rival colors in charts.** Score-over-time and Average-per-round swap the rival series to a contrast orange when the rival's chosen color is too close to the pinned user green, so the two series stay distinguishable.
- **Collapsible "Paste daily scores".** The paste section is now a `<details>` collapsed by default with a hint pointing users to linking their MapTap profile above to auto-sync.
- **Dark `<select>` dropdowns.** Added `color-scheme: dark` and explicit option backgrounds so the native dropdown list renders dark instead of white.

## Test plan
- [ ] History tab dates link to `https://maptap.gg/history/<MonthDay>` in a new tab; month names are full English with no zero-padding (e.g. `January5`).
- [ ] Rival detail's "Best score (you)" and "Best score (rival)" cards each show the date next to the value plus the worst date in the sub-line.
- [ ] Create a rival with color `#4ade80` — Score over time and Average per round draw the rival series in orange, "You" in green.
- [ ] On the dashboard, "Paste daily scores" is collapsed by default with a chevron; clicking it opens the full paste UI.
- [ ] History rival filter dropdown renders dark when opened.