### PR TITLE
chore(seo): use directory form for app URLs

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -76,7 +76,7 @@
         "@type": "SoftwareApplication",
         "name": "Mario Kart Tracker",
         "description": "Track Mario Kart races with comprehensive statistics, player performance analysis, achievements, and race history. Supports both Mario Kart 8 Deluxe and Mario Kart World.",
-        "url": "https://shevato.com/apps/mario-kart/index.html",
+        "url": "https://shevato.com/apps/mario-kart/",
         "applicationCategory": "GameApplication",
         "operatingSystem": "Web Browser",
         "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
@@ -90,7 +90,7 @@
         "@type": "SoftwareApplication",
         "name": "Gym Tracker",
         "description": "Track your gym workouts with exercise logging, program builder, workout history, progress tracking, and achievement system",
-        "url": "https://shevato.com/apps/gym-tracker/index.html",
+        "url": "https://shevato.com/apps/gym-tracker/",
         "applicationCategory": "HealthApplication",
         "operatingSystem": "Web Browser",
         "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
@@ -104,7 +104,7 @@
         "@type": "SoftwareApplication",
         "name": "Football H2H League",
         "description": "Head-to-head football league manager with match recording, penalty shootout tracking, team statistics, and player performance analytics",
-        "url": "https://shevato.com/apps/football-h2h/index.html",
+        "url": "https://shevato.com/apps/football-h2h/",
         "applicationCategory": "SportsApplication",
         "operatingSystem": "Web Browser",
         "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
@@ -118,7 +118,7 @@
         "@type": "SoftwareApplication",
         "name": "Rising Seasons",
         "description": "Discover TV shows by the shape of their episode ratings: rising, consistent, slow-burn, big-finale, rebound, and more. Browse and filter thousands of seasons across all of TV with shape-based analytics.",
-        "url": "https://shevato.com/apps/rising-seasons/index.html",
+        "url": "https://shevato.com/apps/rising-seasons/",
         "applicationCategory": "MultimediaApplication",
         "operatingSystem": "Web Browser",
         "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
@@ -132,7 +132,7 @@
         "@type": "SoftwareApplication",
         "name": "MapTap Rivals",
         "description": "Daily MapTap.gg head-to-head tracker. Log scores against named friends and see win/loss records, streaks, averages, score trends, and per-rival dashboards",
-        "url": "https://shevato.com/apps/maptap-rivals/index.html",
+        "url": "https://shevato.com/apps/maptap-rivals/",
         "applicationCategory": "GameApplication",
         "operatingSystem": "Web Browser",
         "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
@@ -161,60 +161,60 @@
         <section>
           <div class="content">
             <header>
-              <a href="apps/mario-kart/index.html" class="icon fa-gamepad brand-color-primary" aria-label="Open Mario Kart Tracker"></a>
+              <a href="apps/mario-kart/" class="icon fa-gamepad brand-color-primary" aria-label="Open Mario Kart Tracker"></a>
               <h3>Mario Kart Tracker</h3>
             </header>
             <p>Log Mario Kart races, track player stats over time, and dig into performance with charts and achievements.</p>
             <ul class="actions special">
-              <li><a href="apps/mario-kart/index.html" class="button">Track Races</a></li>
+              <li><a href="apps/mario-kart/" class="button">Track Races</a></li>
             </ul>
           </div>
         </section>
         <section>
           <div class="content">
             <header>
-              <a href="apps/gym-tracker/index.html" class="icon fa-heartbeat brand-color-primary" aria-label="Open Gym Tracker"></a>
+              <a href="apps/gym-tracker/" class="icon fa-heartbeat brand-color-primary" aria-label="Open Gym Tracker"></a>
               <h3>Gym Tracker</h3>
             </header>
             <p>An installable PWA for logging workouts, building programs, and watching your numbers move. Works offline once installed.</p>
             <ul class="actions special">
-              <li><a href="apps/gym-tracker/index.html" class="button">Start Tracking</a></li>
+              <li><a href="apps/gym-tracker/" class="button">Start Tracking</a></li>
             </ul>
           </div>
         </section>
         <section>
           <div class="content">
             <header>
-              <a href="apps/football-h2h/index.html" class="icon fa-futbol-o brand-color-primary" aria-label="Open Football H2H League"></a>
+              <a href="apps/football-h2h/" class="icon fa-futbol-o brand-color-primary" aria-label="Open Football H2H League"></a>
               <h3>Football H2H League</h3>
             </header>
             <p>Head-to-head football match recorder. Scores, penalty shootouts, team selections, and a player comparison table for the long-running rivalry at home.</p>
             <ul class="actions special">
