### PR TITLE
maptap-rivals: today's prediction card, 7-day lookahead, smarter predictor, dashboard polish

### DIFF
--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -2451,6 +2451,78 @@ body.maptap-rivals-app select option {
   transform: none;
 }
 
+/* User icon picker in the settings strip — small button showing the
+   current icon, with a floating grid flyout that mirrors the rival
+   icon-swatch palette but at a slightly tighter density. */
+.my-icon-wrap { position: relative; display: inline-flex; }
+.my-icon-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.025);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  font-size: 1.02rem;
+  line-height: 1;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.my-icon-btn:hover { background: var(--surface-3); border-color: var(--border-strong); }
+.my-icon-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.my-icon-current { display: inline-block; }
+.my-icon-flyout {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 40;
+  background: var(--surface-2);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  padding: 0.45rem;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  display: grid;
+  grid-template-columns: repeat(8, 28px);
+  gap: 0.3rem;
+  min-width: max-content;
+}
+.my-icon-flyout[hidden] { display: none; }
+.my-icon-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  font-size: 0.98rem;
+  line-height: 1;
+  padding: 0;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.my-icon-swatch:hover  { background: var(--surface-3); border-color: var(--border-strong); }
+.my-icon-swatch:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.my-icon-swatch.is-selected,
+.my-icon-swatch.is-selected:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+@media (max-width: 520px) {
+  .my-icon-flyout { grid-template-columns: repeat(6, 28px); }
+}
+
 /* Footer — top hairline, compact buttons, balanced hierarchy. */
 .modal-actions {
   display: flex;

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -912,6 +912,130 @@ body.maptap-rivals-app button {
   .pred-row-head { font-size: 0.65rem; }
 }
 
+/* Wraps a player row + its per-round chip strip. Used as a single
+   visual block so the strip reads as "belonging to" the totals above. */
+.pred-row-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.5rem 0.6rem 0.6rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}
+.pred-row-wrap-you { background: var(--accent-soft); }
+.pred-row-wrap > .pred-row { background: transparent; padding: 0; }
+
+/* Day-tab strip across the top of the predictions body. Each pill is
+   roughly square, today is highlighted, future days carry a thinner
+   accent so the upcoming run reads in one glance. */
+.pred-day-tabs {
+  display: flex;
+  gap: 0.4rem;
+  overflow-x: auto;
+  padding: 0 0.15rem 0.65rem;
+  margin: -0.25rem -0.15rem 0.4rem;
+  scrollbar-width: thin;
+}
+.pred-day-tab {
+  flex: 0 0 auto;
+  min-width: 58px;
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--muted);
+  font: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.05rem;
+  line-height: 1.1;
+  transition: border-color 0.12s ease, background 0.12s ease, color 0.12s ease;
+}
+.pred-day-tab:hover { border-color: var(--border-strong); color: var(--text); }
+.pred-day-tab.is-today { border-color: var(--accent-strong); color: var(--text); }
+.pred-day-tab.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+.pred-day-tab.is-loading { opacity: 0.7; }
+.pred-day-tab.is-error   { border-color: rgba(251, 146, 60, 0.5); color: var(--warn); }
+.pred-day-tab:focus-visible { outline: 2px solid var(--accent-2); outline-offset: 2px; }
+.pred-day-tab-name {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+.pred-day-tab-num {
+  font-size: 1.05rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Per-round chip strip — one chip per of today's 5 rounds. Shows the
+   predicted value, the actual value once known, and a colored sliver
+   underneath keyed to the Δ direction. */
+.pred-round-strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.3rem;
+}
+.prc {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.3rem 0.4rem 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  align-items: center;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  position: relative;
+  overflow: hidden;
+}
+.prc-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  font-size: 0.68rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+.prc-slot   { font-weight: 700; color: var(--text); }
+.prc-weight { color: var(--muted); font-weight: 600; }
+.prc-nums {
+  display: flex;
+  align-items: baseline;
+  gap: 0.2rem;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+.prc-pred   { color: var(--accent-2); }
+.prc-arrow  { color: var(--muted-2); font-weight: 500; }
+.prc-actual { color: var(--text); }
+.prc-delta {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.prc-pos  { box-shadow: inset 0 -3px 0 0 var(--good); }
+.prc-pos  .prc-delta { color: var(--good); }
+.prc-neg  { box-shadow: inset 0 -3px 0 0 var(--bad);  }
+.prc-neg  .prc-delta { color: var(--bad);  }
+.prc-zero { box-shadow: inset 0 -3px 0 0 var(--muted); }
+.prc-zero .prc-delta { color: var(--muted); }
+
+@media (max-width: 520px) {
+  .pred-round-strip { gap: 0.2rem; }
+  .prc { padding: 0.25rem 0.2rem 0.3rem; }
+  .prc-nums { font-size: 0.82rem; }
+  .prc-head { font-size: 0.6rem; }
+}
+
 /* ---------- Dashboard rival grid ---------- */
 
 .dash-controls {

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -52,6 +52,12 @@
   --ctrl-pad-x: 0.95rem;
   --ctrl-font: 0.9rem;
 
+  /* Monospace stack used for numeric values in the predictions table so
+     digits march in lockstep — gives the dashboard a sports-board feel
+     without changing the body font. */
+  --mono: "JetBrains Mono", "SF Mono", "Cascadia Code", ui-monospace,
+          "Roboto Mono", "Menlo", monospace;
+
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
 }
 
@@ -903,29 +909,46 @@ body.maptap-rivals-app button {
   border-color: var(--border);
 }
 
-.todays-card-body { display: flex; flex-direction: column; gap: 0.45rem; }
+.todays-card-body { display: flex; flex-direction: column; gap: 0.55rem; }
+
+/* Tiny inline-SVG slot used for column headers, delta arrows, and chip
+   chevrons. Width-bound so the icon always pairs cleanly with adjacent
+   text without nudging the baseline. */
+.pred-ic {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.92em;
+  height: 0.92em;
+  flex-shrink: 0;
+}
+.pred-ic > svg { width: 100%; height: 100%; display: block; }
+.pred-col-ic { color: var(--muted-2); margin-right: 0.32rem; }
+.pred-row-head .pred-cell { display: inline-flex; align-items: center; justify-content: flex-end; gap: 0; }
 
 .pred-row {
   display: grid;
-  grid-template-columns: minmax(140px, 1.6fr) repeat(3, minmax(72px, 1fr));
+  grid-template-columns: minmax(140px, 1.6fr) repeat(3, minmax(74px, 1fr));
   align-items: center;
   gap: 0.75rem;
-  padding: 0.6rem 0.75rem;
+  padding: 0.65rem 0.8rem 0.65rem 0.85rem;
   border-radius: var(--radius-sm);
   background: var(--surface-2);
+  border-left: 3px solid var(--row-accent, transparent);
 }
 .pred-row-head {
   background: transparent;
-  padding: 0 0.75rem 0.35rem;
+  border-left: 0;
+  padding: 0 0.85rem 0.4rem;
   color: var(--muted-2);
   font-size: 0.66rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 0.15rem;
+  margin-bottom: 0.2rem;
 }
-.pred-row-head .pred-cell { text-align: right; color: var(--muted-2); }
+.pred-row-head .pred-cell { text-align: right; color: var(--muted-2); font-family: inherit; }
 .pred-row-you { background: var(--accent-soft); }
 .pred-label {
   font-weight: 600;
@@ -939,14 +962,12 @@ body.maptap-rivals-app button {
   text-align: right;
   font-variant-numeric: tabular-nums;
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.005em;
+  font-family: var(--mono);
 }
 .pred-predicted { color: var(--accent-2); }
 .pred-actual    { color: var(--text); }
-.pred-delta     { color: var(--muted-2); font-weight: 700; }
-.pred-delta-pos { color: var(--good); }
-.pred-delta-neg { color: var(--bad); }
-.pred-delta-zero { color: var(--muted); }
+.pred-delta-cell { display: flex; justify-content: flex-end; }
 .pred-empty {
   margin: 0;
   padding: 0.65rem 0.2rem;
@@ -955,23 +976,66 @@ body.maptap-rivals-app button {
   line-height: 1.5;
 }
 
+/* Pill-shaped delta badge for the Δ column. Soft tint + matching arrow
+   so direction reads instantly even at small sizes. */
+.pred-delta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  font-size: 0.84rem;
+  letter-spacing: -0.01em;
+  padding: 0.18rem 0.5rem 0.18rem 0.42rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  line-height: 1;
+}
+.pred-delta-badge.is-pos {
+  color: var(--good);
+  background: var(--good-soft);
+  border-color: rgba(74, 222, 128, 0.28);
+}
+.pred-delta-badge.is-neg {
+  color: var(--bad);
+  background: var(--bad-soft);
+  border-color: rgba(248, 113, 113, 0.26);
+}
+.pred-delta-badge.is-zero {
+  color: var(--muted);
+  background: var(--tie-soft);
+  border-color: rgba(154, 163, 178, 0.24);
+}
+.pred-delta-badge.is-na {
+  color: var(--muted-2);
+  background: transparent;
+  border-color: transparent;
+  padding: 0 0.4rem;
+  font-family: inherit;
+}
+.pred-delta-num { display: inline-block; }
+
 @media (max-width: 520px) {
-  .pred-row { grid-template-columns: minmax(100px, 1.3fr) repeat(3, minmax(56px, 1fr)); gap: 0.45rem; font-size: 0.92rem; padding: 0.55rem 0.6rem; }
+  .pred-row { grid-template-columns: minmax(100px, 1.3fr) repeat(3, minmax(58px, 1fr)); gap: 0.45rem; font-size: 0.92rem; padding: 0.55rem 0.6rem; }
   .pred-row-head { font-size: 0.6rem; padding: 0 0.6rem 0.3rem; }
+  .pred-delta-badge { font-size: 0.78rem; padding: 0.15rem 0.4rem; }
 }
 
 /* Wraps a player row + its per-round chip strip into one visual block
-   so the strip reads as belonging to the totals above. */
+   so the strip reads as belonging to the totals above. Inherits the
+   per-player left accent so the totals row and chip strip share it. */
 .pred-row-wrap {
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
-  padding: 0.65rem 0.75rem 0.7rem;
+  gap: 0.6rem;
+  padding: 0.7rem 0.85rem 0.75rem;
   border-radius: var(--radius-sm);
   background: var(--surface-2);
+  border-left: 3px solid var(--row-accent, transparent);
 }
 .pred-row-wrap-you { background: var(--accent-soft); }
-.pred-row-wrap > .pred-row { background: transparent; padding: 0; gap: 0.75rem; }
+.pred-row-wrap > .pred-row { background: transparent; padding: 0; gap: 0.75rem; border-left: 0; }
 
 /* Day-tab strip across the top of the predictions body. Inactive pills
    sit on surface-2, today wears a subtle accent ring, and the selected
@@ -1010,10 +1074,26 @@ body.maptap-rivals-app button {
 .pred-day-tab.is-today { color: var(--text); }
 .pred-day-tab.is-today .pred-day-tab-num { color: var(--accent-2); }
 .pred-day-tab.is-active {
-  background: var(--accent-soft);
+  background: linear-gradient(180deg,
+              rgba(99, 102, 241, 0.22) 0%,
+              rgba(99, 102, 241, 0.12) 100%);
   border-color: var(--accent);
   color: var(--accent-2);
+  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.04),
+              0 0 0 1px rgba(99, 102, 241, 0.18);
 }
+.pred-day-tab.is-active::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: -1px;
+  transform: translateX(-50%);
+  width: 24px;
+  height: 2px;
+  border-radius: 0 0 4px 4px;
+  background: var(--accent);
+}
+.pred-day-tab { position: relative; }
 .pred-day-tab.is-active .pred-day-tab-num { color: var(--accent-2); }
 .pred-day-tab.is-loading { opacity: 0.65; }
 .pred-day-tab.is-error   { border-color: rgba(251, 146, 60, 0.45); color: var(--warn); }
@@ -1034,79 +1114,130 @@ body.maptap-rivals-app button {
   letter-spacing: -0.01em;
 }
 
-/* Per-round chips — premium compact stat modules. Background tints
-   gently to the Δ direction (good/bad/neutral) instead of slamming a
-   hard colored bar across the bottom. The predicted value gets the
-   accent text color; the arrow → actual transition is restrained so
-   the eye can scan five chips in a single sweep. */
+/* Per-round chips — premium compact stat modules. A thin top accent
+   line keys the chip to its Δ direction; the background carries a
+   gentle tint of the same semantic so the eye reads five chips in a
+   single sweep without any harsh strokes. ×weight rides as a small
+   superscript badge in the top-right corner. */
 .pred-round-strip {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.4rem;
+  gap: 0.45rem;
 }
 .prc {
+  position: relative;
   background: rgba(255, 255, 255, 0.015);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  padding: 0.45rem 0.5rem 0.5rem;
+  padding: 0.55rem 0.5rem 0.5rem;
   display: grid;
   grid-template-rows: auto auto auto;
-  row-gap: 0.18rem;
+  row-gap: 0.22rem;
   align-items: center;
   justify-items: center;
   text-align: center;
-  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+}
+/* Thin top accent line drawn via ::before so border-radius keeps clean
+   rounded corners on the chip itself. Hidden by default; the Δ status
+   modifiers below promote it. */
+.prc::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 2px;
+  background: transparent;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
 }
 .prc-head {
   display: flex;
   align-items: baseline;
   gap: 0.3rem;
-  font-size: 0.6rem;
+  font-size: 0.58rem;
   color: var(--muted-2);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 .prc-slot   { font-weight: 700; color: var(--muted); }
-.prc-weight { color: var(--muted-2); font-weight: 600; }
+.prc-weight {
+  position: absolute;
+  top: 0.32rem;
+  right: 0.4rem;
+  font-size: 0.54rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.06rem 0.22rem;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
 .prc-nums {
   display: flex;
-  align-items: baseline;
-  gap: 0.28rem;
+  align-items: center;
+  gap: 0.32rem;
+  font-family: var(--mono);
   font-size: 0.98rem;
   font-weight: 700;
-  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
 }
 .prc-pred   { color: var(--accent-2); }
-.prc-arrow  { color: var(--muted-2); font-weight: 500; font-size: 0.82rem; }
 .prc-actual { color: var(--text); }
+.prc-arrow  {
+  color: var(--muted-2);
+  width: 0.72em;
+  height: 0.72em;
+  opacity: 0.85;
+}
 .prc-delta {
-  font-size: 0.68rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-family: var(--mono);
+  font-size: 0.7rem;
   font-weight: 700;
-  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
   min-height: 0.85rem;
   line-height: 1;
 }
+.prc-delta-ic { width: 0.78em; height: 0.78em; }
+
 .prc-pos {
   background: var(--good-soft);
   border-color: rgba(74, 222, 128, 0.30);
 }
+.prc-pos::before { background: linear-gradient(90deg,
+                   transparent 0%, var(--good) 50%, transparent 100%); opacity: 0.65; }
 .prc-pos .prc-delta { color: var(--good); }
+.prc-pos .prc-weight { color: var(--good); border-color: rgba(74, 222, 128, 0.25); background: rgba(74, 222, 128, 0.07); }
+
 .prc-neg {
   background: var(--bad-soft);
   border-color: rgba(248, 113, 113, 0.28);
 }
+.prc-neg::before { background: linear-gradient(90deg,
+                   transparent 0%, var(--bad) 50%, transparent 100%); opacity: 0.6; }
 .prc-neg .prc-delta { color: var(--bad); }
+.prc-neg .prc-weight { color: var(--bad); border-color: rgba(248, 113, 113, 0.22); background: rgba(248, 113, 113, 0.06); }
+
 .prc-zero {
   background: var(--tie-soft);
   border-color: rgba(154, 163, 178, 0.28);
 }
+.prc-zero::before { background: linear-gradient(90deg,
+                    transparent 0%, var(--muted) 50%, transparent 100%); opacity: 0.4; }
 .prc-zero .prc-delta { color: var(--muted); }
 
 @media (max-width: 520px) {
-  .pred-round-strip { gap: 0.28rem; }
-  .prc { padding: 0.35rem 0.3rem 0.4rem; }
-  .prc-nums { font-size: 0.86rem; gap: 0.2rem; }
+  .pred-round-strip { gap: 0.32rem; }
+  .prc { padding: 0.45rem 0.3rem 0.4rem; }
+  .prc-nums { font-size: 0.86rem; gap: 0.22rem; }
   .prc-head { font-size: 0.55rem; }
+  .prc-weight { font-size: 0.5rem; top: 0.25rem; right: 0.28rem; }
 }
 
 /* ---------- Dashboard rival grid ---------- */

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -816,6 +816,102 @@ body.maptap-rivals-app button {
 }
 .dash-summary-card .sub { font-size: 0.78rem; color: var(--muted); margin-top: 0.1rem; }
 
+/* ---------- Today's predictions card ----------
+   Compact head-to-head table comparing each player's predicted total
+   against their actual once results sync. City names from the daily
+   puzzle are intentionally never rendered — only scores. */
+
+.todays-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.1rem;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+.todays-card[hidden] { display: none; }
+.todays-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+.todays-card-title { display: flex; align-items: baseline; gap: 0.6rem; flex-wrap: wrap; }
+.todays-card-title .section-title { margin: 0; }
+.todays-card-sub {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+.todays-card-status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  background: var(--surface-2);
+}
+.todays-card-status.is-loading { color: var(--accent-2); border-color: var(--accent-strong); }
+.todays-card-status.is-warn    { color: var(--warn);     border-color: rgba(251, 146, 60, 0.4); }
+.todays-card-status.is-good    { color: var(--good);     border-color: rgba(74, 222, 128, 0.4); }
+.todays-card-status.is-accent  { color: var(--accent-2); border-color: var(--accent-strong); }
+.todays-card-status.is-muted   { color: var(--muted);    border-color: var(--border); }
+
+.todays-card-body { display: flex; flex-direction: column; gap: 0.25rem; }
+.pred-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1.4fr) repeat(3, minmax(70px, 1fr));
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}
+.pred-row-head {
+  background: transparent;
+  padding: 0.2rem 0.6rem;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.pred-row-head .pred-cell { text-align: right; }
+.pred-row-you { background: var(--accent-soft); }
+.pred-label {
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pred-cell {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+.pred-predicted { color: var(--accent-2); }
+.pred-actual    { color: var(--text); }
+.pred-delta     { color: var(--muted); font-weight: 700; }
+.pred-delta-pos { color: var(--good); }
+.pred-delta-neg { color: var(--bad); }
+.pred-delta-zero { color: var(--muted); }
+.pred-empty {
+  margin: 0;
+  padding: 0.4rem 0.2rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 520px) {
+  .pred-row { grid-template-columns: minmax(100px, 1.2fr) repeat(3, minmax(56px, 1fr)); font-size: 0.92rem; }
+  .pred-row-head { font-size: 0.65rem; }
+}
+
 /* ---------- Dashboard rival grid ---------- */
 
 .dash-controls {

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -242,9 +242,10 @@ body.maptap-rivals-app button {
 
 .section-title {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.08rem;
   font-weight: 600;
   color: var(--text);
+  letter-spacing: -0.01em;
 }
 
 .empty-state {
@@ -393,14 +394,14 @@ body.maptap-rivals-app button {
 }
 
 .profile-hint {
-  margin-top: 0.5rem;
-  padding: 0.5rem 0.7rem;
-  background: var(--surface);
-  border: 1px dashed var(--border);
+  margin-top: 0.55rem;
+  padding: 0.55rem 0.8rem;
+  background: rgba(255, 255, 255, 0.015);
+  border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   font-size: 0.78rem;
   color: var(--muted);
-  line-height: 1.4;
+  line-height: 1.5;
 }
 .profile-hint strong { color: var(--text); font-weight: 600; }
 
@@ -790,97 +791,141 @@ body.maptap-rivals-app button {
 .dash-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 0.75rem;
-  margin-bottom: 1.25rem;
+  gap: 0.65rem;
+  margin-bottom: 1.4rem;
 }
 
+/* Aligned with .stat-card on the rival page so the dashboard's quick
+   stats and the rival detail stats read as the same visual family. */
 .dash-summary-card {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  padding: 0.75rem 0.9rem;
+  padding: 0.7rem 0.85rem;
+  min-height: 78px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.05rem;
 }
 .dash-summary-card .label {
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   font-weight: 600;
 }
 .dash-summary-card .value {
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   font-weight: 700;
-  margin-top: 0.2rem;
+  margin-top: 0.15rem;
   color: var(--text);
   line-height: 1.1;
+  letter-spacing: -0.01em;
 }
-.dash-summary-card .sub { font-size: 0.78rem; color: var(--muted); margin-top: 0.1rem; }
+.dash-summary-card .sub {
+  font-size: 0.74rem;
+  color: var(--muted);
+  margin-top: 0.15rem;
+}
 
 /* ---------- Today's predictions card ----------
-   Compact head-to-head table comparing each player's predicted total
-   against their actual once results sync. City names from the daily
-   puzzle are intentionally never rendered — only scores. */
+   Head-to-head card comparing each player's predicted total against
+   their actual once results sync. Visual language mirrors the rival
+   detail page: surface card, soft section header underline, muted
+   labels, premium pill states. City names from the daily puzzle are
+   intentionally never rendered — only scores. */
 
 .todays-card {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1rem 1.1rem;
-  margin-bottom: 1.25rem;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  padding: 1.05rem 1.15rem 1.15rem;
+  margin-bottom: 1.4rem;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.22);
 }
 .todays-card[hidden] { display: none; }
 .todays-card-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.65rem;
+  gap: 0.65rem 1rem;
   flex-wrap: wrap;
-  margin-bottom: 0.75rem;
+  padding-bottom: 0.85rem;
+  margin-bottom: 0.9rem;
+  border-bottom: 1px solid var(--border);
 }
-.todays-card-title { display: flex; align-items: baseline; gap: 0.6rem; flex-wrap: wrap; }
-.todays-card-title .section-title { margin: 0; }
+.todays-card-title { display: flex; align-items: baseline; gap: 0.65rem; flex-wrap: wrap; }
+.todays-card-title .section-title {
+  margin: 0;
+  letter-spacing: -0.01em;
+}
 .todays-card-sub {
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.01em;
 }
 .todays-card-status {
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: 0.66rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.18rem 0.55rem;
+  letter-spacing: 0.08em;
+  padding: 0.22rem 0.6rem;
   border-radius: 999px;
   border: 1px solid var(--border);
   color: var(--muted);
   background: var(--surface-2);
+  white-space: nowrap;
 }
-.todays-card-status.is-loading { color: var(--accent-2); border-color: var(--accent-strong); }
-.todays-card-status.is-warn    { color: var(--warn);     border-color: rgba(251, 146, 60, 0.4); }
-.todays-card-status.is-good    { color: var(--good);     border-color: rgba(74, 222, 128, 0.4); }
-.todays-card-status.is-accent  { color: var(--accent-2); border-color: var(--accent-strong); }
-.todays-card-status.is-muted   { color: var(--muted);    border-color: var(--border); }
+.todays-card-status.is-loading {
+  color: var(--accent-2);
+  background: var(--accent-soft);
+  border-color: var(--accent-strong);
+}
+.todays-card-status.is-warn {
+  color: var(--warn);
+  background: rgba(251, 146, 60, 0.10);
+  border-color: rgba(251, 146, 60, 0.30);
+}
+.todays-card-status.is-good {
+  color: var(--good);
+  background: var(--good-soft);
+  border-color: rgba(74, 222, 128, 0.30);
+}
+.todays-card-status.is-accent {
+  color: var(--accent-2);
+  background: var(--accent-soft);
+  border-color: var(--accent-strong);
+}
+.todays-card-status.is-muted {
+  color: var(--muted);
+  background: var(--surface-2);
+  border-color: var(--border);
+}
 
-.todays-card-body { display: flex; flex-direction: column; gap: 0.25rem; }
+.todays-card-body { display: flex; flex-direction: column; gap: 0.45rem; }
+
 .pred-row {
   display: grid;
-  grid-template-columns: minmax(120px, 1.4fr) repeat(3, minmax(70px, 1fr));
+  grid-template-columns: minmax(140px, 1.6fr) repeat(3, minmax(72px, 1fr));
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.6rem;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
   border-radius: var(--radius-sm);
   background: var(--surface-2);
 }
 .pred-row-head {
   background: transparent;
-  padding: 0.2rem 0.6rem;
-  color: var(--muted);
-  font-size: 0.72rem;
-  font-weight: 600;
+  padding: 0 0.75rem 0.35rem;
+  color: var(--muted-2);
+  font-size: 0.66rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0.15rem;
 }
-.pred-row-head .pred-cell { text-align: right; }
+.pred-row-head .pred-cell { text-align: right; color: var(--muted-2); }
 .pred-row-you { background: var(--accent-soft); }
 .pred-label {
   font-weight: 600;
@@ -888,58 +933,62 @@ body.maptap-rivals-app button {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  letter-spacing: -0.005em;
 }
 .pred-cell {
   text-align: right;
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 .pred-predicted { color: var(--accent-2); }
 .pred-actual    { color: var(--text); }
-.pred-delta     { color: var(--muted); font-weight: 700; }
+.pred-delta     { color: var(--muted-2); font-weight: 700; }
 .pred-delta-pos { color: var(--good); }
 .pred-delta-neg { color: var(--bad); }
 .pred-delta-zero { color: var(--muted); }
 .pred-empty {
   margin: 0;
-  padding: 0.4rem 0.2rem;
+  padding: 0.65rem 0.2rem;
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
+  line-height: 1.5;
 }
 
 @media (max-width: 520px) {
-  .pred-row { grid-template-columns: minmax(100px, 1.2fr) repeat(3, minmax(56px, 1fr)); font-size: 0.92rem; }
-  .pred-row-head { font-size: 0.65rem; }
+  .pred-row { grid-template-columns: minmax(100px, 1.3fr) repeat(3, minmax(56px, 1fr)); gap: 0.45rem; font-size: 0.92rem; padding: 0.55rem 0.6rem; }
+  .pred-row-head { font-size: 0.6rem; padding: 0 0.6rem 0.3rem; }
 }
 
-/* Wraps a player row + its per-round chip strip. Used as a single
-   visual block so the strip reads as "belonging to" the totals above. */
+/* Wraps a player row + its per-round chip strip into one visual block
+   so the strip reads as belonging to the totals above. */
 .pred-row-wrap {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.5rem 0.6rem 0.6rem;
+  gap: 0.55rem;
+  padding: 0.65rem 0.75rem 0.7rem;
   border-radius: var(--radius-sm);
   background: var(--surface-2);
 }
 .pred-row-wrap-you { background: var(--accent-soft); }
-.pred-row-wrap > .pred-row { background: transparent; padding: 0; }
+.pred-row-wrap > .pred-row { background: transparent; padding: 0; gap: 0.75rem; }
 
-/* Day-tab strip across the top of the predictions body. Each pill is
-   roughly square, today is highlighted, future days carry a thinner
-   accent so the upcoming run reads in one glance. */
+/* Day-tab strip across the top of the predictions body. Inactive pills
+   sit on surface-2, today wears a subtle accent ring, and the selected
+   pill uses accent-soft + accent border to match the rest of the
+   "selected state" treatment elsewhere in the app — no harsh fills. */
 .pred-day-tabs {
   display: flex;
   gap: 0.4rem;
   overflow-x: auto;
-  padding: 0 0.15rem 0.65rem;
-  margin: -0.25rem -0.15rem 0.4rem;
+  padding: 0.05rem 0.15rem 0.75rem;
+  margin: -0.2rem -0.15rem 0.6rem;
   scrollbar-width: thin;
 }
 .pred-day-tab {
   flex: 0 0 auto;
-  min-width: 58px;
-  padding: 0.4rem 0.55rem;
+  min-width: 62px;
+  padding: 0.42rem 0.6rem;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: var(--surface-2);
@@ -949,91 +998,115 @@ body.maptap-rivals-app button {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.05rem;
+  gap: 0.08rem;
   line-height: 1.1;
-  transition: border-color 0.12s ease, background 0.12s ease, color 0.12s ease;
+  transition: border-color 0.16s ease, background 0.16s ease, color 0.16s ease, transform 0.12s ease;
 }
-.pred-day-tab:hover { border-color: var(--border-strong); color: var(--text); }
-.pred-day-tab.is-today { border-color: var(--accent-strong); color: var(--text); }
+.pred-day-tab:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
+  color: var(--text);
+}
+.pred-day-tab.is-today { color: var(--text); }
+.pred-day-tab.is-today .pred-day-tab-num { color: var(--accent-2); }
 .pred-day-tab.is-active {
-  background: var(--accent);
+  background: var(--accent-soft);
   border-color: var(--accent);
-  color: var(--accent-ink);
+  color: var(--accent-2);
 }
-.pred-day-tab.is-loading { opacity: 0.7; }
-.pred-day-tab.is-error   { border-color: rgba(251, 146, 60, 0.5); color: var(--warn); }
+.pred-day-tab.is-active .pred-day-tab-num { color: var(--accent-2); }
+.pred-day-tab.is-loading { opacity: 0.65; }
+.pred-day-tab.is-error   { border-color: rgba(251, 146, 60, 0.45); color: var(--warn); }
 .pred-day-tab:focus-visible { outline: 2px solid var(--accent-2); outline-offset: 2px; }
 .pred-day-tab-name {
-  font-size: 0.68rem;
+  font-size: 0.62rem;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-weight: 600;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: var(--muted);
 }
+.pred-day-tab.is-active .pred-day-tab-name { color: var(--accent-2); }
+.pred-day-tab.is-today  .pred-day-tab-name { color: var(--accent-2); }
 .pred-day-tab-num {
-  font-size: 1.05rem;
+  font-size: 1.02rem;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
 }
 
-/* Per-round chip strip — one chip per of today's 5 rounds. Shows the
-   predicted value, the actual value once known, and a colored sliver
-   underneath keyed to the Δ direction. */
+/* Per-round chips — premium compact stat modules. Background tints
+   gently to the Δ direction (good/bad/neutral) instead of slamming a
+   hard colored bar across the bottom. The predicted value gets the
+   accent text color; the arrow → actual transition is restrained so
+   the eye can scan five chips in a single sweep. */
 .pred-round-strip {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.3rem;
+  gap: 0.4rem;
 }
 .prc {
-  background: var(--surface);
+  background: rgba(255, 255, 255, 0.015);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  padding: 0.3rem 0.4rem 0.35rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
+  padding: 0.45rem 0.5rem 0.5rem;
+  display: grid;
+  grid-template-rows: auto auto auto;
+  row-gap: 0.18rem;
   align-items: center;
+  justify-items: center;
   text-align: center;
   font-variant-numeric: tabular-nums;
-  position: relative;
-  overflow: hidden;
 }
 .prc-head {
   display: flex;
   align-items: baseline;
   gap: 0.3rem;
-  font-size: 0.68rem;
-  color: var(--muted);
-  letter-spacing: 0.04em;
+  font-size: 0.6rem;
+  color: var(--muted-2);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
-.prc-slot   { font-weight: 700; color: var(--text); }
-.prc-weight { color: var(--muted); font-weight: 600; }
+.prc-slot   { font-weight: 700; color: var(--muted); }
+.prc-weight { color: var(--muted-2); font-weight: 600; }
 .prc-nums {
   display: flex;
   align-items: baseline;
-  gap: 0.2rem;
-  font-size: 0.92rem;
+  gap: 0.28rem;
+  font-size: 0.98rem;
   font-weight: 700;
+  letter-spacing: -0.01em;
 }
 .prc-pred   { color: var(--accent-2); }
-.prc-arrow  { color: var(--muted-2); font-weight: 500; }
+.prc-arrow  { color: var(--muted-2); font-weight: 500; font-size: 0.82rem; }
 .prc-actual { color: var(--text); }
 .prc-delta {
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.02em;
+  min-height: 0.85rem;
+  line-height: 1;
 }
-.prc-pos  { box-shadow: inset 0 -3px 0 0 var(--good); }
-.prc-pos  .prc-delta { color: var(--good); }
-.prc-neg  { box-shadow: inset 0 -3px 0 0 var(--bad);  }
-.prc-neg  .prc-delta { color: var(--bad);  }
-.prc-zero { box-shadow: inset 0 -3px 0 0 var(--muted); }
+.prc-pos {
+  background: var(--good-soft);
+  border-color: rgba(74, 222, 128, 0.30);
+}
+.prc-pos .prc-delta { color: var(--good); }
+.prc-neg {
+  background: var(--bad-soft);
+  border-color: rgba(248, 113, 113, 0.28);
+}
+.prc-neg .prc-delta { color: var(--bad); }
+.prc-zero {
+  background: var(--tie-soft);
+  border-color: rgba(154, 163, 178, 0.28);
+}
 .prc-zero .prc-delta { color: var(--muted); }
 
 @media (max-width: 520px) {
-  .pred-round-strip { gap: 0.2rem; }
-  .prc { padding: 0.25rem 0.2rem 0.3rem; }
-  .prc-nums { font-size: 0.82rem; }
-  .prc-head { font-size: 0.6rem; }
+  .pred-round-strip { gap: 0.28rem; }
+  .prc { padding: 0.35rem 0.3rem 0.4rem; }
+  .prc-nums { font-size: 0.86rem; gap: 0.2rem; }
+  .prc-head { font-size: 0.55rem; }
 }
 
 /* ---------- Dashboard rival grid ---------- */
@@ -1273,6 +1346,11 @@ body.maptap-rivals-app button {
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   padding: 0.7rem 0.85rem;
+  min-height: 78px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.05rem;
 }
 .stat-card .label {
   font-size: 0.68rem;
@@ -1286,8 +1364,13 @@ body.maptap-rivals-app button {
   font-weight: 700;
   margin-top: 0.15rem;
   line-height: 1.1;
+  letter-spacing: -0.01em;
 }
-.stat-card .sub { font-size: 0.74rem; color: var(--muted); margin-top: 0.1rem; }
+.stat-card .sub {
+  font-size: 0.74rem;
+  color: var(--muted);
+  margin-top: 0.15rem;
+}
 .stat-card.is-good .value { color: var(--good); }
 .stat-card.is-bad .value { color: var(--bad); }
 .stat-card.is-accent .value { color: var(--accent-2); }

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -181,6 +181,21 @@
 
       <div class="dash-summary" id="dash-summary"></div>
 
+      <!-- Today's predictions: predicted vs actual head-to-head card.
+           Filled in by renderTodaysPredictions() once today's puzzle
+           locations are fetched and per-player history is available.
+           Coordinates only — city names are never rendered. -->
+      <section class="todays-card" id="todays-card" hidden>
+        <header class="todays-card-head">
+          <div class="todays-card-title">
+            <h2 class="section-title">Today's predictions</h2>
+            <span class="todays-card-sub" id="todays-card-sub"></span>
+          </div>
+          <span class="todays-card-status" id="todays-card-status"></span>
+        </header>
+        <div class="todays-card-body" id="todays-card-body"></div>
+      </section>
+
       <div class="dash-controls">
         <h2 class="section-title">Rivalries</h2>
         <button type="button" class="btn btn-ghost" id="add-rival-btn">+ Add rival</button>

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -445,11 +445,18 @@
 
     <!-- Settings strip (compact) -->
     <section class="settings-strip" aria-label="Settings">
-      <div class="settings-field" role="group" aria-label="Your name">
-        <svg class="settings-field-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <circle cx="12" cy="8" r="3.6"/>
-          <path d="M4.5 20c1.2-3.5 4.2-5.5 7.5-5.5s6.3 2 7.5 5.5"/>
-        </svg>
+      <div class="settings-field settings-field-me" role="group" aria-label="Your identity">
+        <!-- Icon picker: button shows current icon, click toggles a small
+             flyout with the same ICONS palette rivals use. Stored under
+             KEY.MY_ICON so the choice survives reloads. -->
+        <div class="my-icon-wrap">
+          <button type="button" class="my-icon-btn" id="my-icon-btn"
+                  aria-haspopup="true" aria-expanded="false"
+                  aria-label="Pick your icon" title="Pick your icon">
+            <span class="my-icon-current" id="my-icon-current">🧍</span>
+          </button>
+          <div class="my-icon-flyout" id="my-icon-flyout" role="menu" hidden></div>
+        </div>
         <input type="text" id="my-name" maxlength="24" placeholder="Your name" aria-label="Your name">
       </div>
 

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -34,6 +34,10 @@
     SETTINGS: 'maptapRivalsSettings',
     SELECTED: 'maptapRivalsSelectedRivalId',
     MATRIX_SEL: 'maptapRivalsMatrixSelection',
+    // Per-ISO-date cache of the day's 5 puzzle lat/lng pairs. Values are
+    // stored under `KEY.DAILY_CITIES_PREFIX + isoDate`. Only coordinates
+    // are persisted — never names or trivia from the daily file.
+    DAILY_CITIES_PREFIX: 'maptapRivalsDailyCities/',
   };
 
   // Public MapTap Cloud Function — returns gameHistory keyed by YYYY-MM-DD.
@@ -41,6 +45,15 @@
   // browser without a proxy.
   const MAPTAP_PROFILE_URL =
     'https://us-central1-jjexperiment-12af6.cloudfunctions.net/getPublicProfile';
+
+  // Daily puzzle locations. MapTap publishes each day's content as a static
+  // JS file at `data/this_day_in_history/<MonthDay>.js`. The file is CORS-
+  // open and contains the same 5 cities every player will play that day
+  // (it lists more for editorial flexibility, but MapTap only plays the
+  // first N_LOCS in file order — verified empirically across 5+ days). We
+  // fetch the text and pull only lat/lng — names and trivia are dropped
+  // before anything reaches the predictor or the UI.
+  const MAPTAP_DAILY_URL_BASE = 'https://maptap.gg/data/this_day_in_history/';
 
   const COLORS = [
     '#6366f1', '#22d3ee', '#4ade80', '#f97316', '#f43f5e',
@@ -256,6 +269,10 @@
     charts: { trend: null, wins: null, diff: null, radar: null, locWinrate: null },
     syncing: new Set(),       // rivalIds currently fetching from MapTap
     syncStatus: new Map(),    // rivalId -> { kind: 'ok'|'flat'|'err', msg }
+    todaysCities: null,       // [{lat,lng}…] x N_LOCS for today, or null
+    todaysCitiesISO: null,    // ISO date the loaded cities are for
+    todaysCitiesError: null,  // null | 'unavailable' (puzzle file missing)
+    todaysCitiesFetching: false,
   };
 
   function persistRivals() { save(KEY.RIVALS, state.rivals); }
@@ -283,16 +300,91 @@
     const d = new Date(iso + 'T00:00:00');
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   }
-  // MapTap deep-link for a given ISO date: full English month name + day,
-  // no zero pad, no year, no separator. Hardcoded month names because the
-  // URL is owned by maptap.gg and must not vary with the user's locale.
-  function mapTapHistoryUrl(iso) {
+  // Shared `<MonthName><Day>` token used by both the maptap.gg history
+  // deep link and the daily-puzzle data URL. English month names are
+  // hardcoded since the URLs are owned by maptap.gg and must not vary
+  // with the user's locale; the day is not zero-padded.
+  const ENGLISH_MONTHS = ['January','February','March','April','May','June',
+                          'July','August','September','October','November','December'];
+  function maptapMonthDay(iso) {
     if (!iso) return null;
     const d = new Date(iso + 'T00:00:00');
     if (Number.isNaN(d.getTime())) return null;
-    const MONTHS = ['January','February','March','April','May','June',
-                    'July','August','September','October','November','December'];
-    return `https://maptap.gg/history/${MONTHS[d.getMonth()]}${d.getDate()}`;
+    return `${ENGLISH_MONTHS[d.getMonth()]}${d.getDate()}`;
+  }
+  function mapTapHistoryUrl(iso) {
+    const tok = maptapMonthDay(iso);
+    return tok ? `https://maptap.gg/history/${tok}` : null;
+  }
+  function mapTapDailyDataUrl(iso) {
+    const tok = maptapMonthDay(iso);
+    return tok ? `${MAPTAP_DAILY_URL_BASE}${tok}.js` : null;
+  }
+
+  // Today's ISO date in the user's local timezone, so the prediction
+  // tracks whatever day MapTap is showing the user (MapTap's day rolls
+  // over at local midnight too — verified from observed gameHistory keys).
+  function todayISO() {
+    const d = new Date();
+    const tz = d.getTimezoneOffset() * 60000;
+    return new Date(d - tz).toISOString().slice(0, 10);
+  }
+
+  // Pull only the first N_LOCS lat/lng pairs from a daily puzzle file.
+  // The MapTap client plays the first 5 cities in file order regardless
+  // of how many the file lists (verified across May 10-14 plays). We
+  // deliberately discard name/trivia/photos so the predictor and any
+  // downstream code never accidentally surface the answer.
+  // Regex: match `lat:` not preceded by a letter (excludes `labelLat:`),
+  // then the nearest `lng:` (same letter-boundary exclusion).
+  const DAILY_LATLNG_RE =
+    /(?<![A-Za-z])lat\s*:\s*(-?\d+(?:\.\d+)?)\s*,[\s\S]{0,80}?(?<![A-Za-z])lng\s*:\s*(-?\d+(?:\.\d+)?)/g;
+  function parseDailyCitiesText(src) {
+    if (typeof src !== 'string' || !src.length) return null;
+    DAILY_LATLNG_RE.lastIndex = 0;
+    const out = [];
+    let m;
+    while ((m = DAILY_LATLNG_RE.exec(src)) !== null) {
+      const lat = parseFloat(m[1]);
+      const lng = parseFloat(m[2]);
+      if (Number.isFinite(lat) && Number.isFinite(lng) &&
+          lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180) {
+        out.push({ lat, lng });
+      }
+      if (out.length >= N_LOCS) break;
+    }
+    return out.length === N_LOCS ? out : null;
+  }
+
+  // Fetch + cache the day's 5 puzzle coordinates. Cache is keyed by ISO
+  // date; once a puzzle's day has passed, the file is immutable so the
+  // cache is valid forever. For today / future dates we still cache but
+  // re-fetch after 6h in case MapTap revises the file before play.
+  async function fetchDailyCities(iso) {
+    const url = mapTapDailyDataUrl(iso);
+    if (!url) return null;
+    const cacheKey = KEY.DAILY_CITIES_PREFIX + iso;
+    try {
+      const cached = JSON.parse(localStorage.getItem(cacheKey) || 'null');
+      if (cached && Array.isArray(cached.cities) && cached.cities.length === N_LOCS) {
+        const isPast = iso < todayISO();
+        const fresh = isPast || (Date.now() - (cached.cachedAt || 0)) < 6 * 3600 * 1000;
+        if (fresh) return cached.cities;
+      }
+    } catch (_) { /* cache corrupted — fall through to fetch */ }
+    try {
+      const res = await fetch(url, { credentials: 'omit' });
+      if (!res.ok) return null;
+      const text = await res.text();
+      const cities = parseDailyCitiesText(text);
+      if (!cities) return null;
+      try {
+        localStorage.setItem(cacheKey, JSON.stringify({ cities, cachedAt: Date.now() }));
+      } catch (_) { /* quota — ignore, prediction still works for this session */ }
+      return cities;
+    } catch (_) {
+      return null;
+    }
   }
   function fmtDateLong(iso) {
     if (!iso) return '—';
@@ -836,8 +928,167 @@
     renderProfileCard();
     renderPasteSection();
     renderDashSummary();
+    renderTodaysPredictions();
     renderRivalGrid();
     $('#dash-empty').hidden = state.rivals.length > 0;
+  }
+
+  // ---------- today's predictions card ----------
+  // Lazy-load the day's puzzle coords on first dashboard paint per
+  // session. Re-runs only when the local date crosses a boundary mid-
+  // session (rare but cheap to guard against).
+  function ensureTodaysCitiesLoaded() {
+    const iso = todayISO();
+    if (state.todaysCitiesISO === iso &&
+        (state.todaysCities || state.todaysCitiesError || state.todaysCitiesFetching)) {
+      return;
+    }
+    state.todaysCitiesISO = iso;
+    state.todaysCities = null;
+    state.todaysCitiesError = null;
+    state.todaysCitiesFetching = true;
+    fetchDailyCities(iso).then(cities => {
+      // Bail if the user rolled past midnight while we were waiting.
+      if (state.todaysCitiesISO !== iso) return;
+      state.todaysCitiesFetching = false;
+      if (cities) state.todaysCities = cities;
+      else state.todaysCitiesError = 'unavailable';
+      if (state.view === 'dashboard') renderTodaysPredictions();
+    }).catch(() => {
+      if (state.todaysCitiesISO !== iso) return;
+      state.todaysCitiesFetching = false;
+      state.todaysCitiesError = 'unavailable';
+      if (state.view === 'dashboard') renderTodaysPredictions();
+    });
+  }
+
+  // Pull today's actual played total for `side` ('mine' | 'theirs') for a
+  // given rival. `mine` uses myProfile.gameHistory (most authoritative);
+  // both fall back to a game record matching today's date.
+  function actualForToday(rivalId) {
+    const iso = state.todaysCitiesISO || todayISO();
+    let mine = null, theirs = null;
+    const mineRound = state.myProfile && state.myProfile.gameHistory &&
+                      state.myProfile.gameHistory[iso];
+    if (mineRound && Array.isArray(mineRound.roundData) &&
+        mineRound.roundData.length === N_LOCS) {
+      const scores = mineRound.roundData.map(r => Number(r.score) || 0);
+      let t = 0;
+      for (let i = 0; i < N_LOCS; i++) t += scores[i] * WEIGHTS[i];
+      mine = Math.round(t);
+    }
+    const g = state.games.find(x => x.rivalId === rivalId && x.date === iso);
+    if (g) {
+      if (mine == null && Array.isArray(g.myScores)) mine = getMyTotal(g);
+      if (Array.isArray(g.theirScores)) theirs = getTheirTotal(g);
+    }
+    return { mine, theirs };
+  }
+
+  function makePredictionRow({ label, predicted, actual, isYou }) {
+    const cls = ['pred-row'];
+    if (isYou) cls.push('pred-row-you');
+    const cells = [el('div', { class: 'pred-label' }, label)];
+    cells.push(el('div', { class: 'pred-cell pred-predicted' },
+      predicted != null ? String(predicted) : '—'));
+    cells.push(el('div', { class: 'pred-cell pred-actual' },
+      actual != null ? String(actual) : '—'));
+    let delta = null;
+    if (predicted != null && actual != null) delta = actual - predicted;
+    const deltaCls = ['pred-cell', 'pred-delta'];
+    if (delta != null) deltaCls.push(delta > 0 ? 'pred-delta-pos' : delta < 0 ? 'pred-delta-neg' : 'pred-delta-zero');
+    cells.push(el('div', { class: deltaCls.join(' ') },
+      delta == null ? '—' : (delta > 0 ? '+' : '') + delta));
+    return el('div', { class: cls.join(' ') }, cells);
+  }
+
+  function renderTodaysPredictions() {
+    ensureTodaysCitiesLoaded();
+    const card = $('#todays-card');
+    if (!card) return;
+    const body = $('#todays-card-body');
+    const sub = $('#todays-card-sub');
+    const status = $('#todays-card-status');
+    body.innerHTML = '';
+
+    // Hide the card entirely when there are no rivals — the empty-state
+    // copy below already handles new users.
+    if (!state.rivals.length) {
+      card.hidden = true;
+      return;
+    }
+    card.hidden = false;
+
+    const iso = state.todaysCitiesISO || todayISO();
+    sub.textContent = fmtDateLong(iso);
+
+    if (state.todaysCitiesFetching) {
+      status.textContent = 'Loading puzzle…';
+      status.className = 'todays-card-status is-loading';
+      body.appendChild(el('p', { class: 'pred-empty' }, 'Fetching today’s puzzle from maptap.gg…'));
+      return;
+    }
+    if (state.todaysCitiesError || !state.todaysCities) {
+      status.textContent = 'Puzzle unavailable';
+      status.className = 'todays-card-status is-warn';
+      body.appendChild(el('p', { class: 'pred-empty' },
+        'Couldn’t load today’s puzzle from maptap.gg. Predictions will appear once it’s available.'));
+      return;
+    }
+
+    // Header row + per-player rows
+    const header = el('div', { class: 'pred-row pred-row-head' }, [
+      el('div', { class: 'pred-label' }, 'Player'),
+      el('div', { class: 'pred-cell' }, 'Predicted'),
+      el('div', { class: 'pred-cell' }, 'Actual'),
+      el('div', { class: 'pred-cell' }, 'Δ'),
+    ]);
+    body.appendChild(header);
+
+    const myRounds = myProfileRounds();
+    const myPrediction = predictTotalForPlayer(myRounds, state.todaysCities);
+    const myActual = (() => {
+      const r = state.myProfile && state.myProfile.gameHistory &&
+                state.myProfile.gameHistory[iso];
+      if (!r || !Array.isArray(r.roundData) || r.roundData.length !== N_LOCS) return null;
+      let t = 0;
+      for (let i = 0; i < N_LOCS; i++) t += (Number(r.roundData[i].score) || 0) * WEIGHTS[i];
+      return Math.round(t);
+    })();
+    body.appendChild(makePredictionRow({
+      label: state.me || 'You',
+      predicted: myPrediction ? myPrediction.score : null,
+      actual: myActual,
+      isYou: true,
+    }));
+
+    let predictedCount = myPrediction ? 1 : 0;
+    state.rivals
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .forEach(r => {
+        const rounds = rivalRounds(r.id);
+        const pred = predictTotalForPlayer(rounds, state.todaysCities);
+        if (pred) predictedCount++;
+        const { theirs } = actualForToday(r.id);
+        body.appendChild(makePredictionRow({
+          label: `${r.icon || '🎯'} ${r.name}`,
+          predicted: pred ? pred.score : null,
+          actual: theirs,
+          isYou: false,
+        }));
+      });
+
+    if (predictedCount === 0) {
+      status.textContent = 'Need more games';
+      status.className = 'todays-card-status is-muted';
+    } else if (myActual != null) {
+      status.textContent = 'Game played ✓';
+      status.className = 'todays-card-status is-good';
+    } else {
+      status.textContent = 'Pre-game';
+      status.className = 'todays-card-status is-accent';
+    }
   }
 
   // ---------- paste-mode entry on dashboard ----------
@@ -2853,6 +3104,85 @@
     }));
     out.sort((a, b) => b.rounds - a.rounds);
     return { rows: out, totalRounds };
+  }
+
+  // ---------- prediction ----------
+  // Build a per-continent raw-round-score average from a player's past
+  // rounds. `rounds` is an array of `{cities: [{lat,lng}…], scores: […]}`
+  // entries. We deliberately mix all five round slots together — the
+  // empirical signal we want is "how this player tends to score at
+  // locations on continent X", regardless of which slot it appeared in.
+  function continentScoreIndex(rounds) {
+    const buckets = new Map();
+    let totalSum = 0, totalCount = 0;
+    for (const r of rounds) {
+      if (!Array.isArray(r.cities) || !Array.isArray(r.scores)) continue;
+      const n = Math.min(r.cities.length, r.scores.length, N_LOCS);
+      for (let i = 0; i < n; i++) {
+        const c = r.cities[i] || {};
+        const s = Number(r.scores[i]);
+        if (!Number.isFinite(s)) continue;
+        const continent = classifyContinent(Number(c.lat), Number(c.lng));
+        let b = buckets.get(continent);
+        if (!b) { b = { sum: 0, count: 0 }; buckets.set(continent, b); }
+        b.sum += s; b.count += 1;
+        totalSum += s; totalCount += 1;
+      }
+    }
+    return { buckets, overallAvg: totalCount ? totalSum / totalCount : null, totalRounds: totalCount };
+  }
+
+  // Extract your own per-round data from `state.myProfile.gameHistory`
+  // (the most complete record of your play). One round entry per day.
+  function myProfileRounds() {
+    const gh = state.myProfile && state.myProfile.gameHistory;
+    if (!gh) return [];
+    const out = [];
+    for (const entry of Object.values(gh)) {
+      if (!entry || !Array.isArray(entry.roundData) || entry.roundData.length !== N_LOCS) continue;
+      const cities = entry.roundData.map(r => ({ lat: Number(r.cityLat), lng: Number(r.cityLng) }));
+      const scores = entry.roundData.map(r => Number(r.score));
+      if (!scores.every(s => Number.isFinite(s))) continue;
+      out.push({ cities, scores });
+    }
+    return out;
+  }
+
+  // Per-rival rounds from `state.games`, restricted to entries that
+  // carry city geometry (i.e. the user had their profile linked when the
+  // game was synced). Returns rounds keyed to the rival's `theirScores`.
+  function rivalRounds(rivalId) {
+    return gamesFor(rivalId)
+      .filter(g => Array.isArray(g.cities) && g.cities.length === N_LOCS &&
+                   Array.isArray(g.theirScores))
+      .map(g => ({ cities: g.cities, scores: g.theirScores }));
+  }
+
+  // Predict a player's weighted total against today's 5 cities. Each
+  // round is projected from their continent average for that round's
+  // location (fallback: their overall round average). Total uses the
+  // same WEIGHTS the rest of the app uses so it's comparable to actual
+  // scores. Returns null when the player has too little history to give
+  // a meaningful number.
+  // `confidence` = number of rounds informing the estimate (rough
+  // sample-size cue for the UI, not a probability).
+  const PREDICTION_MIN_ROUNDS = 5;
+  function predictTotalForPlayer(rounds, todaysCities) {
+    if (!Array.isArray(todaysCities) || todaysCities.length !== N_LOCS) return null;
+    const idx = continentScoreIndex(rounds);
+    if (idx.totalRounds < PREDICTION_MIN_ROUNDS || idx.overallAvg == null) return null;
+    let weighted = 0;
+    for (let i = 0; i < N_LOCS; i++) {
+      const c = todaysCities[i];
+      const cont = classifyContinent(c.lat, c.lng);
+      const b = idx.buckets.get(cont);
+      // Need at least 2 rounds on the continent to trust its bucket;
+      // otherwise fall back to the player's overall round mean.
+      const roundAvg = (b && b.count >= 2) ? (b.sum / b.count) : idx.overallAvg;
+      weighted += roundAvg * WEIGHTS[i];
+    }
+    const score = Math.round(Math.max(0, Math.min(1000, weighted)));
+    return { score, confidence: idx.totalRounds };
   }
 
   async function syncMapTapForRival(rivalId) {

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1784,7 +1784,14 @@
     }
 
     cardsHost.appendChild(makeStatCard('Win rate', `${(s.winPct * 100).toFixed(1)}%`, `${s.wins}W · ${s.losses}L · ${s.ties}T`, s.winPct >= 0.5 ? 'is-good' : 'is-bad'));
-    cardsHost.appendChild(makeStatCard('Cumulative Δ', (s.cumDiff > 0 ? '+' : '') + s.cumDiff, 'your points − theirs', s.cumDiff >= 0 ? 'is-good' : 'is-bad'));
+    // Average per-game point gap rather than cumulative — comparable
+    // across rivals you've played different counts of games against.
+    const avgDiffAll = s.total ? (s.cumDiff / s.total) : 0;
+    const avgDiffSign = avgDiffAll > 0 ? '+' : '';
+    cardsHost.appendChild(makeStatCard('Avg Δ per game',
+      `${avgDiffSign}${avgDiffAll.toFixed(1)}`,
+      'your points − theirs',
+      avgDiffAll >= 0 ? 'is-good' : 'is-bad'));
     cardsHost.appendChild(makeStatCard('Avg score (you)', s.myAvgAll.toFixed(0), `7d ${s.myAvg7 ? s.myAvg7.toFixed(0) : '—'} · 30d ${s.myAvg30 ? s.myAvg30.toFixed(0) : '—'}`));
     cardsHost.appendChild(makeStatCard(`Avg score (${rival.name})`, s.theirAvgAll.toFixed(0), `7d ${s.theirAvg7 ? s.theirAvg7.toFixed(0) : '—'} · 30d ${s.theirAvg30 ? s.theirAvg30.toFixed(0) : '—'}`));
     cardsHost.appendChild(makeStatCard('Current streak',

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1047,7 +1047,13 @@
 
     const myRounds = myProfileRounds();
     const myPrediction = predictTotalForPlayer(myRounds, state.todaysCities);
+    // Your actual: any of today's paired games carries your scores (they
+    // match across rivals by construction since you only played MapTap
+    // once). Falls back to the profile.gameHistory entry if a sync
+    // populated it before any paired game record was written.
     const myActual = (() => {
+      const todays = state.games.find(g => g.date === iso && Array.isArray(g.myScores));
+      if (todays) return getMyTotal(todays);
       const r = state.myProfile && state.myProfile.gameHistory &&
                 state.myProfile.gameHistory[iso];
       if (!r || !Array.isArray(r.roundData) || r.roundData.length !== N_LOCS) return null;
@@ -3132,20 +3138,24 @@
     return { buckets, overallAvg: totalCount ? totalSum / totalCount : null, totalRounds: totalCount };
   }
 
-  // Extract your own per-round data from `state.myProfile.gameHistory`
-  // (the most complete record of your play). One round entry per day.
+  // Your own per-round history derived from `state.games`. `state.myProfile`
+  // intentionally drops `gameHistory` to keep the localStorage payload
+  // small (see summarizeMapTapProfile), so the paired Game records are
+  // the authoritative source. The same day appears once per rival you
+  // played with, so dedupe by date — your scores are identical across
+  // those duplicates by construction.
   function myProfileRounds() {
-    const gh = state.myProfile && state.myProfile.gameHistory;
-    if (!gh) return [];
-    const out = [];
-    for (const entry of Object.values(gh)) {
-      if (!entry || !Array.isArray(entry.roundData) || entry.roundData.length !== N_LOCS) continue;
-      const cities = entry.roundData.map(r => ({ lat: Number(r.cityLat), lng: Number(r.cityLng) }));
-      const scores = entry.roundData.map(r => Number(r.score));
+    const byDate = new Map();
+    for (const g of state.games) {
+      if (byDate.has(g.date)) continue;
+      if (!Array.isArray(g.cities) || g.cities.length !== N_LOCS) continue;
+      if (!Array.isArray(g.myScores) || g.myScores.length !== N_LOCS) continue;
+      const cities = g.cities.map(c => ({ lat: Number(c.lat), lng: Number(c.lng) }));
+      const scores = g.myScores.map(Number);
       if (!scores.every(s => Number.isFinite(s))) continue;
-      out.push({ cities, scores });
+      byDate.set(g.date, { cities, scores });
     }
-    return out;
+    return Array.from(byDate.values());
   }
 
   // Per-rival rounds from `state.games`, restricted to entries that

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1811,9 +1811,6 @@
     cardsHost.appendChild(makeStatCard('Biggest loss', s.biggestLossGame ? `−${s.biggestLossMargin}` : '—',
       s.biggestLossGame ? `${s.biggestLossGame.myScore}–${s.biggestLossGame.theirScore} on ${fmtDateShort(s.biggestLossGame.date)}` : '—',
       s.biggestLossGame ? 'is-bad' : ''));
-    cardsHost.appendChild(makeStatCard('Projected next', s.projection,
-      s.trendSlope > 0.5 ? '↗ improving' : s.trendSlope < -0.5 ? '↘ declining' : '→ flat',
-      s.trendSlope > 0.5 ? 'is-good' : s.trendSlope < -0.5 ? 'is-bad' : ''));
 
     // callouts
     calloutsHost.innerHTML = '';

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -269,10 +269,13 @@
     charts: { trend: null, wins: null, diff: null, radar: null, locWinrate: null },
     syncing: new Set(),       // rivalIds currently fetching from MapTap
     syncStatus: new Map(),    // rivalId -> { kind: 'ok'|'flat'|'err', msg }
-    todaysCities: null,       // [{lat,lng}…] x N_LOCS for today, or null
-    todaysCitiesISO: null,    // ISO date the loaded cities are for
-    todaysCitiesError: null,  // null | 'unavailable' (puzzle file missing)
-    todaysCitiesFetching: false,
+    // Rolling 7-day puzzle window starting at today. Each entry holds:
+    //   { iso, cities: [{lat,lng}…] | null, status: 'idle'|'fetching'|'ok'|'error' }
+    // Reseeded when the local date crosses midnight mid-session.
+    predictWindow: [],
+    predictWindowAnchorISO: null,
+    // ISO date of the day currently shown in the dashboard predictions card.
+    predictSelectedISO: null,
   };
 
   function persistRivals() { save(KEY.RIVALS, state.rivals); }
@@ -329,6 +332,13 @@
     const tz = d.getTimezoneOffset() * 60000;
     return new Date(d - tz).toISOString().slice(0, 10);
   }
+  function addDaysISO(iso, days) {
+    const d = new Date(iso + 'T00:00:00');
+    if (Number.isNaN(d.getTime())) return null;
+    d.setDate(d.getDate() + days);
+    return d.toISOString().slice(0, 10);
+  }
+  const PREDICT_WINDOW_DAYS = 7;
 
   // Pull only the first N_LOCS lat/lng pairs from a daily puzzle file.
   // The MapTap client plays the first 5 cities in file order regardless
@@ -933,77 +943,140 @@
     $('#dash-empty').hidden = state.rivals.length > 0;
   }
 
-  // ---------- today's predictions card ----------
-  // Lazy-load the day's puzzle coords on first dashboard paint per
-  // session. Re-runs only when the local date crosses a boundary mid-
-  // session (rare but cheap to guard against).
-  function ensureTodaysCitiesLoaded() {
-    const iso = todayISO();
-    if (state.todaysCitiesISO === iso &&
-        (state.todaysCities || state.todaysCitiesError || state.todaysCitiesFetching)) {
-      return;
+  // ---------- predictions card (rolling 7-day window) ----------
+  // Anchor the window at today and keep the existing entries' selected
+  // state intact across re-renders. The fetcher is idempotent — each
+  // entry only flips out of 'fetching' once.
+  function ensureSevenDayWindowLoaded() {
+    const today = todayISO();
+    if (state.predictWindowAnchorISO !== today) {
+      state.predictWindowAnchorISO = today;
+      state.predictWindow = Array.from({ length: PREDICT_WINDOW_DAYS }, (_, i) => ({
+        iso: addDaysISO(today, i),
+        cities: null,
+        status: 'idle',
+      }));
+      // Keep the user's selection when possible; otherwise jump to today.
+      if (!state.predictSelectedISO ||
+          !state.predictWindow.some(w => w.iso === state.predictSelectedISO)) {
+        state.predictSelectedISO = today;
+      }
     }
-    state.todaysCitiesISO = iso;
-    state.todaysCities = null;
-    state.todaysCitiesError = null;
-    state.todaysCitiesFetching = true;
-    fetchDailyCities(iso).then(cities => {
-      // Bail if the user rolled past midnight while we were waiting.
-      if (state.todaysCitiesISO !== iso) return;
-      state.todaysCitiesFetching = false;
-      if (cities) state.todaysCities = cities;
-      else state.todaysCitiesError = 'unavailable';
-      if (state.view === 'dashboard') renderTodaysPredictions();
-    }).catch(() => {
-      if (state.todaysCitiesISO !== iso) return;
-      state.todaysCitiesFetching = false;
-      state.todaysCitiesError = 'unavailable';
-      if (state.view === 'dashboard') renderTodaysPredictions();
-    });
+    for (const entry of state.predictWindow) {
+      if (entry.status !== 'idle') continue;
+      entry.status = 'fetching';
+      fetchDailyCities(entry.iso).then(cities => {
+        if (state.predictWindowAnchorISO !== today) return; // stale window
+        if (cities) { entry.cities = cities; entry.status = 'ok'; }
+        else        { entry.status = 'error'; }
+        if (state.view === 'dashboard') renderTodaysPredictions();
+      }).catch(() => {
+        if (state.predictWindowAnchorISO !== today) return;
+        entry.status = 'error';
+        if (state.view === 'dashboard') renderTodaysPredictions();
+      });
+    }
   }
 
-  // Pull today's actual played total for `side` ('mine' | 'theirs') for a
-  // given rival. `mine` uses myProfile.gameHistory (most authoritative);
-  // both fall back to a game record matching today's date.
-  function actualForToday(rivalId) {
-    const iso = state.todaysCitiesISO || todayISO();
-    let mine = null, theirs = null;
-    const mineRound = state.myProfile && state.myProfile.gameHistory &&
-                      state.myProfile.gameHistory[iso];
-    if (mineRound && Array.isArray(mineRound.roundData) &&
-        mineRound.roundData.length === N_LOCS) {
-      const scores = mineRound.roundData.map(r => Number(r.score) || 0);
-      let t = 0;
-      for (let i = 0; i < N_LOCS; i++) t += scores[i] * WEIGHTS[i];
-      mine = Math.round(t);
-    }
+  // Look up actuals for a given day. For "you" the source is any of that
+  // day's paired games (myScores is duplicated across rivals by design,
+  // so the first match is fine). For a rival it's the matching game's
+  // theirScores. Returns nulls when the game wasn't logged.
+  function actualScoresForDay(iso) {
+    const mineGame = state.games.find(g => g.date === iso && Array.isArray(g.myScores));
+    return {
+      mineScores:  mineGame ? mineGame.myScores  : null,
+      mineTotal:   mineGame ? getMyTotal(mineGame) : null,
+    };
+  }
+  function actualScoresForRivalDay(rivalId, iso) {
     const g = state.games.find(x => x.rivalId === rivalId && x.date === iso);
-    if (g) {
-      if (mine == null && Array.isArray(g.myScores)) mine = getMyTotal(g);
-      if (Array.isArray(g.theirScores)) theirs = getTheirTotal(g);
-    }
-    return { mine, theirs };
+    if (!g) return { scores: null, total: null };
+    return {
+      scores: Array.isArray(g.theirScores) ? g.theirScores : null,
+      total:  Array.isArray(g.theirScores) ? getTheirTotal(g) : null,
+    };
   }
 
-  function makePredictionRow({ label, predicted, actual, isYou }) {
+  // One round chip: shows weighted slot, predicted (and actual when known),
+  // and a colored bottom band keyed to Δ. Predicted is never null when
+  // we render — caller skips the strip entirely if the predictor failed.
+  function makeRoundChip(slot, predicted, actual) {
+    const predRound = Math.round(predicted);
+    const hasActual = actual != null && Number.isFinite(actual);
+    const delta = hasActual ? Math.round(actual) - predRound : null;
+    const cls = ['prc'];
+    if (delta != null) cls.push(delta > 0 ? 'prc-pos' : delta < 0 ? 'prc-neg' : 'prc-zero');
+    const w = WEIGHTS[slot];
+    const wLabel = w === 1 ? '' : `×${w}`;
+    return el('div', { class: cls.join(' '), title:
+        hasActual
+          ? `Round ${slot + 1} (×${w}): predicted ${predRound}, actual ${Math.round(actual)}`
+          : `Round ${slot + 1} (×${w}): predicted ${predRound}` }, [
+      el('div', { class: 'prc-head' }, [
+        el('span', { class: 'prc-slot' }, `R${slot + 1}`),
+        wLabel ? el('span', { class: 'prc-weight' }, wLabel) : null,
+      ]),
+      el('div', { class: 'prc-nums' }, [
+        el('span', { class: 'prc-pred' }, String(predRound)),
+        hasActual ? el('span', { class: 'prc-arrow' }, '→') : null,
+        hasActual ? el('span', { class: 'prc-actual' }, String(Math.round(actual))) : null,
+      ]),
+      delta != null
+        ? el('div', { class: 'prc-delta' }, (delta > 0 ? '+' : '') + delta)
+        : null,
+    ]);
+  }
+
+  function makePredictionRow({ label, predictedScores, actualScores, predictedTotal, actualTotal, isYou }) {
     const cls = ['pred-row'];
     if (isYou) cls.push('pred-row-you');
     const cells = [el('div', { class: 'pred-label' }, label)];
     cells.push(el('div', { class: 'pred-cell pred-predicted' },
-      predicted != null ? String(predicted) : '—'));
+      predictedTotal != null ? String(predictedTotal) : '—'));
     cells.push(el('div', { class: 'pred-cell pred-actual' },
-      actual != null ? String(actual) : '—'));
+      actualTotal != null ? String(actualTotal) : '—'));
     let delta = null;
-    if (predicted != null && actual != null) delta = actual - predicted;
+    if (predictedTotal != null && actualTotal != null) delta = actualTotal - predictedTotal;
     const deltaCls = ['pred-cell', 'pred-delta'];
     if (delta != null) deltaCls.push(delta > 0 ? 'pred-delta-pos' : delta < 0 ? 'pred-delta-neg' : 'pred-delta-zero');
     cells.push(el('div', { class: deltaCls.join(' ') },
       delta == null ? '—' : (delta > 0 ? '+' : '') + delta));
-    return el('div', { class: cls.join(' ') }, cells);
+    const head = el('div', { class: cls.join(' ') }, cells);
+    if (!Array.isArray(predictedScores)) return head;
+    const strip = el('div', { class: 'pred-round-strip' },
+      predictedScores.map((p, i) => makeRoundChip(i, p, actualScores ? actualScores[i] : null)));
+    return el('div', { class: 'pred-row-wrap' + (isYou ? ' pred-row-wrap-you' : '') }, [head, strip]);
+  }
+
+  // Day-tab pill. Shows weekday + day-of-month. Today is labelled "Today";
+  // tomorrow gets a thinner accent so the upcoming run reads at a glance.
+  function makeDayTab(entry, todayIso) {
+    const dt = new Date(entry.iso + 'T00:00:00');
+    const isToday = entry.iso === todayIso;
+    const dayNames = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+    const cls = ['pred-day-tab'];
+    if (entry.iso === state.predictSelectedISO) cls.push('is-active');
+    if (isToday) cls.push('is-today');
+    if (entry.status === 'fetching') cls.push('is-loading');
+    if (entry.status === 'error')    cls.push('is-error');
+    return el('button', {
+      type: 'button',
+      class: cls.join(' '),
+      'aria-pressed': entry.iso === state.predictSelectedISO ? 'true' : 'false',
+      onclick: () => {
+        if (state.predictSelectedISO === entry.iso) return;
+        state.predictSelectedISO = entry.iso;
+        renderTodaysPredictions();
+      },
+    }, [
+      el('span', { class: 'pred-day-tab-name' }, isToday ? 'Today' : dayNames[dt.getDay()]),
+      el('span', { class: 'pred-day-tab-num' }, String(dt.getDate())),
+    ]);
   }
 
   function renderTodaysPredictions() {
-    ensureTodaysCitiesLoaded();
+    ensureSevenDayWindowLoaded();
     const card = $('#todays-card');
     if (!card) return;
     const body = $('#todays-card-body');
@@ -1011,32 +1084,39 @@
     const status = $('#todays-card-status');
     body.innerHTML = '';
 
-    // Hide the card entirely when there are no rivals — the empty-state
-    // copy below already handles new users.
-    if (!state.rivals.length) {
-      card.hidden = true;
-      return;
-    }
+    if (!state.rivals.length) { card.hidden = true; return; }
     card.hidden = false;
 
-    const iso = state.todaysCitiesISO || todayISO();
-    sub.textContent = fmtDateLong(iso);
+    const today = todayISO();
+    const selectedISO = state.predictSelectedISO || today;
+    const selected = state.predictWindow.find(w => w.iso === selectedISO) ||
+                     state.predictWindow[0];
 
-    if (state.todaysCitiesFetching) {
-      status.textContent = 'Loading puzzle…';
+    sub.textContent = fmtDateLong(selectedISO);
+
+    // Day-tab strip (always visible — the headline UI for the 7-day view).
+    const tabs = el('div', { class: 'pred-day-tabs', role: 'tablist',
+                             'aria-label': 'Next 7 days' },
+      state.predictWindow.map(entry => makeDayTab(entry, today)));
+    body.appendChild(tabs);
+
+    // Selected-day state branches
+    if (!selected || selected.status === 'fetching') {
+      status.textContent = 'Loading…';
       status.className = 'todays-card-status is-loading';
-      body.appendChild(el('p', { class: 'pred-empty' }, 'Fetching today’s puzzle from maptap.gg…'));
+      body.appendChild(el('p', { class: 'pred-empty' },
+        'Fetching this day’s puzzle from maptap.gg…'));
       return;
     }
-    if (state.todaysCitiesError || !state.todaysCities) {
+    if (selected.status === 'error' || !selected.cities) {
       status.textContent = 'Puzzle unavailable';
       status.className = 'todays-card-status is-warn';
       body.appendChild(el('p', { class: 'pred-empty' },
-        'Couldn’t load today’s puzzle from maptap.gg. Predictions will appear once it’s available.'));
+        'Couldn’t load this day’s puzzle from maptap.gg. Predictions will appear once it’s available.'));
       return;
     }
 
-    // Header row + per-player rows
+    // Per-player rows
     const header = el('div', { class: 'pred-row pred-row-head' }, [
       el('div', { class: 'pred-label' }, 'Player'),
       el('div', { class: 'pred-cell' }, 'Predicted'),
@@ -1045,42 +1125,34 @@
     ]);
     body.appendChild(header);
 
+    const isPastOrToday = selectedISO <= today;
     const myRounds = myProfileRounds();
-    const myPrediction = predictTotalForPlayer(myRounds, state.todaysCities);
-    // Your actual: any of today's paired games carries your scores (they
-    // match across rivals by construction since you only played MapTap
-    // once). Falls back to the profile.gameHistory entry if a sync
-    // populated it before any paired game record was written.
-    const myActual = (() => {
-      const todays = state.games.find(g => g.date === iso && Array.isArray(g.myScores));
-      if (todays) return getMyTotal(todays);
-      const r = state.myProfile && state.myProfile.gameHistory &&
-                state.myProfile.gameHistory[iso];
-      if (!r || !Array.isArray(r.roundData) || r.roundData.length !== N_LOCS) return null;
-      let t = 0;
-      for (let i = 0; i < N_LOCS; i++) t += (Number(r.roundData[i].score) || 0) * WEIGHTS[i];
-      return Math.round(t);
-    })();
+    const myPred = predictRoundsForPlayer(myRounds, selected.cities);
+    const myActuals = isPastOrToday ? actualScoresForDay(selectedISO) : { mineScores: null, mineTotal: null };
     body.appendChild(makePredictionRow({
       label: state.me || 'You',
-      predicted: myPrediction ? myPrediction.score : null,
-      actual: myActual,
+      predictedScores: myPred ? myPred.scores : null,
+      actualScores:    myActuals.mineScores,
+      predictedTotal:  myPred ? predTotalFromScores(myPred.scores) : null,
+      actualTotal:     myActuals.mineTotal,
       isYou: true,
     }));
 
-    let predictedCount = myPrediction ? 1 : 0;
+    let predictedCount = myPred ? 1 : 0;
     state.rivals
       .slice()
       .sort((a, b) => a.name.localeCompare(b.name))
       .forEach(r => {
         const rounds = rivalRounds(r.id);
-        const pred = predictTotalForPlayer(rounds, state.todaysCities);
+        const pred = predictRoundsForPlayer(rounds, selected.cities);
         if (pred) predictedCount++;
-        const { theirs } = actualForToday(r.id);
+        const act = isPastOrToday ? actualScoresForRivalDay(r.id, selectedISO) : { scores: null, total: null };
         body.appendChild(makePredictionRow({
           label: `${r.icon || '🎯'} ${r.name}`,
-          predicted: pred ? pred.score : null,
-          actual: theirs,
+          predictedScores: pred ? pred.scores : null,
+          actualScores:    act.scores,
+          predictedTotal:  pred ? predTotalFromScores(pred.scores) : null,
+          actualTotal:     act.total,
           isYou: false,
         }));
       });
@@ -1088,13 +1160,24 @@
     if (predictedCount === 0) {
       status.textContent = 'Need more games';
       status.className = 'todays-card-status is-muted';
-    } else if (myActual != null) {
+    } else if (selectedISO > today) {
+      status.textContent = 'Upcoming';
+      status.className = 'todays-card-status is-accent';
+    } else if (myActuals.mineTotal != null) {
       status.textContent = 'Game played ✓';
       status.className = 'todays-card-status is-good';
     } else {
-      status.textContent = 'Pre-game';
+      status.textContent = selectedISO === today ? 'Pre-game' : 'Not logged';
       status.className = 'todays-card-status is-accent';
     }
+  }
+
+  // Sum a round score array using the standard WEIGHTS.
+  function predTotalFromScores(scores) {
+    if (!Array.isArray(scores) || scores.length !== N_LOCS) return null;
+    let t = 0;
+    for (let i = 0; i < N_LOCS; i++) t += scores[i] * WEIGHTS[i];
+    return Math.round(Math.max(0, Math.min(1000, t)));
   }
 
   // ---------- paste-mode entry on dashboard ----------
@@ -3177,22 +3260,33 @@
   // `confidence` = number of rounds informing the estimate (rough
   // sample-size cue for the UI, not a probability).
   const PREDICTION_MIN_ROUNDS = 5;
-  function predictTotalForPlayer(rounds, todaysCities) {
+  // Return per-round 0-100 predictions for a player against a given
+  // 5-city array. Each round uses the player's continent average for
+  // that location (needs ≥2 rounds in-continent to trust the bucket;
+  // otherwise the player's overall round mean takes over). Returns null
+  // when the player's total history is too small to predict at all.
+  function predictRoundsForPlayer(rounds, todaysCities) {
     if (!Array.isArray(todaysCities) || todaysCities.length !== N_LOCS) return null;
     const idx = continentScoreIndex(rounds);
     if (idx.totalRounds < PREDICTION_MIN_ROUNDS || idx.overallAvg == null) return null;
-    let weighted = 0;
+    const scores = new Array(N_LOCS);
     for (let i = 0; i < N_LOCS; i++) {
       const c = todaysCities[i];
       const cont = classifyContinent(c.lat, c.lng);
       const b = idx.buckets.get(cont);
-      // Need at least 2 rounds on the continent to trust its bucket;
-      // otherwise fall back to the player's overall round mean.
-      const roundAvg = (b && b.count >= 2) ? (b.sum / b.count) : idx.overallAvg;
-      weighted += roundAvg * WEIGHTS[i];
+      scores[i] = (b && b.count >= 2) ? (b.sum / b.count) : idx.overallAvg;
     }
-    const score = Math.round(Math.max(0, Math.min(1000, weighted)));
-    return { score, confidence: idx.totalRounds };
+    return { scores, confidence: idx.totalRounds };
+  }
+  function predictTotalForPlayer(rounds, todaysCities) {
+    const rp = predictRoundsForPlayer(rounds, todaysCities);
+    if (!rp) return null;
+    let weighted = 0;
+    for (let i = 0; i < N_LOCS; i++) weighted += rp.scores[i] * WEIGHTS[i];
+    return {
+      score: Math.round(Math.max(0, Math.min(1000, weighted))),
+      confidence: rp.confidence,
+    };
   }
 
   async function syncMapTapForRival(rivalId) {

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1006,9 +1006,40 @@
     };
   }
 
+  // SVG icon helpers — tiny stroke glyphs used as score-cell adornments
+  // and as the prediction → actual chevron. Each returns a fresh node so
+  // they're safe to call once per row/chip.
+  function svgIcon(pathD, opts) {
+    const o = opts || {};
+    const wrap = el('span', { class: 'pred-ic' + (o.cls ? ' ' + o.cls : ''), 'aria-hidden': 'true' });
+    wrap.innerHTML =
+      '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" ' +
+      'stroke-width="' + (o.sw || 1.6) + '" stroke-linecap="round" stroke-linejoin="round">' +
+      pathD + '</svg>';
+    return wrap;
+  }
+  const ICON_TARGET = '<circle cx="8" cy="8" r="6"/><circle cx="8" cy="8" r="3"/><circle cx="8" cy="8" r="0.6" fill="currentColor"/>';
+  const ICON_CHECK  = '<path d="M3.5 8.5l3 3 6-6"/>';
+  const ICON_UP     = '<path d="M8 13V4"/><path d="M4 8l4-4 4 4"/>';
+  const ICON_DOWN   = '<path d="M8 3v9"/><path d="M4 8l4 4 4-4"/>';
+  const ICON_DASH   = '<path d="M4 8h8"/>';
+  const ICON_CHEV   = '<path d="M4 4l4 4-4 4"/>';
+
+  function makeDeltaBadge(delta) {
+    if (delta == null) {
+      return el('span', { class: 'pred-delta-badge is-na' }, '—');
+    }
+    const sign = delta > 0 ? 'is-pos' : delta < 0 ? 'is-neg' : 'is-zero';
+    const ic = delta > 0 ? ICON_UP : delta < 0 ? ICON_DOWN : ICON_DASH;
+    return el('span', { class: 'pred-delta-badge ' + sign }, [
+      svgIcon(ic, { sw: 2 }),
+      el('span', { class: 'pred-delta-num' }, (delta > 0 ? '+' : '') + delta),
+    ]);
+  }
+
   // One round chip: shows weighted slot, predicted (and actual when known),
-  // and a colored bottom band keyed to Δ. Predicted is never null when
-  // we render — caller skips the strip entirely if the predictor failed.
+  // and a top accent line keyed to Δ. Predicted is never null when we
+  // render — caller skips the strip entirely if the predictor failed.
   function makeRoundChip(slot, predicted, actual) {
     const predRound = Math.round(predicted);
     const hasActual = actual != null && Number.isFinite(actual);
@@ -1016,27 +1047,30 @@
     const cls = ['prc'];
     if (delta != null) cls.push(delta > 0 ? 'prc-pos' : delta < 0 ? 'prc-neg' : 'prc-zero');
     const w = WEIGHTS[slot];
-    const wLabel = w === 1 ? '' : `×${w}`;
     return el('div', { class: cls.join(' '), title:
         hasActual
           ? `Round ${slot + 1} (×${w}): predicted ${predRound}, actual ${Math.round(actual)}`
           : `Round ${slot + 1} (×${w}): predicted ${predRound}` }, [
       el('div', { class: 'prc-head' }, [
         el('span', { class: 'prc-slot' }, `R${slot + 1}`),
-        wLabel ? el('span', { class: 'prc-weight' }, wLabel) : null,
       ]),
+      w > 1 ? el('span', { class: 'prc-weight' }, `×${w}`) : null,
       el('div', { class: 'prc-nums' }, [
         el('span', { class: 'prc-pred' }, String(predRound)),
-        hasActual ? el('span', { class: 'prc-arrow' }, '→') : null,
+        hasActual ? svgIcon(ICON_CHEV, { cls: 'prc-arrow', sw: 1.8 }) : null,
         hasActual ? el('span', { class: 'prc-actual' }, String(Math.round(actual))) : null,
       ]),
       delta != null
-        ? el('div', { class: 'prc-delta' }, (delta > 0 ? '+' : '') + delta)
+        ? el('div', { class: 'prc-delta' }, [
+            svgIcon(delta > 0 ? ICON_UP : delta < 0 ? ICON_DOWN : ICON_DASH,
+                    { cls: 'prc-delta-ic', sw: 2 }),
+            el('span', {}, (delta > 0 ? '+' : '') + delta),
+          ])
         : null,
     ]);
   }
 
-  function makePredictionRow({ label, predictedScores, actualScores, predictedTotal, actualTotal, isYou }) {
+  function makePredictionRow({ label, predictedScores, actualScores, predictedTotal, actualTotal, isYou, accentColor }) {
     const cls = ['pred-row'];
     if (isYou) cls.push('pred-row-you');
     const cells = [el('div', { class: 'pred-label' }, label)];
@@ -1046,15 +1080,19 @@
       actualTotal != null ? String(actualTotal) : '—'));
     let delta = null;
     if (predictedTotal != null && actualTotal != null) delta = actualTotal - predictedTotal;
-    const deltaCls = ['pred-cell', 'pred-delta'];
-    if (delta != null) deltaCls.push(delta > 0 ? 'pred-delta-pos' : delta < 0 ? 'pred-delta-neg' : 'pred-delta-zero');
-    cells.push(el('div', { class: deltaCls.join(' ') },
-      delta == null ? '—' : (delta > 0 ? '+' : '') + delta));
+    cells.push(el('div', { class: 'pred-cell pred-delta-cell' }, [makeDeltaBadge(delta)]));
     const head = el('div', { class: cls.join(' ') }, cells);
-    if (!Array.isArray(predictedScores)) return head;
+    const accentStyle = accentColor ? `--row-accent:${accentColor};` : '';
+    if (!Array.isArray(predictedScores)) {
+      if (accentStyle) head.setAttribute('style', accentStyle);
+      return head;
+    }
     const strip = el('div', { class: 'pred-round-strip' },
       predictedScores.map((p, i) => makeRoundChip(i, p, actualScores ? actualScores[i] : null)));
-    return el('div', { class: 'pred-row-wrap' + (isYou ? ' pred-row-wrap-you' : '') }, [head, strip]);
+    return el('div', {
+      class: 'pred-row-wrap' + (isYou ? ' pred-row-wrap-you' : ''),
+      style: accentStyle || null,
+    }, [head, strip]);
   }
 
   // Day-tab pill. Shows weekday + day-of-month. Today is labelled "Today";
@@ -1124,11 +1162,19 @@
       return;
     }
 
-    // Per-player rows
+    // Per-player rows. Column headers carry tiny status glyphs so the
+    // PREDICTED / ACTUAL split is scannable even from the chart strip
+    // below it.
     const header = el('div', { class: 'pred-row pred-row-head' }, [
       el('div', { class: 'pred-label' }, 'Player'),
-      el('div', { class: 'pred-cell' }, 'Predicted'),
-      el('div', { class: 'pred-cell' }, 'Actual'),
+      el('div', { class: 'pred-cell' }, [
+        svgIcon(ICON_TARGET, { cls: 'pred-col-ic' }),
+        el('span', {}, 'Predicted'),
+      ]),
+      el('div', { class: 'pred-cell' }, [
+        svgIcon(ICON_CHECK, { cls: 'pred-col-ic' }),
+        el('span', {}, 'Actual'),
+      ]),
       el('div', { class: 'pred-cell' }, 'Δ'),
     ]);
     body.appendChild(header);
@@ -1144,6 +1190,7 @@
       predictedTotal:  myPred ? predTotalFromScores(myPred.scores) : null,
       actualTotal:     myActuals.mineTotal,
       isYou: true,
+      accentColor: 'var(--accent-2)',
     }));
 
     let predictedCount = myPred ? 1 : 0;
@@ -1162,6 +1209,7 @@
           predictedTotal:  pred ? predTotalFromScores(pred.scores) : null,
           actualTotal:     act.total,
           isYou: false,
+          accentColor: r.color,
         }));
       });
 

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -30,6 +30,7 @@
     GAMES: 'maptapRivalsGames',
     ME: 'maptapRivalsMe',
     MY_MAPTAP: 'maptapRivalsMyMapTap',
