### PR TITLE
seo: convert sitemap.xml to a sitemap-index

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -38,7 +38,5 @@ Allow: /
 User-agent: WhatsApp
 Allow: /
 
-# Sitemap
+# Sitemap index — references the page, show, and exercise sub-sitemaps.
 Sitemap: https://shevato.com/sitemap.xml
-Sitemap: https://shevato.com/apps/rising-seasons/sitemap-shows.xml
-Sitemap: https://shevato.com/apps/gym-tracker/sitemap-exercises.xml

--- a/sitemap-pages.xml
+++ b/sitemap-pages.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://shevato.com/</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://shevato.com/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://shevato.com/"/>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/home.html</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/work.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/about.html</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/contact.html</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps.html</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/moadon-alef.html</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="he-IL" href="https://shevato.com/moadon-alef.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://shevato.com/moadon-alef.html"/>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/mario-kart/</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/gym-tracker/</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/gym-tracker/exercises/</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/football-h2h/</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/rising-seasons/</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/rising-seasons/shows/</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/maptap-rivals/</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/brain-arena/</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,112 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  <url>
-    <loc>https://shevato.com/</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://shevato.com/"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://shevato.com/"/>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/home.html</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/work.html</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/about.html</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/contact.html</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps.html</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/moadon-alef.html</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-    <xhtml:link rel="alternate" hreflang="he-IL" href="https://shevato.com/moadon-alef.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://shevato.com/moadon-alef.html"/>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps/mario-kart/</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps/gym-tracker/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps/gym-tracker/exercises/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps/football-h2h/</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps/rising-seasons/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps/rising-seasons/shows/</loc>
-    <lastmod>2026-05-18</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps/maptap-rivals/</loc>
-    <lastmod>2026-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps/brain-arena/</loc>
+<!--
+  Sitemap index file. References the three sub-sitemaps:
+    - sitemap-pages.xml      — static marketing + app-landing pages
+    - sitemap-shows.xml      — auto-generated per-show pages for Rising Seasons
+    - sitemap-exercises.xml  — auto-generated per-exercise pages for Gym Tracker
+  Submitting this single URL to Google Search Console covers all three.
+-->
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://shevato.com/sitemap-pages.xml</loc>
     <lastmod>2026-05-19</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-</urlset>
+  </sitemap>
+  <sitemap>
+    <loc>https://shevato.com/apps/rising-seasons/sitemap-shows.xml</loc>
+    <lastmod>2026-05-19</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://shevato.com/apps/gym-tracker/sitemap-exercises.xml</loc>
+    <lastmod>2026-05-19</lastmod>
+  </sitemap>
+</sitemapindex>

--- a/sync-system/tests/app-naming-consistency.test.mjs
+++ b/sync-system/tests/app-naming-consistency.test.mjs
@@ -63,42 +63,85 @@ test('no app directory contains a stray non-index *.html entry alongside index.h
     assert.deepEqual(offenders, [], `unexpected top-level HTML beside index.html:\n  ${offenders.join('\n  ')}`);
 });
 