-              <li><a href="apps/football-h2h/index.html" class="button">View League</a></li>
+              <li><a href="apps/football-h2h/" class="button">View League</a></li>
             </ul>
           </div>
         </section>
         <section>
           <div class="content">
             <header>
-              <a href="apps/rising-seasons/index.html" class="icon fa-line-chart brand-color-primary" aria-label="Open Rising Seasons"></a>
+              <a href="apps/rising-seasons/" class="icon fa-line-chart brand-color-primary" aria-label="Open Rising Seasons"></a>
               <h3>Rising Seasons</h3>
             </header>
             <p>Find TV shows by the shape of their episode ratings. Rising, consistent, slow-burn, big-finale, or rebound seasons across thousands of shows.</p>
             <ul class="actions special">
-              <li><a href="apps/rising-seasons/index.html" class="button">Browse Seasons</a></li>
+              <li><a href="apps/rising-seasons/" class="button">Browse Seasons</a></li>
             </ul>
           </div>
         </section>
         <section>
           <div class="content">
             <header>
-              <a href="apps/maptap-rivals/index.html" class="icon fa-crosshairs brand-color-primary" aria-label="Open MapTap Rivals"></a>
+              <a href="apps/maptap-rivals/" class="icon fa-crosshairs brand-color-primary" aria-label="Open MapTap Rivals"></a>
               <h3>MapTap Rivals</h3>
             </header>
             <p>Log daily MapTap.gg head-to-head scores against named friends. Win streaks, averages, score trends, and per-rival dashboards in one place.</p>
             <ul class="actions special">
-              <li><a href="apps/maptap-rivals/index.html" class="button">Track Rivals</a></li>
+              <li><a href="apps/maptap-rivals/" class="button">Track Rivals</a></li>
             </ul>
           </div>
         </section>

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -21,13 +21,13 @@
     <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://shevato.com/apps/football-h2h/index.html" />
+    <link rel="canonical" href="https://shevato.com/apps/football-h2h/" />
 
     <!-- Open Graph tags -->
     <meta property="og:title" content="Football Head-to-Head League Manager | Free Match Tracker" />
     <meta property="og:description" content="Track head-to-head football matches with comprehensive statistics, penalty shootout recording, and team performance analytics." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://shevato.com/apps/football-h2h/index.html" />
+    <meta property="og:url" content="https://shevato.com/apps/football-h2h/" />
     <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
     <meta property="og:image:type" content="image/svg+xml" />
     <meta property="og:image:alt" content="Football Head-to-Head League Manager" />
@@ -49,7 +49,7 @@
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
         { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
-        { "@type": "ListItem", "position": 3, "name": "Football H2H League", "item": "https://shevato.com/apps/football-h2h/index.html" }
+        { "@type": "ListItem", "position": 3, "name": "Football H2H League", "item": "https://shevato.com/apps/football-h2h/" }
       ]
     }
     </script>
@@ -61,7 +61,7 @@
       "@type": "WebApplication",
       "name": "Football Head-to-Head League Manager",
       "description": "Free head-to-head football league manager with match recording, penalty shootout tracking, team statistics, and player performance analytics",
-      "url": "https://shevato.com/apps/football-h2h/index.html",
+      "url": "https://shevato.com/apps/football-h2h/",
       "applicationCategory": "SportsApplication",
       "operatingSystem": "Web Browser",
       "browserRequirements": "Requires JavaScript. Works on all modern browsers.",

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -19,13 +19,13 @@
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://shevato.com/apps/gym-tracker/index.html" />
+    <link rel="canonical" href="https://shevato.com/apps/gym-tracker/" />
 
     <!-- Open Graph tags -->
     <meta property="og:title" content="Gym Tracker | Free Workout Log & Strength Progress App" />
     <meta property="og:description" content="Log workouts, build programs, track strength progress and body measurements. Free, installable as a PWA, works offline." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://shevato.com/apps/gym-tracker/index.html" />
+    <meta property="og:url" content="https://shevato.com/apps/gym-tracker/" />
     <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
     <meta property="og:image:type" content="image/svg+xml" />
     <meta property="og:image:alt" content="Gym Tracker - Free Workout Log" />