+    MY_ICON: 'maptapRivalsMyIcon',
     MY_PROFILE: 'maptapRivalsMyProfile',
     SETTINGS: 'maptapRivalsSettings',
     SELECTED: 'maptapRivalsSelectedRivalId',
@@ -247,6 +248,7 @@
     games: load(KEY.GAMES, []),
     me: loadString(KEY.ME, 'Me'),
     myMapTap: loadString(KEY.MY_MAPTAP, ''),
+    myIcon: loadString(KEY.MY_ICON, '🧍'),
     myProfile: load(KEY.MY_PROFILE, null),
     profileEditMode: false,        // true → username input is shown
     profileVerifying: false,
@@ -282,6 +284,7 @@
   function persistGames() { save(KEY.GAMES, state.games); }
   function persistSettings() { save(KEY.SETTINGS, state.settings); }
   function persistMe() { saveString(KEY.ME, state.me); }
+  function persistMyIcon() { saveString(KEY.MY_ICON, state.myIcon); }
   function persistMyMapTap() { saveString(KEY.MY_MAPTAP, state.myMapTap); }
   function persistMyProfile() { save(KEY.MY_PROFILE, state.myProfile); }
   function persistSelected() { saveString(KEY.SELECTED, state.selectedRivalId); }
@@ -698,6 +701,7 @@
 
   // ---------- view switching ----------
   function setView(view) {
+    const changed = state.view !== view;
     state.view = view;
     $$('.view-tab').forEach(tab => {
       const active = tab.dataset.view === view;
@@ -717,6 +721,10 @@
     else if (view === 'history') renderHistory();
 
     syncUrlHash();
+    // Reset scroll when the view changes so a deep-scrolled dashboard
+    // doesn't leave the rival detail mid-page after a card click.
+    // Skip on no-op re-renders so a renderRival mid-scroll stays put.
+    if (changed) window.scrollTo(0, 0);
   }
 
   // ---------- URL routing ----------
@@ -1130,7 +1138,7 @@
     const myPred = predictRoundsForPlayer(myRounds, selected.cities);
     const myActuals = isPastOrToday ? actualScoresForDay(selectedISO) : { mineScores: null, mineTotal: null };
     body.appendChild(makePredictionRow({
-      label: state.me || 'You',
+      label: `${state.myIcon || '🧍'} ${state.me || 'You'}`,
       predictedScores: myPred ? myPred.scores : null,
       actualScores:    myActuals.mineScores,
       predictedTotal:  myPred ? predTotalFromScores(myPred.scores) : null,
@@ -2639,7 +2647,7 @@
     // Participants in display order: You first, then rivals alphabetically.
     const sortedRivals = rivals.slice().sort((a, b) => a.name.localeCompare(b.name));
     const participants = [
-      { type: 'you', label: state.me || 'You', icon: '🧍', color: 'var(--accent-2)' },
+      { type: 'you', label: state.me || 'You', icon: state.myIcon || '🧍', color: 'var(--accent-2)' },
       ...sortedRivals.map(r => ({ type: 'rival', id: r.id, label: r.name, icon: r.icon, color: r.color })),
     ];
 
@@ -3881,6 +3889,7 @@
       version: 1,
       exportedAt: new Date().toISOString(),
       me: state.me,
+      myIcon: state.myIcon,
       rivals: state.rivals,
       games: state.games,
     }, null, 2)], { type: 'application/json' });
@@ -3905,10 +3914,13 @@
         state.rivals = parsed.rivals;
         state.games = parsed.games;
         if (typeof parsed.me === 'string') state.me = parsed.me;
+        if (typeof parsed.myIcon === 'string') state.myIcon = parsed.myIcon;
         persistRivals();
         persistGames();
         persistMe();
+        persistMyIcon();
         $('#my-name').value = state.me;
+        const cur = $('#my-icon-current'); if (cur) cur.textContent = state.myIcon || '🧍';
         refreshRivalSelects();
         if (state.view === 'dashboard') renderDashboard();
         else if (state.view === 'rival') renderRival();
@@ -3940,6 +3952,10 @@
     }
     else if (e.key === KEY.MY_MAPTAP) {
       state.myMapTap = loadString(KEY.MY_MAPTAP, '');
+    }
+    else if (e.key === KEY.MY_ICON) {
+      state.myIcon = loadString(KEY.MY_ICON, '🧍');
+      const cur = $('#my-icon-current'); if (cur) cur.textContent = state.myIcon;
     }
     else if (e.key === KEY.MY_PROFILE) {
       state.myProfile = load(KEY.MY_PROFILE, null);
@@ -3996,6 +4012,60 @@
       persistMe();
     });
 
