### PR TITLE
ci(rising-seasons): route daily refresh through auto-merged PR

### DIFF
--- a/.github/workflows/refresh-rising-seasons.yml
+++ b/.github/workflows/refresh-rising-seasons.yml
@@ -25,6 +25,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   refresh:
@@ -103,15 +104,30 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Commit data.json + changelog.json if changed
+      # master is protected by a "PR before Merge" ruleset, so direct pushes
+      # are rejected. We push to a short-lived branch, open a PR, and merge
+      # it immediately — the ruleset requires 0 approvals and no status
+      # checks, and tests already ran above on this exact tree.
+      - name: Open and merge PR if data changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           if git diff --quiet apps/rising-seasons/data.json; then
             echo "No changes — nothing to commit."
             exit 0
           fi
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="bot/refresh-rising-seasons-$(date -u +%Y%m%d-%H%M%S)"
           git config user.name "shevato-bot"
           git config user.email "actions@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add apps/rising-seasons/data.json apps/rising-seasons/changelog.json
-          git commit -m "chore(rising-seasons): refresh data $(date -u +%Y-%m-%d)"
-          git push
+          git commit -m "chore(rising-seasons): refresh data $DATE"
+          git push --set-upstream origin "$BRANCH"
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "chore(rising-seasons): refresh data $DATE" \
+            --body "Automated refresh of IMDb + TMDB data."
+          gh pr merge "$BRANCH" --merge --delete-branch


### PR DESCRIPTION
## Summary
- The scheduled `refresh-rising-seasons` workflow was failing at the final push step with `GH013` — the `master` branch has a **PR before Merge** ruleset that blocks direct pushes.
- Reworked the final step to push to a short-lived `bot/refresh-rising-seasons-<timestamp>` branch, open a PR with `gh pr create`, and immediately self-merge with `gh pr merge --merge --delete-branch`.
- Added `pull-requests: write` to the workflow permissions.

## Why this stays fully unattended
- The ruleset requires **0 approvals** and no required status checks, so `gh pr merge --merge` succeeds without human input.
- Tests already run earlier in the same job (`Run tests` step) on the exact tree being committed, so we lose no signal by skipping the PR-triggered CI run.
- Cron continues to fire daily at 06:00 UTC.

## Test plan
- [ ] Trigger `Refresh Rising Seasons data` via `workflow_dispatch` on this branch (or after merge) and confirm: branch is created, PR opens, PR auto-merges, master gets the refresh commit.
- [ ] Confirm no leftover `bot/refresh-rising-seasons-*` branches (delete-on-merge handles this).