@@ -46,7 +46,7 @@
       "@type": "WebApplication",
       "name": "Gym Tracker",
       "description": "Free gym tracker for logging workouts, building programs, tracking strength progress, body measurements, and achievements. Installable as a PWA.",
-      "url": "https://shevato.com/apps/gym-tracker/index.html",
+      "url": "https://shevato.com/apps/gym-tracker/",
       "applicationCategory": "HealthApplication",
       "operatingSystem": "Web Browser",
       "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
@@ -80,7 +80,7 @@
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
         { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
-        { "@type": "ListItem", "position": 3, "name": "Gym Tracker", "item": "https://shevato.com/apps/gym-tracker/index.html" }
+        { "@type": "ListItem", "position": 3, "name": "Gym Tracker", "item": "https://shevato.com/apps/gym-tracker/" }
       ]
     }
     </script>

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -12,14 +12,14 @@
   <meta name="robots" content="index, follow, max-image-preview:large">
   <meta name="theme-color" content="#0b0d12">
   <meta name="color-scheme" content="dark">
-  <link rel="canonical" href="https://shevato.com/apps/maptap-rivals/index.html" />
+  <link rel="canonical" href="https://shevato.com/apps/maptap-rivals/" />
   <title>MapTap Rivals | Daily MapTap H2H tracker - Shevato</title>
 
   <!-- Open Graph -->
   <meta property="og:title" content="MapTap Rivals | Daily MapTap.gg head-to-head tracker" />
   <meta property="og:description" content="Log your daily MapTap.gg scores against named friends. Streaks, averages, score trends, continent breakdowns, and per-rival dashboards." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://shevato.com/apps/maptap-rivals/index.html" />
+  <meta property="og:url" content="https://shevato.com/apps/maptap-rivals/" />
   <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
   <meta property="og:image:type" content="image/svg+xml" />
   <meta property="og:image:alt" content="MapTap Rivals — daily MapTap.gg head-to-head tracker" />
@@ -41,7 +41,7 @@
     "itemListElement": [
       { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
       { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
-      { "@type": "ListItem", "position": 3, "name": "MapTap Rivals", "item": "https://shevato.com/apps/maptap-rivals/index.html" }
+      { "@type": "ListItem", "position": 3, "name": "MapTap Rivals", "item": "https://shevato.com/apps/maptap-rivals/" }
     ]
   }
   </script>
@@ -53,7 +53,7 @@
     "@type": "WebApplication",
     "name": "MapTap Rivals",
     "description": "Daily MapTap.gg head-to-head tracker — log scores against named friends and see win/loss records, streaks, averages, score trends, round-by-round breakdowns, continent stats, and per-rival dashboards.",
-    "url": "https://shevato.com/apps/maptap-rivals/index.html",
+    "url": "https://shevato.com/apps/maptap-rivals/",
     "applicationCategory": "GameApplication",
     "operatingSystem": "Web Browser",
     "browserRequirements": "Requires JavaScript. Works on all modern browsers.",

--- a/apps/mario-kart/index.html
+++ b/apps/mario-kart/index.html
@@ -17,13 +17,13 @@
     <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://shevato.com/apps/mario-kart/index.html" />
+    <link rel="canonical" href="https://shevato.com/apps/mario-kart/" />
 
     <!-- Open Graph tags -->
     <meta property="og:title" content="Mario Kart 8 Deluxe Race Tracker | Free Statistics & Analytics" />
     <meta property="og:description" content="Track Mario Kart 8 Deluxe races with comprehensive statistics, player performance analysis, and detailed race history." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://shevato.com/apps/mario-kart/index.html" />
+    <meta property="og:url" content="https://shevato.com/apps/mario-kart/" />
     <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
     <meta property="og:image:type" content="image/svg+xml" />
     <meta property="og:image:alt" content="Mario Kart 8 Deluxe Race Tracker" />
@@ -45,7 +45,7 @@
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
         { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
-        { "@type": "ListItem", "position": 3, "name": "Mario Kart Tracker", "item": "https://shevato.com/apps/mario-kart/index.html" }
+        { "@type": "ListItem", "position": 3, "name": "Mario Kart Tracker", "item": "https://shevato.com/apps/mario-kart/" }
       ]
     }
     </script>
@@ -57,7 +57,7 @@
       "@type": "WebApplication",
       "name": "Mario Kart 8 Deluxe Race Tracker",
       "description": "Free race tracking application for Mario Kart 8 Deluxe with comprehensive statistics, player performance analysis, achievements, and race history",
