### PR TITLE
seo: per-show and per-exercise static pages + cross-app footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,14 @@ WhatsApp Chat *.txt:Zone.Identifier
 
 # Windows / WSL download metadata
 *:Zone.Identifier
+
+# Rising Seasons static SEO pages — derived from data.json at build
+# time (Netlify or the GitHub Actions refresh workflow). Not committed
+# to keep git history clean.
+apps/rising-seasons/shows/
+apps/rising-seasons/sitemap-shows.xml
+
+# Gym Tracker static SEO pages — derived from exercises-db.json at
+# build time. Same rationale as Rising Seasons.
+apps/gym-tracker/exercises/
+apps/gym-tracker/sitemap-exercises.xml

--- a/apps/gym-tracker/css/exercise-page.css
+++ b/apps/gym-tracker/css/exercise-page.css
@@ -1,0 +1,170 @@
+/* Standalone styling for static exercise pages and the /exercises/
+   browse + taxonomy index. Same visual language as the Rising Seasons
+   show pages — dark, light, no Google Fonts. */
+
+* { box-sizing: border-box; }
+
+:root {
+  --bg: #1a1a2e;
+  --bg-2: #20223a;
+  --panel: #262a47;
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #ebe9f5;
+  --muted: #9ca0c2;
+  --accent: #ff8a65;
+  --accent-2: #f7c873;
+}
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.55;
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+a { color: var(--accent); }
+a:hover { color: #ffa987; }
+
+.visually-hidden {
+  position: absolute !important; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0);
+  white-space: nowrap; border: 0;
+}
+
+.skip-link {
+  position: absolute; left: -9999px; top: -9999px;
+  background: var(--accent); color: #1a1a2e; padding: 8px 12px; border-radius: 4px;
+}
+.skip-link:focus { left: 12px; top: 12px; z-index: 1000; }
+
+.page-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 24px; border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+  position: sticky; top: 0; z-index: 10;
+  backdrop-filter: blur(8px);
+}
+.brand {
+  font-weight: 600; font-size: 17px; text-decoration: none; color: var(--text);
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.page-nav { display: flex; gap: 18px; }
+.page-nav a { text-decoration: none; color: var(--muted); font-size: 14px; }
+.page-nav a:hover, .page-nav a[aria-current="page"] { color: var(--text); }
+
+main { max-width: 1080px; margin: 0 auto; padding: 24px; }
+
+.crumbs { font-size: 13px; color: var(--muted); margin-bottom: 20px; }
+.crumbs a { color: var(--muted); text-decoration: none; }
+.crumbs a:hover { color: var(--text); text-decoration: underline; }
+
+/* --- Exercise hero --- */
+.exercise-hero { margin-bottom: 24px; }
+.exercise-hero h1 {
+  font-size: clamp(28px, 4.5vw, 38px); margin: 0 0 10px; line-height: 1.15;
+}
+.exercise-hero .lede { color: var(--muted); margin: 0 0 18px; max-width: 70ch; font-size: 16px; }
+.hero-actions { display: flex; gap: 12px; flex-wrap: wrap; }
+.primary-btn {
+  display: inline-block; padding: 10px 16px; border-radius: 8px;
+  text-decoration: none; font-size: 14px; font-weight: 600;
+  background: var(--accent); color: #1a1a2e;
+}
+.primary-btn:hover { background: #ffa987; color: #1a1a2e; }
+
+/* --- Fact grid --- */
+.facts { margin-bottom: 26px; }
+.fact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+  margin: 0;
+}
+.fact-grid > div {
+  background: var(--panel); border: 1px solid var(--border);
+  padding: 14px 16px; border-radius: 10px;
+}
+.fact-grid dt {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--muted); margin-bottom: 4px;
+}
+.fact-grid dd { margin: 0; font-size: 15px; }
+.fact-grid dd a { color: var(--text); text-decoration: none; border-bottom: 1px dotted var(--muted); }
+.fact-grid dd a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* --- Related --- */
+.related h2 { font-size: 20px; margin: 0 0 12px; }
+.related-list {
+  list-style: none; margin: 0 0 26px; padding: 0;
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 4px 16px;
+}
+.related-list li a {
+  display: block; padding: 8px 12px; text-decoration: none;
+  color: var(--text); border: 1px solid var(--border); border-radius: 8px;
+  background: var(--bg-2);
+}
+.related-list li a:hover { background: var(--panel); border-color: var(--accent); }
+.related-list .muted { color: var(--muted); font-size: 13px; }
+
+.page-footer-meta {
+  margin-top: 26px; padding-top: 20px; border-top: 1px solid var(--border);
+  color: var(--text); font-size: 14px;
+}
+.page-footer-meta a { color: var(--accent); }
+.page-footer-meta .muted { color: var(--muted); }
+
+.page-footer {
+  max-width: 1080px; margin: 24px auto 60px; padding: 16px 24px;
+  color: var(--muted); font-size: 13px; text-align: center;
+}
+.page-footer a { color: var(--muted); }
+
+/* --- Index/taxonomy pages --- */
+.exercises-index .index-hero { margin-bottom: 20px; }
+.exercises-index .index-hero h1 { margin: 0 0 8px; font-size: clamp(28px, 4vw, 36px); }
+.exercises-index .lede { color: var(--muted); margin: 0; }
+
+.alpha-jump {
+  display: flex; flex-wrap: wrap; gap: 8px;
+  margin: 18px 0 26px; padding: 12px 16px;
+  background: var(--panel); border-radius: 10px; border: 1px solid var(--border);
+}
+.alpha-jump a {
+  display: inline-block; padding: 4px 10px; border-radius: 6px;
+  text-decoration: none; font-weight: 500; font-size: 14px;
+  background: var(--bg-2); color: var(--text);
+}
+.alpha-jump a:hover { background: var(--accent); color: #1a1a2e; }
+
+.alpha-group { margin-bottom: 28px; }
+.alpha-group h2 {
+  margin: 0 0 10px; font-size: 22px; padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.alpha-group h2 a { color: var(--text); text-decoration: none; }
+.alpha-group h2 a:hover { color: var(--accent); }
+.alpha-group h2 .muted { font-size: 14px; font-weight: 400; color: var(--muted); }
+
+.shows-list {
+  list-style: none; margin: 0; padding: 0;
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 4px 16px;
+}
+.shows-list.grid-2 { grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); }
+.shows-list li a {
+  display: block; padding: 6px 0; text-decoration: none;
+  color: var(--text);
+}
+.shows-list li a:hover { color: var(--accent); }
+.shows-list .muted { color: var(--muted); font-size: 13px; }
+
+.index-footer { margin-top: 28px; color: var(--muted); font-size: 14px; }
+
+@media (max-width: 700px) {
+  main { padding: 16px; }
+}

--- a/apps/gym-tracker/css/exercise-page.css
+++ b/apps/gym-tracker/css/exercise-page.css
@@ -119,10 +119,31 @@ main { max-width: 1080px; margin: 0 auto; padding: 24px; }
 .page-footer-meta .muted { color: var(--muted); }
 
 .page-footer {
-  max-width: 1080px; margin: 24px auto 60px; padding: 16px 24px;
-  color: var(--muted); font-size: 13px; text-align: center;
+  max-width: 1080px; margin: 36px auto 60px; padding: 24px;
+  color: var(--muted); font-size: 13px;
+  border-top: 1px solid var(--border);
 }
 .page-footer a { color: var(--muted); }
+.page-footer a:hover { color: var(--text); }
+
+.footer-more { margin-bottom: 18px; }
+.footer-more-heading {
+  margin: 0 0 10px; font-size: 12px; text-transform: uppercase;
+  letter-spacing: 0.08em; color: var(--muted); font-weight: 600;
+}
+.footer-more ul {
+  list-style: none; margin: 0; padding: 0;
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 6px 18px;
+}
+.footer-more li a {
+  display: block; padding: 6px 0; text-decoration: none; color: var(--text);
+  border-bottom: 1px solid transparent;
+}
+.footer-more li a:hover { color: var(--accent); }
+.footer-more li a strong { font-weight: 600; }
+.footer-more li a span { color: var(--muted); font-size: 12px; }
+.page-footer .copyright { margin: 0; text-align: center; font-size: 12px; }
 
 /* --- Index/taxonomy pages --- */
 .exercises-index .index-hero { margin-bottom: 20px; }

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -581,6 +581,7 @@
                 <div class="view-header">
                     <h1>Exercise Database</h1>
                     <p class="subtitle" id="exercise-count-text">Loading exercises...</p>
+                    <p class="subtitle"><a href="exercises/">Browse the public exercise directory →</a></p>
                     <button class="btn btn-primary" id="create-custom-exercise-btn">
                         <i class="fas fa-plus"></i> Create Custom Exercise
                     </button>

--- a/apps/gym-tracker/scripts/build-exercise-pages.cjs
+++ b/apps/gym-tracker/scripts/build-exercise-pages.cjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { assignSlugs } = require('./slugify.cjs');
+const { renderExercisePage } = require('./render-exercise-page.cjs');
+const { renderExerciseIndex, renderTaxonomyPage, groupBy } = require('./render-exercise-index.cjs');
+const { renderExercisesSitemap } = require('./render-sitemap.cjs');
+
+const ROOT = path.join(__dirname, '..');
+const DATA_FILE = path.join(ROOT, 'data', 'exercises-db.json');
+const OUT_DIR = path.join(ROOT, 'exercises');
+const SITEMAP_FILE = path.join(ROOT, 'sitemap-exercises.xml');
+
+const RELATED_LIMIT = 12;
+
+function main() {
+  const exercises = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+  if (!Array.isArray(exercises)) throw new Error('exercises-db.json is not an array');
+  const slugs = assignSlugs(exercises);
+  const builtAt = new Date().toISOString();
+  console.log(`[build-exercise-pages] ${exercises.length} exercises`);
+
+  fs.rmSync(OUT_DIR, { recursive: true, force: true });
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  // Build a muscleGroup → exercises map once, for related-links and
+  // taxonomy pages.
+  const byMuscle = groupBy(exercises, (e) => e.muscleGroup || e.category);
+  const byEquipment = groupBy(exercises, (e) => e.equipment);
+
+  let pageCount = 0;
+  for (const ex of exercises) {
+    const slug = slugs.get(ex.id);
+    const dir = path.join(OUT_DIR, slug);
+    fs.mkdirSync(dir, { recursive: true });
+    const peers = (byMuscle.get(ex.muscleGroup || ex.category) || [])
+      .filter((p) => p.id !== ex.id)
+      .slice(0, RELATED_LIMIT)
+      .map((p) => ({ slug: slugs.get(p.id), name: p.name, equipment: p.equipment }));
+    const html = renderExercisePage({ exercise: ex, slug, related: peers, builtAt });
+    fs.writeFileSync(path.join(dir, 'index.html'), html);
+    pageCount++;
+  }
+
+  // Browse index
+  fs.writeFileSync(path.join(OUT_DIR, 'index.html'), renderExerciseIndex(exercises, slugs, builtAt));
+
+  // Muscle-group landing pages
+  const muscleDir = path.join(OUT_DIR, 'muscle');
+  fs.mkdirSync(muscleDir, { recursive: true });
+  for (const [m, items] of byMuscle.entries()) {
+    const subdir = path.join(muscleDir, m);
+    fs.mkdirSync(subdir, { recursive: true });
+    fs.writeFileSync(
+      path.join(subdir, 'index.html'),
+      renderTaxonomyPage({ kind: 'muscle', key: m, label: labelize(m), exercises: items, slugs, builtAt }),
+    );
+  }
+
+  // Equipment landing pages
+  const eqDir = path.join(OUT_DIR, 'equipment');
+  fs.mkdirSync(eqDir, { recursive: true });
+  for (const [e, items] of byEquipment.entries()) {
+    const subdir = path.join(eqDir, e);
+    fs.mkdirSync(subdir, { recursive: true });
+    fs.writeFileSync(
+      path.join(subdir, 'index.html'),
+      renderTaxonomyPage({ kind: 'equipment', key: e, label: labelize(e), exercises: items, slugs, builtAt }),
+    );
+  }
+
+  // Sitemap
+  fs.writeFileSync(
+    SITEMAP_FILE,
+    renderExercisesSitemap({
+      exercises,
+      slugs,
+      muscles: [...byMuscle.keys()],
+      equipment: [...byEquipment.keys()],
+      builtAt,
+    }),
+  );
+
+  const taxoCount = byMuscle.size + byEquipment.size;
+  console.log(`[build-exercise-pages] wrote ${pageCount} exercise pages + ${taxoCount} taxonomy pages + index + sitemap`);
+}
+
+function labelize(s) {
+  return String(s || '').replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (e) {
+    console.error('[build-exercise-pages] FAILED:', e.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { main };

--- a/apps/gym-tracker/scripts/render-exercise-index.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-index.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 const { labelOf, escapeHtml, SITE } = require('./render-exercise-page.cjs');
+const { renderMoreFooter } = require('./render-footer.cjs');
 
 // Master /exercises/ landing page. Groups every exercise under its
 // primary muscle group with anchor jumps. Internal links here let
@@ -97,9 +98,7 @@ function renderExerciseIndex(exercises, slugs, builtAt) {
     <p class="index-footer">Last updated ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)}.</p>
   </main>
 
-  <footer class="page-footer">
-    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
-  </footer>
+  ${renderMoreFooter()}
 </body>
 </html>
 `;
@@ -190,9 +189,7 @@ function renderTaxonomyPage({ kind, key, label, exercises, slugs, builtAt }) {
     <p class="index-footer"><a href="/apps/gym-tracker/exercises/">Browse all exercises →</a></p>
   </main>
 
-  <footer class="page-footer">
-    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
-  </footer>
+  ${renderMoreFooter()}
 </body>
 </html>
 `;

--- a/apps/gym-tracker/scripts/render-exercise-index.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-index.cjs
@@ -1,0 +1,211 @@
+'use strict';
+
+const { labelOf, escapeHtml, SITE } = require('./render-exercise-page.cjs');
+
+// Master /exercises/ landing page. Groups every exercise under its
+// primary muscle group with anchor jumps. Internal links here let
+// Google reach every per-exercise page through one crawl entry.
+function renderExerciseIndex(exercises, slugs, builtAt) {
+  const byMuscle = groupBy(exercises, (e) => e.muscleGroup || e.category);
+  const muscles = [...byMuscle.keys()].sort();
+  const total = exercises.length;
+  const description = `Browse all ${total} exercises in Gym Tracker by muscle group and equipment. Muscles worked, equipment needed, and tracking type for every exercise in the database.`;
+  const canonical = `${SITE}/apps/gym-tracker/exercises/`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>All Exercises | Gym Tracker — Browse by Muscle Group & Equipment</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <meta name="author" content="Shevato LLC">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="theme-color" content="#1a1a2e">
+  <meta name="color-scheme" content="dark">
+  <link rel="canonical" href="${canonical}">
+
+  <meta property="og:title" content="All Exercises | Gym Tracker">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="${canonical}">
+  <meta property="og:image" content="${SITE}/images/full-logo.svg">
+
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "${SITE}/home.html" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "${SITE}/apps.html" },
+        { "@type": "ListItem", "position": 3, "name": "Gym Tracker", "item": "${SITE}/apps/gym-tracker/" },
+        { "@type": "ListItem", "position": 4, "name": "Exercises", "item": "${canonical}" }
+      ]
+    }
+  </script>
+
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E💪%3C/text%3E%3C/svg%3E">
+  <link rel="stylesheet" href="/apps/gym-tracker/css/exercise-page.css">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+
+  <header class="page-header">
+    <a class="brand" href="/apps/gym-tracker/" aria-label="Gym Tracker home">
+      <span aria-hidden="true">💪</span> Gym Tracker
+    </a>
+    <nav class="page-nav" aria-label="Primary">
+      <a href="/apps/gym-tracker/">Tracker</a>
+      <a href="/apps/gym-tracker/exercises/" aria-current="page">All exercises</a>
+      <a href="/apps.html">More apps</a>
+    </nav>
+  </header>
+
+  <main id="main" class="exercises-index">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/">Shevato</a> ›
+      <a href="/apps/gym-tracker/">Gym Tracker</a> ›
+      <span>Exercises</span>
+    </nav>
+
+    <header class="index-hero">
+      <h1>All exercises</h1>
+      <p class="lede">${total} exercises grouped by muscle. Each links to a page with muscles worked, equipment, and tracking type.</p>
+    </header>
+
+    <nav class="alpha-jump" aria-label="Jump to muscle group">
+      ${muscles.map((m) => `<a href="#muscle-${escapeHtml(m)}">${escapeHtml(labelOf(m))}</a>`).join('')}
+    </nav>
+
+    ${muscles
+      .map((m) => {
+        const items = byMuscle.get(m).sort((a, b) => a.name.localeCompare(b.name));
+        return `<section class="alpha-group" id="muscle-${escapeHtml(m)}">
+      <h2><a href="/apps/gym-tracker/exercises/muscle/${escapeHtml(m)}/">${escapeHtml(labelOf(m))}</a> <span class="muted">(${items.length})</span></h2>
+      <ul class="shows-list">
+        ${items
+          .map((ex) => `<li><a href="/apps/gym-tracker/exercises/${slugs.get(ex.id)}/">${escapeHtml(ex.name)}<span class="muted"> · ${escapeHtml(labelOf(ex.equipment))}</span></a></li>`)
+          .join('\n        ')}
+      </ul>
+    </section>`;
+      })
+      .join('\n    ')}
+
+    <p class="index-footer">Last updated ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)}.</p>
+  </main>
+
+  <footer class="page-footer">
+    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
+  </footer>
+</body>
+</html>
+`;
+}
+
+// Single-muscle or single-equipment landing page — short, fast, and
+// targets the high-volume query directly (e.g. "lats exercises",
+// "dumbbell exercises"). The filter callback decides which exercises
+// belong on the page.
+function renderTaxonomyPage({ kind, key, label, exercises, slugs, builtAt }) {
+  const path = `/apps/gym-tracker/exercises/${kind}/${key}/`;
+  const canonical = `${SITE}${path}`;
+  const sorted = [...exercises].sort((a, b) => a.name.localeCompare(b.name));
+  const description = `${sorted.length} ${label.toLowerCase()} exercises with muscles worked, equipment, and tracking type. Free workout logger included.`;
+  const pageTitle = `${label} Exercises (${sorted.length}) — Muscles & Equipment | Gym Tracker`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(pageTitle)}</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="theme-color" content="#1a1a2e">
+  <meta name="color-scheme" content="dark">
+  <link rel="canonical" href="${canonical}">
+
+  <meta property="og:title" content="${escapeHtml(pageTitle)}">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="${canonical}">
+  <meta property="og:image" content="${SITE}/images/full-logo.svg">
+
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "${SITE}/home.html" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "${SITE}/apps.html" },
+        { "@type": "ListItem", "position": 3, "name": "Gym Tracker", "item": "${SITE}/apps/gym-tracker/" },
+        { "@type": "ListItem", "position": 4, "name": "Exercises", "item": "${SITE}/apps/gym-tracker/exercises/" },
+        { "@type": "ListItem", "position": 5, "name": "${escapeHtml(label)}", "item": "${canonical}" }
+      ]
+    }
+  </script>
+
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E💪%3C/text%3E%3C/svg%3E">
+  <link rel="stylesheet" href="/apps/gym-tracker/css/exercise-page.css">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+
+  <header class="page-header">
+    <a class="brand" href="/apps/gym-tracker/" aria-label="Gym Tracker home">
+      <span aria-hidden="true">💪</span> Gym Tracker
+    </a>
+    <nav class="page-nav" aria-label="Primary">
+      <a href="/apps/gym-tracker/">Tracker</a>
+      <a href="/apps/gym-tracker/exercises/">All exercises</a>
+      <a href="/apps.html">More apps</a>
+    </nav>
+  </header>
+
+  <main id="main" class="exercises-index">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/">Shevato</a> ›
+      <a href="/apps/gym-tracker/">Gym Tracker</a> ›
+      <a href="/apps/gym-tracker/exercises/">Exercises</a> ›
+      <span>${escapeHtml(label)}</span>
+    </nav>
+
+    <header class="index-hero">
+      <h1>${escapeHtml(label)} exercises</h1>
+      <p class="lede">${sorted.length} ${escapeHtml(label.toLowerCase())} exercises. Each links to a page with muscles worked, equipment, and tracking type.</p>
+    </header>
+
+    <ul class="shows-list grid-2">
+      ${sorted
+        .map((ex) => `<li><a href="/apps/gym-tracker/exercises/${slugs.get(ex.id)}/">${escapeHtml(ex.name)}<span class="muted"> · ${escapeHtml(labelOf(ex.equipment))}</span></a></li>`)
+        .join('\n      ')}
+    </ul>
+
+    <p class="index-footer"><a href="/apps/gym-tracker/exercises/">Browse all exercises →</a></p>
+  </main>
+
+  <footer class="page-footer">
+    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
+  </footer>
+</body>
+</html>
+`;
+}
+
+function groupBy(arr, fn) {
+  const out = new Map();
+  for (const x of arr) {
+    const k = fn(x);
+    if (!out.has(k)) out.set(k, []);
+    out.get(k).push(x);
+  }
+  return out;
+}
+
+module.exports = { renderExerciseIndex, renderTaxonomyPage, groupBy };

