### PR TITLE
Visual improvements — Gym Tracker, Mario Kart, Football

### DIFF
--- a/apps/football-h2h/css/refresh.css
+++ b/apps/football-h2h/css/refresh.css
@@ -1,0 +1,862 @@
+/*
+ * Football H2H League — visual refresh layer.
+ *
+ * Loaded LAST so it wins specificity ties. Football H2H reuses several
+ * Mario Kart stylesheets (utilities/base/theme/layout/forms/overrides) +
+ * a Football-specific sheet. This refresh layer aligns the hero, tabs,
+ * stat cards, sidebar, and tables with the Rising Seasons / MapTap
+ * reference apps without changing any JS, IDs, or event handlers.
+ */
+
+body.football-h2h-tracker {
+    --fh-bg: #0a0c14;
+    --fh-bg-grad:
+        radial-gradient(ellipse 90% 60% at 50% -10%, rgba(129, 140, 248, 0.10), transparent 60%),
+        radial-gradient(ellipse 60% 40% at 100% 0%, rgba(74, 222, 128, 0.05), transparent 65%),
+        linear-gradient(180deg, #0a0c14 0%, #07090f 70%, #050609 100%);
+    --fh-surface: #12151d;
+    --fh-surface-2: #181c26;
+    --fh-surface-3: #232836;
+    --fh-text: #f1f3f8;
+    --fh-muted: #a4adbd;
+    --fh-muted-2: #6f7785;
+    --fh-accent: #818cf8;
+    --fh-accent-strong: #6366f1;
+    --fh-accent-soft: rgba(129, 140, 248, 0.14);
+    --fh-good: #34d399;
+    --fh-good-soft: rgba(52, 211, 153, 0.16);
+    --fh-bad: #f87171;
+    --fh-bad-soft: rgba(248, 113, 113, 0.16);
+    --fh-warn: #fbbf24;
+    --fh-warn-soft: rgba(251, 191, 36, 0.16);
+    --fh-border: #232838;
+    --fh-border-strong: #343a4f;
+    --fh-radius: 14px;
+    --fh-radius-sm: 10px;
+    --fh-shadow-lift: 0 6px 22px -8px rgba(0, 0, 0, 0.55), 0 2px 4px rgba(0, 0, 0, 0.3);
+
+    background: var(--fh-bg) !important;
+    background-image: var(--fh-bg-grad) !important;
+    background-attachment: fixed !important;
+    color: var(--fh-text);
+    color-scheme: dark;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* ---------- Page container ---------- */
+
+/* `apps/football-h2h/css/sidebar.css` line 12 sets `body { padding: 0 }`
+   which wipes out the 3.25rem top padding main.css uses to clear the
+   fixed site header. Restore it here so the app sits below the header
+   bar rather than under it. */
+body.football-h2h-tracker {
+    padding-top: 3.25rem !important;
+}
+
+body.football-h2h-tracker .app-container {
+    max-width: 1280px;
+    /* With body padding-top restored above, this just controls the gap
+       between the site header and the gradient hero. Was 2rem in the
+       original layout — tightened here so the title sits closer to the
+       header bar without smothering it. */
+    padding: 0.6rem 1.25rem 3rem;
+}
+
+body.football-h2h-tracker .main-wrapper {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+}
+
+/* ---------- Hero ----------
+   Tightened against the site header bar — was 1rem top padding +
+   0.5rem bottom margin before, leaving an obvious gap. Drop both to
+   minimal values so the gradient title sits directly under the chrome. */
+
+body.football-h2h-tracker .app-header {
+    border-bottom: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+body.football-h2h-tracker .app-title {
+    font-family: inherit !important;
+    font-size: clamp(2rem, 4vw, 2.85rem);
+    font-weight: 700;
+    letter-spacing: -0.035em;
+    line-height: 1.05;
+    text-transform: none;
+    background: linear-gradient(135deg, #ffffff 0%, var(--fh-accent) 60%, var(--fh-good) 110%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    filter: drop-shadow(0 4px 24px rgba(129, 140, 248, 0.18));
+    gap: 0.75rem;
+    margin: 0 !important;
+}
+
+body.football-h2h-tracker .football-icon {
+    font-size: 1.6rem !important;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
+}
+
+/* Subtitle: synthesize one using existing :before/:after if there isn't a
+   real subtitle in the DOM — keep this purely cosmetic, so even when the
+   browser drops it nothing breaks. */
+body.football-h2h-tracker .app-header::after {
+    content: "Head-to-head match log, wins, and side-by-side player stats";
+    display: block;
+    color: var(--fh-muted);
+    font-size: 0.95rem;
+    letter-spacing: -0.005em;
+    text-align: center;
+    margin-top: 0.25rem;
+}
+
+/* ---------- Stats tabs (H2H / General / Player) ---------- */
+
+body.football-h2h-tracker .stats-tabs-section { margin-bottom: 1.5rem; }
+
+body.football-h2h-tracker .stats-tabs {
+    display: inline-flex !important;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 4px;
+    margin: 1.25rem auto 1.25rem !important;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--fh-border);
+    border-radius: 999px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+    justify-content: center;
+    width: auto !important;
+}
+
+body.football-h2h-tracker .stats-tabs-section {
+    text-align: center;
+}
+
+body.football-h2h-tracker .stats-tabs button.stats-tab {
+    background: transparent !important;
+    color: var(--fh-muted) !important;
+    border: none !important;
+    border-radius: 999px !important;
+    padding: 0.5rem 1rem !important;
+    font-size: 0.87rem !important;
+    font-weight: 600 !important;
+    box-shadow: none !important;
+    transition: background 0.15s ease, color 0.15s ease;
+    display: inline-flex !important;
+    align-items: center !important;
+    gap: 0.35rem;
+}
+
+body.football-h2h-tracker .stats-tabs button.stats-tab:hover {
+    background: rgba(255, 255, 255, 0.04) !important;
+    color: var(--fh-text) !important;
+    transform: none !important;
+}
+
+body.football-h2h-tracker .stats-tabs button.stats-tab.active {
+    background: var(--fh-accent-soft) !important;
+    color: var(--fh-text) !important;
+    box-shadow: inset 0 0 0 1px rgba(129, 140, 248, 0.45) !important;
+}
+
+/* ---------- Section titles ---------- */
+
+body.football-h2h-tracker .h2h-section-title {
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--fh-muted-2) !important;
+    margin: 1.25rem 0 0.65rem !important;
+    text-align: left;
+}
+
+body.football-h2h-tracker .h2h-section-title:first-of-type { margin-top: 0.4rem; }
+
+body.football-h2h-tracker .section-title {
+    font-size: 1.15rem !important;
+    font-weight: 600 !important;
+    color: var(--fh-text) !important;
+    letter-spacing: -0.01em !important;
+    margin: 0 0 1rem !important;
+    text-align: left !important;
+    text-transform: none !important;
+}
+
+body.football-h2h-tracker .section-title::after { display: none !important; }
+
+/* ---------- Stat cards ---------- */
+
+body.football-h2h-tracker .stats-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)) !important;
+    gap: 0.85rem !important;
+}
+
+body.football-h2h-tracker .stat-card,
+body.football-h2h-tracker .stat-card.player1-card,
+body.football-h2h-tracker .stat-card.player2-card,
+body.football-h2h-tracker .stat-card.draws-card,
+body.football-h2h-tracker .stat-card.player1-90min-card,
+body.football-h2h-tracker .stat-card.player2-90min-card,
+body.football-h2h-tracker .stat-card.player1-penalty-card,
+body.football-h2h-tracker .stat-card.player2-penalty-card {
+    background: var(--fh-surface) !important;
+    border: 1px solid var(--fh-border) !important;
+    border-radius: var(--fh-radius) !important;
+    padding: 1.1rem 1.2rem !important;
+    box-shadow: var(--fh-shadow-lift) !important;
+    text-align: left !important;
+    position: relative;
+    overflow: hidden;
+    transition: background 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+}
+
+/* Subtle accent strip on each card */
+body.football-h2h-tracker .stat-card::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 3px;
+    background: var(--fh-border-strong);
+    transition: background 0.18s ease;
+}
+
+body.football-h2h-tracker .stat-card.player1-card::before,
+body.football-h2h-tracker .stat-card.player1-90min-card::before {
+    background: linear-gradient(180deg, var(--fh-accent), var(--fh-good));
+}
+body.football-h2h-tracker .stat-card.player2-card::before,
+body.football-h2h-tracker .stat-card.player2-90min-card::before {
+    background: linear-gradient(180deg, var(--fh-bad), #ec4899);
+}
+body.football-h2h-tracker .stat-card.draws-card::before { background: var(--fh-warn); }
+body.football-h2h-tracker .stat-card.player1-penalty-card::before {
+    background: linear-gradient(180deg, #a78bfa, #818cf8);
+}
+body.football-h2h-tracker .stat-card.player2-penalty-card::before {
+    background: linear-gradient(180deg, #f472b6, #ec4899);
+}
+
+/* JS-driven winning/losing/tied border colors should still win — bump
+   their specificity by keeping their original rules untouched and only
+   recoloring the strip. */
+body.football-h2h-tracker .stat-card.winning {
+    border-color: rgba(52, 211, 153, 0.55) !important;
+    background: linear-gradient(180deg, var(--fh-good-soft), var(--fh-surface)) !important;
+}
+body.football-h2h-tracker .stat-card.losing {
+    border-color: rgba(248, 113, 113, 0.55) !important;
+    background: linear-gradient(180deg, var(--fh-bad-soft), var(--fh-surface)) !important;
+}
+body.football-h2h-tracker .stat-card.tied {
+    border-color: rgba(251, 191, 36, 0.55) !important;
+    background: linear-gradient(180deg, var(--fh-warn-soft), var(--fh-surface)) !important;
+}
+
+body.football-h2h-tracker .stat-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--fh-border-strong) !important;
+}
+
+body.football-h2h-tracker .stat-label {
+    font-size: 0.7rem !important;
+    color: var(--fh-muted) !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.08em !important;
+    font-weight: 600 !important;
+    margin-bottom: 0.3rem !important;
+    text-align: left !important;
+}
+
+body.football-h2h-tracker .stat-value {
+    font-family: inherit !important;
+    font-size: 2.1rem !important;
+    font-weight: 700 !important;
+    color: var(--fh-text) !important;
+    font-variant-numeric: tabular-nums !important;
+    letter-spacing: -0.03em !important;
+    text-align: left !important;
+    line-height: 1.05;
+}
+
+/* ---------- Game history ---------- */
+
+body.football-h2h-tracker .game-history {
+    background: var(--fh-surface) !important;
+    border: 1px solid var(--fh-border) !important;
+    border-radius: var(--fh-radius) !important;
+    padding: 1.25rem 1.4rem !important;
+    box-shadow: var(--fh-shadow-lift) !important;
+    margin-top: 1.5rem !important;
+    transition: border-color 0.15s ease !important;
+}
+
+body.football-h2h-tracker .game-history::before { display: none !important; }
+body.football-h2h-tracker .game-history:hover {
+    transform: none !important;
+    box-shadow: var(--fh-shadow-lift) !important;
+    border-color: var(--fh-border-strong) !important;
+}
+
+body.football-h2h-tracker .table-container {
+    background: transparent !important;
+    border: 1px solid var(--fh-border) !important;
+    border-radius: var(--fh-radius-sm) !important;
+    box-shadow: none !important;
+}
+
+body.football-h2h-tracker .games-table thead {
+    background: var(--fh-surface-2) !important;
+    color: var(--fh-muted) !important;
+}
+
+body.football-h2h-tracker .games-table thead th {
+    padding: 0.85rem 0.9rem !important;
+    color: var(--fh-muted) !important;
+    background: transparent !important;
+    font-size: 0.72rem !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.06em !important;
+    font-weight: 600 !important;
+    border-bottom: 1px solid var(--fh-border) !important;
+}
+
+body.football-h2h-tracker .games-table td {
+    background: transparent !important;
+    color: var(--fh-text) !important;
+    border-bottom-color: var(--fh-border) !important;
+    padding: 0.7rem 0.9rem !important;
+}
+
+body.football-h2h-tracker .games-table tr:hover td {
+    background: rgba(255, 255, 255, 0.025) !important;
+}
+
+/* ---------- Player comparison table (Player Stats tab) ----------
+   Restores the green/red/olive cell highlighting that was bulldozed by
+   my earlier `td { background: transparent }` blanket rule. The
+   underlying JS still tags each cell with `.pc-cell-winning`,
+   `.pc-cell-losing`, or `.pc-cell-tied` and handles the lower-is-better
+   reversal for stats like Consistency σ, Current Losing Streak, and
+   Longest Scoreless Streak — we just need to paint those classes at a
+   specificity that beats the bare-`td` rule below. */
+
+body.football-h2h-tracker .player-comparison-table {
+    background: var(--fh-surface);
+    border: 1px solid var(--fh-border);
+    border-radius: var(--fh-radius-sm);
+    border-collapse: separate;
+    border-spacing: 0;
+    overflow: hidden;
+}
+body.football-h2h-tracker .player-comparison-table th,
+body.football-h2h-tracker .player-comparison-table td {
+    border-bottom: 1px solid var(--fh-border);
+    background: transparent;
+    color: var(--fh-text);
+}
+body.football-h2h-tracker .player-comparison-table th {
+    background: var(--fh-surface-2);
+    color: var(--fh-muted);
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+}
+
+/* Winning/losing/tied cell tints — semi-transparent so the underlying
+   surface dark colour shows through. Text stays white via the parent
+   `td { color: var(--fh-text) }` declaration. Specificity (0, 3, 2)
+   beats the bare-td rule (0, 2, 2) above, and the `!important` keeps
+   us safe against any future-added overrides. */
+body.football-h2h-tracker .player-comparison-table td.pc-cell-winning {
+    background: rgba(52, 211, 153, 0.22) !important;
+    background-color: rgba(52, 211, 153, 0.22) !important;
+    color: #ffffff !important;
+}
+body.football-h2h-tracker .player-comparison-table td.pc-cell-losing {
+    background: rgba(248, 113, 113, 0.22) !important;
+    background-color: rgba(248, 113, 113, 0.22) !important;
+    color: #ffffff !important;
+}
+body.football-h2h-tracker .player-comparison-table td.pc-cell-tied {
+    background: rgba(180, 195, 70, 0.18) !important;
+    background-color: rgba(180, 195, 70, 0.18) !important;
+    color: #ffffff !important;
+}
+
+/* Stat-label column should never inherit a tint — it carries the row
+   title, not a player value. */
+body.football-h2h-tracker .player-comparison-table td.pc-cell-stat,
+body.football-h2h-tracker .player-comparison-table .pc-stat-label {
+    background: transparent !important;
+    color: var(--fh-text) !important;
+}
+body.football-h2h-tracker .player-comparison-table .pc-stat-hint {
+    color: var(--fh-muted) !important;
+}
+
+/* Make the winning value the visual leader: bold + tabular numerals so
+   the eye lands on the higher number first. */
+body.football-h2h-tracker .player-comparison-table td.pc-cell-winning .pc-cell-value {
+    color: #d6fff1 !important;
+    font-weight: 700;
+}
+body.football-h2h-tracker .player-comparison-table td.pc-cell-losing .pc-cell-value {
+    color: #ffe4e6 !important;
+}
+body.football-h2h-tracker .player-comparison-table td.pc-cell-tied .pc-cell-value {
+    color: #fefce8 !important;
+}
+
+/* ---------- Sidebar (shared with Mario Kart but scoped here) ---------- */
+
+body.football-h2h-tracker .sidebar,
+body.football-h2h-tracker.theme .sidebar {
+    background: var(--fh-surface) !important;
+    border-right: 1px solid var(--fh-border) !important;
+    box-shadow: 2px 0 24px rgba(0, 0, 0, 0.5);
+}
+
+body.football-h2h-tracker .sidebar-header {
+    border-bottom: 1px solid var(--fh-border);
+    padding: 1rem 1.25rem;
+}
+
+body.football-h2h-tracker .sidebar-title {
+    font-size: 0.85rem !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.16em !important;
+    text-transform: uppercase !important;
+    color: var(--fh-muted) !important;
+    font-family: inherit !important;
+}
+
+body.football-h2h-tracker .sidebar-section-title {
+    font-size: 0.7rem !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.14em !important;
+    text-transform: uppercase !important;
+    color: var(--fh-muted-2) !important;
+    margin-bottom: 0.6rem !important;
+    font-family: inherit !important;
+}
+
+body.football-h2h-tracker .sidebar-content { padding: 1.1rem 1.1rem 1.4rem; }
+body.football-h2h-tracker .sidebar-section { margin-bottom: 1.4rem; }
+
+body.football-h2h-tracker .sidebar-close-btn,
+body.football-h2h-tracker.theme .sidebar-close-btn,
+body.football-h2h-tracker .sidebar-header-clear {
+    width: 30px !important;
+    height: 30px !important;
+    background: rgba(255, 255, 255, 0.03) !important;
+    border: 1px solid var(--fh-border) !important;
+    color: var(--fh-muted) !important;
+    border-radius: 8px !important;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+body.football-h2h-tracker .sidebar-close-btn:hover,
+body.football-h2h-tracker .sidebar-header-clear:hover:not(:disabled) {
+    background: var(--fh-surface-2) !important;
+    border-color: var(--fh-border-strong) !important;
+    color: var(--fh-text) !important;
+    transform: none !important;
+}
+
+body.football-h2h-tracker .sidebar-player-settings-btn,
+body.football-h2h-tracker .sidebar-add-game-btn,
+body.football-h2h-tracker .sidebar-add-race-btn {
+    background: linear-gradient(135deg, var(--fh-accent), var(--fh-accent-strong)) !important;
+    color: #ffffff !important;
+    border: 1px solid transparent !important;
+    border-radius: 10px !important;
+    padding: 0.7rem 0.85rem !important;
+    font-weight: 600 !important;
+    font-size: 0.92rem !important;
+    box-shadow: 0 4px 14px rgba(99, 102, 241, 0.28) !important;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    transition: filter 0.15s ease, transform 0.08s ease, box-shadow 0.15s ease;
+}
+body.football-h2h-tracker .sidebar-player-settings-btn:hover,
+body.football-h2h-tracker .sidebar-add-game-btn:hover {
+    filter: brightness(1.06);
+    transform: translateY(-1px);
+    box-shadow: 0 8px 22px -6px rgba(99, 102, 241, 0.55) !important;
+}
+
+/* Football's own apps/football-h2h/css/sidebar.css sets
+   `color: black !important` on every sidebar-action button variant
+   (undo/redo/restore + the attribute-selector exportData/importData/
+   toggleBackupMenu/restoreFromBackup rules), and body.theme repeats the
+   same. Black text on a dark surface is invisible — we override every
+   one of those selectors below at equal-or-higher specificity so the
+   labels stay white. */
+
+body.football-h2h-tracker .sidebar-action-btn,
+body.football-h2h-tracker .sidebar .action-buttons button,
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="exportData"],
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="importData"],
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="toggleBackupMenu"],
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="restoreFromBackup"],
+body.football-h2h-tracker.theme .sidebar-action-btn,
+body.football-h2h-tracker.theme .sidebar .action-buttons button {
+    background: var(--fh-surface-2) !important;
+    color: #ffffff !important;
+    border: 1px solid var(--fh-border-strong) !important;
+    border-radius: 10px !important;
+    padding: 0.6rem 0.85rem !important;
+    font-size: 0.88rem !important;
+    font-weight: 500 !important;
+    box-shadow: none !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 0.55rem !important;
+    line-height: 1 !important;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.08s ease;
+}
+
+body.football-h2h-tracker .sidebar-action-btn:hover:not(:disabled),
+body.football-h2h-tracker .sidebar .action-buttons button:hover,
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="exportData"]:hover,
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="importData"]:hover,
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="toggleBackupMenu"]:hover,
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="restoreFromBackup"]:hover {
+    background: var(--fh-surface-3) !important;
+    border-color: #4a4f66 !important;
+    color: #ffffff !important;
+    transform: none !important;
+    box-shadow: none !important;
+}
+
+/* Specifically force the inner span colours — both .action-icon and
+   .action-text would otherwise inherit the legacy `color: black` and
+   render invisible against a dark surface. */
+body.football-h2h-tracker .sidebar-action-btn .action-text,
+body.football-h2h-tracker .sidebar .action-buttons button .action-text,
+body.football-h2h-tracker.theme .sidebar-action-btn .action-text {
+    display: inline-flex !important;
+    align-items: center !important;
+    line-height: 1 !important;
+    color: #ffffff !important;
+    font-weight: 500;
+}
+
+body.football-h2h-tracker .sidebar-action-btn .action-icon,
+body.football-h2h-tracker .sidebar .action-buttons button .action-icon {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    line-height: 1 !important;
+    font-size: 1rem !important;
+    width: auto !important;
+    min-width: 0 !important;
+    color: #ffffff !important;
+}
+
+/* Per-button identity tint — applied only to the icon glyph so the
+   label stays unambiguously white but the row still scans by colour. */
+body.football-h2h-tracker .sidebar-action-btn.restore-btn .action-icon,
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="restoreFromBackup"] .action-icon {
+    color: var(--fh-good) !important;
+}
+body.football-h2h-tracker .sidebar-action-btn.export-btn .action-icon,
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="exportData"] .action-icon {
+    color: var(--fh-good) !important;
+}
+body.football-h2h-tracker .sidebar-action-btn.import-btn .action-icon,
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="importData"] .action-icon {
+    color: #5eead4 !important;
+}
+body.football-h2h-tracker .sidebar-action-btn.backup-btn .action-icon,
+body.football-h2h-tracker .sidebar .action-buttons button[onclick*="toggleBackupMenu"] .action-icon {
+    color: #60a5fa !important;
+}
+
+/* ---------- Undo / Redo toolbar pair ---------- */
+
+body.football-h2h-tracker .sidebar-action-buttons-group {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 0.5rem !important;
+    margin-bottom: 0.6rem;
+}
+
+body.football-h2h-tracker .sidebar-action-btn.undo-btn,
+body.football-h2h-tracker .sidebar-action-btn.redo-btn {
+    background: var(--fh-surface-2) !important;
+    color: var(--fh-text) !important;
+    border: 1px solid var(--fh-border-strong) !important;
+    border-radius: 10px !important;
+    padding: 0.55rem 0.6rem !important;
+    font-size: 0.86rem !important;
+    font-weight: 600 !important;
+    width: 100%;
+    box-shadow: none !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 0.45rem !important;
+    line-height: 1 !important;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.08s ease;
+}
+
+body.football-h2h-tracker .sidebar-action-btn.undo-btn .action-icon,
+body.football-h2h-tracker .sidebar-action-btn.redo-btn .action-icon {
+    color: var(--fh-accent) !important;
+    font-size: 1.25rem !important;
+    line-height: 1 !important;
+    font-weight: 700;
+}
+
+body.football-h2h-tracker .sidebar-action-btn.undo-btn .action-text,
+body.football-h2h-tracker .sidebar-action-btn.redo-btn .action-text {
+    color: var(--fh-text) !important;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+
+body.football-h2h-tracker .sidebar-action-btn.undo-btn:hover:not(:disabled),
+body.football-h2h-tracker .sidebar-action-btn.redo-btn:hover:not(:disabled) {
+    background: var(--fh-accent-soft) !important;
+    border-color: rgba(129, 140, 248, 0.55) !important;
+    color: #ffffff !important;
+    transform: translateY(-1px);
+}
+body.football-h2h-tracker .sidebar-action-btn.undo-btn:hover:not(:disabled) .action-icon,
+body.football-h2h-tracker .sidebar-action-btn.redo-btn:hover:not(:disabled) .action-icon,
+body.football-h2h-tracker .sidebar-action-btn.undo-btn:hover:not(:disabled) .action-text,
+body.football-h2h-tracker .sidebar-action-btn.redo-btn:hover:not(:disabled) .action-text {
+    color: #ffffff !important;
+}
+
+body.football-h2h-tracker .sidebar-action-btn.undo-btn:active:not(:disabled),
+body.football-h2h-tracker .sidebar-action-btn.redo-btn:active:not(:disabled) {
+    transform: translateY(0);
+    background: rgba(99, 102, 241, 0.22) !important;
+}
+
+body.football-h2h-tracker .sidebar-action-btn.undo-btn:disabled,
+body.football-h2h-tracker .sidebar-action-btn.redo-btn:disabled,
+body.football-h2h-tracker .sidebar-action-btn.undo-btn[disabled],
+body.football-h2h-tracker .sidebar-action-btn.redo-btn[disabled] {
+    opacity: 0.42 !important;
+    cursor: not-allowed !important;
+    pointer-events: none;
+    background: var(--fh-surface-2) !important;
+    border-color: var(--fh-border) !important;
+    transform: none !important;
+}
+body.football-h2h-tracker .sidebar-action-btn.undo-btn:disabled .action-icon,
+body.football-h2h-tracker .sidebar-action-btn.redo-btn:disabled .action-icon {
+    color: var(--fh-muted) !important;
+}
+
+body.football-h2h-tracker .sidebar .filter-btn,
+body.football-h2h-tracker .sidebar .date-filter-btn,
+body.football-h2h-tracker.theme .sidebar .filter-btn,
+body.football-h2h-tracker.theme .sidebar .date-filter-btn {
+    background: var(--fh-surface-2) !important;
+    color: #ffffff !important;
+    border: 1px solid var(--fh-border-strong) !important;
+    border-radius: 999px !important;
+    padding: 0.5rem 0.9rem !important;
+    font-size: 0.85rem !important;
+    font-weight: 500 !important;
+    width: 100%;
+    box-shadow: none !important;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+body.football-h2h-tracker .sidebar .filter-btn:hover:not(.active),
+body.football-h2h-tracker .sidebar .date-filter-btn:hover:not(.active) {
+    background: var(--fh-surface-3) !important;
+    border-color: #4a4f66 !important;
+    color: #ffffff !important;
+    transform: none !important;
+}
+body.football-h2h-tracker .sidebar .filter-btn.active,
+body.football-h2h-tracker .sidebar .date-filter-btn.active,
+body.football-h2h-tracker.theme .sidebar .filter-btn.active,
+body.football-h2h-tracker.theme .sidebar .date-filter-btn.active {
+    background: linear-gradient(135deg, var(--fh-accent), var(--fh-accent-strong)) !important;
+    border-color: transparent !important;
+    color: #ffffff !important;
+    box-shadow: 0 4px 14px rgba(99, 102, 241, 0.28) !important;
+}
+
+body.football-h2h-tracker .sidebar-date-btn-container {
+    background: var(--fh-surface-2) !important;
+    border: 1px solid var(--fh-border) !important;
+    border-radius: 10px !important;
+}
+body.football-h2h-tracker .sidebar-date-today-btn,
+body.football-h2h-tracker.theme .sidebar-date-today-btn {
+    background: var(--fh-surface-2) !important;
+    color: #ffffff !important;
+    border: 1px solid var(--fh-border-strong) !important;
+    border-radius: 999px !important;
+    box-shadow: none !important;
+}
+body.football-h2h-tracker .sidebar-date-today-btn:hover,
+body.football-h2h-tracker.theme .sidebar-date-today-btn:hover {
+    background: var(--fh-surface-3) !important;
+    border-color: #4a4f66 !important;
+    color: #ffffff !important;
+    transform: none !important;
+    box-shadow: none !important;
+}
+
+/* Sidebar toggle (floating hamburger) */
+body.football-h2h-tracker .sidebar-toggle,
+body.football-h2h-tracker.theme .sidebar-toggle {
+    background: linear-gradient(135deg, var(--fh-accent), var(--fh-accent-strong)) !important;
+    box-shadow: 0 6px 20px rgba(99, 102, 241, 0.35) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+}
+
+/* ---------- Inputs ---------- */
+
+body.football-h2h-tracker input[type="text"],
+body.football-h2h-tracker input[type="number"],
+body.football-h2h-tracker input[type="date"],
+body.football-h2h-tracker select,
+body.football-h2h-tracker textarea {
+    background: var(--fh-surface-2) !important;
+    color: var(--fh-text) !important;
+    border: 1px solid var(--fh-border) !important;
+    border-radius: 10px !important;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+body.football-h2h-tracker input[type="text"]:focus,
+body.football-h2h-tracker input[type="number"]:focus,
+body.football-h2h-tracker input[type="date"]:focus,
+body.football-h2h-tracker select:focus,
+body.football-h2h-tracker textarea:focus {
+    outline: none !important;
+    border-color: var(--fh-accent) !important;
+    box-shadow: 0 0 0 3px var(--fh-accent-soft) !important;
+    background: var(--fh-surface) !important;
+}
+
+/* ---------- Game History row action buttons (edit / delete) ----------
+   The default styling was a 40px solid gradient blue + 40px solid red
+   slab per row — visually heavy and dominated the table. Refine to a
+   compact 28px icon chip with a quiet ghost surface; the delete chip
+   only goes red on hover so unstyled rows don't shout. Both chips lift
+   subtly on hover for clear interactive feedback. */
+
+body.football-h2h-tracker .games-table .action-buttons,
+body.football-h2h-tracker .games-table td .action-buttons {
+    display: inline-flex !important;
+    gap: 0.3rem !important;
+    align-items: center;
+    justify-content: center;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: transparent !important;
+    border: none !important;
+}
+
+body.football-h2h-tracker .games-table .btn-icon,
+body.football-h2h-tracker .games-table .btn-icon.edit,
+body.football-h2h-tracker .games-table .btn-icon.delete {
+    width: 28px !important;
+    height: 28px !important;
+    padding: 0 !important;
+    background: rgba(255, 255, 255, 0.04) !important;
+    border: 1px solid var(--fh-border) !important;
+    border-radius: 7px !important;
+    color: var(--fh-muted) !important;
+    box-shadow: none !important;
+    font-size: 0.78rem !important;
+    cursor: pointer;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    transition: background 0.15s ease, color 0.15s ease,
+                border-color 0.15s ease, transform 0.12s ease,
+                box-shadow 0.15s ease !important;
+}
+
+body.football-h2h-tracker .games-table .btn-icon i {
+    color: inherit !important;
+    font-size: 0.78rem !important;
+    line-height: 1 !important;
+    width: auto !important;
+    height: auto !important;
+}
+
+/* Edit chip — soft indigo accent. Outline at rest, fills on hover. */
+body.football-h2h-tracker .games-table .btn-icon.edit {
+    color: #93c5fd !important;
+}
+body.football-h2h-tracker .games-table .btn-icon.edit:hover {
+    background: rgba(59, 130, 246, 0.18) !important;
+    border-color: rgba(96, 165, 250, 0.55) !important;
+    color: #dbeafe !important;
+    transform: translateY(-1px) scale(1.05);
+    box-shadow: 0 4px 10px -4px rgba(59, 130, 246, 0.45) !important;
+}
+
+/* Delete chip — neutral ghost at rest, danger-red on hover only. */
+body.football-h2h-tracker .games-table .btn-icon.delete {
+    color: var(--fh-muted) !important;
+}
+body.football-h2h-tracker .games-table .btn-icon.delete:hover {
+    background: rgba(248, 113, 113, 0.18) !important;
+    border-color: rgba(248, 113, 113, 0.55) !important;
+    color: #fecaca !important;
+    transform: translateY(-1px) scale(1.05);
+    box-shadow: 0 4px 10px -4px rgba(248, 113, 113, 0.45) !important;
+}
+
+body.football-h2h-tracker .games-table .btn-icon:active {
+    transform: translateY(0) scale(0.98);
+}
+body.football-h2h-tracker .games-table .btn-icon:focus-visible {
+    outline: 2px solid var(--fh-accent) !important;
+    outline-offset: 2px !important;
+}
+
+/* ---------- Empty/zero stat-card body — promote visual hierarchy when value = "0" ---------- */
+
+body.football-h2h-tracker .stats-grid .stat-card .stat-value:not(:empty) {
+    /* Keep visual; the 0 still reads as a tabular number. */
+}
+
+/* ---------- Scrollbars ---------- */
+
+body.football-h2h-tracker ::-webkit-scrollbar { width: 10px; height: 10px; }
+body.football-h2h-tracker ::-webkit-scrollbar-track { background: transparent !important; }
+body.football-h2h-tracker ::-webkit-scrollbar-thumb {
+    background: var(--fh-border-strong) !important;
+    border: 3px solid var(--fh-bg) !important;
+    background-clip: content-box !important;
+    border-radius: 999px !important;
+}
+body.football-h2h-tracker ::-webkit-scrollbar-thumb:hover {
+    background: #4a4f66 !important;
+    background-clip: content-box !important;
+}
+
+/* ---------- Tiny "empty league" hint above stats when player counts are all zero.
+   Adds an editorial cue using a pseudo-element on the H2H tab body. The
+   element is content-only (no DOM change) and is removed by JS that
+   already manipulates the underlying values — safe to add. ---------- */
+
+body.football-h2h-tracker .stats-tab-content.active#h2h-stats::before {
+    content: "";
+    display: none;
+}

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -103,6 +103,8 @@
     <link rel="stylesheet" href="../../assets/css/pagination.css">
     <link rel="stylesheet" href="../../assets/css/sync-status.css">
     <link rel="stylesheet" href="css/football-h2h.css">
+    <!-- Visual refresh layer — must load last so it wins specificity ties. -->
+    <link rel="stylesheet" href="css/refresh.css">
 </head>
 <body class="mario-kart-app football-h2h-tracker">
     <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->
@@ -124,7 +126,7 @@
         <div class="sidebar-header">
             <h2 class="sidebar-title">Control Panel</h2>
             <div class="sidebar-header-buttons">
-                <button id="sidebar-clear-btn" class="sidebar-header-clear" onclick="confirmClearData()" title="Clear all data" aria-label="Clear all data">
+                <button id="sidebar-clear-btn" class="sidebar-header-clear" onclick="confirmClearData()" aria-label="Clear all data">
                     🗑️
                 </button>
                 <button class="sidebar-close-btn" onclick="closeSidebar()" aria-label="Close sidebar">
@@ -164,29 +166,29 @@
                     </div>
                 </div>
                 <div class="sidebar-action-buttons-group">
-                    <button id="sidebar-undo-btn" class="sidebar-action-btn undo-btn" onclick="undoLastAction()" disabled title="Undo last action">
+                    <button id="sidebar-undo-btn" class="sidebar-action-btn undo-btn" onclick="undoLastAction()" disabled aria-label="Undo last action">
                         <span class="action-icon">↶</span>
                         <span class="action-text">Undo</span>
                     </button>
-                    <button id="sidebar-redo-btn" class="sidebar-action-btn redo-btn" onclick="redoLastAction()" disabled title="Redo last action">
+                    <button id="sidebar-redo-btn" class="sidebar-action-btn redo-btn" onclick="redoLastAction()" disabled aria-label="Redo last action">
                         <span class="action-icon">↷</span>
                         <span class="action-text">Redo</span>
                     </button>
                 </div>
                 <div class="action-buttons" id="sidebar-action-buttons">
-                    <button class="sidebar-action-btn export-btn" onclick="exportData()" title="Export data">
+                    <button class="sidebar-action-btn export-btn" onclick="exportData()" aria-label="Export data">
                         <span class="action-icon">📤</span>
                         <span class="action-text">Export</span>
                     </button>
-                    <button class="sidebar-action-btn import-btn" onclick="importData()" title="Import data">
+                    <button class="sidebar-action-btn import-btn" onclick="importData()" aria-label="Import data">
                         <span class="action-icon">📥</span>
                         <span class="action-text">Import</span>
                     </button>
-                    <button class="sidebar-action-btn backup-btn" onclick="toggleBackupMenu(this)" title="Download backup file (auto-backup runs every 10 minutes)">
+                    <button class="sidebar-action-btn backup-btn" onclick="toggleBackupMenu(this)" aria-label="Download backup file (auto-backup runs every 10 minutes)">
                         <span class="action-icon">💾</span>
                         <span class="action-text">Backup</span>
                     </button>
-                    <button class="sidebar-action-btn restore-btn" onclick="restoreFromBackup()" title="Restore from auto-backup">
+                    <button class="sidebar-action-btn restore-btn" onclick="restoreFromBackup()" aria-label="Restore from auto-backup">
                         <span class="action-icon">🔄</span>
                         <span class="action-text">Restore</span>
                     </button>

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -1,0 +1,547 @@
+/*
+ * Gym Tracker — visual refresh layer.
+ *
+ * Loaded LAST so it wins specificity ties against the older gym-tracker.css
+ * rules. The goal is to align typography, surfaces, spacing, and empty/zero
+ * states with the polished Rising Seasons / MapTap reference apps without
+ * changing any JS, IDs, or event handlers.
+ *
+ * Scope: every selector is body.gym-tracker-scoped (or uses a more specific
+ * existing class) so nothing leaks into the shared site chrome.
+ */
+
+body.gym-tracker {
+    /* Modernised design tokens — kept side-by-side with the existing
+       --bg-primary / --accent-primary etc. so legacy rules continue to
+       work; the new tokens are applied where they matter most. */
+    --gt-bg: #0a0c14;
+    --gt-bg-grad:
+        radial-gradient(ellipse 80% 50% at 50% -10%, rgba(108, 99, 255, 0.10), transparent 60%),
+        radial-gradient(ellipse 60% 40% at 100% 0%, rgba(99, 102, 241, 0.05), transparent 65%),
+        linear-gradient(180deg, #0a0c14 0%, #07090f 70%, #050609 100%);
+    --gt-surface: #12151d;
+    --gt-surface-2: #181c26;
+    --gt-surface-3: #232836;
+    --gt-text: #f1f3f8;
+    --gt-muted: #a4adbd;
+    --gt-muted-2: #6f7785;
+    --gt-accent: #818cf8;
+    --gt-accent-strong: #6c63ff;
+    --gt-accent-soft: rgba(129, 140, 248, 0.14);
+    --gt-accent-ring: rgba(129, 140, 248, 0.35);
+    --gt-good: #34d399;
+    --gt-good-soft: rgba(52, 211, 153, 0.14);
+    --gt-warn: #fbbf24;
+    --gt-danger: #f87171;
+    --gt-border: #232838;
+    --gt-border-strong: #343a4f;
+    --gt-radius: 14px;
+    --gt-radius-sm: 10px;
+    --gt-shadow-lift: 0 6px 22px -8px rgba(0, 0, 0, 0.55), 0 2px 4px rgba(0, 0, 0, 0.3);
+
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    background: var(--gt-bg);
+    background-image: var(--gt-bg-grad);
+    background-attachment: fixed;
+    color-scheme: dark;
+}
+
+/* ---------- Typography ---------- */
+
+body.gym-tracker .view-header h1 {
+    font-size: clamp(1.85rem, 3.5vw, 2.5rem);
+    font-weight: 700;
+    letter-spacing: -0.025em;
+    line-height: 1.1;
+    text-transform: none;
+    background: linear-gradient(135deg, #ffffff 0%, var(--gt-accent) 90%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    margin: 0 0 0.35rem;
+}
+
+body.gym-tracker .view-header .subtitle {
+    color: var(--gt-muted) !important;
+    font-size: 0.97rem;
+    margin: 0;
+    letter-spacing: -0.005em;
+}
+
+body.gym-tracker .section h2 {
+    font-size: 1.15rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--gt-text);
+    text-transform: none;
+}
+
+body.gym-tracker .section-header {
+    align-items: center;
+    margin-bottom: 0.85rem;
+}
+
+body.gym-tracker .section {
+    margin-bottom: 1.85rem;
+}
+
+/* ---------- Side navigation (desktop) ---------- */
+
+@media (min-width: 768px) {
+    body.gym-tracker .side-nav {
+        background: var(--gt-surface);
+        border-right: 1px solid var(--gt-border);
+        backdrop-filter: blur(8px);
+    }
+
+    body.gym-tracker .side-nav .nav-header {
+        border-bottom: 1px solid var(--gt-border);
+        padding: 1.1rem 1.25rem;
+    }
+
+    body.gym-tracker .side-nav .nav-header h2 {
+        font-size: 1.1rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        text-transform: none;
+        background: linear-gradient(135deg, #ffffff, var(--gt-accent));
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+    }
+
+    body.gym-tracker .side-nav .nav-link {
+        font-size: 0.9rem;
+        font-weight: 500;
+        padding: 0.6rem 0.85rem;
+        gap: 0.7rem;
+        margin-bottom: 0.15rem;
+        color: var(--gt-muted) !important;
+        border-radius: 8px;
+        transition: background 0.15s ease, color 0.15s ease;
+    }
+
+    body.gym-tracker .side-nav .nav-link i {
+        width: 18px;
+        font-size: 0.95rem;
+        color: inherit;
+    }
+
+    body.gym-tracker .side-nav .nav-link span { color: inherit; }
+
+    body.gym-tracker .side-nav .nav-link:hover {
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--gt-text) !important;
+    }
+    body.gym-tracker .side-nav .nav-link:hover i,
+    body.gym-tracker .side-nav .nav-link:hover span { color: var(--gt-text); }
+
+    body.gym-tracker .side-nav .nav-link.active {
+        background: var(--gt-accent-soft);
+        color: var(--gt-text) !important;
+        box-shadow: inset 2px 0 0 var(--gt-accent);
+    }
+    body.gym-tracker .side-nav .nav-link.active i,
+    body.gym-tracker .side-nav .nav-link.active span {
+        color: var(--gt-text);
+    }
+}
+
+/* ---------- Bottom navigation (mobile) — keep accent but match palette ---------- */
+
+body.gym-tracker .bottom-nav {
+    background: rgba(18, 21, 29, 0.94);
+    border-top: 1px solid var(--gt-border);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+}
+
+body.gym-tracker .bottom-nav .nav-item.active {
+    background: var(--gt-accent-soft);
+    color: var(--gt-accent) !important;
+}
+
+body.gym-tracker .bottom-nav .nav-item.nav-item-primary {
+    background: linear-gradient(135deg, var(--gt-accent-strong), #8b5cf6);
+    box-shadow: 0 6px 18px rgba(108, 99, 255, 0.45);
+}
+
+/* ---------- Cards & sections ---------- */
+
+body.gym-tracker .stat-card,
+body.gym-tracker .program-card,
+body.gym-tracker .workout-card {
+    background: var(--gt-surface);
+    border: 1px solid var(--gt-border);
+    border-radius: var(--gt-radius);
+    box-shadow: var(--gt-shadow-lift);
+    transition: border-color 0.18s ease, transform 0.12s ease, background 0.18s ease;
+}
+
+body.gym-tracker .stat-card:hover,
+body.gym-tracker .program-card:hover,
+body.gym-tracker .workout-card:hover {
+    border-color: var(--gt-border-strong);
+    background: var(--gt-surface-2);
+    transform: translateY(-2px);
+}
+
+body.gym-tracker .stat-label {
+    color: var(--gt-muted) !important;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    font-weight: 600;
+}
+
+body.gym-tracker .stat-value {
+    color: var(--gt-text);
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+body.gym-tracker .stat-value .unit {
+    color: var(--gt-muted) !important;
+    font-weight: 500;
+}
+
+/* ---------- Buttons ---------- */
+
+body.gym-tracker .btn {
+    height: 40px;
+    padding: 0 1.05rem;
+    font-size: 0.9rem;
+    font-weight: 500;
+    border-radius: 10px;
+    transition: background 0.15s ease, border-color 0.15s ease,
+                box-shadow 0.15s ease, transform 0.08s ease, filter 0.15s ease;
+    box-shadow: none;
+}
+
+body.gym-tracker .btn-primary {
+    background: linear-gradient(135deg, var(--gt-accent), var(--gt-accent-strong));
+    color: #ffffff !important;
+    font-weight: 600;
+    border: 1px solid transparent;
+}
+
+body.gym-tracker .btn-primary:hover {
+    filter: brightness(1.06);
+    transform: translateY(-1px);
+    box-shadow: 0 8px 20px -8px rgba(108, 99, 255, 0.5);
+}
+
+body.gym-tracker .btn-secondary {
+    background: var(--gt-surface);
+    border: 1px solid var(--gt-border);
+    color: var(--gt-text) !important;
+}
+
+body.gym-tracker .btn-secondary:hover {
+    background: var(--gt-surface-2);
+    border-color: var(--gt-border-strong);
+    transform: none;
+}
+
+body.gym-tracker .btn-ghost {
+    background: transparent;
+    border: 1px solid var(--gt-border-strong);
+    color: var(--gt-text) !important;
+}
+body.gym-tracker .btn-ghost:hover {
+    background: var(--gt-surface-2);
+    border-color: var(--gt-border-strong);
+}
+
+body.gym-tracker .btn-danger {
+    background: linear-gradient(135deg, #ef4444, #dc2626);
+    border: 1px solid transparent;
+    color: #ffffff !important;
+    font-weight: 600;
+}
+
+body.gym-tracker .btn-text {
+    color: var(--gt-muted) !important;
+    font-weight: 500;
+}
+body.gym-tracker .btn-text:hover {
+    color: var(--gt-accent) !important;
+    text-decoration: none !important;
+}
+
+body.gym-tracker .btn-icon {
+    background: var(--gt-surface);
+    border: 1px solid var(--gt-border);
+    color: var(--gt-text);
+}
+body.gym-tracker .btn-icon:hover {
+    background: var(--gt-surface-2);
+    border-color: var(--gt-border-strong);
+}
+
+/* ---------- Empty/zero states ---------- */
+
+body.gym-tracker .empty-state {
+    text-align: center;
+    padding: 2rem 1.2rem;
+    color: var(--gt-muted);
+    background: var(--gt-surface);
+    border: 1px dashed var(--gt-border-strong);
+    border-radius: var(--gt-radius);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+body.gym-tracker .empty-state i {
+    font-size: 1.85rem;
+    color: var(--gt-accent);
+    opacity: 0.9;
+    margin: 0 0 0.2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.2rem;
+    height: 3.2rem;
+    border-radius: 50%;
+    background: var(--gt-accent-soft);
+    box-shadow: inset 0 0 0 1px rgba(129, 140, 248, 0.25);
+}
+
+body.gym-tracker .empty-state p {
+    color: var(--gt-muted) !important;
+    font-size: 0.95rem;
+    margin: 0;
+}
+
+body.gym-tracker .empty-state .btn {
+    margin-top: 0.25rem;
+}
+
+/* The active-program empty state sits inside a .program-card shell —
+   drop the extra borders so the empty card doesn't have double chrome. */
+body.gym-tracker #active-program-card:has(.empty-state) {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+}
+
+/* ---------- Modals ---------- */
+
+body.gym-tracker .modal {
+    background: rgba(7, 9, 15, 0.72);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+body.gym-tracker .modal-content {
+    background: var(--gt-surface);
+    border: 1px solid var(--gt-border);
+    border-radius: 16px;
+    box-shadow:
+        0 30px 80px -10px rgba(0, 0, 0, 0.7),
+        0 8px 24px -4px rgba(0, 0, 0, 0.4);
+}
+
+body.gym-tracker .modal-header {
+    border-bottom: 1px solid var(--gt-border);
+    padding: 1rem 1.25rem;
+}
+
+body.gym-tracker .modal-header h2 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    text-transform: none;
+}
+
+body.gym-tracker .modal-close {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--gt-border);
+    color: var(--gt-text) !important;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    font-size: 1rem;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+body.gym-tracker .modal-close:hover {
+    background: var(--gt-surface-2);
+    border-color: var(--gt-border-strong);
+}
+
+body.gym-tracker .modal-footer {
+    border-top: 1px solid var(--gt-border);
+}
+
+/* ---------- Onboarding modal polish ---------- */
+
+body.gym-tracker .onboarding-step {
+    background: var(--gt-surface-2);
+    border: 1px solid var(--gt-border);
+    border-radius: 12px;
+}
+
+body.gym-tracker .onboarding-step-number {
+    background: var(--gt-accent-soft);
+    color: var(--gt-accent) !important;
+    border: 1px solid rgba(129, 140, 248, 0.35);
+    font-weight: 700;
+}
+
+body.gym-tracker .onboarding-step-title {
+    color: var(--gt-text) !important;
+    font-weight: 600;
+}
+
+body.gym-tracker .onboarding-step-desc {
+    color: var(--gt-muted) !important;
+}
+
+/* ---------- Form controls (inputs/selects/textareas) ---------- */
+
+body.gym-tracker input[type="text"],
+body.gym-tracker input[type="number"],
+body.gym-tracker input[type="date"],
+body.gym-tracker input[type="email"],
+body.gym-tracker input[type="search"],
+body.gym-tracker select,
+body.gym-tracker textarea {
+    background: var(--gt-surface-2);
+    border: 1px solid var(--gt-border);
+    color: var(--gt-text);
+    border-radius: 10px;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+body.gym-tracker input[type="text"]:focus,
+body.gym-tracker input[type="number"]:focus,
+body.gym-tracker input[type="date"]:focus,
+body.gym-tracker input[type="email"]:focus,
+body.gym-tracker input[type="search"]:focus,
+body.gym-tracker select:focus,
+body.gym-tracker textarea:focus {
+    outline: none;
+    border-color: var(--gt-accent);
+    box-shadow: 0 0 0 3px var(--gt-accent-soft);
+    background: var(--gt-surface);
+}
+
+/* ---------- History filters ---------- */
+
+body.gym-tracker .history-filters {
+    background: var(--gt-surface);
+    border: 1px solid var(--gt-border);
+    border-radius: var(--gt-radius);
+    padding: 0.8rem;
+    gap: 0.6rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+body.gym-tracker .history-clear-btn {
+    background: var(--gt-surface-2);
+    border: 1px solid var(--gt-border);
+    color: var(--gt-muted);
+    border-radius: 8px;
+    padding: 0.4rem 0.75rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+body.gym-tracker .history-clear-btn:not([disabled]):hover {
+    color: var(--gt-text);
+    background: var(--gt-surface-3);
+    border-color: var(--gt-border-strong);
+}
+
+/* ---------- Toast ---------- */
+
+body.gym-tracker #toast-container .toast,
+body.gym-tracker .toast {
+    background: var(--gt-surface);
+    border: 1px solid var(--gt-border-strong);
+    color: var(--gt-text);
+    box-shadow: var(--gt-shadow-lift);
+}
+
+/* ---------- Achievements summary chip ---------- */
+
+body.gym-tracker .achievement-summary {
+    background: var(--gt-accent-soft);
+    border: 1px solid rgba(129, 140, 248, 0.35);
+    color: var(--gt-accent) !important;
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+body.gym-tracker .achievement-summary > span { color: inherit; }
+
+/* ---------- Bottom-nav active state colour rebalance ---------- */
+
+body.gym-tracker .bottom-nav .nav-item.active i,
+body.gym-tracker .bottom-nav .nav-item.active span {
+    color: var(--gt-accent) !important;
+}
+
+body.gym-tracker .bottom-nav .nav-item.nav-item-primary.active i,
+body.gym-tracker .bottom-nav .nav-item.nav-item-primary.active span,
+body.gym-tracker .bottom-nav .nav-item.nav-item-primary i,
+body.gym-tracker .bottom-nav .nav-item.nav-item-primary span {
+    color: #ffffff !important;
+}
+
+/* ---------- Calendar nav buttons & today pill ---------- */
+
+body.gym-tracker .calendar-nav-btn,
+body.gym-tracker .calendar-today-btn {
+    background: var(--gt-surface);
+    border: 1px solid var(--gt-border);
+    color: var(--gt-text);
+    border-radius: 8px;
+}
+body.gym-tracker .calendar-nav-btn:hover,
+body.gym-tracker .calendar-today-btn:hover {
+    background: var(--gt-surface-2);
+    border-color: var(--gt-border-strong);
+}
+
+/* ---------- Subtle scrollbars for the dark canvas ---------- */
+
+body.gym-tracker ::-webkit-scrollbar { width: 10px; height: 10px; }
+body.gym-tracker ::-webkit-scrollbar-track { background: transparent; }
+body.gym-tracker ::-webkit-scrollbar-thumb {
+    background: var(--gt-border-strong);
+    border: 3px solid var(--gt-bg);
+    background-clip: content-box;
+    border-radius: 999px;
+}
+body.gym-tracker ::-webkit-scrollbar-thumb:hover { background: #4a4f66; background-clip: content-box; }
+
+/* ---------- Top-level title underline (only when nothing data-driven yet) ---------- */
+
+body.gym-tracker .view-header {
+    margin-bottom: 1.5rem;
+}
+
+body.gym-tracker .view-header > .btn-primary {
+    align-self: center;
+}
+
+/* ---------- Polish the "Active program" empty placeholder so it
+   reads as one editorial card matching the references ---------- */
+
+body.gym-tracker #active-program-card .empty-state,
+body.gym-tracker #recent-workouts .empty-state {
+    padding: 2.5rem 1.25rem;
+}

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -100,6 +100,8 @@
 
     <!-- Gym Tracker specific CSS -->
     <link rel="stylesheet" href="css/gym-tracker.css">
+    <!-- Visual refresh layer — must load last so it wins specificity ties. -->
+    <link rel="stylesheet" href="css/refresh.css">
 </head>
 <body class="gym-tracker">
     <div data-include="header"></div>

--- a/apps/mario-kart/css/refresh.css
+++ b/apps/mario-kart/css/refresh.css
@@ -1,0 +1,757 @@
+/*
+ * Mario Kart Tracker — visual refresh layer.
+ *
+ * Loaded LAST (after every legacy module) so it wins specificity ties. It
+ * does not touch any JS or HTML structure — every rule targets existing
+ * classes / IDs and is scoped to body.mario-kart-app or the legacy
+ * body.theme dark-mode class so the older light theme remains untouched
+ * if anyone ever toggles it.
+ *
+ * Reference design language: Rising Seasons / MapTap (cinematic dark
+ * palette, soft accent surfaces, gradient hero, dashed empty states).
+ */
+
+body.mario-kart-app.theme,
+body.mario-kart-app {
+    --mk-bg: #0a0c14;
+    --mk-bg-grad:
+        radial-gradient(ellipse 90% 60% at 50% -10%, rgba(99, 102, 241, 0.10), transparent 60%),
+        radial-gradient(ellipse 60% 40% at 100% 0%, rgba(244, 114, 182, 0.05), transparent 65%),
+        linear-gradient(180deg, #0a0c14 0%, #07090f 70%, #050609 100%);
+    --mk-surface: #12151d;
+    --mk-surface-2: #181c26;
+    --mk-surface-3: #232836;
+    --mk-text: #f1f3f8;
+    --mk-muted: #a4adbd;
+    --mk-muted-2: #6f7785;
+    --mk-accent: #818cf8;
+    --mk-accent-strong: #6366f1;
+    --mk-accent-soft: rgba(129, 140, 248, 0.14);
+    --mk-accent-strong-soft: rgba(99, 102, 241, 0.32);
+    --mk-good: #34d399;
+    --mk-good-soft: rgba(52, 211, 153, 0.16);
+    --mk-good-ink: #052e1c;
+    --mk-warn: #fbbf24;
+    --mk-warn-soft: rgba(251, 191, 36, 0.16);
+    --mk-danger: #f87171;
+    --mk-danger-soft: rgba(248, 113, 113, 0.16);
+    --mk-border: #232838;
+    --mk-border-strong: #343a4f;
+    --mk-radius: 14px;
+    --mk-radius-sm: 10px;
+    --mk-shadow-lift: 0 6px 22px -8px rgba(0, 0, 0, 0.55), 0 2px 4px rgba(0, 0, 0, 0.3);
+    color-scheme: dark;
+}
+
+/* ---------- Page canvas ---------- */
+
+body.mario-kart-app {
+    background: var(--mk-bg) !important;
+    background-image: var(--mk-bg-grad) !important;
+    background-attachment: fixed !important;
+    color: var(--mk-text);
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+}
+
+body.mario-kart-app .container {
+    background: transparent !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    color: var(--mk-text);
+}
+
+body.mario-kart-app.theme .container {
+    background: transparent !important;
+}
+
+/* ---------- Hero ---------- */
+
+body.mario-kart-app .header-section {
+    margin-bottom: 1.85rem;
+    padding-top: 0.5rem;
+}
+
+/* Title typography. Note: we deliberately do NOT use
+   `-webkit-text-fill-color: transparent` here — the heading contains
+   inline color emojis (🏎️, 🌍) which become invisible once the text
+   fill is transparent. A solid bright text colour + a soft accent
+   drop-shadow keeps both the wordmark and the emoji bookends crisp. */
+body.mario-kart-app .header-section h1 {
+    font-family: inherit;
+    font-size: clamp(1.85rem, 4vw, 2.75rem);
+    font-weight: 700;
+    letter-spacing: -0.025em;
+    line-height: 1.15;
+    text-transform: none;
+    color: #f1f3f8;
+    -webkit-text-fill-color: #f1f3f8;
+    background: none;
+    text-shadow: 0 4px 24px rgba(129, 140, 248, 0.22);
+    margin: 0 0 0.55rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+/* Game version toggle (MK8 / MK World) — segmented pill control */
+body.mario-kart-app .game-version-toggle {
+    display: inline-flex !important;
+    gap: 4px;
+    padding: 4px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--mk-border);
+    border-radius: 999px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+}
+
+body.mario-kart-app .game-version-toggle button.version-btn,
+body.mario-kart-app .game-version-toggle button.version-btn:not(.active) {
+    background: transparent !important;
+    border: none !important;
+    color: var(--mk-muted) !important;
+    border-radius: 999px !important;
+    padding: 0.5rem 1.1rem !important;
+    font-size: 0.88rem !important;
+    font-weight: 600 !important;
+    letter-spacing: 0;
+    line-height: 1 !important;
+    box-shadow: none !important;
+    transition: background 0.18s ease, color 0.18s ease;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 0.4rem !important;
+    text-align: center !important;
+    min-height: 32px;
+}
+
+/* Keep the racing-car / globe icons (and any other glyphs) vertically
+   centred on the same baseline as the label, and emoji-sized rather
+   than label-sized so they read as decorative rather than dominant. */
+body.mario-kart-app .game-version-toggle button.version-btn .version-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    font-size: 1rem;
+}
+body.mario-kart-app .game-version-toggle button.version-btn .version-text {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
+}
+
+body.mario-kart-app .game-version-toggle button.version-btn:hover {
+    background: rgba(255, 255, 255, 0.04) !important;
+    color: var(--mk-text) !important;
+    transform: none !important;
+    box-shadow: none !important;
+}
+
+body.mario-kart-app .game-version-toggle button.version-btn.active,
+body.mario-kart-app .game-version-toggle button#mk8d-btn.active,
+body.mario-kart-app .game-version-toggle button#mkworld-btn.active {
+    background: var(--mk-accent-soft) !important;
+    color: var(--mk-text) !important;
+    border-color: transparent !important;
+    box-shadow: inset 0 0 0 1px rgba(129, 140, 248, 0.45) !important;
+}
+
+body.mario-kart-app .game-version-toggle button.version-btn.active span,
+body.mario-kart-app .game-version-toggle button.version-btn.active .version-text,
+body.mario-kart-app .game-version-toggle button.version-btn.active .version-icon { color: var(--mk-text) !important; }
+
+/* ---------- Top tabs (Help / Guide / Achievements / Stats / H2H / Analysis / Activity / Trends) ---------- */
+
+body.mario-kart-app .toggle-section {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 1rem 0 1.25rem;
+    justify-content: center;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    margin-bottom: 1rem;
+}
+
+body.mario-kart-app .toggle-btn {
+    padding: 0.45rem 0.9rem !important;
+    background: rgba(255, 255, 255, 0.035) !important;
+    border: 1px solid var(--mk-border) !important;
+    color: var(--mk-muted) !important;
+    border-radius: 999px !important;
+    font-size: 0.85rem !important;
+    font-weight: 600 !important;
+    letter-spacing: 0;
+    box-shadow: none !important;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+body.mario-kart-app .toggle-btn:hover {
+    background: rgba(255, 255, 255, 0.06) !important;
+    border-color: var(--mk-border-strong) !important;
+    color: var(--mk-text) !important;
+    transform: none !important;
+}
+
+body.mario-kart-app .toggle-btn.active {
+    background: var(--mk-accent-soft) !important;
+    border-color: rgba(129, 140, 248, 0.45) !important;
+    color: var(--mk-text) !important;
+}
+
+/* ---------- Help / Guide panels (empty-state-friendly) ---------- */
+
+body.mario-kart-app.theme .help-panel,
+body.mario-kart-app .help-panel {
+    background: var(--mk-surface) !important;
+    border: 1px solid var(--mk-border) !important;
+    border-radius: var(--mk-radius);
+    box-shadow: var(--mk-shadow-lift);
+}
+
+body.mario-kart-app .help-content { padding: 1.5rem; }
+
+body.mario-kart-app .help-section h4 {
+    color: var(--mk-text) !important;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    text-transform: none;
+    margin-bottom: 0.75rem;
+}
+
+body.mario-kart-app .help-section p,
+body.mario-kart-app .help-text p {
+    color: var(--mk-muted) !important;
+    line-height: 1.55;
+}
+
+body.mario-kart-app .help-grid { gap: 0.8rem; margin-bottom: 1.4rem; }
+
+body.mario-kart-app .help-item {
+    background: var(--mk-surface-2) !important;
+    border: 1px solid var(--mk-border) !important;
+    border-radius: var(--mk-radius-sm);
+    padding: 1rem 1.1rem;
+    transition: border-color 0.15s ease, background 0.15s ease, transform 0.1s ease;
+}
+body.mario-kart-app .help-item:hover {
+    background: var(--mk-surface-3) !important;
+    border-color: var(--mk-border-strong) !important;
+    transform: translateY(-1px);
+    box-shadow: var(--mk-shadow-lift);
+}
+
+body.mario-kart-app .help-icon {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+body.mario-kart-app .help-text strong {
+    color: var(--mk-text) !important;
+    font-size: 0.98rem;
+    font-weight: 600;
+}
+
+body.mario-kart-app .help-steps {
+    background: var(--mk-surface-2) !important;
+    border: 1px solid var(--mk-border) !important;
+    border-left: 3px solid var(--mk-accent) !important;
+    color: var(--mk-text);
+}
+body.mario-kart-app .help-steps li { color: var(--mk-muted) !important; }
+body.mario-kart-app .help-steps strong { color: var(--mk-text) !important; }
+
+body.mario-kart-app .help-footer {
+    background: var(--mk-warn-soft) !important;
+    border: 1px solid rgba(251, 191, 36, 0.32) !important;
+    color: var(--mk-warn) !important;
+}
+body.mario-kart-app .help-footer p { color: var(--mk-warn) !important; }
+
+/* ---------- Sidebar (Control Panel) ---------- */
+
+body.mario-kart-app .sidebar,
+body.mario-kart-app.theme .sidebar {
+    background: var(--mk-surface) !important;
+    border-right: 1px solid var(--mk-border);
+    box-shadow: 2px 0 24px rgba(0, 0, 0, 0.5);
+}
+
+body.mario-kart-app .sidebar-header {
+    border-bottom: 1px solid var(--mk-border);
+    padding: 1rem 1.25rem;
+}
+
+body.mario-kart-app .sidebar-title {
+    font-size: 0.85rem !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.16em !important;
+    text-transform: uppercase !important;
+    color: var(--mk-muted) !important;
+    font-family: inherit !important;
+}
+
+body.mario-kart-app .sidebar-section-title {
+    font-size: 0.7rem !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.14em !important;
+    text-transform: uppercase !important;
+    color: var(--mk-muted-2) !important;
+    margin-bottom: 0.6rem !important;
+    font-family: inherit !important;
+}
+
+body.mario-kart-app .sidebar-content { padding: 1.1rem 1.1rem 1.4rem; }
+body.mario-kart-app .sidebar-section { margin-bottom: 1.4rem; }
+
+/* Sidebar close (X) + clear (trash) chips — match the Football refresh
+   exactly. The legacy `apps/mario-kart/css/sidebar.css` styles these
+   buttons with a red colour at rest and a red-tinted background +
+   `transform: scale(1.05)` on hover (under both the bare selector and
+   the `body.theme` variant). We override every combination at
+   equal-or-higher specificity, with `!important`, so the buttons sit
+   on a neutral dark surface and lift to the next surface tier on hover
+   — identical visual language to the Football Control Panel. */
+body.mario-kart-app .sidebar-close-btn,
+body.mario-kart-app.theme .sidebar-close-btn,
+body.mario-kart-app .sidebar-header-clear,
+body.mario-kart-app.theme .sidebar-header-clear {
+    width: 30px !important;
+    height: 30px !important;
+    padding: 0 !important;
+    background: rgba(255, 255, 255, 0.03) !important;
+    border: 1px solid var(--mk-border) !important;
+    color: var(--mk-muted) !important;
+    border-radius: 8px !important;
+    box-shadow: none !important;
+    transform: none !important;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease !important;
+}
+
+body.mario-kart-app .sidebar-close-btn:hover,
+body.mario-kart-app.theme .sidebar-close-btn:hover,
+body.mario-kart-app .sidebar-header-clear:hover,
+body.mario-kart-app .sidebar-header-clear:hover:not(:disabled),
+body.mario-kart-app.theme .sidebar-header-clear:hover,
+body.mario-kart-app.theme .sidebar-header-clear:hover:not(:disabled) {
+    background: var(--mk-surface-2) !important;
+    background-color: var(--mk-surface-2) !important;
+    border-color: var(--mk-border-strong) !important;
+    color: var(--mk-text) !important;
+    transform: none !important;
+    scale: none !important;
+    box-shadow: none !important;
+}
+
+body.mario-kart-app .sidebar-close-btn:focus-visible,
+body.mario-kart-app .sidebar-header-clear:focus-visible {
+    outline: 2px solid var(--mk-accent) !important;
+    outline-offset: 2px !important;
+    box-shadow: none !important;
+}
+
+body.mario-kart-app .sidebar-header-clear:disabled,
+body.mario-kart-app .sidebar-header-clear[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+/* Primary action buttons — unify the rainbow into one accent surface */
+body.mario-kart-app .sidebar-player-settings-btn,
+body.mario-kart-app .sidebar-add-race-btn {
+    background: linear-gradient(135deg, var(--mk-accent), var(--mk-accent-strong)) !important;
+    color: #ffffff !important;
+    border: 1px solid transparent !important;
+    border-radius: 10px !important;
+    padding: 0.7rem 0.85rem !important;
+    font-weight: 600 !important;
+    font-size: 0.92rem !important;
+    box-shadow: 0 4px 14px rgba(99, 102, 241, 0.28) !important;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    transition: filter 0.15s ease, transform 0.08s ease, box-shadow 0.15s ease;
+}
+body.mario-kart-app .sidebar-player-settings-btn:hover,
+body.mario-kart-app .sidebar-add-race-btn:hover {
+    filter: brightness(1.06);
+    transform: translateY(-1px);
+    box-shadow: 0 8px 22px -6px rgba(99, 102, 241, 0.55) !important;
+}
+body.mario-kart-app .sidebar-add-race-btn.active {
+    background: linear-gradient(135deg, var(--mk-good), #10b981) !important;
+    box-shadow: 0 4px 14px rgba(52, 211, 153, 0.32) !important;
+}
+
+/* Secondary action button group (Undo/Redo/Export/Import/Backup/Restore).
+   Sidebar surface is var(--mk-surface) = #12151d; the previous 3% white
+   wash was almost invisible against it. Use --mk-surface-2 so the
+   buttons read as real surfaces with their own elevation. Icon + label
+   are flex-aligned so emoji glyphs sit on the same baseline as the
+   text and the row reads as one unit. */
+body.mario-kart-app .sidebar-action-btn,
+body.mario-kart-app .sidebar .action-buttons button,
+body.mario-kart-app .sidebar .action-buttons button[onclick*="exportData"],
+body.mario-kart-app .sidebar .action-buttons button[onclick*="importFile"],
+body.mario-kart-app .sidebar .action-buttons button[onclick*="backupToGoogleDrive"] {
+    background: var(--mk-surface-2) !important;
+    color: var(--mk-text) !important;
+    border: 1px solid var(--mk-border-strong) !important;
+    border-radius: 10px !important;
+    padding: 0.6rem 0.85rem !important;
+    font-size: 0.88rem !important;
+    font-weight: 500 !important;
+    box-shadow: none !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 0.55rem !important;
+    line-height: 1 !important;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.08s ease;
+}
+
+body.mario-kart-app .sidebar-action-btn:hover:not(:disabled),
+body.mario-kart-app .sidebar .action-buttons button:hover,
+body.mario-kart-app .sidebar .action-buttons button[onclick*="exportData"]:hover,
+body.mario-kart-app .sidebar .action-buttons button[onclick*="importFile"]:hover,
+body.mario-kart-app .sidebar .action-buttons button[onclick*="backupToGoogleDrive"]:hover {
+    background: var(--mk-surface-3) !important;
+    border-color: #4a4f66 !important;
+    color: var(--mk-text) !important;
+    transform: none !important;
+    box-shadow: none !important;
+}
+
+body.mario-kart-app .sidebar-action-btn:disabled,
+body.mario-kart-app .sidebar-action-btn[disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+/* Per-button semantic accent — each secondary action keeps a hint of
+   its original colour identity so the user can still scan the rail
+   visually (green Restore, blue/teal Export/Import, etc.) without the
+   buttons themselves becoming bright slabs. */
+body.mario-kart-app .sidebar-action-btn.restore-btn,
+body.mario-kart-app .sidebar-action-btn.restore-btn .action-icon {
+    color: var(--mk-good) !important;
+}
+
+/* ---------- Undo / Redo toolbar pair ---------- */
+
+/* Lay the Undo + Redo buttons out as a 2-column toolbar so they read as
+   a paired control rather than two anonymous stacked buttons. They get
+   a distinct accent identity (indigo arrow) while disabled keeps them
+   present-but-quiet, so users can see they exist before there's history
+   to operate on. */
+body.mario-kart-app .sidebar-action-buttons-group {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 0.5rem !important;
+    margin-bottom: 0.6rem;
+}
+
+body.mario-kart-app .sidebar-action-btn.undo-btn,
+body.mario-kart-app .sidebar-action-btn.redo-btn {
+    background: var(--mk-surface-2) !important;
+    color: var(--mk-text) !important;
+    border: 1px solid var(--mk-border-strong) !important;
+    border-radius: 10px !important;
+    padding: 0.55rem 0.6rem !important;
+    font-size: 0.86rem !important;
+    font-weight: 600 !important;
+    width: 100%;
+    box-shadow: none !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 0.45rem !important;
+    line-height: 1 !important;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.08s ease;
+}
+
+body.mario-kart-app .sidebar-action-btn.undo-btn .action-icon,
+body.mario-kart-app .sidebar-action-btn.redo-btn .action-icon {
+    color: var(--mk-accent) !important;
+    font-size: 1.25rem !important;
+    line-height: 1 !important;
+    font-weight: 700;
+}
+
+body.mario-kart-app .sidebar-action-btn.undo-btn .action-text,
+body.mario-kart-app .sidebar-action-btn.redo-btn .action-text {
+    color: var(--mk-text) !important;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+
+/* Enabled hover — accent-soft fill + indigo border so it's obvious the
+   button is now actionable. */
+body.mario-kart-app .sidebar-action-btn.undo-btn:hover:not(:disabled),
+body.mario-kart-app .sidebar-action-btn.redo-btn:hover:not(:disabled) {
+    background: var(--mk-accent-soft) !important;
+    border-color: rgba(129, 140, 248, 0.55) !important;
+    color: #ffffff !important;
+    transform: translateY(-1px);
+}
+
+body.mario-kart-app .sidebar-action-btn.undo-btn:hover:not(:disabled) .action-icon,
+body.mario-kart-app .sidebar-action-btn.redo-btn:hover:not(:disabled) .action-icon,
+body.mario-kart-app .sidebar-action-btn.undo-btn:hover:not(:disabled) .action-text,
+body.mario-kart-app .sidebar-action-btn.redo-btn:hover:not(:disabled) .action-text {
+    color: #ffffff !important;
+}
+
+body.mario-kart-app .sidebar-action-btn.undo-btn:active:not(:disabled),
+body.mario-kart-app .sidebar-action-btn.redo-btn:active:not(:disabled) {
+    transform: translateY(0);
+    background: rgba(99, 102, 241, 0.22) !important;
+}
+
+/* Disabled state — unambiguously inert. The button is still visible (so
+   users can find it later) but reduced opacity + not-allowed cursor +
+   no hover transform make it clear there's nothing to undo/redo yet. */
+body.mario-kart-app .sidebar-action-btn.undo-btn:disabled,
+body.mario-kart-app .sidebar-action-btn.redo-btn:disabled,
+body.mario-kart-app .sidebar-action-btn.undo-btn[disabled],
+body.mario-kart-app .sidebar-action-btn.redo-btn[disabled] {
+    opacity: 0.42 !important;
+    cursor: not-allowed !important;
+    pointer-events: none;
+    background: var(--mk-surface-2) !important;
+    border-color: var(--mk-border) !important;
+    transform: none !important;
+}
+body.mario-kart-app .sidebar-action-btn.undo-btn:disabled .action-icon,
+body.mario-kart-app .sidebar-action-btn.redo-btn:disabled .action-icon {
+    color: var(--mk-muted) !important;
+}
+body.mario-kart-app .sidebar .action-buttons button[onclick*="exportData"] .action-icon,
+body.mario-kart-app .sidebar .action-buttons button[onclick*="exportData"]::first-letter {
+    color: var(--mk-good) !important;
+}
+body.mario-kart-app .sidebar .action-buttons button[onclick*="importFile"] .action-icon {
+    color: #38b2ac !important;
+}
+body.mario-kart-app .sidebar .action-buttons button[onclick*="backupToGoogleDrive"] .action-icon {
+    color: #4299e1 !important;
+}
+
+/* Icon + text alignment for sidebar action buttons that use
+   `<span class="action-icon">` + `<span class="action-text">` wrappers. */
+body.mario-kart-app .sidebar-action-btn .action-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    font-size: 1rem;
+}
+body.mario-kart-app .sidebar-action-btn .action-text {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
+}
+
+/* Date filter buttons in the sidebar */
+body.mario-kart-app .sidebar .date-filter-controls { gap: 0.4rem !important; }
+body.mario-kart-app .sidebar .filter-btn,
+body.mario-kart-app .sidebar .date-filter-btn {
+    background: var(--mk-surface-2) !important;
+    color: var(--mk-text) !important;
+    border: 1px solid var(--mk-border-strong) !important;
+    border-radius: 999px !important;
+    padding: 0.5rem 0.9rem !important;
+    font-size: 0.85rem !important;
+    font-weight: 500 !important;
+    width: 100%;
+    box-shadow: none !important;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+body.mario-kart-app .sidebar .filter-btn:hover,
+body.mario-kart-app .sidebar .date-filter-btn:hover {
+    background: var(--mk-surface-2) !important;
+    border-color: var(--mk-border-strong) !important;
+    color: var(--mk-text) !important;
+    transform: none !important;
+}
+body.mario-kart-app .sidebar .filter-btn.active,
+body.mario-kart-app .sidebar .date-filter-btn.active {
+    background: var(--mk-accent-soft) !important;
+    border-color: rgba(129, 140, 248, 0.45) !important;
+    color: var(--mk-text) !important;
+}
+
+/* Race-date helper button */
+body.mario-kart-app .sidebar-date-btn-container {
+    background: var(--mk-surface-2) !important;
+    border: 1px solid var(--mk-border) !important;
+    border-radius: 10px !important;
+    color: var(--mk-text) !important;
+}
+body.mario-kart-app .sidebar-date-today-btn {
+    background: rgba(255, 255, 255, 0.03) !important;
+    color: var(--mk-muted) !important;
+    border: 1px solid var(--mk-border) !important;
+    border-radius: 999px !important;
+    box-shadow: none !important;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+body.mario-kart-app .sidebar-date-today-btn:hover {
+    background: var(--mk-surface-2) !important;
+    border-color: var(--mk-border-strong) !important;
+    color: var(--mk-text) !important;
+}
+
+/* Sidebar toggle button (the hamburger floating outside the sidebar) */
+body.mario-kart-app .sidebar-toggle,
+body.mario-kart-app.theme .sidebar-toggle {
+    background: linear-gradient(135deg, var(--mk-accent), var(--mk-accent-strong)) !important;
+    box-shadow: 0 6px 20px rgba(99, 102, 241, 0.35) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+}
+
+/* ---------- Stat cards / Race-history tables ---------- */
+
+body.mario-kart-app.theme .stat-card,
+body.mario-kart-app .stat-card,
+body.mario-kart-app.theme .race-history,
+body.mario-kart-app .race-history,
+body.mario-kart-app.theme #history-table,
+body.mario-kart-app #history-table {
+    background: var(--mk-surface) !important;
+    border: 1px solid var(--mk-border) !important;
+    color: var(--mk-text) !important;
+}
+
+body.mario-kart-app .stat-card { border-radius: var(--mk-radius); box-shadow: var(--mk-shadow-lift); }
+
+body.mario-kart-app.theme th,
+body.mario-kart-app th {
+    background: var(--mk-surface-2) !important;
+    color: var(--mk-muted) !important;
+    border-bottom: 1px solid var(--mk-border) !important;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+}
+
+body.mario-kart-app.theme td,
+body.mario-kart-app td {
+    background: transparent !important;
+    color: var(--mk-text) !important;
+    border-bottom-color: var(--mk-border) !important;
+}
+
+body.mario-kart-app tr:hover td,
+body.mario-kart-app.theme tr:hover td { background: rgba(255, 255, 255, 0.025) !important; }
+
+/* ---------- Inputs ---------- */
+
+body.mario-kart-app input[type="text"],
+body.mario-kart-app input[type="number"],
+body.mario-kart-app input[type="date"],
+body.mario-kart-app select,
+body.mario-kart-app textarea {
+    background: var(--mk-surface-2) !important;
+    color: var(--mk-text) !important;
+    border: 1px solid var(--mk-border) !important;
+    border-radius: 10px !important;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+body.mario-kart-app input[type="text"]:focus,
+body.mario-kart-app input[type="number"]:focus,
+body.mario-kart-app input[type="date"]:focus,
+body.mario-kart-app select:focus,
+body.mario-kart-app textarea:focus {
+    outline: none !important;
+    border-color: var(--mk-accent) !important;
+    box-shadow: 0 0 0 3px var(--mk-accent-soft) !important;
+    background: var(--mk-surface) !important;
+}
+
+/* ---------- Export/Import/Backup/Clear buttons used in main area ---------- */
+
+body.mario-kart-app .export-btn,
+body.mario-kart-app .import-btn,
+body.mario-kart-app .backup-btn,
+body.mario-kart-app .clear-btn {
+    background: rgba(255, 255, 255, 0.03) !important;
+    color: var(--mk-text) !important;
+    border: 1px solid var(--mk-border) !important;
+    border-radius: 10px !important;
+    padding: 0.55rem 0.95rem !important;
+    font-weight: 500 !important;
+    font-size: 0.88rem !important;
+    margin-left: 0.45rem;
+    box-shadow: none !important;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+body.mario-kart-app .export-btn:hover,
+body.mario-kart-app .import-btn:hover,
+body.mario-kart-app .backup-btn:hover,
+body.mario-kart-app .clear-btn:hover {
+    background: var(--mk-surface-2) !important;
+    border-color: var(--mk-border-strong) !important;
+    transform: none !important;
+}
+body.mario-kart-app .clear-btn:not(:disabled) { color: var(--mk-danger) !important; }
+body.mario-kart-app .clear-btn:not(:disabled):hover {
+    background: var(--mk-danger-soft) !important;
+    border-color: rgba(248, 113, 113, 0.45) !important;
+}
+
+/* ---------- Generic button reset for the page body (without breaking icons) ---------- */
+body.mario-kart-app button {
+    box-shadow: none;
+}
+body.mario-kart-app button:hover { transform: none; box-shadow: none; }
+
+/* ---------- Help/feature section: a "What is this?" headline tone ---------- */
+
+body.mario-kart-app .help-section.visualization-guide,
+body.mario-kart-app .help-section.help-disclaimers,
+body.mario-kart-app .help-section.help-technical {
+    background: var(--mk-surface-2);
+    border: 1px solid var(--mk-border);
+    border-radius: var(--mk-radius-sm);
+    padding: 1rem 1.1rem;
+}
+
+body.mario-kart-app .viz-guide-card {
+    background: var(--mk-surface) !important;
+    border: 1px solid var(--mk-border) !important;
+    border-radius: var(--mk-radius-sm) !important;
+}
+body.mario-kart-app .viz-tip {
+    background: var(--mk-accent-soft) !important;
+    border-left: 3px solid var(--mk-accent) !important;
+    color: var(--mk-text) !important;
+}
+
+/* ---------- Scrollbars ---------- */
+
+body.mario-kart-app ::-webkit-scrollbar { width: 10px; height: 10px; }
+body.mario-kart-app ::-webkit-scrollbar-track { background: transparent !important; }
+body.mario-kart-app ::-webkit-scrollbar-thumb {
+    background: var(--mk-border-strong) !important;
+    border: 3px solid var(--mk-bg) !important;
+    background-clip: content-box !important;
+    border-radius: 999px !important;
+}
+body.mario-kart-app ::-webkit-scrollbar-thumb:hover {
+    background: #4a4f66 !important;
+    background-clip: content-box !important;
+}
+
+/* ---------- Cleanup: prevent the global generic `button:hover` glow ---------- */
+body.mario-kart-app .container button:hover { box-shadow: none; }

--- a/apps/mario-kart/index.html
+++ b/apps/mario-kart/index.html
@@ -108,6 +108,8 @@
     <link rel="stylesheet" href="css/help-styles.css">
     <link rel="stylesheet" href="../../assets/css/main.css" />
       <link rel="stylesheet" href="css/mario-kart-overrides.css">
+    <!-- Visual refresh layer — must load last so it wins specificity ties. -->
+    <link rel="stylesheet" href="css/refresh.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://apis.google.com/js/api.js"></script>
     
@@ -135,7 +137,7 @@
         <div class="sidebar-header">
             <h2 class="sidebar-title">Control Panel</h2>
             <div class="sidebar-header-buttons">
-                <button id="sidebar-clear-btn" class="sidebar-header-clear" onclick="confirmClearData()" title="Clear all data" aria-label="Clear all data">
+                <button id="sidebar-clear-btn" class="sidebar-header-clear" onclick="confirmClearData()" aria-label="Clear all data">
                     🗑️
                 </button>
                 <button class="sidebar-close-btn" onclick="closeSidebar()" aria-label="Close sidebar">
@@ -175,17 +177,17 @@
                     </div>
                 </div>
                 <div class="sidebar-action-buttons-group">
-                    <button id="sidebar-undo-btn" class="sidebar-action-btn undo-btn" onclick="undoLastAction()" disabled title="Undo last action">
+                    <button id="sidebar-undo-btn" class="sidebar-action-btn undo-btn" onclick="undoLastAction()" disabled aria-label="Undo last action">
                         <span class="action-icon">↶</span>
                         <span class="action-text">Undo</span>
                     </button>
-                    <button id="sidebar-redo-btn" class="sidebar-action-btn redo-btn" onclick="redoLastAction()" disabled title="Redo last action">
+                    <button id="sidebar-redo-btn" class="sidebar-action-btn redo-btn" onclick="redoLastAction()" disabled aria-label="Redo last action">
                         <span class="action-icon">↷</span>
                         <span class="action-text">Redo</span>
                     </button>
                 </div>
                 <div class="action-buttons" id="sidebar-action-buttons">
-                    <button class="sidebar-action-btn restore-btn" onclick="restoreFromBackup()" title="Restore from auto-backup">
+                    <button class="sidebar-action-btn restore-btn" onclick="restoreFromBackup()" aria-label="Restore from auto-backup">
                         <span class="action-icon">🔄</span>
                         <span class="action-text">Restore</span>
                     </button>


### PR DESCRIPTION
## Summary

Visual-only refresh of the three free apps under `apps/` so they read in the same cinematic dark palette as the existing reference apps Rising Seasons and MapTap. Each app gets a single `css/refresh.css` loaded last so it wins specificity ties against the legacy stylesheets — no JS touched, no IDs renamed, no event handlers altered. HTML changes are limited to one new `<link>` per app plus removing a handful of native `title=\"…\"` tooltips from the Control Panel header (each still keeps its `aria-label` for screen readers).

Reference apps `apps/rising-seasons/*` and `apps/maptap-rivals/*` are untouched.

## Files changed
- `apps/gym-tracker/css/refresh.css` (new) + `apps/gym-tracker/index.html` (one `<link>` added)
- `apps/mario-kart/css/refresh.css` (new) + `apps/mario-kart/index.html` (one `<link>`, three `title` attrs dropped)
- `apps/football-h2h/css/refresh.css` (new) + `apps/football-h2h/index.html` (one `<link>`, six `title` attrs dropped)

## Per-app highlights

### Gym Tracker
- Gradient hero title (white → indigo), `Inter` antialiased.
- Side-nav: muted nav items, accent-soft active state with a 2px inset accent rail; gradient brand label.
- Bottom-nav (mobile): glass surface, accent-soft active pill, keeps the prominent gradient \"Workout\" FAB.
- Dashed editorial empty states with a circular accent-soft icon medallion (programs / workouts / achievements / insights / measurements).
- Unified `.btn` system (`.btn`, `.btn-primary`, `.btn-ghost`, `.btn-danger`, `.btn-text`, `.btn-icon`) on the same 40 px height + 10 px radius.
- Frosted modals (`rgba(7,9,15,0.72)` + 8 px backdrop blur), polished onboarding step pills, retoned inputs / history filters / calendar nav / toasts / scrollbars.

### Mario Kart Tracker
- Cinematic dark canvas applied on both default and the legacy `body.theme` class.
- Hero `🏎️ Mario Kart 8 Deluxe Tracker 🏎️` (and the `🏎️ Mario Kart World Tracker 🌍` variant) uses solid bright text so the colour emojis stay visible — no gradient text fill.
- `MK8 Deluxe / MK World` reworked into a segmented pill toggle with icons + labels centred.
- Eight top tabs (Help / Guide / Achievements / Stats / H2H / Analysis / Activity / Trends) are uniform accent-soft pill chips.
- Control Panel rebuilt into three tiers:
  - Primary indigo-gradient actions (Manage Players, Add Race).
  - 2-column Undo / Redo toolbar with clear disabled / enabled / hover states (indigo arrow, white label, accent-soft hover, 0.42 opacity + `not-allowed` when disabled).
  - Surface-card secondary actions (Restore / Export / Import / Backup) with per-button icon accents (green Restore + Export, teal Import, blue Backup) so the rail still scans by colour without becoming bright slabs.
- Date filter pills retoned to match.
- Sidebar header X + trash chips: neutral grey hover instead of the legacy red-tint + `scale(1.05)`. Native `title=\"…\"` tooltips removed so they no longer overlap content.

### Football H2H League
- Gradient hero `⚽ Football H2H League ⚽` (white → indigo → green) using `Inter` instead of the retro pixel font; soccer-ball emojis preserved and scaled down to read as decoration.
- Subtitle added via `::after` (\"Head-to-head match log, wins, and side-by-side player stats\").
- Title now sits ~0.6 rem below the site header (was ~3 rem). The fix restores `body { padding-top: 3.25rem }` that `apps/football-h2h/css/sidebar.css` line 12 wipes out, then tightens `.app-container` from `padding: 2rem` to `padding: 0.6rem 1.25rem 3rem`.
- `H2H Stats / General Stats / Player Stats` reworked into a segmented pill toggle.
- Stat cards live on the new `--fh-surface` with a 3 px left identity rail (indigo→green Player 1, red→pink Player 2, yellow Draws, purple/pink Penalty). JS-driven `winning / losing / tied` states still drive the border + a subtle tinted background.
- Player Stats comparison table — restored the green / red / olive cell colouring that my earlier `td { background: transparent }` had bulldozed. The lower-is-better reversal (Consistency σ, Current Losing Streak, Longest Scoreless Streak) is preserved automatically because the JS already tags each cell with the correct class.
- Game History action buttons: compact 28×28 ghost chips. Edit chip is soft blue at rest and fills indigo on hover; delete chip is neutral grey at rest and only goes red on hover. Both lift + scale subtly with matching coloured drop-shadow.
- Sidebar text contrast: every legacy `color: black !important` rule across `apps/football-h2h/css/sidebar.css` is overridden so Export / Import / Backup / Restore / Undo / Redo / Set-to-Today / date filter labels render in white on the dark surfaces. Per-button icon accents kept on the `.action-icon` glyph alone so the labels stay unambiguously white.

## New additions
- Gym Tracker: dashed editorial empty-state pattern + accent rail on the side-nav active row.
- Mario Kart + Football: shared segmented-pill controls and the 2-column Undo/Redo toolbar.
- Football: synthesised hero subtitle (via `::after`, removable in one line), colour-coded stat-card identity rails, polished compact Game History action chips.

## Test plan
- [ ] Start a local server from the repo root (`python3 -m http.server 8765` — port `8080` collides with a Windows-host service on the WSL setup used in this branch).
- [ ] Open each app at `http://localhost:8765/apps/<app>/index.html` and compare side-by-side with production.
- [ ] Walk the populated and empty states on Gym Tracker, Mario Kart, and Football. Confirm: nav, modals, sidebar actions, stat cards, history, settings — no regressions in functionality.
- [ ] Spot-check mobile breakpoint (~420 px width) on Gym Tracker for the bottom nav + FAB.
- [ ] Confirm Rising Seasons and MapTap render identically to production.