-      "url": "https://shevato.com/apps/mario-kart/index.html",
+      "url": "https://shevato.com/apps/mario-kart/",
       "applicationCategory": "GameApplication",
       "operatingSystem": "Web Browser",
       "browserRequirements": "Requires JavaScript. Works on all modern browsers.",

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -15,14 +15,14 @@
   <meta name="robots" content="index, follow, max-image-preview:large">
   <meta name="theme-color" content="#0b0d12">
   <meta name="color-scheme" content="dark">
-  <link rel="canonical" href="https://shevato.com/apps/rising-seasons/index.html" />
+  <link rel="canonical" href="https://shevato.com/apps/rising-seasons/" />
   <title>Rising Seasons | TV by the shape of episode ratings - Shevato</title>
 
   <!-- Open Graph -->
   <meta property="og:title" content="Rising Seasons | Discover TV by the shape of episode ratings" />
   <meta property="og:description" content="Browse thousands of TV seasons by episode-rating shape — rising, consistent, slow-burn, big-finale, rebound, mid-peak, and more." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://shevato.com/apps/rising-seasons/index.html" />
+  <meta property="og:url" content="https://shevato.com/apps/rising-seasons/" />
   <meta property="og:image" content="https://shevato.com/images/full-logo.svg" />
   <meta property="og:image:type" content="image/svg+xml" />
   <meta property="og:image:alt" content="Rising Seasons — TV by the shape of episode ratings" />
@@ -44,7 +44,7 @@
     "itemListElement": [
       { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
       { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
-      { "@type": "ListItem", "position": 3, "name": "Rising Seasons", "item": "https://shevato.com/apps/rising-seasons/index.html" }
+      { "@type": "ListItem", "position": 3, "name": "Rising Seasons", "item": "https://shevato.com/apps/rising-seasons/" }
     ]
   }
   </script>
@@ -56,7 +56,7 @@
     "@type": "WebApplication",
     "name": "Rising Seasons",
     "description": "Discover TV shows by the shape of their episode ratings. Browse rising, consistent, slow-burn, big-finale, rebound, mid-peak, and other shape patterns across thousands of seasons.",
-    "url": "https://shevato.com/apps/rising-seasons/index.html",
+    "url": "https://shevato.com/apps/rising-seasons/",
     "applicationCategory": "MultimediaApplication",
     "operatingSystem": "Web Browser",
     "browserRequirements": "Requires JavaScript. Works on all modern browsers.",

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,7 +25,7 @@
 # anything Google already has indexed.
 [[redirects]]
   from = "/apps/mario-kart/tracker.html"
-  to = "/apps/mario-kart/index.html"
+  to = "/apps/mario-kart/"
   status = 301
   force = true
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -55,35 +55,35 @@
   </url>
 
   <url>
-    <loc>https://shevato.com/apps/mario-kart/index.html</loc>
+    <loc>https://shevato.com/apps/mario-kart/</loc>
     <lastmod>2026-05-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <url>
-    <loc>https://shevato.com/apps/gym-tracker/index.html</loc>
+    <loc>https://shevato.com/apps/gym-tracker/</loc>
     <lastmod>2026-05-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <url>
-    <loc>https://shevato.com/apps/football-h2h/index.html</loc>
+    <loc>https://shevato.com/apps/football-h2h/</loc>
     <lastmod>2026-05-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <url>
-    <loc>https://shevato.com/apps/rising-seasons/index.html</loc>
+    <loc>https://shevato.com/apps/rising-seasons/</loc>
     <lastmod>2026-05-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <url>
-    <loc>https://shevato.com/apps/maptap-rivals/index.html</loc>
+    <loc>https://shevato.com/apps/maptap-rivals/</loc>
     <lastmod>2026-05-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/sync-system/tests/app-naming-consistency.test.mjs
+++ b/sync-system/tests/app-naming-consistency.test.mjs
@@ -57,24 +57,49 @@ test('no app directory contains a stray non-index *.html entry alongside index.h
     assert.deepEqual(offenders, [], `unexpected top-level HTML beside index.html:\n  ${offenders.join('\n  ')}`);
 });
 