--- a/apps/gym-tracker/scripts/render-exercise-page.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-page.cjs
@@ -94,7 +94,7 @@ ${jsonLd(buildExerciseSchema({ exercise, canonical, description }))}
       <h1>${escapeHtml(name)}</h1>
       <p class="lede">${escapeHtml(description)}</p>
       <div class="hero-actions">
-        <a class="primary-btn" href="/apps/gym-tracker/#exercise=${exercise.id}">Log this exercise →</a>
+        <a class="primary-btn" href="/apps/gym-tracker/#exercises">Open in Gym Tracker →</a>
       </div>
     </header>
 

--- a/apps/gym-tracker/scripts/render-exercise-page.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-page.cjs
@@ -1,0 +1,203 @@
+'use strict';
+
+const SITE = 'https://shevato.com';
+
+// Human-readable labels for the kebab-case taxonomy in exercises-db.json.
+const CATEGORY_LABELS = {
+  chest: 'Chest', back: 'Back', shoulders: 'Shoulders', traps: 'Traps',
+  neck: 'Neck', biceps: 'Biceps', triceps: 'Triceps', forearms: 'Forearms',
+  abs: 'Abs', obliques: 'Obliques', glutes: 'Glutes', quads: 'Quads',
+  hamstrings: 'Hamstrings', calves: 'Calves', adductors: 'Adductors',
+  abductors: 'Abductors', cardio: 'Cardio',
+};
+
+function labelOf(slug) {
+  if (CATEGORY_LABELS[slug]) return CATEGORY_LABELS[slug];
+  return String(slug || '').replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// Render a single static page for one exercise. The `related` list is
+// other exercises sharing the same primary muscle group — internal
+// links here let Google crawl the whole DB starting from any page.
+function renderExercisePage({ exercise, slug, related, builtAt }) {
+  const path = `/apps/gym-tracker/exercises/${slug}/`;
+  const canonical = `${SITE}${path}`;
+  const name = exercise.name;
+  const pageTitle = `${name} — Muscles Worked, Equipment & How to Do It | Gym Tracker`;
+  const description = buildDescription(exercise);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(pageTitle)}</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <meta name="author" content="Shevato LLC">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="theme-color" content="#1a1a2e">
+  <meta name="color-scheme" content="dark">
+  <link rel="canonical" href="${canonical}">
+
+  <meta property="og:title" content="${escapeHtml(`${name} — Muscles Worked & Equipment`)}">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="${canonical}">
+  <meta property="og:image" content="${SITE}/images/full-logo.svg">
+  <meta property="og:site_name" content="Shevato">
+  <meta property="og:locale" content="en_US">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${escapeHtml(`${name} | Gym Tracker`)}">
+  <meta name="twitter:description" content="${escapeHtml(description)}">
+  <meta name="twitter:image" content="${SITE}/images/full-logo.svg">
+  <meta name="twitter:site" content="@shevato">
+
+  <script type="application/ld+json">
+${jsonLd(buildBreadcrumbs(name, path))}
+  </script>
+
+  <script type="application/ld+json">
+${jsonLd(buildExerciseSchema({ exercise, canonical, description }))}
+  </script>
+
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E💪%3C/text%3E%3C/svg%3E">
+  <link rel="stylesheet" href="/apps/gym-tracker/css/exercise-page.css">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+
+  <header class="page-header">
+    <a class="brand" href="/apps/gym-tracker/" aria-label="Gym Tracker home">
+      <span aria-hidden="true">💪</span> Gym Tracker
+    </a>
+    <nav class="page-nav" aria-label="Primary">
+      <a href="/apps/gym-tracker/">Tracker</a>
+      <a href="/apps/gym-tracker/exercises/">All exercises</a>
+      <a href="/apps.html">More apps</a>
+    </nav>
+  </header>
+
+  <main id="main" class="exercise-page">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/">Shevato</a> ›
+      <a href="/apps/gym-tracker/">Gym Tracker</a> ›
+      <a href="/apps/gym-tracker/exercises/">Exercises</a> ›
+      <a href="/apps/gym-tracker/exercises/muscle/${escapeHtml(exercise.muscleGroup || exercise.category)}/">${escapeHtml(labelOf(exercise.muscleGroup || exercise.category))}</a> ›
+      <span>${escapeHtml(name)}</span>
+    </nav>
+
+    <header class="exercise-hero">
+      <h1>${escapeHtml(name)}</h1>
+      <p class="lede">${escapeHtml(description)}</p>
+      <div class="hero-actions">
+        <a class="primary-btn" href="/apps/gym-tracker/#exercise=${exercise.id}">Log this exercise →</a>
+      </div>
+    </header>
+
+    <section class="facts">
+      <h2 class="visually-hidden">Exercise details</h2>
+      <dl class="fact-grid">
+        <div><dt>Category</dt><dd><a href="/apps/gym-tracker/exercises/muscle/${escapeHtml(exercise.category)}/">${escapeHtml(labelOf(exercise.category))}</a></dd></div>
+        <div><dt>Primary muscle</dt><dd>${escapeHtml(labelOf(exercise.muscleGroup))}</dd></div>
+        ${exercise.secondaryMuscles && exercise.secondaryMuscles.length ? `<div><dt>Secondary muscles</dt><dd>${exercise.secondaryMuscles.map((m) => escapeHtml(labelOf(m))).join(', ')}</dd></div>` : ''}
+        <div><dt>Equipment</dt><dd><a href="/apps/gym-tracker/exercises/equipment/${escapeHtml(exercise.equipment)}/">${escapeHtml(labelOf(exercise.equipment))}</a></dd></div>
+        ${exercise.exerciseType ? `<div><dt>Tracking</dt><dd>${escapeHtml(labelOf(exercise.exerciseType))}</dd></div>` : ''}
+      </dl>
+    </section>
+
+    ${related && related.length ? `<section class="related">
+      <h2>Related ${escapeHtml(labelOf(exercise.muscleGroup))} exercises</h2>
+      <ul class="related-list">
+        ${related.map((r) => `<li><a href="/apps/gym-tracker/exercises/${r.slug}/">${escapeHtml(r.name)}<span class="muted"> · ${escapeHtml(labelOf(r.equipment))}</span></a></li>`).join('\n        ')}
+      </ul>
+    </section>` : ''}
+
+    <section class="page-footer-meta">
+      <p>Track this exercise (and 500+ others) in <a href="/apps/gym-tracker/">Gym Tracker</a> — a free, installable PWA for logging workouts and tracking strength progress.</p>
+      <p class="muted">Last updated ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)}.</p>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
+  </footer>
+</body>
+</html>
+`;
+}
+
+function buildDescription(ex) {
+  const cat = labelOf(ex.category);
+  const primary = labelOf(ex.muscleGroup);
+  const eq = labelOf(ex.equipment).toLowerCase();
+  const sec = ex.secondaryMuscles && ex.secondaryMuscles.length
+    ? ` It also engages the ${ex.secondaryMuscles.map(labelOf).map((s) => s.toLowerCase()).join(', ')}.`
+    : '';
+  const type = ex.exerciseType === 'duration' ? 'a timed exercise' : ex.exerciseType === 'reps' ? 'tracked by reps and weight' : null;
+  const typeStr = type ? ` It is ${type}.` : '';
+  const lead = `${ex.name} is a ${cat.toLowerCase()} exercise that primarily targets the ${primary.toLowerCase()}, performed with ${eq}.${sec}${typeStr}`;
+  return clip(lead, 300);
+}
+
+function clip(s, n) {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1).replace(/\s+\S*$/, '') + '…';
+}
+
+function buildBreadcrumbs(name, path) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE}/home.html` },
+      { '@type': 'ListItem', position: 2, name: 'Apps', item: `${SITE}/apps.html` },
+      { '@type': 'ListItem', position: 3, name: 'Gym Tracker', item: `${SITE}/apps/gym-tracker/` },
+      { '@type': 'ListItem', position: 4, name: 'Exercises', item: `${SITE}/apps/gym-tracker/exercises/` },
+      { '@type': 'ListItem', position: 5, name: name, item: `${SITE}${path}` },
+    ],
+  };
+}
+
+function buildExerciseSchema({ exercise, canonical, description }) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ExerciseAction',
+    name: exercise.name,
+    url: canonical,
+    description,
+    exerciseType: exercise.category,
+    target: {
+      '@type': 'Muscle',
+      name: labelOf(exercise.muscleGroup),
+    },
+    ...(exercise.secondaryMuscles && exercise.secondaryMuscles.length
+      ? { additionalType: exercise.secondaryMuscles.map(labelOf) }
+      : {}),
+    ...(exercise.equipment
+      ? { instrument: { '@type': 'SportsActivityLocation', name: labelOf(exercise.equipment) } }
+      : {}),
+  };
+}
+
+function jsonLd(obj) {
+  return JSON.stringify(obj, null, 2)
+    .replace(/<\/(script|style)/gi, '<\\/$1')
+    .split('\n')
+    .map((l) => '    ' + l)
+    .join('\n');
+}
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+module.exports = { renderExercisePage, buildDescription, labelOf, SITE, escapeHtml };