+    // User icon picker — flyout with the same ICONS palette as rivals,
+    // plus 🧍 as a neutral "no animal" choice for users who don't want
+    // an animal avatar. Closes on outside click or Escape.
+    const myIconBtn     = $('#my-icon-btn');
+    const myIconCurrent = $('#my-icon-current');
+    const myIconFlyout  = $('#my-icon-flyout');
+    const MY_ICONS = ['🧍', ...ICONS];
+    function renderMyIconCurrent() {
+      myIconCurrent.textContent = state.myIcon || '🧍';
+    }
+    function renderMyIconFlyout() {
+      myIconFlyout.innerHTML = '';
+      MY_ICONS.forEach(ic => {
+        myIconFlyout.appendChild(el('button', {
+          type: 'button',
+          class: 'my-icon-swatch' + (ic === state.myIcon ? ' is-selected' : ''),
+          role: 'menuitemradio',
+          'aria-checked': ic === state.myIcon ? 'true' : 'false',
+          'aria-label': `Choose icon ${ic}`,
+          onclick: () => {
+            state.myIcon = ic;
+            persistMyIcon();
+            renderMyIconCurrent();
+            closeMyIconFlyout();
+            // Refresh anywhere the icon is on screen
+            if (state.view === 'dashboard') renderDashboard();
+            else if (state.view === 'matrix') renderMatrix();
+          },
+        }, ic));
+      });
+    }
+    function openMyIconFlyout() {
+      renderMyIconFlyout();
+      myIconFlyout.hidden = false;
+      myIconBtn.setAttribute('aria-expanded', 'true');
+    }
+    function closeMyIconFlyout() {
+      myIconFlyout.hidden = true;
+      myIconBtn.setAttribute('aria-expanded', 'false');
+    }
+    renderMyIconCurrent();
+    myIconBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (myIconFlyout.hidden) openMyIconFlyout();
+      else closeMyIconFlyout();
+    });
+    document.addEventListener('click', (e) => {
+      if (myIconFlyout.hidden) return;
+      if (myIconFlyout.contains(e.target) || myIconBtn.contains(e.target)) return;
+      closeMyIconFlyout();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !myIconFlyout.hidden) closeMyIconFlyout();
+    });
 
     $('#clear-games-btn').addEventListener('click', clearAllGames);
 

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1181,7 +1181,7 @@
 
     const isPastOrToday = selectedISO <= today;
     const myRounds = myProfileRounds();