-test('apps.html and sitemap.xml link to every app via /apps/<name>/index.html', () => {
+test('apps.html and sitemap.xml link to every app via the directory form /apps/<name>/', () => {
+    // We link to the directory (not /index.html) so that the rendered URL,
+    // the canonical tag, the sitemap entry, and the user-facing href all
+    // agree — Netlify's pretty-URLs would otherwise redirect /index.html
+    // off and break that alignment.
     const appsHtml = readFileSync(join(REPO_ROOT, 'apps.html'), 'utf8');
     const sitemap = readFileSync(join(REPO_ROOT, 'sitemap.xml'), 'utf8');
 
     const apps = listDirs(APPS_DIR);
     const missing = [];
     for (const app of apps) {
-        const expected = `apps/${app}/index.html`;
-        // apps.html and sitemap may use either relative or full URL form.
-        if (!appsHtml.includes(expected)) missing.push(`apps.html → ${expected}`);
-        if (!sitemap.includes(expected)) missing.push(`sitemap.xml → ${expected}`);
+        // Match the href closing quote in apps.html (href="apps/<name>/")
+        // and the loc closing tag in the sitemap (.../apps/<name>/</loc>)
+        // so we don't accidentally match deeper sub-paths.
+        const hrefPattern = new RegExp(`href="apps/${app}/"`);
+        const locPattern = new RegExp(`apps/${app}/</loc>`);
+        if (!hrefPattern.test(appsHtml)) missing.push(`apps.html → href="apps/${app}/"`);
+        if (!locPattern.test(sitemap)) missing.push(`sitemap.xml → apps/${app}/</loc>`);
     }
     assert.deepEqual(missing, [], `links/loc entries missing:\n  ${missing.join('\n  ')}`);
+});
+
+test('apps.html and sitemap.xml never expose /apps/<name>/index.html as a URL', () => {
+    // Guards against drift back to the /index.html form, which would put
+    // the markup out of sync with Netlify's pretty-URL behavior.
+    const appsHtml = readFileSync(join(REPO_ROOT, 'apps.html'), 'utf8');
+    const sitemap = readFileSync(join(REPO_ROOT, 'sitemap.xml'), 'utf8');
+
+    const apps = listDirs(APPS_DIR);
+    const offenders = [];
+    for (const app of apps) {
+        const bad = `apps/${app}/index.html`;
+        if (appsHtml.includes(bad)) offenders.push(`apps.html → ${bad}`);
+        if (sitemap.includes(bad)) offenders.push(`sitemap.xml → ${bad}`);
+    }
+    assert.deepEqual(offenders, [], `unexpected /index.html URL forms:\n  ${offenders.join('\n  ')}`);
 });
 
 test('netlify.toml keeps a 301 from tracker.html to the new mario-kart entry', () => {
     const toml = readFileSync(join(REPO_ROOT, 'netlify.toml'), 'utf8');
     assert.match(toml, /from\s*=\s*"\/apps\/mario-kart\/tracker\.html"/);
-    assert.match(toml, /to\s*=\s*"\/apps\/mario-kart\/index\.html"/);
+    // Target is the directory form so the redirect lands on the
+    // pretty-URL canonical in a single hop.
+    assert.match(toml, /to\s*=\s*"\/apps\/mario-kart\/"/);
     assert.match(toml, /status\s*=\s*301/);
 });


### PR DESCRIPTION
## Summary
- `/apps` link href, canonical, `og:url`, breadcrumb items, and JSON-LD `url` fields all named `apps/<name>/index.html`, but Netlify's default Pretty URLs serves the page at `apps/<name>/` — the URL bar and the markup didn't match.
- Strips `index.html` everywhere it's used as a URL (apps.html links + CollectionPage JSON-LD, each app's canonical/og:url/breadcrumb/WebApplication JSON-LD, sitemap.xml, and the mario-kart legacy redirect target) so link → canonical → address-bar URL are all the same string.
- README rows showing on-disk file paths are intentionally left alone (those are file paths, not URLs).

## Test plan
- [ ] Visit `/apps` in a deploy preview and confirm clicking each app card lands on `https://<host>/apps/<name>/` with the page rendering correctly.
- [ ] View page source for each app's `index.html` and confirm canonical, `og:url`, breadcrumb item, and JSON-LD `url` all read `https://shevato.com/apps/<name>/`.
- [ ] Hit `/apps/mario-kart/tracker.html` and confirm the redirect lands at `/apps/mario-kart/` (single hop).
- [ ] Validate `sitemap.xml` parses and entries match canonical URLs.