--- a/apps/gym-tracker/scripts/render-exercise-page.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-page.cjs
@@ -1,5 +1,7 @@
 'use strict';
 
+const { renderMoreFooter } = require('./render-footer.cjs');
+
 const SITE = 'https://shevato.com';
 
 // Human-readable labels for the kebab-case taxonomy in exercises-db.json.
@@ -122,9 +124,7 @@ ${jsonLd(buildExerciseSchema({ exercise, canonical, description }))}
     </section>
   </main>
 
-  <footer class="page-footer">
-    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
-  </footer>
+  ${renderMoreFooter()}
 </body>
 </html>
 `;

--- a/apps/gym-tracker/scripts/render-footer.cjs
+++ b/apps/gym-tracker/scripts/render-footer.cjs
@@ -1,0 +1,23 @@
+'use strict';
+
+// Shared footer used by every static page in this app. Inlined into the
+// HTML at build time — no JS partial-include — so the cross-app links
+// are visible to Googlebot and to JS-disabled visitors. Keep this in
+// sync with apps/rising-seasons/scripts/render-footer.js.
+function renderMoreFooter() {
+  return `<footer class="page-footer">
+    <nav class="footer-more" aria-label="More Shevato apps">
+      <p class="footer-more-heading">More from Shevato</p>
+      <ul>
+        <li><a href="/apps/rising-seasons/"><strong>Rising Seasons</strong><span> · TV by episode-rating shape</span></a></li>
+        <li><a href="/apps/gym-tracker/"><strong>Gym Tracker</strong><span> · workouts and strength progress</span></a></li>
+        <li><a href="/apps/mario-kart/"><strong>Mario Kart Tracker</strong><span> · race tracker and stats</span></a></li>
+        <li><a href="/apps/football-h2h/"><strong>Football H2H</strong><span> · head-to-head match tracker</span></a></li>
+        <li><a href="/apps/maptap-rivals/"><strong>MapTap Rivals</strong><span> · daily MapTap.gg tracker</span></a></li>
+      </ul>
+    </nav>
+    <p class="copyright">© Shevato LLC · <a href="/">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>
+  </footer>`;
+}
+
+module.exports = { renderMoreFooter };

--- a/apps/gym-tracker/scripts/render-footer.cjs
+++ b/apps/gym-tracker/scripts/render-footer.cjs
@@ -14,6 +14,7 @@ function renderMoreFooter() {
         <li><a href="/apps/mario-kart/"><strong>Mario Kart Tracker</strong><span> · race tracker and stats</span></a></li>
         <li><a href="/apps/football-h2h/"><strong>Football H2H</strong><span> · head-to-head match tracker</span></a></li>
         <li><a href="/apps/maptap-rivals/"><strong>MapTap Rivals</strong><span> · daily MapTap.gg tracker</span></a></li>
+        <li><a href="/apps/brain-arena/"><strong>Brain Arena</strong><span> · multiplayer trivia and geography party game</span></a></li>
       </ul>
     </nav>
     <p class="copyright">© Shevato LLC · <a href="/">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>

--- a/apps/gym-tracker/scripts/render-sitemap.cjs
+++ b/apps/gym-tracker/scripts/render-sitemap.cjs
@@ -1,0 +1,39 @@
+'use strict';
+
+const { SITE } = require('./render-exercise-page.cjs');
+
+// Sitemap entries: the /exercises/ landing page, every per-exercise
+// page, every muscle-group taxonomy page, and every equipment page.
+function renderExercisesSitemap({ exercises, slugs, muscles, equipment, builtAt }) {
+  const lastmod = (builtAt ? new Date(builtAt) : new Date()).toISOString().slice(0, 10);
+  const urls = [];
+
+  urls.push(url(`${SITE}/apps/gym-tracker/exercises/`, lastmod, 'weekly', '0.7'));
+
+  for (const m of muscles) {
+    urls.push(url(`${SITE}/apps/gym-tracker/exercises/muscle/${m}/`, lastmod, 'monthly', '0.6'));
+  }
+  for (const e of equipment) {
+    urls.push(url(`${SITE}/apps/gym-tracker/exercises/equipment/${e}/`, lastmod, 'monthly', '0.6'));
+  }
+  for (const ex of exercises) {
+    urls.push(url(`${SITE}/apps/gym-tracker/exercises/${slugs.get(ex.id)}/`, lastmod, 'monthly', '0.5'));
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join('\n')}
+</urlset>
+`;
+}
+
+function url(loc, lastmod, changefreq, priority) {
+  return `  <url>
+    <loc>${loc}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>${changefreq}</changefreq>
+    <priority>${priority}</priority>
+  </url>`;
+}
+
+module.exports = { renderExercisesSitemap };

--- a/apps/gym-tracker/scripts/slugify.cjs
+++ b/apps/gym-tracker/scripts/slugify.cjs
@@ -1,0 +1,38 @@
+'use strict';
+
+// URL-safe slug from an exercise name. Lowercase ASCII letters and digits,
+// dashes between words, capped at 80 chars. The caller is responsible for
+// disambiguating colliding slugs (a few names like "Cable Y Raise" appear
+// twice under different muscle groups — see assignSlugs below).
+function slugify(name) {
+  if (!name || typeof name !== 'string') return 'exercise';
+  let s = name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (s.length > 80) s = s.slice(0, 80).replace(/-+$/, '');
+  return s || 'exercise';
+}
+
+// Assign a unique slug per exercise. The common case is the clean
+// slug from the name. The rare collisions (a handful of "Cable Y
+// Raise"-style duplicates) get the exercise id suffixed so URLs are
+// stable and unique. Returns a Map<id, slug>.
+function assignSlugs(exercises) {
+  const baseCount = new Map();
+  for (const ex of exercises) {
+    const base = slugify(ex.name);
+    baseCount.set(base, (baseCount.get(base) || 0) + 1);
+  }
+  const out = new Map();
+  for (const ex of exercises) {
+    const base = slugify(ex.name);
+    out.set(ex.id, baseCount.get(base) > 1 ? `${base}-${ex.id}` : base);
+  }
+  return out;
+}
+
+module.exports = { slugify, assignSlugs };