-    const myPred = predictRoundsForPlayer(myRounds, selected.cities);
+    const myPred = predictRoundsForPlayer(myRounds, selected.cities, selectedISO);
     const myActuals = isPastOrToday ? actualScoresForDay(selectedISO) : { mineScores: null, mineTotal: null };
     body.appendChild(makePredictionRow({
       label: `${state.myIcon || '🧍'} ${state.me || 'You'}`,
@@ -1199,7 +1199,7 @@
       .sort((a, b) => a.name.localeCompare(b.name))
       .forEach(r => {
         const rounds = rivalRounds(r.id);
-        const pred = predictRoundsForPlayer(rounds, selected.cities);
+        const pred = predictRoundsForPlayer(rounds, selected.cities, selectedISO);
         if (pred) predictedCount++;
         const act = isPastOrToday ? actualScoresForRivalDay(r.id, selectedISO) : { scores: null, total: null };
         body.appendChild(makePredictionRow({
@@ -3256,29 +3256,82 @@
   }
 
   // ---------- prediction ----------
-  // Build a per-continent raw-round-score average from a player's past
-  // rounds. `rounds` is an array of `{cities: [{lat,lng}…], scores: […]}`
-  // entries. We deliberately mix all five round slots together — the
-  // empirical signal we want is "how this player tends to score at
-  // locations on continent X", regardless of which slot it appeared in.
-  function continentScoreIndex(rounds) {
-    const buckets = new Map();
-    let totalSum = 0, totalCount = 0;
+  // Per-round prediction blends three signals:
+  //   (1) Geographic similarity (haversine distance) — closer past
+  //       rounds get more weight via 1/(km + ε).
+  //   (2) Recency — exponential decay with a 30-day half-life so a
+  //       player's recent skill dominates over stale rounds.
+  //   (3) Bayesian shrinkage toward the player's overall mean —
+  //       sparse-evidence predictions get pulled back to the baseline
+  //       so a single hot/cold local round can't whipsaw the estimate.
+  // Continent buckets are *not* used here; classifyContinent is still
+  // around for the rival detail's continent breakdown view.
+  const PREDICTION_MIN_ROUNDS = 5;
+  const PREDICTION_RECENCY_HALF_LIFE_DAYS = 30;
+  const PREDICTION_SHRINKAGE_K = 5;       // pseudo-rounds at the player's mean
+  const PREDICTION_DISTANCE_EPS_KM = 25;  // floor on inverse-distance to avoid divide-by-zero / over-weighting exact matches
+  const EARTH_RADIUS_KM = 6371;
+
+  function haversineKm(aLat, aLng, bLat, bLng) {
+    const toRad = (d) => (d * Math.PI) / 180;
+    const dLat = toRad(bLat - aLat);
+    const dLng = toRad(bLng - aLng);
+    const h = Math.sin(dLat / 2) ** 2 +
+              Math.cos(toRad(aLat)) * Math.cos(toRad(bLat)) * Math.sin(dLng / 2) ** 2;
+    return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h));
+  }
+
+  // Flatten `rounds` (one entry per day) into individual {lat, lng,
+  // score, daysAgo} samples relative to `asOfISO`. Rounds on or after
+  // asOfISO are excluded so we never "predict" using data from the
+  // same day or later — back-testing stays honest, and same-day
+  // actuals don't bleed into their own prediction.
+  function flattenRoundsForPrediction(rounds, asOfISO) {
+    const out = [];
+    if (!asOfISO || !Array.isArray(rounds)) return out;
+    const asOf = Date.parse(asOfISO + 'T00:00:00');
+    if (!Number.isFinite(asOf)) return out;
     for (const r of rounds) {
-      if (!Array.isArray(r.cities) || !Array.isArray(r.scores)) continue;
+      if (!r || !Array.isArray(r.cities) || !Array.isArray(r.scores) || !r.date) continue;
+      const t = Date.parse(r.date + 'T00:00:00');
+      if (!Number.isFinite(t) || t >= asOf) continue;
+      const daysAgo = (asOf - t) / 86400000;
       const n = Math.min(r.cities.length, r.scores.length, N_LOCS);
       for (let i = 0; i < n; i++) {
         const c = r.cities[i] || {};
+        const lat = Number(c.lat);
+        const lng = Number(c.lng);
         const s = Number(r.scores[i]);
-        if (!Number.isFinite(s)) continue;
-        const continent = classifyContinent(Number(c.lat), Number(c.lng));
-        let b = buckets.get(continent);
-        if (!b) { b = { sum: 0, count: 0 }; buckets.set(continent, b); }
-        b.sum += s; b.count += 1;
-        totalSum += s; totalCount += 1;
+        if (!Number.isFinite(lat) || !Number.isFinite(lng) || !Number.isFinite(s)) continue;
+        out.push({ lat, lng, score: s, daysAgo });
       }
     }
-    return { buckets, overallAvg: totalCount ? totalSum / totalCount : null, totalRounds: totalCount };
+    return out;
+  }
+
+  function predictRoundScoreFromHistory(history, targetLat, targetLng, playerMean) {
+    if (!history.length || !Number.isFinite(playerMean)) return playerMean;
+    const recencyLambda = Math.LN2 / PREDICTION_RECENCY_HALF_LIFE_DAYS;
+    let sumW = 0, sumWX = 0, sumW2 = 0;
+    for (const r of history) {
+      const km = haversineKm(targetLat, targetLng, r.lat, r.lng);
+      const distW = 1 / (km + PREDICTION_DISTANCE_EPS_KM);
+      const recW = Math.exp(-r.daysAgo * recencyLambda);
+      const w = distW * recW;
+      sumW += w;
+      sumWX += w * r.score;
+      sumW2 += w * w;
+    }
+    if (sumW <= 0 || sumW2 <= 0) return playerMean;
+    const weightedAvg = sumWX / sumW;
+    // Kish's effective sample size: (Σw)² / Σw² — counts evidence by
+    // weight concentration. A handful of close-and-recent rounds give
+    // nEff ≈ their count; lots of far/old rounds give nEff ≈ 1-2.
+    const nEff = (sumW * sumW) / sumW2;
+    // Shrinkage toward the player's long-term mean. With nEff = 0 we
+    // get the prior outright; with nEff >> K we trust the local mean.
+    return (nEff * weightedAvg + PREDICTION_SHRINKAGE_K * playerMean) /
+           (nEff + PREDICTION_SHRINKAGE_K);
   }
 
   // Your own per-round history derived from `state.games`. `state.myProfile`
@@ -3286,7 +3339,8 @@
   // small (see summarizeMapTapProfile), so the paired Game records are
   // the authoritative source. The same day appears once per rival you
   // played with, so dedupe by date — your scores are identical across
-  // those duplicates by construction.
+  // those duplicates by construction. `date` is preserved so the
+  // predictor's recency decay and same-day cutoff can use it.
   function myProfileRounds() {
     const byDate = new Map();
     for (const g of state.games) {
@@ -3296,7 +3350,7 @@
       const cities = g.cities.map(c => ({ lat: Number(c.lat), lng: Number(c.lng) }));
       const scores = g.myScores.map(Number);
       if (!scores.every(s => Number.isFinite(s))) continue;
-      byDate.set(g.date, { cities, scores });
+      byDate.set(g.date, { date: g.date, cities, scores });
     }
     return Array.from(byDate.values());
   }
@@ -3308,38 +3362,35 @@
     return gamesFor(rivalId)
       .filter(g => Array.isArray(g.cities) && g.cities.length === N_LOCS &&
                    Array.isArray(g.theirScores))
-      .map(g => ({ cities: g.cities, scores: g.theirScores }));
+      .map(g => ({ date: g.date, cities: g.cities, scores: g.theirScores }));
   }
 
-  // Predict a player's weighted total against today's 5 cities. Each
-  // round is projected from their continent average for that round's
-  // location (fallback: their overall round average). Total uses the
-  // same WEIGHTS the rest of the app uses so it's comparable to actual
-  // scores. Returns null when the player has too little history to give
-  // a meaningful number.
+  // Predict a player's weighted total + per-round breakdown for a given
+  // 5-city array, computed as of `asOfISO` (excludes any rounds from
+  // that day or later). Returns null when the player has too little
+  // pre-cutoff history to give a meaningful number.
   // `confidence` = number of rounds informing the estimate (rough
   // sample-size cue for the UI, not a probability).
-  const PREDICTION_MIN_ROUNDS = 5;
-  // Return per-round 0-100 predictions for a player against a given
-  // 5-city array. Each round uses the player's continent average for
-  // that location (needs ≥2 rounds in-continent to trust the bucket;
-  // otherwise the player's overall round mean takes over). Returns null
-  // when the player's total history is too small to predict at all.
-  function predictRoundsForPlayer(rounds, todaysCities) {
+  function predictRoundsForPlayer(rounds, todaysCities, asOfISO) {
     if (!Array.isArray(todaysCities) || todaysCities.length !== N_LOCS) return null;
-    const idx = continentScoreIndex(rounds);
-    if (idx.totalRounds < PREDICTION_MIN_ROUNDS || idx.overallAvg == null) return null;
+    const history = flattenRoundsForPrediction(rounds, asOfISO);
+    if (history.length < PREDICTION_MIN_ROUNDS) return null;
+    // Player's overall mean used as the shrinkage prior. Straight
+    // unweighted average keeps the prior stable over time — recency
+    // already lives in the per-round weights.
+    let total = 0;
+    for (const r of history) total += r.score;
+    const playerMean = total / history.length;
     const scores = new Array(N_LOCS);
     for (let i = 0; i < N_LOCS; i++) {
       const c = todaysCities[i];
-      const cont = classifyContinent(c.lat, c.lng);
-      const b = idx.buckets.get(cont);
-      scores[i] = (b && b.count >= 2) ? (b.sum / b.count) : idx.overallAvg;
+      const s = predictRoundScoreFromHistory(history, c.lat, c.lng, playerMean);
+      scores[i] = Math.max(0, Math.min(100, s));
     }
-    return { scores, confidence: idx.totalRounds };
+    return { scores, confidence: history.length };
   }
-  function predictTotalForPlayer(rounds, todaysCities) {
-    const rp = predictRoundsForPlayer(rounds, todaysCities);
+  function predictTotalForPlayer(rounds, todaysCities, asOfISO) {
+    const rp = predictRoundsForPlayer(rounds, todaysCities, asOfISO);
     if (!rp) return null;
     let weighted = 0;
     for (let i = 0; i < N_LOCS; i++) weighted += rp.scores[i] * WEIGHTS[i];

--- a/sync-system/app-sync-init.js
+++ b/sync-system/app-sync-init.js
@@ -74,6 +74,7 @@ const APP_SYNC_CONFIG = {
       'maptapRivalsRivals',         // Rival list (id, name, color, icon, maptapUsername, createdAt)
       'maptapRivalsGames',          // All daily games (id, rivalId, date, myScore, theirScore, note)
       'maptapRivalsMe',             // Owner display name
+      'maptapRivalsMyIcon',         // Owner avatar icon (emoji from ICONS palette)
       'maptapRivalsMyMapTap',       // Your maptap.gg username (for syncing)
       'maptapRivalsMyProfile',      // Verified profile snapshot (nickname/joinDate/avg/best)
       'maptapRivalsSettings',       // UI prefs (last-selected rival, etc.)


### PR DESCRIPTION
## Summary

Adds a "Today's predictions" card to the dashboard that pulls each day's puzzle locations from MapTap's public static feed, projects each player's score per round, and compares against actuals once the day syncs. Plus a meaningful predictor upgrade, a UI polish pass, and a stack of small fixes that accumulated along the way.

## Today's predictions card

- **Source.** MapTap publishes each day's puzzle as a CORS-open static JS file at `maptap.gg/data/this_day_in_history/<MonthDay>.js`. The first 5 cities in file order are the rounds every player actually plays — verified empirically against a public profile's `roundData` across May 10–14 (file lists 6–10 cities, played = first 5).
- **Fetcher.** Pulls the file, regex-extracts only `lat`/`lng` (excludes `labelLat`/`labelLng` via letter-boundary lookbehind), caches per ISO date in localStorage. Past days are cached forever (immutable); today/future re-fetch after 6h.
- **7-day strip.** Pills for today + 6 future days. Click any to switch the card body. All 7 fetched in parallel on dashboard render; per-ISO cache makes revisits zero-fetch.
- **Per-row breakdown.** Each player gets a totals row (Predicted / Actual / Δ pill badge) plus a 5-chip round strip beneath it. Each chip shows R# label, ×weight badge for R3-R5, predicted → actual via SVG chevron, and a Δ band tinted by direction.
- **Status badge.** PRE-GAME / GAME PLAYED ✓ / UPCOMING / NOT LOGGED / NEED MORE GAMES depending on the selected day.
- **Integrity.** The daily file contains city names and trivia (i.e. the answers). We drop everything except lat/lng before anything reaches state, localStorage, or the DOM. Verified via headless probe: cached payload keys = `[cachedAt, cities]`, first city = `{lat, lng}` only, no name fields in cache or rendered card.

## Prediction algorithm

Replaced the v1 continent-bucket averages with a denser three-signal blend:

| Signal | How it works |
|---|---|
| Geographic similarity | Haversine distance with `1 / (km + 25)` weight per past round. Lyon learns from Paris, not "all of Europe". |
| Recency decay | Multiplied by `exp(-daysAgo · ln2 / 30)` — 30-day half-life so the last month dominates and stale rounds fade. |
| Bayesian shrinkage | Kish's effective sample size `(Σw)² / Σw²` blended with the player's overall mean using K = 5 pseudo-rounds. Sparse local evidence smoothly pulled back to baseline. |

A new `asOfISO` parameter excludes rounds on or after that date so back-testing past days is honest and same-day actuals never bleed into their own prediction. Tuning constants (`PREDICTION_RECENCY_HALF_LIFE_DAYS`, `PREDICTION_SHRINKAGE_K`, `PREDICTION_DISTANCE_EPS_KM`) are exposed at the top of the predictor block.

Smoke-test on a synthetic Paris (95) + Tokyo (60) player, mean 77.5:

| Target | Old (continent avg) | New |
|---|---|---|
| Lyon (near Paris) | 95 | **88** (Paris signal, lightly shrunk) |
| Osaka (near Tokyo) | 60 | **67** (Tokyo signal, lightly shrunk) |
| Sydney (far from both) | ~77 fallback | **73** (drifts to mean) |
| Single 100 round, target nearby, mean=50 | 100 | **58** (shrunk toward prior, not over-confident) |

## UI polish

- **Dashboard polish pass.** Standardized stat-card backgrounds / border opacity / radius / shadows between dashboard and rival detail; tightened section-title typography; soft tinted-pill status badges; calmer accent-soft active day-tabs; section dividers under card heads.
- **Predictions table polish.** Per-player left-edge accent stripe in each rival's own color (your row uses `--accent-2`); Δ totals → pill badges with up/down/dash SVG icons; column headers grow tiny target/check glyphs; round chips swap the harsh inset bottom bar for a thin top accent gradient + tinted background; ×weight rides as a small superscript badge in the top-right corner; styled SVG chevron between predicted/actual; numeric values use a new `--mono` font stack (JetBrains/SF/Cascadia/Roboto Mono) for sports-board feel.

## Other changes (rolled up during the same PR)

- **History tab dates link to `maptap.gg/history/<MonthDay>`** in a new tab — dotted-underlined, accent on hover/focus.
- **Best score cards on rival detail** now show the date next to the value and the worst-score date in the sub-line.
- **Cumulative Δ → Avg Δ per game** on rival detail. Comparable across rivals you've played different counts of games against.
- **"Projected next" card removed** from rival detail.
- **Score-over-time and Average-per-round** chart series swap the rival's color to a contrast orange when it's too close to the pinned user green, so the two lines stay distinguishable.
- **"Paste daily scores"** is now a `<details>` collapsed by default, nudging users toward profile-link auto-sync.
- **Dark `<select>` dropdowns.** Added `color-scheme: dark` + explicit option backgrounds so native open lists render dark instead of white.
- **User icon picker** in the settings strip — same `ICONS` palette as rivals + 🧍, persisted under `KEY.MY_ICON`, exports/imports with the rest of state, syncs cross-device (added to `sync-system/app-sync-init.js` allowlist).
- **Scroll-to-top on view change** in `setView` — clicking a rival card from a deep-scrolled dashboard no longer leaves the rival detail mid-page.
- **Fix:** "your" predicted/actual was always `—` because the code read `state.myProfile.gameHistory`, which `summarizeMapTapProfile` deliberately drops to keep localStorage small. Now derived from `state.games` like rival stats already were.
- **Fix:** runtime crash where `Object.entries(null)` blew up after three new `el()` calls passed `null` for attrs — caught and silently rendered as "Puzzle unavailable". Switched the three sites to `{}`.

## Test plan
- [ ] Open `apps/maptap-rivals/` with linked profile + at least one rival who has paired games with city data. Dashboard shows the new card with predicted scores and a PRE-GAME pill.
- [ ] After the day's MapTap results sync, the card flips to GAME PLAYED ✓; ACTUAL and Δ columns fill in; Δ badges color-coded green / red.
- [ ] Click the day pills to scrub forward — predicted scores update; UPCOMING pill appears for future days; round chips show predicted only.
- [ ] Pick a new avatar from the settings strip — persists, syncs across devices.
- [ ] History tab dates open `https://maptap.gg/history/<MonthDay>` in a new tab.
- [ ] Open Network tab in devtools: one request per day to `maptap.gg/data/this_day_in_history/<MonthDay>.js` per session; subsequent loads hit localStorage cache.
- [ ] localStorage `maptapRivalsDailyCities/<iso>` keys contain only `{cachedAt, cities: [{lat, lng}, ...]}` — no `name`/`cityName` fields. Rendered card DOM contains no city names, country names, or trivia.