-test('apps.html and sitemap.xml link to every app via the directory form /apps/<name>/', () => {
+// Concatenates every sitemap XML in the repo into one string so the
+// assertions below pass whether app URLs live in the legacy flat
+// sitemap.xml or, post-split, in sitemap-pages.xml referenced by the
+// sitemap-index at sitemap.xml. Excludes the auto-generated
+// sitemap-shows.xml and sitemap-exercises.xml — those are per-app
+// children and never carry app-root URLs.
+function readSitemapContent() {
+    const files = ['sitemap.xml', 'sitemap-pages.xml'];
+    let out = '';
+    for (const f of files) {
+        try {
+            out += '\n' + readFileSync(join(REPO_ROOT, f), 'utf8');
+        } catch {
+            // ok — sitemap-pages.xml is optional if everything is still flat.
+        }
+    }
+    return out;
+}
+
+test('apps.html and the sitemap link to every app via the directory form /apps/<name>/', () => {
     // We link to the directory (not /index.html) so that the rendered URL,
     // the canonical tag, the sitemap entry, and the user-facing href all
     // agree — Netlify's pretty-URLs would otherwise redirect /index.html
     // off and break that alignment.
     const appsHtml = readFileSync(join(REPO_ROOT, 'apps.html'), 'utf8');
-    const sitemap = readFileSync(join(REPO_ROOT, 'sitemap.xml'), 'utf8');
+    const sitemap = readSitemapContent();
 
     const apps = listDirs(APPS_DIR);
     const missing = [];
     for (const app of apps) {
         // Match the href closing quote in apps.html (href="apps/<name>/")
-        // and the loc closing tag in the sitemap (.../apps/<name>/</loc>)
+        // and the loc closing tag in any sitemap file (.../apps/<name>/</loc>)
         // so we don't accidentally match deeper sub-paths.
         const hrefPattern = new RegExp(`href="apps/${app}/"`);
         const locPattern = new RegExp(`apps/${app}/</loc>`);
         if (!hrefPattern.test(appsHtml)) missing.push(`apps.html → href="apps/${app}/"`);
-        if (!locPattern.test(sitemap)) missing.push(`sitemap.xml → apps/${app}/</loc>`);
+        if (!locPattern.test(sitemap)) missing.push(`sitemap → apps/${app}/</loc>`);
     }
     assert.deepEqual(missing, [], `links/loc entries missing:\n  ${missing.join('\n  ')}`);
 });
 
-test('apps.html and sitemap.xml never expose /apps/<name>/index.html as a URL', () => {
+test('apps.html and the sitemap never expose /apps/<name>/index.html as a URL', () => {
     // Guards against drift back to the /index.html form, which would put
     // the markup out of sync with Netlify's pretty-URL behavior.
     const appsHtml = readFileSync(join(REPO_ROOT, 'apps.html'), 'utf8');
-    const sitemap = readFileSync(join(REPO_ROOT, 'sitemap.xml'), 'utf8');
+    const sitemap = readSitemapContent();
 
     const apps = listDirs(APPS_DIR);
     const offenders = [];
     for (const app of apps) {
         const bad = `apps/${app}/index.html`;
         if (appsHtml.includes(bad)) offenders.push(`apps.html → ${bad}`);
-        if (sitemap.includes(bad)) offenders.push(`sitemap.xml → ${bad}`);
+        if (sitemap.includes(bad)) offenders.push(`sitemap → ${bad}`);
     }
     assert.deepEqual(offenders, [], `unexpected /index.html URL forms:\n  ${offenders.join('\n  ')}`);
+});
+
+test('sitemap.xml is a sitemap-index that references every sub-sitemap', () => {
+    // The root sitemap is a <sitemapindex> wrapper so a single submission
+    // to Google Search Console covers the page, show, and exercise
+    // sub-sitemaps without us having to keep three submissions in sync.
+    const index = readFileSync(join(REPO_ROOT, 'sitemap.xml'), 'utf8');
+    assert.match(index, /<sitemapindex /, 'sitemap.xml should be a sitemapindex, not a flat urlset');
+    const required = [
+        'https://shevato.com/sitemap-pages.xml',
+        'https://shevato.com/apps/rising-seasons/sitemap-shows.xml',
+        'https://shevato.com/apps/gym-tracker/sitemap-exercises.xml',
+    ];
+    const missing = required.filter((u) => !index.includes(`<loc>${u}</loc>`));
+    assert.deepEqual(missing, [], `sitemap-index missing references:\n  ${missing.join('\n  ')}`);
+});
+
+test('robots.txt advertises exactly the sitemap-index URL', () => {
+    // Once we moved to a sitemap-index, listing the child sitemaps in
+    // robots.txt is redundant. Google discovers them through the index.
+    const robots = readFileSync(join(REPO_ROOT, 'robots.txt'), 'utf8');
+    const sitemapLines = robots.split(/\r?\n/).filter((l) => /^Sitemap:/i.test(l.trim()));
+    assert.equal(sitemapLines.length, 1, `expected one Sitemap: line in robots.txt, got ${sitemapLines.length}`);
+    assert.match(sitemapLines[0], /https:\/\/shevato\.com\/sitemap\.xml\s*$/);
 });
 
 test('netlify.toml keeps a 301 from tracker.html to the new mario-kart entry', () => {


### PR DESCRIPTION
## Why

Follow-up to #87, which added two new sitemaps (`sitemap-shows.xml`, `sitemap-exercises.xml`) and listed all three sitemap URLs in `robots.txt`. With three separate sitemaps to keep submitted in Google Search Console, future additions mean another submission to remember. A sitemap index file fixes that — one URL covers everything, and any new child sitemap is picked up automatically once it is referenced from the index.

## What

- `sitemap.xml` is now a `<sitemapindex>` wrapper that references:
  - `sitemap-pages.xml` (new file — the body of the old flat `sitemap.xml`)
  - `apps/rising-seasons/sitemap-shows.xml`
  - `apps/gym-tracker/sitemap-exercises.xml`
- `robots.txt` drops the two redundant child-sitemap lines. Google discovers them through the index.
- Cross-cutting `app-naming-consistency.test.mjs` updated to read both `sitemap.xml` and `sitemap-pages.xml` so the existing per-app URL invariants still hold after the split.
- Two new tests pin the sitemap-index structure and the single robots.txt sitemap entry so future drift fails loudly.

## Action after merge

In [Google Search Console](https://search.google.com/search-console) → Sitemaps, you can now **remove** the two separately-submitted child sitemaps (if you submitted them per the #87 follow-up). The single `https://shevato.com/sitemap.xml` submission covers all three.

## Test plan

- [x] `npm test` — 544/544 passing
- [x] Curl-verified the served sitemap chain (`sitemap.xml` → `sitemapindex`, `sitemap-pages.xml` → flat urlset)
- [x] Curl-verified `robots.txt` has exactly one `Sitemap:` line
- [x] New tests guard the sitemap-index structure + single robots entry