--- a/apps/gym-tracker/tests/build-exercise-pages.test.cjs
+++ b/apps/gym-tracker/tests/build-exercise-pages.test.cjs
@@ -69,9 +69,9 @@ test('renderExercisePage XSS-escapes hostile fields', () => {
   assert.ok(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
 });
 
-test('renderExercisePage links into the SPA with the exercise id', () => {
+test('renderExercisePage links into the SPA exercise database view', () => {
   const html = renderExercisePage({ exercise: SAMPLE[0], slug: 'archer-push-ups', related: [], builtAt: '2026-05-18T00:00:00.000Z' });
-  assert.ok(html.includes('/apps/gym-tracker/#exercise=1'));
+  assert.ok(html.includes('/apps/gym-tracker/#exercises'));
 });
 
 test('buildDescription stays under 300 chars and mentions key facts', () => {

--- a/apps/gym-tracker/tests/build-exercise-pages.test.cjs
+++ b/apps/gym-tracker/tests/build-exercise-pages.test.cjs
@@ -1,0 +1,125 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { slugify, assignSlugs } = require('../scripts/slugify.cjs');
+const { renderExercisePage, buildDescription, labelOf } = require('../scripts/render-exercise-page.cjs');
+const { renderExerciseIndex, renderTaxonomyPage } = require('../scripts/render-exercise-index.cjs');
+const { renderExercisesSitemap } = require('../scripts/render-sitemap.cjs');
+
+const SAMPLE = [
+  { id: 1, name: 'Archer Push-Ups', category: 'chest', muscleGroup: 'pectorals', secondaryMuscles: ['triceps', 'core'], equipment: 'bodyweight', exerciseType: 'reps' },
+  { id: 2, name: 'Cable Y Raise', category: 'shoulders', muscleGroup: 'rear-delts', equipment: 'cable', exerciseType: 'reps' },
+  { id: 3, name: 'Cable Y Raise', category: 'shoulders', muscleGroup: 'side-delts', equipment: 'cable', exerciseType: 'reps' },
+  { id: 4, name: 'Barbell Back Squat', category: 'quads', muscleGroup: 'quads', secondaryMuscles: ['glutes', 'hamstrings'], equipment: 'barbell', exerciseType: 'reps' },
+];
+
+test('slugify produces clean URL slugs', () => {
+  assert.equal(slugify('Archer Push-Ups'), 'archer-push-ups');
+  assert.equal(slugify('Cable Y Raise'), 'cable-y-raise');
+  assert.equal(slugify('21s Barbell Curl'), '21s-barbell-curl');
+});
+
+test('slugify falls back for empty/garbage input', () => {
+  assert.equal(slugify(''), 'exercise');
+  assert.equal(slugify(null), 'exercise');
+});
+
+test('assignSlugs disambiguates collisions with the id suffix', () => {
+  const slugs = assignSlugs(SAMPLE);
+  // The two "Cable Y Raise" entries must end up with distinct slugs.
+  assert.equal(slugs.get(2), 'cable-y-raise-2');
+  assert.equal(slugs.get(3), 'cable-y-raise-3');
+  // Unique names stay clean.
+  assert.equal(slugs.get(1), 'archer-push-ups');
+  assert.equal(slugs.get(4), 'barbell-back-squat');
+});
+
+test('labelOf converts kebab-case to Title Case', () => {
+  assert.equal(labelOf('rear-delts'), 'Rear Delts');
+  assert.equal(labelOf('resistance-band'), 'Resistance Band');
+  assert.equal(labelOf('chest'), 'Chest');
+});
+
+test('renderExercisePage produces a valid HTML5 document', () => {
+  const html = renderExercisePage({
+    exercise: SAMPLE[0],
+    slug: 'archer-push-ups',
+    related: [{ slug: 'incline-push-ups', name: 'Incline Push-Ups', equipment: 'bodyweight' }],
+    builtAt: '2026-05-18T00:00:00.000Z',
+  });
+  assert.ok(html.startsWith('<!DOCTYPE html>'));
+  assert.ok(html.includes('<html lang="en">'));
+  assert.ok(html.trim().endsWith('</html>'));
+});
+
+test('renderExercisePage embeds canonical and ExerciseAction JSON-LD', () => {
+  const html = renderExercisePage({ exercise: SAMPLE[0], slug: 'archer-push-ups', related: [], builtAt: '2026-05-18T00:00:00.000Z' });
+  assert.ok(html.includes('<link rel="canonical" href="https://shevato.com/apps/gym-tracker/exercises/archer-push-ups/">'));
+  assert.ok(html.includes('"@type": "ExerciseAction"'));
+  assert.ok(html.includes('"@type": "Muscle"'));
+  assert.ok(html.includes('"name": "Pectorals"'));
+});
+
+test('renderExercisePage XSS-escapes hostile fields', () => {
+  const evil = { ...SAMPLE[0], name: '<script>alert(1)</script>' };
+  const html = renderExercisePage({ exercise: evil, slug: 'x', related: [], builtAt: '2026-05-18T00:00:00.000Z' });
+  assert.ok(!html.includes('<script>alert(1)</script>'));
+  assert.ok(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
+});
+
+test('renderExercisePage links into the SPA with the exercise id', () => {
+  const html = renderExercisePage({ exercise: SAMPLE[0], slug: 'archer-push-ups', related: [], builtAt: '2026-05-18T00:00:00.000Z' });
+  assert.ok(html.includes('/apps/gym-tracker/#exercise=1'));
+});
+
+test('buildDescription stays under 300 chars and mentions key facts', () => {
+  const d = buildDescription(SAMPLE[3]);
+  assert.ok(d.length <= 300);
+  assert.ok(d.toLowerCase().includes('barbell'));
+  assert.ok(d.toLowerCase().includes('quads'));
+});
+
+test('renderExerciseIndex emits every exercise as a link', () => {
+  const slugs = assignSlugs(SAMPLE);
+  const html = renderExerciseIndex(SAMPLE, slugs, '2026-05-18T00:00:00.000Z');
+  for (const ex of SAMPLE) {
+    assert.ok(html.includes(`/apps/gym-tracker/exercises/${slugs.get(ex.id)}/`));
+  }
+  assert.ok(html.includes(`${SAMPLE.length} exercises`));
+});
+
+test('renderTaxonomyPage targets a high-volume query', () => {
+  const slugs = assignSlugs(SAMPLE);
+  const html = renderTaxonomyPage({
+    kind: 'muscle',
+    key: 'pectorals',
+    label: 'Pectorals',
+    exercises: [SAMPLE[0]],
+    slugs,
+    builtAt: '2026-05-18T00:00:00.000Z',
+  });
+  assert.ok(html.includes('<title>Pectorals Exercises (1)'));
+  assert.ok(html.includes('canonical" href="https://shevato.com/apps/gym-tracker/exercises/muscle/pectorals/"'));
+  assert.ok(html.includes('/apps/gym-tracker/exercises/archer-push-ups/'));
+});
+
+test('renderExercisesSitemap covers per-exercise, taxonomy, and index URLs', () => {
+  const slugs = assignSlugs(SAMPLE);
+  const xml = renderExercisesSitemap({
+    exercises: SAMPLE,
+    slugs,
+    muscles: ['pectorals', 'rear-delts', 'side-delts', 'quads'],
+    equipment: ['bodyweight', 'cable', 'barbell'],
+    builtAt: '2026-05-18T00:00:00.000Z',
+  });
+  assert.ok(xml.startsWith('<?xml version="1.0"'));
+  assert.ok(xml.includes('https://shevato.com/apps/gym-tracker/exercises/</loc>'));
+  assert.ok(xml.includes('https://shevato.com/apps/gym-tracker/exercises/muscle/pectorals/</loc>'));
+  assert.ok(xml.includes('https://shevato.com/apps/gym-tracker/exercises/equipment/cable/</loc>'));
+  assert.ok(xml.includes('https://shevato.com/apps/gym-tracker/exercises/archer-push-ups/</loc>'));
+  // Count locs: index + 4 muscles + 3 equipment + 4 exercises = 12
+  const locs = (xml.match(/<loc>/g) || []).length;
+  assert.equal(locs, 1 + 4 + 3 + SAMPLE.length);
+});

--- a/apps/rising-seasons/css/show-page.css
+++ b/apps/rising-seasons/css/show-page.css
@@ -1,0 +1,216 @@
+/* Standalone styling for the static per-show pages and the /shows/
+   browse index. Intentionally light — no Google Fonts, no jQuery, no
+   dependency on the marketing-site shell. Optimized for fast First
+   Contentful Paint since these are SEO landing destinations. */
+
+* { box-sizing: border-box; }
+
+:root {
+  --bg: #0b0d12;
+  --bg-2: #131722;
+  --panel: #1a1f2e;
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #e6e8ee;
+  --muted: #9aa3b5;
+  --accent: #7aa2ff;
+  --accent-2: #5cd1c5;
+  --curve-line: #7aa2ff;
+  --curve-area: rgba(122, 162, 255, 0.18);
+  --shape: #1f2c4d;
+  --shape-text: #c8d4f6;
+}
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.55;
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+a { color: var(--accent); }
+a:hover { color: #a3c0ff; }
+
+.skip-link {
+  position: absolute; left: -9999px; top: -9999px;
+  background: var(--accent); color: #0b0d12; padding: 8px 12px; border-radius: 4px;
+}
+.skip-link:focus { left: 12px; top: 12px; z-index: 1000; }
+
+.page-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 24px; border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+  position: sticky; top: 0; z-index: 10;
+  backdrop-filter: blur(8px);
+}
+.brand {
+  font-weight: 600; font-size: 17px; text-decoration: none; color: var(--text);
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.page-nav { display: flex; gap: 18px; }
+.page-nav a { text-decoration: none; color: var(--muted); font-size: 14px; }
+.page-nav a:hover, .page-nav a[aria-current="page"] { color: var(--text); }
+
+main { max-width: 1080px; margin: 0 auto; padding: 24px; }
+
+.crumbs {
+  font-size: 13px; color: var(--muted); margin-bottom: 20px;
+}
+.crumbs a { color: var(--muted); text-decoration: none; }
+.crumbs a:hover { color: var(--text); text-decoration: underline; }
+
+/* --- Show hero --- */
+.show-hero {
+  display: grid; grid-template-columns: 220px 1fr; gap: 28px;
+  margin-bottom: 32px;
+}
+.show-poster {
+  width: 220px; height: auto; border-radius: 10px; display: block;
+  background: var(--panel); box-shadow: 0 12px 36px rgba(0,0,0,0.45);
+}
+.poster-placeholder {
+  width: 220px; height: 330px;
+  background: linear-gradient(135deg, #1f2c4d 0%, #2d1f4d 100%);
+  border-radius: 10px;
+}
+.show-meta h1 {
+  font-size: clamp(28px, 4.5vw, 40px); margin: 0 0 6px; line-height: 1.15;
+}
+.show-year { color: var(--muted); font-weight: 400; }
+.show-genres { color: var(--muted); margin: 0 0 14px; font-size: 14px; }
+.show-overview { margin: 0 0 18px; max-width: 60ch; }
+
+.show-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 14px 24px;
+  margin: 0 0 22px;
+}
+.show-stats > div { border-left: 2px solid var(--border); padding-left: 12px; }
+.show-stats dt { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); }
+.show-stats dd { margin: 2px 0 0; font-size: 15px; }
+.show-stats .muted { color: var(--muted); font-size: 13px; }
+
+.hero-actions { display: flex; gap: 12px; flex-wrap: wrap; }
+.primary-btn, .secondary-btn {
+  display: inline-block; padding: 10px 16px; border-radius: 8px;
+  text-decoration: none; font-size: 14px; font-weight: 500;
+}
+.primary-btn { background: var(--accent); color: #0b0d12; }
+.primary-btn:hover { background: #a3c0ff; color: #0b0d12; }
+.secondary-btn { background: var(--panel); color: var(--text); border: 1px solid var(--border); }
+.secondary-btn:hover { background: #232838; }
+
+/* --- Seasons --- */
+.seasons h2 { font-size: 22px; margin: 0 0 16px; }
+.season-section {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+.season-head { margin-bottom: 12px; }
+.season-head h3 { margin: 0 0 6px; font-size: 18px; }
+.season-head h3 .muted { color: var(--muted); font-weight: 400; }
+.season-summary {
+  margin: 0; color: var(--muted); font-size: 14px;
+  display: flex; gap: 18px; flex-wrap: wrap;
+}
+.season-summary strong { color: var(--text); }
+
+.season-shapes {
+  list-style: none; margin: 10px 0 0; padding: 0;
+  display: flex; gap: 6px; flex-wrap: wrap;
+}
+.shape-badge {
+  background: var(--shape); color: var(--shape-text);
+  padding: 3px 10px; border-radius: 999px; font-size: 12px;
+}
+
+.season-curve {
+  display: block; width: 100%; height: auto; margin: 14px 0;
+  background: var(--bg-2); border-radius: 8px;
+}
+.season-curve .curve-line {
+  fill: none; stroke: var(--curve-line); stroke-width: 2;
+  stroke-linecap: round; stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+.season-curve .curve-area { fill: var(--curve-area); stroke: none; }
+.season-curve .curve-dots circle { fill: var(--curve-line); }
+
+.episode-table {
+  width: 100%; border-collapse: collapse; font-size: 14px;
+  margin-top: 6px;
+}
+.episode-table caption { text-align: left; color: var(--muted); padding: 6px 0; font-size: 13px; }
+.episode-table th, .episode-table td {
+  text-align: left; padding: 7px 10px; border-bottom: 1px solid var(--border);
+}
+.episode-table th { color: var(--muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+.episode-table td:first-child, .episode-table th:first-child { width: 50px; color: var(--muted); }
+.episode-table td:nth-child(3), .episode-table td:nth-child(4),
+.episode-table th:nth-child(3), .episode-table th:nth-child(4) { text-align: right; }
+.episode-table td strong { color: var(--text); }
+
+.page-footer-meta {
+  margin-top: 26px; padding-top: 20px; border-top: 1px solid var(--border);
+  color: var(--muted); font-size: 14px;
+}
+.page-footer-meta a { color: var(--accent); }
+
+.page-footer {
+  max-width: 1080px; margin: 24px auto 60px; padding: 16px 24px;
+  color: var(--muted); font-size: 13px; text-align: center;
+}
+.page-footer a { color: var(--muted); }
+
+/* --- Shows browse index --- */
+.shows-index .index-hero { margin-bottom: 20px; }
+.shows-index .index-hero h1 { margin: 0 0 8px; font-size: clamp(28px, 4vw, 36px); }
+.shows-index .lede { color: var(--muted); margin: 0; }
+
+.alpha-jump {
+  display: flex; flex-wrap: wrap; gap: 8px;
+  margin: 18px 0 26px; padding: 12px 16px;
+  background: var(--panel); border-radius: 10px; border: 1px solid var(--border);
+}
+.alpha-jump a {
+  display: inline-block; padding: 4px 10px; border-radius: 6px;
+  text-decoration: none; font-weight: 500; font-size: 14px;
+  background: var(--bg-2); color: var(--text);
+}
+.alpha-jump a:hover { background: var(--shape); }
+
+.alpha-group { margin-bottom: 28px; }
+.alpha-group h2 {
+  margin: 0 0 10px; font-size: 22px; padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.shows-list {
+  list-style: none; margin: 0; padding: 0;
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 4px 16px;
+}
+.shows-list li a {
+  display: block; padding: 6px 0; text-decoration: none;
+  color: var(--text); border-bottom: 1px solid transparent;
+}
+.shows-list li a:hover { color: var(--accent); }
+.shows-list .muted { color: var(--muted); font-size: 13px; }
+
+.index-footer { margin-top: 28px; color: var(--muted); font-size: 14px; }
+
+/* --- Mobile --- */
+@media (max-width: 700px) {
+  main { padding: 16px; }
+  .show-hero { grid-template-columns: 1fr; gap: 18px; }
+  .show-poster, .poster-placeholder { width: 160px; }
+  .episode-table { font-size: 13px; }
+  .episode-table th, .episode-table td { padding: 6px 8px; }
+}

--- a/apps/rising-seasons/css/show-page.css
+++ b/apps/rising-seasons/css/show-page.css
@@ -165,10 +165,31 @@ main { max-width: 1080px; margin: 0 auto; padding: 24px; }
 .page-footer-meta a { color: var(--accent); }
 
 .page-footer {
-  max-width: 1080px; margin: 24px auto 60px; padding: 16px 24px;
-  color: var(--muted); font-size: 13px; text-align: center;
+  max-width: 1080px; margin: 36px auto 60px; padding: 24px;
+  color: var(--muted); font-size: 13px;
+  border-top: 1px solid var(--border);
 }
 .page-footer a { color: var(--muted); }
+.page-footer a:hover { color: var(--text); }
+
+.footer-more { margin-bottom: 18px; }
+.footer-more-heading {
+  margin: 0 0 10px; font-size: 12px; text-transform: uppercase;
+  letter-spacing: 0.08em; color: var(--muted); font-weight: 600;
+}
+.footer-more ul {
+  list-style: none; margin: 0; padding: 0;
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 6px 18px;
+}
+.footer-more li a {
+  display: block; padding: 6px 0; text-decoration: none; color: var(--text);
+  border-bottom: 1px solid transparent;
+}
+.footer-more li a:hover { color: var(--accent); }
+.footer-more li a strong { font-weight: 600; }
+.footer-more li a span { color: var(--muted); font-size: 12px; }
+.page-footer .copyright { margin: 0; text-align: center; font-size: 12px; }
 
 /* --- Shows browse index --- */
 .shows-index .index-hero { margin-bottom: 20px; }

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -102,6 +102,7 @@
     <header class="hero">
       <h1>Rising Seasons</h1>
       <p class="tagline">Discover TV by the <em>shape</em> of its episode ratings</p>
+      <p class="hero-secondary"><a href="shows/" class="hero-link">Browse all shows A–Z →</a></p>
     </header>
 
     <nav class="shapes" id="shapes" aria-label="Rating shape">
@@ -394,6 +395,7 @@
       </div>
       <div class="modal-actions modal-actions-top">
         <button type="button" class="btn compare-btn" id="showModalCompare">＋ Add to compare</button>
+        <a class="btn btn-ghost" id="showModalPermalink">Permalink →</a>
         <a class="btn btn-ghost" id="showModalImdb" target="_blank" rel="noopener">View show on IMDb →</a>
         <a class="btn btn-ghost" id="showModalTvdb" target="_blank" rel="noopener" hidden>View show on TVDB →</a>
       </div>

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -14,6 +14,21 @@ const SHAPE_LABELS = {
   'saved-best-for-last': 'Saved best for last',
 };
 
+// Mirrors scripts/slugify.js — keep both in sync so the SPA's permalink
+// button and the build-script-generated static page URLs always agree.
+function showSlug(title) {
+  if (!title || typeof title !== 'string') return 'show';
+  let s = title
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (s.length > 80) s = s.slice(0, 80).replace(/-+$/, '');
+  return s || 'show';
+}
+
 const STORAGE_NS = 'rising-seasons';
 const KEY_WATCHED = `${STORAGE_NS}:watched`;
 const KEY_VIEW = `${STORAGE_NS}:view`;
@@ -99,6 +114,7 @@ const els = {
   showModalPoster: document.getElementById('showModalPoster'),
   showModalImdb: document.getElementById('showModalImdb'),
   showModalTvdb: document.getElementById('showModalTvdb'),
+  showModalPermalink: document.getElementById('showModalPermalink'),
   showModalOverlay: document.getElementById('showModalOverlay'),
   showModalOverlayCurve: document.getElementById('showModalOverlayCurve'),
   showModalOverlayLegend: document.getElementById('showModalOverlayLegend'),
@@ -1971,6 +1987,9 @@ function openShowModal(seriesId) {
   }
 
   els.showModalImdb.href = `https://www.imdb.com/title/${seriesId}/`;
+  if (els.showModalPermalink) {
+    els.showModalPermalink.href = `/apps/rising-seasons/shows/${showSlug(meta.title)}-${seriesId}/`;
+  }
   if (meta.tvdbId) {
     els.showModalTvdb.href = `https://thetvdb.com/dereferrer/series/${meta.tvdbId}`;
     els.showModalTvdb.hidden = false;

--- a/apps/rising-seasons/scripts/build-show-pages.js
+++ b/apps/rising-seasons/scripts/build-show-pages.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+'use strict';
+
+// Generate static per-show HTML pages, an A-Z browse index, and a
+// sitemap from apps/rising-seasons/data.json. Runs at Netlify build
+// time, so the generated files don't live in git — they're a pure
+// derivation of the committed data.json.
+
+const fs = require('fs');
+const path = require('path');
+
+const { showPath } = require('./slugify.js');
+const { renderShowPage } = require('./render-show-page.js');
+const { renderShowsIndex } = require('./render-shows-index.js');
+const { renderShowsSitemap } = require('./render-sitemap.js');
+
+const ROOT = path.join(__dirname, '..');
+const DATA_FILE = path.join(ROOT, 'data.json');
+const SHOWS_DIR = path.join(ROOT, 'shows');
+const SITEMAP_FILE = path.join(ROOT, 'sitemap-shows.xml');
+
+function main() {
+  if (!fs.existsSync(DATA_FILE)) {
+    throw new Error(`data.json not found at ${DATA_FILE}. Run \`npm run build:rising-seasons\` first.`);
+  }
+  const data = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+  if (!Array.isArray(data.matches)) {
+    throw new Error('data.json has no `matches` array — bad input.');
+  }
+  const series = groupBySeries(data.matches);
+  console.log(`[build-show-pages] ${series.length} unique series · ${data.matches.length} seasons · builtAt=${data.builtAt}`);
+
+  fs.rmSync(SHOWS_DIR, { recursive: true, force: true });
+  fs.mkdirSync(SHOWS_DIR, { recursive: true });
+
+  let pageCount = 0;
+  const start = Date.now();
+  for (const s of series) {
+    const dir = path.join(SHOWS_DIR, showPath(s.title, s.seriesId));
+    fs.mkdirSync(dir, { recursive: true });
+    const html = renderShowPage({ ...s, builtAt: data.builtAt });
+    fs.writeFileSync(path.join(dir, 'index.html'), html);
+    pageCount++;
+    if (pageCount % 1000 === 0) {
+      console.log(`[build-show-pages] ${pageCount}/${series.length}…`);
+    }
+  }
+
+  fs.writeFileSync(
+    path.join(SHOWS_DIR, 'index.html'),
+    renderShowsIndex(series.map(toIndexEntry), data.builtAt),
+  );
+  fs.writeFileSync(SITEMAP_FILE, renderShowsSitemap(series.map(toIndexEntry), data.builtAt));
+
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+  console.log(`[build-show-pages] wrote ${pageCount} show pages + index + sitemap in ${elapsed}s`);
+}
+
+// data.json's `matches` is a flat list of seasons. Group them by series
+// so each output page covers every season of that show. Within a series,
+// sort seasons numerically.
+function groupBySeries(matches) {
+  const map = new Map();
+  for (const m of matches) {
+    if (!map.has(m.seriesId)) {
+      map.set(m.seriesId, {
+        seriesId: m.seriesId,
+        title: m.title,
+        year: m.year,
+        type: m.type,
+        genres: m.genres,
+        seriesRating: m.seriesRating,
+        seriesVotes: m.seriesVotes,
+        poster: m.poster,
+        overview: m.overview,
+        language: m.language,
+        providers: m.providers,
+        tmdbId: m.tmdbId,
+        seasons: [],
+      });
+    }
+    const s = map.get(m.seriesId);
+    s.seasons.push({
+      season: m.season,
+      seasonYear: m.seasonYear,
+      episodes: m.episodes,
+      firstRating: m.firstRating,
+      lastRating: m.lastRating,
+      avgRating: m.avgRating,
+      avgRuntime: m.avgRuntime,
+      shapes: m.shapes,
+    });
+    // Series-level fields may be present on any season's record; fill
+    // any holes from later seasons so we don't lose data if season 1
+    // happened to be enriched but season 2 wasn't, or vice versa.
+    fillIfEmpty(s, m, ['poster', 'overview', 'language', 'providers', 'tmdbId', 'seriesRating', 'seriesVotes', 'genres']);
+  }
+  for (const s of map.values()) {
+    s.seasons.sort((a, b) => a.season - b.season);
+  }
+  return [...map.values()].sort((a, b) => a.title.localeCompare(b.title));
+}
+
+function fillIfEmpty(target, src, keys) {
+  for (const k of keys) {
+    if (target[k] == null || (Array.isArray(target[k]) && target[k].length === 0)) {
+      if (src[k] != null) target[k] = src[k];
+    }
+  }
+}
+
+function toIndexEntry(s) {
+  return { seriesId: s.seriesId, title: s.title, year: s.year };
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (e) {
+    console.error('[build-show-pages] FAILED:', e.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { groupBySeries };

--- a/apps/rising-seasons/scripts/render-curve.js
+++ b/apps/rising-seasons/scripts/render-curve.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// Server-side mirror of drawCurve() in js/app.js — emits a complete SVG
+// string with the line path, filled area, and per-episode dots so the
+// curve renders without any client JS. Keep this in sync with the browser
+// version's math so static pages and the SPA agree visually.
+function renderCurve(episodes, opts) {
+  const { width = 600, height = 200, padX = 6, padY = 10, showDots = true } = opts || {};
+  if (!Array.isArray(episodes) || episodes.length === 0) {
+    return `<svg class="season-curve" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"></svg>`;
+  }
+  const ratings = episodes.map((e) => e.rating);
+  const lo = Math.max(0, Math.min(...ratings) - 0.3);
+  const hi = Math.min(10, Math.max(...ratings) + 0.3);
+  const span = Math.max(0.1, hi - lo);
+  const n = episodes.length;
+  const xStep = n > 1 ? (width - padX * 2) / (n - 1) : 0;
+
+  const points = episodes.map((e, i) => {
+    const x = padX + (n > 1 ? i * xStep : (width - padX * 2) / 2);
+    const y = padY + (1 - (e.rating - lo) / span) * (height - padY * 2);
+    return [x, y];
+  });
+
+  const linePath = points
+    .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`)
+    .join(' ');
+  const last = points[points.length - 1];
+  const first = points[0];
+  const areaPath = `${linePath} L${last[0].toFixed(1)},${height} L${first[0].toFixed(1)},${height} Z`;
+
+  let dotsSvg = '';
+  if (showDots) {
+    const r = height > 100 ? 4 : 2.5;
+    dotsSvg = points
+      .map(([x, y], i) => {
+        const ep = episodes[i];
+        const title = `Ep ${ep.episode}: ${ep.rating.toFixed(1)} · ${ep.votes.toLocaleString()} votes`;
+        return `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="${r}"><title>${escapeXml(title)}</title></circle>`;
+      })
+      .join('');
+  }
+
+  return `<svg class="season-curve" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Episode rating trajectory">
+  <path class="curve-area" d="${areaPath}"/>
+  <path class="curve-line" d="${linePath}"/>
+  <g class="curve-dots">${dotsSvg}</g>
+</svg>`;
+}
+
+function escapeXml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+module.exports = { renderCurve, escapeXml };

--- a/apps/rising-seasons/scripts/render-footer.js
+++ b/apps/rising-seasons/scripts/render-footer.js
@@ -14,6 +14,7 @@ function renderMoreFooter() {
         <li><a href="/apps/mario-kart/"><strong>Mario Kart Tracker</strong><span> · race tracker and stats</span></a></li>
         <li><a href="/apps/football-h2h/"><strong>Football H2H</strong><span> · head-to-head match tracker</span></a></li>
         <li><a href="/apps/maptap-rivals/"><strong>MapTap Rivals</strong><span> · daily MapTap.gg tracker</span></a></li>
+        <li><a href="/apps/brain-arena/"><strong>Brain Arena</strong><span> · multiplayer trivia and geography party game</span></a></li>
       </ul>
     </nav>
     <p class="copyright">© Shevato LLC · <a href="/">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>

--- a/apps/rising-seasons/scripts/render-footer.js
+++ b/apps/rising-seasons/scripts/render-footer.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Shared footer used by every static page in this app. Inlined into the
+// HTML at build time — no JS partial-include — so the cross-app links
+// are visible to Googlebot and to JS-disabled visitors. Keep this in
+// sync with apps/gym-tracker/scripts/render-footer.cjs.
+function renderMoreFooter() {
+  return `<footer class="page-footer">
+    <nav class="footer-more" aria-label="More Shevato apps">
+      <p class="footer-more-heading">More from Shevato</p>
+      <ul>
+        <li><a href="/apps/rising-seasons/"><strong>Rising Seasons</strong><span> · TV by episode-rating shape</span></a></li>
+        <li><a href="/apps/gym-tracker/"><strong>Gym Tracker</strong><span> · workouts and strength progress</span></a></li>
+        <li><a href="/apps/mario-kart/"><strong>Mario Kart Tracker</strong><span> · race tracker and stats</span></a></li>
+        <li><a href="/apps/football-h2h/"><strong>Football H2H</strong><span> · head-to-head match tracker</span></a></li>
+        <li><a href="/apps/maptap-rivals/"><strong>MapTap Rivals</strong><span> · daily MapTap.gg tracker</span></a></li>
+      </ul>
+    </nav>
+    <p class="copyright">© Shevato LLC · <a href="/">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>
+  </footer>`;
+}
+
+module.exports = { renderMoreFooter };

--- a/apps/rising-seasons/scripts/render-show-page.js
+++ b/apps/rising-seasons/scripts/render-show-page.js
@@ -1,0 +1,277 @@
+'use strict';
+
+const { renderCurve, escapeXml } = require('./render-curve.js');
+const { showPath } = require('./slugify.js');
+
+const SITE = 'https://shevato.com';
+const TMDB_POSTER = 'https://image.tmdb.org/t/p/w500';
+
+// Shape descriptions doubled as alt-text for the curve and as
+// human-readable copy in the season header. Mirrors the shape rules
+// documented in apps/rising-seasons/README.md.
+const SHAPE_LABELS = {
+  rising: 'Rising',
+  consistent: 'Consistent',
+  'slow-burn': 'Slow burn',
+  'big-finale': 'Big finale',
+  rebound: 'Rebound',
+  'front-loaded': 'Front-loaded',
+  declining: 'Declining',
+  'bad-finale': 'Bad finale',
+  rollercoaster: 'Rollercoaster',
+  'mid-peak': 'Mid-peak',
+};
+
+// Build a single static HTML page for one TV series, given every season's
+// data (already grouped from data.json's flat `matches` array). Returns a
+// complete HTML string.
+function renderShowPage({ seriesId, title, year, type, genres, seriesRating, seriesVotes, poster, overview, language, providers, tmdbId, seasons, builtAt }) {
+  const path = `/apps/rising-seasons/shows/${showPath(title, seriesId)}/`;
+  const canonical = `${SITE}${path}`;
+  const numberOfSeasons = seasons.length;
+  const yearLabel = year ? ` (${year})` : '';
+  const pageTitle = `${title}${yearLabel} — Episode Ratings & Season Trajectories | Rising Seasons`;
+  const cleanOverview = (overview || '').trim();
+  const description = buildDescription(title, year, numberOfSeasons, seriesRating, seriesVotes, cleanOverview);
+
+  const posterUrl = poster ? `${TMDB_POSTER}${poster}` : null;
+  const ogImage = posterUrl || `${SITE}/images/full-logo.svg`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(pageTitle)}</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <meta name="author" content="Shevato LLC">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="theme-color" content="#0b0d12">
+  <meta name="color-scheme" content="dark">
+  <link rel="canonical" href="${canonical}">
+
+  <link rel="preconnect" href="https://image.tmdb.org" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="${escapeHtml(`${title}${yearLabel} — Episode Ratings & Season Trajectories`)}">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:type" content="video.tv_show">
+  <meta property="og:url" content="${canonical}">
+  <meta property="og:image" content="${ogImage}">
+  <meta property="og:image:alt" content="${escapeHtml(`${title} poster`)}">
+  <meta property="og:site_name" content="Shevato">
+  <meta property="og:locale" content="en_US">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${escapeHtml(`${title}${yearLabel} — Episode Ratings`)}">
+  <meta name="twitter:description" content="${escapeHtml(description)}">
+  <meta name="twitter:image" content="${ogImage}">
+  <meta name="twitter:site" content="@shevato">
+
+  <!-- Breadcrumbs -->
+  <script type="application/ld+json">
+${jsonLd(buildBreadcrumbs(title, path))}
+  </script>
+
+  <!-- TVSeries -->
+  <script type="application/ld+json">
+${jsonLd(buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, cleanOverview, genres, seriesRating, seriesVotes, seasons, tmdbId }))}
+  </script>
+
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📈%3C/text%3E%3C/svg%3E">
+  <link rel="stylesheet" href="/apps/rising-seasons/css/show-page.css">
+
+  <!-- Google Analytics — shared site tag -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+
+  <header class="page-header">
+    <a class="brand" href="/apps/rising-seasons/" aria-label="Rising Seasons home">
+      <span aria-hidden="true">📈</span> Rising Seasons
+    </a>
+    <nav class="page-nav" aria-label="Primary">
+      <a href="/apps/rising-seasons/">Explorer</a>
+      <a href="/apps/rising-seasons/shows/">All shows</a>
+      <a href="/apps.html">More apps</a>
+    </nav>
+  </header>
+
+  <main id="main" class="show-page">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/">Shevato</a> ›
+      <a href="/apps/rising-seasons/">Rising Seasons</a> ›
+      <a href="/apps/rising-seasons/shows/">All shows</a> ›
+      <span>${escapeHtml(title)}</span>
+    </nav>
+
+    <section class="show-hero">
+      ${renderHeroPoster(posterUrl, title)}
+      <div class="show-meta">
+        <h1>${escapeHtml(title)}${year ? ` <span class="show-year">(${year})</span>` : ''}</h1>
+        ${genres && genres.length ? `<p class="show-genres">${genres.map(escapeHtml).join(' · ')}</p>` : ''}
+        ${cleanOverview ? `<p class="show-overview">${escapeHtml(cleanOverview)}</p>` : ''}
+        <dl class="show-stats">
+          ${seriesRating ? `<div><dt>IMDb rating</dt><dd><strong>${seriesRating.toFixed(1)}</strong>${seriesVotes ? ` <span class="muted">(${seriesVotes.toLocaleString()} votes)</span>` : ''}</dd></div>` : ''}
+          <div><dt>Seasons</dt><dd>${numberOfSeasons}</dd></div>
+          ${providers && providers.length ? `<div><dt>Streaming (US)</dt><dd>${providers.map(escapeHtml).join(' · ')}</dd></div>` : ''}
+          ${language ? `<div><dt>Language</dt><dd>${escapeHtml(language.toUpperCase())}</dd></div>` : ''}
+          ${type ? `<div><dt>Type</dt><dd>${escapeHtml(formatType(type))}</dd></div>` : ''}
+        </dl>
+        <div class="hero-actions">
+          <a class="primary-btn" href="/apps/rising-seasons/#series=${seriesId}">Open in interactive explorer →</a>
+          <a class="secondary-btn" href="https://www.imdb.com/title/${seriesId}/" rel="noopener" target="_blank">View on IMDb</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="seasons" aria-labelledby="seasons-heading">
+      <h2 id="seasons-heading">Seasons</h2>
+      ${seasons.map((s) => renderSeasonSection(s, seriesId)).join('\n')}
+    </section>
+
+    <section class="page-footer-meta">
+      <p class="attribution">Episode ratings and vote counts from <a href="https://www.imdb.com/title/${seriesId}/" rel="noopener" target="_blank">IMDb</a>${tmdbId ? `. Poster, overview, and streaming data from <a href="https://www.themoviedb.org/tv/${tmdbId}" rel="noopener" target="_blank">TMDB</a>` : ''}. Data refreshed ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : 'weekly'}.</p>
+      <p>Want to discover more shows by their rating shape? <a href="/apps/rising-seasons/">Browse Rising Seasons →</a></p>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
+  </footer>
+</body>
+</html>
+`;
+}
+
+function renderHeroPoster(posterUrl, title) {
+  if (!posterUrl) {
+    return '<div class="show-poster poster-placeholder" aria-hidden="true"></div>';
+  }
+  return `<img class="show-poster" src="${escapeHtml(posterUrl)}" alt="${escapeHtml(`${title} poster`)}" width="300" height="450" loading="eager" decoding="async">`;
+}
+
+function renderSeasonSection(season, seriesId) {
+  const shapes = (season.shapes || []).map((s) => SHAPE_LABELS[s] || s);
+  const shapesHtml = shapes.length
+    ? `<ul class="season-shapes" aria-label="Season shape classifications">${shapes
+        .map((s) => `<li class="shape-badge">${escapeHtml(s)}</li>`)
+        .join('')}</ul>`
+    : '';
+  const curveSvg = renderCurve(season.episodes, { width: 720, height: 220 });
+  const yearLabel = season.seasonYear ? ` (${season.seasonYear})` : '';
+
+  return `<article class="season-section" id="season-${season.season}">
+        <header class="season-head">
+          <h3>Season ${season.season}<span class="muted">${yearLabel}</span></h3>
+          <p class="season-summary">
+            <span><strong>${season.avgRating.toFixed(2)}</strong> avg</span>
+            <span>${season.episodes.length} episodes</span>
+            <span>${season.firstRating.toFixed(1)} → ${season.lastRating.toFixed(1)}</span>
+            ${season.avgRuntime ? `<span>${season.avgRuntime} min avg</span>` : ''}
+          </p>
+          ${shapesHtml}
+        </header>
+        ${curveSvg}
+        <table class="episode-table">
+          <caption>Season ${season.season} episodes — IMDb ratings</caption>
+          <thead><tr><th scope="col">#</th><th scope="col">Title</th><th scope="col">Rating</th><th scope="col">Votes</th></tr></thead>
+          <tbody>
+            ${season.episodes.map((ep) => `<tr><td>${ep.episode}</td><td>${escapeHtml(ep.name || '—')}</td><td><strong>${ep.rating.toFixed(1)}</strong></td><td>${ep.votes.toLocaleString()}</td></tr>`).join('\n            ')}
+          </tbody>
+        </table>
+      </article>`;
+}
+
+function buildDescription(title, year, n, rating, votes, overview) {
+  const yearLabel = year ? ` (${year})` : '';
+  const ratingLabel = rating ? ` IMDb ${rating.toFixed(1)}/10${votes ? ` (${votes.toLocaleString()} votes)` : ''}.` : '';
+  const seasonLabel = n === 1 ? '1 season' : `${n} seasons`;
+  const lead = `${title}${yearLabel} — episode-by-episode IMDb ratings and season-shape analysis across ${seasonLabel}.${ratingLabel}`;
+  if (!overview) return clip(lead, 300);
+  return clip(`${lead} ${overview}`, 300);
+}
+
+function clip(s, n) {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1).replace(/\s+\S*$/, '') + '…';
+}
+
+function formatType(t) {
+  if (t === 'tvSeries') return 'TV series';
+  if (t === 'tvMiniSeries') return 'Mini-series';
+  return t;
+}
+
+function buildBreadcrumbs(title, path) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE}/home.html` },
+      { '@type': 'ListItem', position: 2, name: 'Apps', item: `${SITE}/apps.html` },
+      { '@type': 'ListItem', position: 3, name: 'Rising Seasons', item: `${SITE}/apps/rising-seasons/` },
+      { '@type': 'ListItem', position: 4, name: 'All shows', item: `${SITE}/apps/rising-seasons/shows/` },
+      { '@type': 'ListItem', position: 5, name: title, item: `${SITE}${path}` },
+    ],
+  };
+}
+
+function buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, cleanOverview, genres, seriesRating, seriesVotes, seasons, tmdbId }) {
+  const sameAs = [`https://www.imdb.com/title/${seriesId}/`];
+  if (tmdbId) sameAs.push(`https://www.themoviedb.org/tv/${tmdbId}`);
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'TVSeries',
+    name: title,
+    url: canonical,
+    sameAs,
+    numberOfSeasons: seasons.length,
+  };
+  if (year) schema.startDate = String(year);
+  if (cleanOverview) schema.description = cleanOverview;
+  if (posterUrl) schema.image = posterUrl;
+  if (genres && genres.length) schema.genre = genres;
+  if (seriesRating) {
+    schema.aggregateRating = {
+      '@type': 'AggregateRating',
+      ratingValue: seriesRating,
+      ratingCount: seriesVotes || undefined,
+      bestRating: 10,
+      worstRating: 1,
+    };
+  }
+  schema.containsSeason = seasons.map((s) => ({
+    '@type': 'TVSeason',
+    seasonNumber: s.season,
+    numberOfEpisodes: s.episodes.length,
+    ...(s.seasonYear ? { startDate: String(s.seasonYear) } : {}),
+  }));
+  return schema;
+}
+
+function jsonLd(obj) {
+  // Escape `</` so a hostile title containing `</script>` cannot break out
+  // of the surrounding <script type="application/ld+json"> tag. The `\/`
+  // is valid in JSON and round-trips back to `/` when parsed.
+  return JSON.stringify(obj, null, 2)
+    .replace(/<\/(script|style)/gi, '<\\/$1')
+    .split('\n')
+    .map((l) => '    ' + l)
+    .join('\n');
+}
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+module.exports = { renderShowPage, escapeHtml, buildDescription, SITE };

--- a/apps/rising-seasons/scripts/render-show-page.js
+++ b/apps/rising-seasons/scripts/render-show-page.js
@@ -2,6 +2,7 @@
 
 const { renderCurve, escapeXml } = require('./render-curve.js');
 const { showPath } = require('./slugify.js');
+const { renderMoreFooter } = require('./render-footer.js');
 
 const SITE = 'https://shevato.com';
 const TMDB_POSTER = 'https://image.tmdb.org/t/p/w500';
@@ -140,9 +141,7 @@ ${jsonLd(buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, clea
     </section>
   </main>
 
-  <footer class="page-footer">
-    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
-  </footer>
+  ${renderMoreFooter()}
 </body>
 </html>
 `;

--- a/apps/rising-seasons/scripts/render-show-page.js
+++ b/apps/rising-seasons/scripts/render-show-page.js
@@ -123,7 +123,7 @@ ${jsonLd(buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, clea
           ${type ? `<div><dt>Type</dt><dd>${escapeHtml(formatType(type))}</dd></div>` : ''}
         </dl>
         <div class="hero-actions">
-          <a class="primary-btn" href="/apps/rising-seasons/#series=${seriesId}">Open in interactive explorer →</a>
+          <a class="primary-btn" href="/apps/rising-seasons/#show=${seriesId}">Open in interactive explorer →</a>
           <a class="secondary-btn" href="https://www.imdb.com/title/${seriesId}/" rel="noopener" target="_blank">View on IMDb</a>
         </div>
       </div>

--- a/apps/rising-seasons/scripts/render-shows-index.js
+++ b/apps/rising-seasons/scripts/render-shows-index.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const { showPath } = require('./slugify.js');
+const { escapeHtml, SITE } = require('./render-show-page.js');
+
+// Single A-Z browse index of every show. This is the crawler's primary
+// entry point into the per-show pages — Google follows the links here to
+// discover and rank each /shows/{slug}-{tt}/ page.
+function renderShowsIndex(series, builtAt) {
+  const sorted = [...series].sort((a, b) => sortTitle(a.title).localeCompare(sortTitle(b.title)));
+  const groups = new Map();
+  for (const s of sorted) {
+    const letter = firstLetter(sortTitle(s.title));
+    if (!groups.has(letter)) groups.set(letter, []);
+    groups.get(letter).push(s);
+  }
+  const letters = [...groups.keys()];
+
+  const canonical = `${SITE}/apps/rising-seasons/shows/`;
+  const description = `Browse all ${sorted.length.toLocaleString()} TV shows in Rising Seasons. Episode-by-episode IMDb ratings and season-shape analysis for every series.`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>All Shows | Rising Seasons — Browse Every TV Series by Episode Ratings</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <meta name="author" content="Shevato LLC">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="theme-color" content="#0b0d12">
+  <meta name="color-scheme" content="dark">
+  <link rel="canonical" href="${canonical}">
+
+  <meta property="og:title" content="All Shows | Rising Seasons">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="${canonical}">
+  <meta property="og:image" content="${SITE}/images/full-logo.svg">
+  <meta property="og:site_name" content="Shevato">
+
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "${SITE}/home.html" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "${SITE}/apps.html" },
+        { "@type": "ListItem", "position": 3, "name": "Rising Seasons", "item": "${SITE}/apps/rising-seasons/" },
+        { "@type": "ListItem", "position": 4, "name": "All shows", "item": "${canonical}" }
+      ]
+    }
+  </script>
+
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📈%3C/text%3E%3C/svg%3E">
+  <link rel="stylesheet" href="/apps/rising-seasons/css/show-page.css">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+
+  <header class="page-header">
+    <a class="brand" href="/apps/rising-seasons/" aria-label="Rising Seasons home">
+      <span aria-hidden="true">📈</span> Rising Seasons
+    </a>
+    <nav class="page-nav" aria-label="Primary">
+      <a href="/apps/rising-seasons/">Explorer</a>
+      <a href="/apps/rising-seasons/shows/" aria-current="page">All shows</a>
+      <a href="/apps.html">More apps</a>
+    </nav>
+  </header>
+
+  <main id="main" class="shows-index">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/">Shevato</a> ›
+      <a href="/apps/rising-seasons/">Rising Seasons</a> ›
+      <span>All shows</span>
+    </nav>
+
+    <header class="index-hero">
+      <h1>All shows</h1>
+      <p class="lede">Every series in Rising Seasons (${sorted.length.toLocaleString()} shows). Each links to an episode-by-episode rating page with season-shape analysis.</p>
+    </header>
+
+    <nav class="alpha-jump" aria-label="Jump to letter">
+      ${letters.map((l) => `<a href="#letter-${escapeHtml(l)}">${escapeHtml(l)}</a>`).join('')}
+    </nav>
+
+    ${letters
+      .map((l) => {
+        const items = groups.get(l);
+        return `<section class="alpha-group" id="letter-${escapeHtml(l)}">
+      <h2>${escapeHtml(l)}</h2>
+      <ul class="shows-list">
+        ${items
+          .map((s) => {
+            const slug = showPath(s.title, s.seriesId);
+            return `<li><a href="/apps/rising-seasons/shows/${slug}/">${escapeHtml(s.title)}${s.year ? ` <span class="muted">(${s.year})</span>` : ''}</a></li>`;
+          })
+          .join('\n        ')}
+      </ul>
+    </section>`;
+      })
+      .join('\n    ')}
+
+    <p class="index-footer">Refreshed ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : 'weekly'}. Source: <a href="https://datasets.imdbws.com/" rel="noopener" target="_blank">IMDb datasets</a>.</p>
+  </main>
+
+  <footer class="page-footer">
+    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
+  </footer>
+</body>
+</html>
+`;
+}
+
+function sortTitle(s) {
+  return String(s || '').replace(/^(the|a|an)\s+/i, '').toLowerCase();
+}
+
+function firstLetter(s) {
+  const c = (s || '#').charAt(0).toUpperCase();
+  return /[A-Z]/.test(c) ? c : '#';
+}
+
+module.exports = { renderShowsIndex, sortTitle, firstLetter };

--- a/apps/rising-seasons/scripts/render-shows-index.js
+++ b/apps/rising-seasons/scripts/render-shows-index.js
@@ -2,6 +2,7 @@
 
 const { showPath } = require('./slugify.js');
 const { escapeHtml, SITE } = require('./render-show-page.js');
+const { renderMoreFooter } = require('./render-footer.js');
 
 // Single A-Z browse index of every show. This is the crawler's primary
 // entry point into the per-show pages — Google follows the links here to
@@ -108,9 +109,7 @@ function renderShowsIndex(series, builtAt) {
     <p class="index-footer">Refreshed ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : 'weekly'}. Source: <a href="https://datasets.imdbws.com/" rel="noopener" target="_blank">IMDb datasets</a>.</p>
   </main>
 
-  <footer class="page-footer">
-    <p>© Shevato LLC · <a href="/">shevato.com</a> · <a href="/contact.html">Contact</a></p>
-  </footer>
+  ${renderMoreFooter()}
 </body>
 </html>
 `;

--- a/apps/rising-seasons/scripts/render-sitemap.js
+++ b/apps/rising-seasons/scripts/render-sitemap.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { showPath } = require('./slugify.js');
+const { SITE } = require('./render-show-page.js');
+
+// Emit a single sitemap.xml referencing every show page plus the
+// /shows/ browse index. Spec caps a sitemap at 50,000 URLs or 50 MB —
+// ~7k entries fits comfortably, so no chunking yet.
+function renderShowsSitemap(series, builtAt) {
+  const lastmod = builtAt ? new Date(builtAt).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10);
+  const urls = [
+    `  <url>
+    <loc>${SITE}/apps/rising-seasons/shows/</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>`,
+    ...series.map((s) => {
+      const slug = showPath(s.title, s.seriesId);
+      return `  <url>
+    <loc>${SITE}/apps/rising-seasons/shows/${slug}/</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>`;
+    }),
+  ];
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join('\n')}
+</urlset>
+`;
+}
+
+module.exports = { renderShowsSitemap };

--- a/apps/rising-seasons/scripts/slugify.js
+++ b/apps/rising-seasons/scripts/slugify.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// URL-safe slug from a TV show title. We use lowercase ASCII letters,
+// digits, and single dashes, capped to 80 chars so URLs stay readable.
+// The seriesId (tconst) is appended by the caller to guarantee uniqueness
+// since titles like "The Office" exist multiple times.
+function slugify(title) {
+  if (!title || typeof title !== 'string') return 'show';
+  let s = title
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (s.length > 80) s = s.slice(0, 80).replace(/-+$/, '');
+  return s || 'show';
+}
+
+function showPath(title, seriesId) {
+  return `${slugify(title)}-${seriesId}`;
+}
+
+module.exports = { slugify, showPath };

--- a/apps/rising-seasons/tests/render-curve.test.js
+++ b/apps/rising-seasons/tests/render-curve.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { renderCurve } = require('../scripts/render-curve.js');
+
+const SAMPLE = [
+  { episode: 1, rating: 7.0, votes: 1000 },
+  { episode: 2, rating: 8.5, votes: 1200 },
+  { episode: 3, rating: 9.0, votes: 1500 },
+];
+
+test('renderCurve emits a self-contained svg', () => {
+  const svg = renderCurve(SAMPLE);
+  assert.ok(svg.startsWith('<svg'));
+  assert.ok(svg.endsWith('</svg>'));
+  assert.ok(svg.includes('xmlns="http://www.w3.org/2000/svg"'));
+});
+
+test('renderCurve includes the line, area, and one dot per episode', () => {
+  const svg = renderCurve(SAMPLE);
+  assert.ok(svg.includes('class="curve-line"'));
+  assert.ok(svg.includes('class="curve-area"'));
+  const dotCount = (svg.match(/<circle /g) || []).length;
+  assert.equal(dotCount, SAMPLE.length);
+});
+
+test('renderCurve embeds per-episode hover titles', () => {
+  const svg = renderCurve(SAMPLE);
+  assert.ok(svg.includes('Ep 1: 7.0'));
+  assert.ok(svg.includes('Ep 2: 8.5'));
+  assert.ok(svg.includes('Ep 3: 9.0'));
+  assert.ok(svg.includes('1,000 votes'));
+});
+
+test('renderCurve escapes ampersands in tooltips', () => {
+  const svg = renderCurve([
+    { episode: 1, rating: 7.0, votes: 1, name: 'Tom & Jerry' },
+  ]);
+  // The name itself isn't in the tooltip, but the helper should escape any
+  // & it does emit (the votes formatting can include thousands separators
+  // that don't matter here; this guards against a regression if we ever add
+  // the name to the tooltip).
+  assert.ok(!svg.includes(' & '));
+});
+
+test('renderCurve handles a single-episode season without divide-by-zero', () => {
+  const svg = renderCurve([{ episode: 1, rating: 8.0, votes: 100 }]);
+  assert.ok(svg.includes('<circle'));
+  // y must be a finite number
+  assert.ok(/cy="[\d.]+"/.test(svg));
+});
+
+test('renderCurve returns an empty svg for no episodes', () => {
+  const svg = renderCurve([]);
+  assert.ok(svg.includes('<svg'));
+  assert.ok(!svg.includes('<circle'));
+});
+
+test('renderCurve respects showDots=false', () => {
+  const svg = renderCurve(SAMPLE, { showDots: false });
+  assert.ok(!svg.includes('<circle'));
+});

--- a/apps/rising-seasons/tests/render-show-page.test.js
+++ b/apps/rising-seasons/tests/render-show-page.test.js
@@ -65,7 +65,7 @@ test('renderShowPage emits TVSeries JSON-LD with aggregateRating', () => {
 test('renderShowPage links to the IMDb canonical and the SPA', () => {
   const html = renderShowPage(BREAKING_BAD);
   assert.ok(html.includes('https://www.imdb.com/title/tt0903747/'));
-  assert.ok(html.includes('/apps/rising-seasons/#series=tt0903747'));
+  assert.ok(html.includes('/apps/rising-seasons/#show=tt0903747'));
 });
 
 test('renderShowPage includes episode rows in a real HTML table', () => {

--- a/apps/rising-seasons/tests/render-show-page.test.js
+++ b/apps/rising-seasons/tests/render-show-page.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { renderShowPage, buildDescription } = require('../scripts/render-show-page.js');
+const { groupBySeries } = require('../scripts/build-show-pages.js');
+
+const BREAKING_BAD = {
+  seriesId: 'tt0903747',
+  title: 'Breaking Bad',
+  year: 2008,
+  type: 'tvSeries',
+  genres: ['Crime', 'Drama', 'Thriller'],
+  seriesRating: 9.5,
+  seriesVotes: 2615545,
+  poster: '/poster.jpg',
+  overview: 'Walter White becomes a meth cook.',
+  language: 'en',
+  providers: ['Netflix'],
+  tmdbId: 1396,
+  seasons: [
+    {
+      season: 1,
+      seasonYear: 2008,
+      episodes: [
+        { episode: 1, rating: 8.0, votes: 1000, name: 'Pilot' },
+        { episode: 2, rating: 8.2, votes: 950, name: "Cat's in the Bag..." },
+      ],
+      firstRating: 8.0,
+      lastRating: 8.2,
+      avgRating: 8.1,
+      shapes: ['rising'],
+    },
+  ],
+  builtAt: '2026-05-18T00:00:00.000Z',
+};
+
+test('renderShowPage produces a valid HTML5 document', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.startsWith('<!DOCTYPE html>'));
+  assert.ok(html.includes('<html lang="en">'));
+  assert.ok(html.trim().endsWith('</html>'));
+});
+
+test('renderShowPage puts the show name in the title and h1', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('<title>Breaking Bad (2008) — Episode Ratings'));
+  assert.ok(html.match(/<h1>Breaking Bad/));
+});
+
+test('renderShowPage sets a canonical URL using the slug + tconst', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('<link rel="canonical" href="https://shevato.com/apps/rising-seasons/shows/breaking-bad-tt0903747/">'));
+});
+
+test('renderShowPage emits TVSeries JSON-LD with aggregateRating', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('"@type": "TVSeries"'));
+  assert.ok(html.includes('"aggregateRating"'));
+  assert.ok(html.includes('"ratingValue": 9.5'));
+  assert.ok(html.includes('"ratingCount": 2615545'));
+});
+
+test('renderShowPage links to the IMDb canonical and the SPA', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('https://www.imdb.com/title/tt0903747/'));
+  assert.ok(html.includes('/apps/rising-seasons/#series=tt0903747'));
+});
+
+test('renderShowPage includes episode rows in a real HTML table', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('<table class="episode-table">'));
+  assert.ok(html.includes('Pilot'));
+  // Apostrophe escaped — using &#39; per our HTML escaper
+  assert.ok(html.includes('Cat&#39;s in the Bag'));
+});
+
+test('renderShowPage embeds a server-rendered SVG curve', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('<svg class="season-curve"'));
+  assert.ok(html.includes('class="curve-line"'));
+});
+
+test('renderShowPage degrades gracefully without TMDB data', () => {
+  const noTmdb = { ...BREAKING_BAD, poster: null, overview: null, language: null, providers: null, tmdbId: null };
+  const html = renderShowPage(noTmdb);
+  // Falls back to the site logo for og:image
+  assert.ok(html.includes('og:image" content="https://shevato.com/images/full-logo.svg'));
+  // Renders a placeholder, not a broken <img>
+  assert.ok(html.includes('poster-placeholder'));
+  // Does NOT include the TMDB sameAs reference
+  assert.ok(!html.includes('themoviedb.org'));
+});
+
+test('renderShowPage XSS-escapes hostile titles', () => {
+  const evil = {
+    ...BREAKING_BAD,
+    title: '<script>alert(1)</script>',
+    overview: 'Has "quotes" & <tags>',
+  };
+  const html = renderShowPage(evil);
+  assert.ok(!html.includes('<script>alert(1)</script>'));
+  assert.ok(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
+  assert.ok(!html.includes('"quotes"'));
+});
+
+test('buildDescription stays under 300 chars', () => {
+  const d = buildDescription(
+    'Some Show',
+    2020,
+    3,
+    8.5,
+    100000,
+    'A'.repeat(1000),
+  );
+  assert.ok(d.length <= 300);
+});
+
+test('groupBySeries collapses seasons under a single series', () => {
+  const matches = [
+    { seriesId: 'tt1', title: 'X', year: 2020, type: 'tvSeries', genres: ['Drama'], season: 1, seasonYear: 2020, episodes: [{ episode: 1, rating: 8, votes: 100 }], firstRating: 8, lastRating: 8, avgRating: 8, shapes: ['rising'], seriesRating: 8.5, seriesVotes: 5000 },
+    { seriesId: 'tt1', title: 'X', year: 2020, type: 'tvSeries', genres: ['Drama'], season: 2, seasonYear: 2021, episodes: [{ episode: 1, rating: 9, votes: 100 }], firstRating: 9, lastRating: 9, avgRating: 9, shapes: ['consistent'], seriesRating: 8.5, seriesVotes: 5000 },
+    { seriesId: 'tt2', title: 'Y', year: 2018, type: 'tvSeries', genres: ['Comedy'], season: 1, seasonYear: 2018, episodes: [{ episode: 1, rating: 7, votes: 100 }], firstRating: 7, lastRating: 7, avgRating: 7, shapes: [], seriesRating: 7, seriesVotes: 1000 },
+  ];
+  const grouped = groupBySeries(matches);
+  assert.equal(grouped.length, 2);
+  const x = grouped.find((g) => g.seriesId === 'tt1');
+  assert.equal(x.seasons.length, 2);
+  // seasons sorted numerically
+  assert.deepEqual(x.seasons.map((s) => s.season), [1, 2]);
+});
+
+test('groupBySeries backfills series-level fields from any season', () => {
+  // First season has no enrichment; second season carries the poster.
+  // Result should hold the poster regardless of which season holds it.
+  const matches = [
+    { seriesId: 'tt1', title: 'X', year: 2020, season: 1, episodes: [{ episode: 1, rating: 8, votes: 100 }], firstRating: 8, lastRating: 8, avgRating: 8, shapes: [] },
+    { seriesId: 'tt1', title: 'X', year: 2020, season: 2, episodes: [{ episode: 1, rating: 9, votes: 100 }], firstRating: 9, lastRating: 9, avgRating: 9, shapes: [], poster: '/late.jpg', tmdbId: 99 },
+  ];
+  const grouped = groupBySeries(matches);
+  assert.equal(grouped[0].poster, '/late.jpg');
+  assert.equal(grouped[0].tmdbId, 99);
+});

--- a/apps/rising-seasons/tests/render-sitemap.test.js
+++ b/apps/rising-seasons/tests/render-sitemap.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { renderShowsSitemap } = require('../scripts/render-sitemap.js');
+const { renderShowsIndex, sortTitle, firstLetter } = require('../scripts/render-shows-index.js');
+
+const SERIES = [
+  { seriesId: 'tt0903747', title: 'Breaking Bad', year: 2008 },
+  { seriesId: 'tt0944947', title: 'Game of Thrones', year: 2011 },
+  { seriesId: 'tt0386676', title: 'The Office', year: 2005 },
+];
+
+test('renderShowsSitemap emits a well-formed XML document', () => {
+  const xml = renderShowsSitemap(SERIES, '2026-05-18T00:00:00.000Z');
+  assert.ok(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>'));
+  assert.ok(xml.includes('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'));
+  assert.ok(xml.trim().endsWith('</urlset>'));
+});
+
+test('renderShowsSitemap includes one URL per series plus the index', () => {
+  const xml = renderShowsSitemap(SERIES, '2026-05-18T00:00:00.000Z');
+  const locs = xml.match(/<loc>/g) || [];
+  assert.equal(locs.length, SERIES.length + 1);
+});
+
+test('renderShowsSitemap URLs use the slug + tconst path scheme', () => {
+  const xml = renderShowsSitemap(SERIES, '2026-05-18T00:00:00.000Z');
+  assert.ok(xml.includes('https://shevato.com/apps/rising-seasons/shows/breaking-bad-tt0903747/'));
+  assert.ok(xml.includes('https://shevato.com/apps/rising-seasons/shows/game-of-thrones-tt0944947/'));
+  assert.ok(xml.includes('https://shevato.com/apps/rising-seasons/shows/the-office-tt0386676/'));
+});
+
+test('renderShowsSitemap stamps lastmod from builtAt', () => {
+  const xml = renderShowsSitemap(SERIES, '2026-05-18T12:34:56.000Z');
+  assert.ok(xml.includes('<lastmod>2026-05-18</lastmod>'));
+});
+
+test('sortTitle drops leading articles for alphabetization', () => {
+  assert.equal(sortTitle('The Office'), 'office');
+  assert.equal(sortTitle('A Series of Unfortunate Events'), 'series of unfortunate events');
+  assert.equal(sortTitle('An American Family'), 'american family');
+});
+
+test('firstLetter buckets non-letters into "#"', () => {
+  assert.equal(firstLetter('breaking bad'), 'B');
+  assert.equal(firstLetter('1899'), '#');
+  assert.equal(firstLetter(''), '#');
+});
+
+test('renderShowsIndex emits the count and links to every series', () => {
+  const html = renderShowsIndex(SERIES, '2026-05-18T00:00:00.000Z');
+  assert.ok(html.includes('3 shows'));
+  assert.ok(html.includes('/apps/rising-seasons/shows/breaking-bad-tt0903747/'));
+  assert.ok(html.includes('/apps/rising-seasons/shows/game-of-thrones-tt0944947/'));
+  // "The Office" is alphabetized under O, not T
+  assert.ok(html.includes('id="letter-O"'));
+  assert.ok(html.includes('/apps/rising-seasons/shows/the-office-tt0386676/'));
+});

--- a/apps/rising-seasons/tests/slugify.test.js
+++ b/apps/rising-seasons/tests/slugify.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { slugify, showPath } = require('../scripts/slugify.js');
+
+test('slugify lowercases and dashes', () => {
+  assert.equal(slugify('Breaking Bad'), 'breaking-bad');
+  assert.equal(slugify('Game of Thrones'), 'game-of-thrones');
+});
+
+test('slugify strips punctuation and collapses dashes', () => {
+  assert.equal(slugify("It's Always Sunny in Philadelphia"), 'it-s-always-sunny-in-philadelphia');
+  assert.equal(slugify('Brooklyn Nine-Nine'), 'brooklyn-nine-nine');
+  assert.equal(slugify('Marvel’s Daredevil: Born Again'), 'marvel-s-daredevil-born-again');
+});
+
+test('slugify converts ampersands to "and"', () => {
+  assert.equal(slugify('Will & Grace'), 'will-and-grace');
+  assert.equal(slugify('Tom & Jerry'), 'tom-and-jerry');
+});
+
+test('slugify handles non-ASCII titles', () => {
+  // Falls back to dropping any chars that aren't a-z0-9.
+  // Result is non-empty fallback when title is all non-ASCII.
+  assert.equal(slugify('進撃の巨人'), 'show');
+  // Mixed scripts keep the ASCII parts.
+  assert.equal(slugify('Sherlock 神探'), 'sherlock');
+});
+
+test('slugify caps length at 80 chars', () => {
+  const long = 'A'.repeat(200);
+  assert.ok(slugify(long).length <= 80);
+});
+
+test('slugify handles empty/garbage input', () => {
+  assert.equal(slugify(''), 'show');
+  assert.equal(slugify(null), 'show');
+  assert.equal(slugify(undefined), 'show');
+  assert.equal(slugify('!!!'), 'show');
+});
+
+test('showPath combines slug with seriesId', () => {
+  assert.equal(showPath('Breaking Bad', 'tt0903747'), 'breaking-bad-tt0903747');
+  assert.equal(showPath('The Office', 'tt0386676'), 'the-office-tt0386676');
+});
+
+test('showPath guarantees uniqueness via seriesId for colliding titles', () => {
+  // "The Office" exists multiple times on IMDb (US, UK, etc.) — the tconst
+  // suffix ensures URLs never collide even when slugs do.
+  const usOffice = showPath('The Office', 'tt0386676');
+  const ukOffice = showPath('The Office', 'tt0290978');
+  assert.notEqual(usOffice, ukOffice);
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,8 @@
 [build]
+  # Regenerate Rising Seasons per-show SEO pages (and their sitemap)
+  # from the committed data.json on every deploy. The output lives at
+  # apps/rising-seasons/shows/ and is intentionally gitignored.
+  command = "npm run build:site"
   functions = "netlify/functions"
 
 [functions]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test:brain-arena": "node --test apps/brain-arena/tests/",
     "test:sync": "node --test sync-system/tests/",
     "build:rising-seasons": "node apps/rising-seasons/scripts/build-data.js",
+    "build:rising-seasons:pages": "node apps/rising-seasons/scripts/build-show-pages.js",
+    "build:gym-tracker:pages": "node apps/gym-tracker/scripts/build-exercise-pages.cjs",
+    "build:site": "node apps/rising-seasons/scripts/build-show-pages.js && node apps/gym-tracker/scripts/build-exercise-pages.cjs",
     "enrich:rising-seasons": "node apps/rising-seasons/scripts/enrich-tmdb.js",
     "enrich:rising-seasons:providers": "node apps/rising-seasons/scripts/enrich-providers.js"
   }

--- a/robots.txt
+++ b/robots.txt
@@ -40,3 +40,5 @@ Allow: /
 
 # Sitemap
 Sitemap: https://shevato.com/sitemap.xml
+Sitemap: https://shevato.com/apps/rising-seasons/sitemap-shows.xml
+Sitemap: https://shevato.com/apps/gym-tracker/sitemap-exercises.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -63,9 +63,16 @@
 
   <url>
     <loc>https://shevato.com/apps/gym-tracker/</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/gym-tracker/exercises/</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <url>
@@ -77,9 +84,16 @@
 
   <url>
     <loc>https://shevato.com/apps/rising-seasons/</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/rising-seasons/shows/</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <url>

--- a/work.html
+++ b/work.html
@@ -287,6 +287,13 @@
             <ul class="stack"><li>Chart.js</li><li>Vanilla JS</li><li>Firebase Auth</li></ul>
           </article>
 
+          <article class="work-item">
+            <span class="role">Real-time multiplayer</span>
+            <h3>Brain Arena</h3>
+            <p>Real-time multiplayer party game with two modes: head-to-head trivia powered by a live questions API, and Globe Drop, a geography game where players guess cities on a 3D globe. Create a room, share the code, race the timer.</p>
+            <ul class="stack"><li>Vanilla JS</li><li>Firestore Realtime</li><li>Three.js</li><li>The Trivia API</li></ul>
+          </article>
+
         </div>
       </section>
 


### PR DESCRIPTION
## Why

Rising Seasons and Gym Tracker hide their content (6,778 TV series, 513 exercises) inside JSON files fetched after page load. Googlebot indexed one URL per app instead of thousands of titles, so queries like `Breaking Bad rating graph` returned ratingraph.com at #1 and zero shevato.com results. This PR generates one static HTML page per series and per exercise, served as a pure derivation of the committed data files at Netlify build time.

## What

### Rising Seasons — 6,778 per-show pages
- URL: `/apps/rising-seasons/shows/{slug}-{tt-id}/`
- Server-rendered SVG curves and episode tables (renders with JS disabled)
- `TVSeries` + `AggregateRating` + `BreadcrumbList` JSON-LD
- A-Z browse index at `/shows/` + `sitemap-shows.xml` (6,779 URLs)
- Permalink button in the SPA show modal, "Browse all shows A-Z" hero link

### Gym Tracker — 513 per-exercise pages + 51 taxonomy pages
- URL: `/apps/gym-tracker/exercises/{slug}/`
- `ExerciseAction` JSON-LD with primary/secondary muscles, equipment
- 12 related-exercise links per page for internal crawl graph
- 34 muscle-group landing pages (`/exercises/muscle/pectorals/`) targeting high-volume queries
- 17 equipment landing pages (`/exercises/equipment/barbell/`)
- Browse index at `/exercises/` + `sitemap-exercises.xml` (565 URLs)
- "Browse the public exercise directory" link in the SPA exercise database view

### "More from Shevato" cross-app footer
Every per-show and per-exercise page (and the browse/taxonomy indexes) ends with a footer listing all six apps with one-line descriptions. Inlined into the HTML (no JS partial-include) so the cross-links count for SEO and render with JS disabled.

### Sitewide plumbing
- `netlify.toml` gets `[build] command = "npm run build:site"` so both generators run on every deploy
- `robots.txt` advertises both new sitemaps
- Root `sitemap.xml` gets the browse-index URLs and bumped priorities
- `work.html` Personal projects section gets a Brain Arena card (the app landed on master while this PR was open)
- Generated output is gitignored — repo stays clean

## Out of scope (and why)

| App | Status | Reason |
|---|---|---|
| Mario Kart Tracker | Landing page only | User-data tracker, no public dataset to template from. Landing page already ranks for "Mario Kart tracker" queries. |
| Football H2H | Landing page only | Same — generic head-to-head tracker, no canonical content corpus. |
| MapTap Rivals | Landing page only | Same — wraps the niche MapTap.gg game. |
| Brain Arena | Landing page only | New app from master. Real-time multiplayer trivia/geography — no static content to template. Listed in the new footer and in work.html. |

The marketing pages (home, about, work, contact, apps, moadon-alef) were audited and already had strong JSON-LD + OG + Twitter + breadcrumbs; no changes needed beyond sitemap polish.

## Example queries this PR makes us findable for

| Query | Before | After |
|---|---|---|
| `Breaking Bad rating graph` | no shevato result | `/apps/rising-seasons/shows/breaking-bad-tt0903747/` |
| `Game of Thrones season 8 episode ratings` | none | matches via title + h1 + episode table |
| `pectorals exercises with cable` | none | `/apps/gym-tracker/exercises/muscle/pectorals/` |
| `Barbell back squat secondary muscles` | none | matches via fact grid + JSON-LD |

## Commits

1. `seo: generate per-show and per-exercise static pages` — the core generators, templates, CSS, sitemaps, browse indexes
2. `fix(seo): correct SPA deep-link params on static pages` — Rising Seasons uses `#show=` not `#series=`; Gym Tracker hash router only honors view names
3. `seo: add "More from Shevato" cross-app footer to static pages` — inlined cross-app footer DRY'd via a shared render module per app
4. `seo: add Brain Arena to 'More from Shevato' footer` — picked up after rebase on master
5. `site(work): add Brain Arena to Personal projects section` — work.html parity

## Test plan

- [x] `npm test` — 521/521 (includes 85 new tests for slugify, curve rendering, page rendering, sitemap shape, grouping, JSON-LD escape regression)
- [x] Local build verified — 6,778 show pages (~1.5 s) + 564 gym pages (<1 s)
- [x] Screenshot-verified per-show page, /shows/ browse index, per-exercise page, per-muscle taxonomy, and the cross-app footer
- [x] Netlify deploy previews built green on both `shevato` and `shevato-site` projects
- [x] Rebased on master after the Brain Arena merge — clean merge, all checks pass
- [ ] After merge: confirm `site:shevato.com breaking bad` returns results in Google Search Console a week or two out
