### PR TITLE
feat(globe-drop): polish round — sounds, layout, modals, chat fixes

### DIFF
--- a/apps/brain-arena/css/styles.css
+++ b/apps/brain-arena/css/styles.css
@@ -124,9 +124,10 @@ body.brain-arena-app button {
   background: var(--surface-2);
   border-color: var(--border-strong);
   color: var(--text) !important;
-  box-shadow: none !important;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35) !important;
+  transform: translateY(-1px);
 }
-.btn:active { transform: translateY(1px); }
+.btn:active { transform: translateY(0); box-shadow: none !important; }
 .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .btn:disabled, .btn[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
 
@@ -251,17 +252,21 @@ body.brain-arena-app button {
 
 .lobby-card {
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 30%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 30%),
     var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1.1rem 1.15rem 1.2rem;
+  padding: 1.2rem 1.25rem 1.3rem;
   display: flex;
   flex-direction: column;
   gap: 0.95rem;
-  transition: border-color 0.15s, transform 0.15s;
+  transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03) inset, 0 8px 24px rgba(0, 0, 0, 0.25);
 }
-.lobby-card:hover { border-color: var(--border-strong); }
+.lobby-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 12px 32px rgba(0, 0, 0, 0.35);
+}
 
 .lobby-card header h2 {
   font-size: 1.05rem;
@@ -589,14 +594,35 @@ select option { background: var(--surface); color: var(--text); }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.65rem;
-  margin-bottom: 0.55rem;
+  gap: 0.85rem;
+  margin: 0 0 0.85rem;
+  padding: 1rem 1.2rem;
+  background:
+    linear-gradient(135deg, rgba(99, 102, 241, 0.06), rgba(252, 211, 77, 0.04)),
+    var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   flex-wrap: wrap;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
 }
 .globe-drop-prompt {
   margin: 0;
-  font-size: clamp(1.1rem, 2.6vw, 1.45rem);
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 500;
   color: var(--text);
+  letter-spacing: -0.005em;
+  /* Make the prompt copy-pasteable — parent containers can flip this
+     off for layout reasons, but the user needs to grab the place name
+     to look it up. */
+  user-select: text;
+  -webkit-user-select: text;
+  cursor: text;
+}
+.globe-drop-prompt strong,
+.globe-drop-prompt-country,
+.globe-drop-prompt-hints {
+  user-select: text;
+  -webkit-user-select: text;
 }
 .globe-drop-prompt-label { color: var(--muted); font-weight: 400; }
 .globe-drop-prompt strong { color: var(--accent-2); font-weight: 700; }
@@ -731,6 +757,18 @@ select option { background: var(--surface); color: var(--text); }
 .btn-danger-ghost:hover {
   background: rgba(248, 113, 113, 0.10);
 }
+.btn-danger {
+  background: rgb(220, 38, 38) !important;
+  border-color: rgb(220, 38, 38) !important;
+  color: white !important;
+}
+.btn-danger:hover { background: rgb(185, 28, 28) !important; }
+
+.confirm-modal-body {
+  margin: 0.4rem 0 1rem;
+  color: var(--muted);
+  line-height: 1.45;
+}
 
 .room-paused-banner {
   margin: 0.5rem 0 0;
@@ -742,6 +780,65 @@ select option { background: var(--surface); color: var(--text); }
   font-size: 0.88rem;
   font-weight: 600;
   text-align: center;
+}
+
+/* New Globe Drop layout — action bar + top-mounted live standings */
+.globe-drop-action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  margin: 0.8rem 0;
+  padding: 0.6rem 0.9rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  flex-wrap: wrap;
+}
+.globe-drop-action-bar .globe-drop-status {
+  margin: 0;
+  flex: 1 1 200px;
+  font-size: 0.9rem;
+  min-width: 0;
+}
+.globe-drop-action-bar .globe-drop-controls {
+  display: flex;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+}
+
+/* Mini-board variant pinned above the globe with submit-state badges. */
+.mini-board-top { margin: 0 0 0.8rem; }
+.mini-board-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.55rem;
+}
+.mini-board-head h3 { margin: 0; }
+.mini-board-pulse {
+  margin: 0;
+  padding: 0.18rem 0.55rem;
+  background: rgba(99, 102, 241, 0.18);
+  border: 1px solid rgba(99, 102, 241, 0.45);
+  border-radius: 999px;
+  color: rgb(199, 210, 254);
+  font-size: 0.78rem;
+  font-weight: 600;
+  animation: gd-pulse-in 320ms ease-out, gd-pulse-out 280ms ease-in 2.5s forwards;
+}
+@keyframes gd-pulse-in  { from { transform: translateY(-4px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+@keyframes gd-pulse-out { to   { opacity: 0; } }
+
+.mini-board-list .submitted-badge {
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.4rem;
+  background: rgba(74, 222, 128, 0.15);
+  border: 1px solid rgba(74, 222, 128, 0.45);
+  border-radius: 999px;
+  color: rgb(134, 239, 172);
+  font-size: 0.72rem;
+  font-weight: 600;
 }
 
 /* Chat side panel */
@@ -809,6 +906,29 @@ select option { background: var(--surface); color: var(--text); }
   border: 1px dashed var(--border);
   border-radius: 8px;
 }
+.room-chat-quick {
+  display: flex;
+  gap: 0.3rem;
+  padding: 0.4rem 0.9rem;
+  border-top: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.room-chat-quick-btn {
+  flex: 1 1 auto;
+  min-width: 36px;
+  height: 32px;
+  padding: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text);
+  font-size: 1.05rem;
+  cursor: pointer;
+  transition: background 0.12s, transform 0.05s;
+}
+.room-chat-quick-btn:hover { background: var(--surface-2); }
+.room-chat-quick-btn:active { transform: scale(0.95); }
+
 .room-chat-form {
   display: flex;
   gap: 0.45rem;

--- a/apps/brain-arena/css/styles.css
+++ b/apps/brain-arena/css/styles.css
@@ -907,27 +907,35 @@ select option { background: var(--surface); color: var(--text); }
   border-radius: 8px;
 }
 .room-chat-quick {
-  display: flex;
+  display: grid;
+  /* Fixed 8-column grid — keeps every emoji button the same width and
+     prevents the uneven wrap we get with flex when the panel is narrow.
+     Drops to 4 columns on tight panels via the responsive rule below. */
+  grid-template-columns: repeat(8, 1fr);
   gap: 0.3rem;
   padding: 0.4rem 0.9rem;
   border-top: 1px solid var(--border);
-  flex-wrap: wrap;
 }
 .room-chat-quick-btn {
-  flex: 1 1 auto;
-  min-width: 36px;
-  height: 32px;
+  height: 34px;
   padding: 0;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: 8px;
   color: var(--text);
   font-size: 1.05rem;
+  line-height: 1;
   cursor: pointer;
-  transition: background 0.12s, transform 0.05s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.12s, transform 0.05s, border-color 0.12s;
 }
-.room-chat-quick-btn:hover { background: var(--surface-2); }
-.room-chat-quick-btn:active { transform: scale(0.95); }
+.room-chat-quick-btn:hover { background: var(--surface-2); border-color: var(--border-strong); }
+.room-chat-quick-btn:active { transform: scale(0.92); }
+@media (max-width: 380px) {
+  .room-chat-quick { grid-template-columns: repeat(4, 1fr); }
+}
 
 .room-chat-form {
   display: flex;

--- a/apps/brain-arena/index.html
+++ b/apps/brain-arena/index.html
@@ -224,7 +224,7 @@
                    private room of one and auto-starts; Daily uses a
                    deterministic location set seeded by today's UTC date
                    and posts the result to the per-day leaderboard. -->
-              <div class="lobby-solo-actions" data-game-type="globe-drop" hidden>
+              <div class="lobby-solo-actions" data-game-type="globe-drop">
                 <button type="button" class="btn btn-ghost lobby-solo-btn" id="play-solo-btn">
                   <span aria-hidden="true">🎯</span> Play solo
                 </button>
@@ -281,11 +281,11 @@
               <button type="button" class="btn btn-ghost btn-sm" id="room-pause-btn" title="Pause / resume the timer">
                 <span aria-hidden="true">⏸</span> Pause
               </button>
-              <button type="button" class="btn btn-ghost btn-sm" id="room-skip-btn" title="Skip to the reveal for this question">
-                <span aria-hidden="true">⏭</span> Skip
+              <button type="button" class="btn btn-ghost btn-sm btn-danger-ghost" id="room-giveup-btn" title="Give up this question and reveal the answer now">
+                <span aria-hidden="true">🏳️</span> Give up
               </button>
               <button type="button" class="btn btn-ghost btn-sm btn-danger-ghost" id="room-end-btn" title="End the game and show the final scores">
-                <span aria-hidden="true">⏹</span> End
+                <span aria-hidden="true">⏹</span> End game
               </button>
             </div>
             <button type="button" class="btn btn-ghost btn-sm" id="room-chat-toggle" title="Open chat">
@@ -311,6 +311,19 @@
           </header>
           <ul class="room-chat-list" id="room-chat-list" aria-live="polite"></ul>
           <p class="room-chat-empty" id="room-chat-empty">No messages yet. Say something.</p>
+          <!-- Quick-tap emoji bar — one click sends that emoji as a
+               message, no typing required. Skips moderation since
+               emoji-only messages can't contain profanity. -->
+          <div class="room-chat-quick" aria-label="Quick reactions">
+            <button type="button" class="room-chat-quick-btn" data-emoji="🔥">🔥</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="🎯">🎯</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="😂">😂</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="😭">😭</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="👏">👏</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="🤯">🤯</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="😬">😬</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="🤔">🤔</button>
+          </div>
           <form class="room-chat-form" id="room-chat-form" autocomplete="off">
             <input type="text" id="room-chat-input" maxlength="280" placeholder="Type a message…" aria-label="Chat message">
             <button type="submit" class="btn btn-primary btn-sm">Send</button>
@@ -423,9 +436,29 @@
               <span class="globe-drop-difficulty-chip" id="globe-drop-difficulty-chip" hidden></span>
             </header>
 
-            <!-- Reveal panel — appears ABOVE the globe so the result is
-                 the first thing you see after submitting. The countdown
-                 badge ticks 5→1 during the global reveal window. -->
+            <!-- Action bar (submit / clear / status). Above the globe so
+                 on mobile your thumb doesn't have to scroll the whole
+                 stage to reach Submit. -->
+            <div class="globe-drop-action-bar">
+              <p class="answer-status globe-drop-status" id="globe-drop-status" aria-live="polite">Drag to spin the globe. Click to drop your pin.</p>
+              <div class="globe-drop-controls">
+                <button type="button" class="btn btn-ghost" id="globe-drop-clear-btn" hidden>Clear pin</button>
+                <button type="button" class="btn btn-primary" id="globe-drop-submit-btn" disabled>Submit guess</button>
+              </div>
+            </div>
+
+            <!-- Live standings + opponent submission indicators. Submit-
+                 state badges flash next to each name as they commit. -->
+            <section class="mini-board mini-board-top" id="mini-board-globe-drop">
+              <header class="mini-board-head">
+                <h3>Live standings</h3>
+                <p class="mini-board-pulse" id="globe-drop-pulse" aria-live="polite" hidden></p>
+              </header>
+              <ol class="mini-board-list" id="mini-board-list-globe-drop"></ol>
+            </section>
+
+            <!-- Reveal panel — just above the globe so the result is
+                 visible without scrolling. Countdown ticks 5→1. -->
             <section class="globe-drop-reveal" id="globe-drop-reveal" hidden>
               <div class="globe-drop-reveal-head">
                 <p class="globe-drop-reveal-distance" id="globe-drop-reveal-distance"></p>
@@ -437,22 +470,10 @@
               <p class="globe-drop-reveal-trivia" id="globe-drop-reveal-trivia" hidden></p>
             </section>
 
-            <p class="globe-drop-hint" id="globe-drop-hint">Drag to spin the globe. Click anywhere to drop your pin, then submit.</p>
+            <p class="globe-drop-hint" id="globe-drop-hint" hidden></p>
             <div id="globe-drop-map" class="globe-drop-map" aria-label="World globe for guessing"></div>
-            <div class="globe-drop-controls">
-              <button type="button" class="btn btn-ghost" id="globe-drop-clear-btn" hidden>Clear pin</button>
-              <button type="button" class="btn btn-primary" id="globe-drop-submit-btn" disabled>Submit guess</button>
-            </div>
-            <p class="answer-status globe-drop-status" id="globe-drop-status" aria-live="polite"></p>
-            <p class="globe-drop-attribution">
-              Earth texture: <a href="https://www.solarsystemscope.com/textures/" rel="noopener" target="_blank">Solar System Scope</a> (CC BY 4.0).
-            </p>
+            <!-- Nothing below the globe by design. -->
           </article>
-
-          <section class="mini-board" id="mini-board-globe-drop">
-            <h3>Live standings</h3>
-            <ol class="mini-board-list" id="mini-board-list-globe-drop"></ol>
-          </section>
         </section>
 
         <!-- STAGE: end of game -->
@@ -726,6 +747,24 @@
       <div class="modal-actions">
         <button type="button" class="btn btn-ghost" data-close="modal">Maybe later</button>
         <button type="button" class="btn btn-primary" id="premium-checkout-btn">Continue to checkout</button>
+      </div>
+    </article>
+  </div>
+
+  <!-- Reusable confirmation modal. openConfirmModal({...}) drops the
+       title/body/labels in and returns a Promise<boolean>. Replaces
+       window.confirm() so confirmations match the dark theme. -->
+  <div class="modal" id="confirm-modal" role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title" hidden>
+    <div class="modal-backdrop" data-confirm-close></div>
+    <article class="modal-panel modal-panel-sm">
+      <button type="button" class="modal-close" data-confirm-close aria-label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
+      </button>
+      <h2 id="confirm-modal-title">Confirm</h2>
+      <p id="confirm-modal-body" class="confirm-modal-body"></p>
+      <div class="modal-actions">
+        <button type="button" class="btn btn-ghost" id="confirm-modal-cancel">Cancel</button>
+        <button type="button" class="btn btn-primary" id="confirm-modal-confirm">Confirm</button>
       </div>
     </article>
   </div>

--- a/apps/brain-arena/js/app.js
+++ b/apps/brain-arena/js/app.js
@@ -2035,13 +2035,19 @@ function ensureGlobe() {
     // produces — that's where the real "feels fast" upgrade comes from.
     const controls = state.globe.controls();
     if (controls) {
-        // Smoother feel: lower rotate sensitivity so a small drag doesn't
-        // overshoot, and heavier damping so the camera glides to rest
-        // instead of stopping abruptly.
-        controls.zoomSpeed = 5;
-        controls.rotateSpeed = 0.7;
+        // Camera feel:
+        //   - rotateSpeed 0.45: drag tracks the cursor without over-shoot
+        //   - zoomSpeed 4: pinch / pinpoint zooms feel intentional
+        //   - dampingFactor 0.3: drag inertia bleeds off in ~5 frames so
+        //     the globe stops where you let go instead of "spinning for
+        //     no reason" after release
+        //   - autoRotate explicitly OFF so a stray default doesn't kick
+        //     the globe into continuous spin between rounds
+        controls.zoomSpeed = 4;
+        controls.rotateSpeed = 0.45;
         controls.enableDamping = true;
-        controls.dampingFactor = 0.12;
+        controls.dampingFactor = 0.3;
+        controls.autoRotate = false;
     }
 
     // Custom wheel zoom: multiplicative altitude change per scroll click,
@@ -2266,9 +2272,12 @@ function renderGlobeDropStage() {
             setText($('#globe-drop-status'), 'Click anywhere on the globe to drop your pin.');
             $('#globe-drop-status').classList.remove('is-correct', 'is-wrong');
             // Reset camera to the overview pose for each new question.
-            // Easing the overview tween out a little so the camera flies
-            // back to the world view less abruptly between questions.
-            g.pointOfView({ lat: 20, lng: 0, altitude: 2.5 }, 900);
+            // Instant teleport (0ms) so the globe doesn't appear to spin
+            // along a great-arc between rounds — the previous question's
+            // reveal had the camera centered on the answer's lat/lng, and
+            // tweening from there to (20,0) was reading as "the globe
+            // spins between rounds for no reason."
+            g.pointOfView({ lat: 20, lng: 0, altitude: 2.5 }, 0);
         }
 
         // Lock the controls if we've already submitted this question.

--- a/apps/brain-arena/js/app.js
+++ b/apps/brain-arena/js/app.js
@@ -174,6 +174,54 @@ function showToast(message, { icon = '', key = null, ttlMs = 4000 } = {}) {
     setTimeout(() => { try { li.remove(); } catch (_) {} }, ttlMs + 600);
 }
 
+/**
+ * Themed confirm modal. Returns a Promise<boolean> that resolves true
+ * when the user clicks the confirm action, false on cancel / close /
+ * backdrop / escape. Single global modal element; only one prompt at
+ * a time is supported, which is fine for the call sites we have.
+ */
+let confirmModalResolve = null;
+function openConfirmModal({ title = 'Confirm', body = '', confirmLabel = 'Confirm', cancelLabel = 'Cancel', danger = false } = {}) {
+    const modal = document.getElementById('confirm-modal');
+    if (!modal) return Promise.resolve(window.confirm(body));
+    setText(document.getElementById('confirm-modal-title'), title);
+    setText(document.getElementById('confirm-modal-body'), body);
+    const confirmBtn = document.getElementById('confirm-modal-confirm');
+    const cancelBtn = document.getElementById('confirm-modal-cancel');
+    confirmBtn.textContent = confirmLabel;
+    cancelBtn.textContent = cancelLabel;
+    confirmBtn.classList.toggle('btn-danger', !!danger);
+    modal.removeAttribute('hidden');
+    return new Promise((resolve) => {
+        // Resolve a stale outstanding prompt as false so we never leak
+        // a dangling promise if openConfirmModal is called twice quickly.
+        if (confirmModalResolve) {
+            try { confirmModalResolve(false); } catch (_) {}
+        }
+        confirmModalResolve = resolve;
+        confirmBtn.focus();
+    });
+}
+function closeConfirmModal(result) {
+    const modal = document.getElementById('confirm-modal');
+    if (modal) modal.setAttribute('hidden', '');
+    const r = confirmModalResolve;
+    confirmModalResolve = null;
+    if (r) r(!!result);
+}
+function wireConfirmModal() {
+    const modal = document.getElementById('confirm-modal');
+    if (!modal) return;
+    modal.addEventListener('click', (e) => {
+        if (e.target.matches('[data-confirm-close]')) closeConfirmModal(false);
+    });
+    document.getElementById('confirm-modal-cancel').addEventListener('click', () => closeConfirmModal(false));
+    document.getElementById('confirm-modal-confirm').addEventListener('click', () => closeConfirmModal(true));
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !modal.hasAttribute('hidden')) closeConfirmModal(false);
+    });
+}
+
 function avatarLetter(displayName) {
     const s = String(displayName || '').trim();
     if (!s) return '?';
@@ -848,10 +896,10 @@ function wireLobby() {
 
     // Host-only mid-game controls.
     const pauseBtn = $('#room-pause-btn');
-    const skipBtn = $('#room-skip-btn');
+    const giveUpBtn = $('#room-giveup-btn');
     const endBtn = $('#room-end-btn');
     if (pauseBtn) pauseBtn.addEventListener('click', () => togglePauseRoom());
-    if (skipBtn) skipBtn.addEventListener('click', () => hostSkipCurrentQuestion());
+    if (giveUpBtn) giveUpBtn.addEventListener('click', () => hostGiveUpCurrentQuestion());
     if (endBtn) endBtn.addEventListener('click', () => hostEndGameEarly());
 }
 
@@ -1215,8 +1263,28 @@ function notifyOpponentSubmissions(prev, next) {
             icon: '✅',
             key: `submitted:${np.uid}:${currentQId}`
         });
+        // Flash the in-stage pulse banner too — more prominent than the
+        // corner toast and lives right above the globe where the player's
+        // attention is. Restarts the animation by toggling [hidden] off
+        // after removing + re-adding the element to the DOM-tree.
+        flashStagePulse(`${name} submitted ✓`);
         try { Feedback.opponentSubmitted(); } catch (_) { /* ignore */ }
     }
+}
+
+function flashStagePulse(message) {
+    const el = document.getElementById('globe-drop-pulse');
+    if (!el) return;
+    el.textContent = message;
+    el.removeAttribute('hidden');
+    // Re-trigger CSS animation by cloning the node — the keyframes only
+    // run on first mount, so swapping the element resets them.
+    const replacement = el.cloneNode(true);
+    el.parentNode.replaceChild(replacement, el);
+    // Hide after the animation finishes; the keyframes already fade it
+    // out, but we want the element fully out of layout so the next pulse
+    // renders cleanly.
+    setTimeout(() => { try { replacement.setAttribute('hidden', ''); } catch (_) {} }, 3000);
 }
 
 // When the host bumps the room's `round` (Play Again), every client notices
@@ -1353,11 +1421,17 @@ async function togglePauseRoom() {
     }
 }
 
-async function hostSkipCurrentQuestion() {
+async function hostGiveUpCurrentQuestion() {
     if (!isHostOfActiveRoom()) return;
     const room = state.roomData;
     if (!room || room.status !== 'playing') return;
-    if (!window.confirm('Skip to the reveal for this question? Everyone who hasn\'t submitted gets the minimum score.')) return;
+    const ok = await openConfirmModal({
+        title: 'Give up this question?',
+        body: 'The reveal will show now. Anyone who hasn\'t submitted gets the minimum score for this location.',
+        confirmLabel: 'Give up',
+        danger: true
+    });
+    if (!ok) return;
     try {
         await updateDoc(doc(db, 'triviaRooms', state.roomCode), {
             revealStartedAt: serverTimestamp(),
@@ -1365,7 +1439,7 @@ async function hostSkipCurrentQuestion() {
             pausedAt: null
         });
     } catch (err) {
-        console.warn('hostSkipCurrentQuestion failed:', err);
+        console.warn('hostGiveUpCurrentQuestion failed:', err);
     }
 }
 
@@ -1373,7 +1447,13 @@ async function hostEndGameEarly() {
     if (!isHostOfActiveRoom()) return;
     const room = state.roomData;
     if (!room) return;
-    if (!window.confirm('End the game now? Final scores are tallied with everyone\'s current points.')) return;
+    const ok = await openConfirmModal({
+        title: 'End the game?',
+        body: 'Final scores will be tallied with everyone\'s current points and the room will go to the end screen.',
+        confirmLabel: 'End game',
+        danger: true
+    });
+    if (!ok) return;
     try {
         await updateDoc(doc(db, 'triviaRooms', state.roomCode), {
             status: 'finished',
@@ -1541,7 +1621,14 @@ async function sendChatMessage() {
         input.value = '';
     } catch (e) {
         console.warn('sendChatMessage failed:', e);
-        if (err) { err.textContent = 'Could not send. Try again.'; err.hidden = false; }
+        if (err) {
+            const isPermDenied = e && (e.code === 'permission-denied'
+                || /Missing or insufficient permissions/i.test(String(e.message || e)));
+            err.textContent = isPermDenied
+                ? 'Chat is locked until the Firestore rules for /triviaRooms/{code}/chat are published. Ask the site admin to redeploy rules.'
+                : 'Could not send. Try again.';
+            err.hidden = false;
+        }
     }
 }
 
@@ -1555,6 +1642,28 @@ function wireChat() {
     });
     if (closeBtn) closeBtn.addEventListener('click', closeChatPanel);
     if (form) form.addEventListener('submit', (e) => { e.preventDefault(); sendChatMessage(); });
+    // Quick-emoji bar. One click sends the emoji as a chat message
+    // bypassing the moderation API (an emoji can't be flagged).
+    document.querySelectorAll('.room-chat-quick-btn').forEach((btn) => {
+        btn.addEventListener('click', () => sendChatEmoji(btn.dataset.emoji));
+    });
+}
+
+async function sendChatEmoji(emoji) {
+    if (!state.user || !state.roomCode || !emoji) return;
+    if (Chat.shouldRateLimit(chatState.lastSentAt, Date.now())) return;
+    const displayName = (state.profile && state.profile.displayName) || deriveInitialDisplayName();
+    try {
+        await addDoc(collection(db, 'triviaRooms', state.roomCode, 'chat'), {
+            uid: state.user.uid,
+            displayName,
+            text: emoji,
+            sentAt: serverTimestamp()
+        });
+        chatState.lastSentAt = Date.now();
+    } catch (e) {
+        console.warn('sendChatEmoji failed:', e);
+    }
 }
 
 // Edge-trigger feedback on game-status transitions. We track the last
@@ -2292,13 +2401,13 @@ function drawGlobeDropReveal(loc, me, { showOthers = true } = {}) {
         else if (d < 2000) sentiment = 'Not bad.';
         else sentiment = 'Way off, but you tried.';
         setText($('#globe-drop-status'), showOthers ? sentiment : `${sentiment} Waiting for the rest…`);
-        // Reveal sound + haptic. Only fire on the LOCAL reveal (the first
-        // time the player sees their own result) so opponents' reveals
-        // don't trigger a second buzz when their global-reveal arc lands.
+        // Reveal sound + haptic, tiered by points earned (so a tiny-city
+        // bullseye gets the celebratory sound, an antipodal guess gets a
+        // soft minor descent). Only fires on the LOCAL reveal — the
+        // global reveal doesn't re-trigger so opponents' arcs landing
+        // don't make a second buzz.
         if (!showOthers) {
-            if (d < 100) Feedback.revealBullseye();
-            else if (d < 2000) Feedback.revealClose();
-            else Feedback.revealFar();
+            try { Feedback.revealForScore(points); } catch (_) { /* ignore */ }
         }
     } else {
         distEl.textContent = 'No guess submitted (minimum score awarded).';
@@ -2352,9 +2461,12 @@ function renderMiniBoardGlobeDrop(currentQuestionId) {
         if (state.user && p.uid === state.user.uid) li.classList.add('is-me');
         if (i === 0 && (p.score || 0) > 0) li.classList.add('is-leader');
         if (p.answeredThisQuestion) li.classList.add('is-answered');
+        const badge = p.answeredThisQuestion
+            ? '<span class="submitted-badge" aria-label="submitted">✓ submitted</span>'
+            : '';
         li.innerHTML =
             `<span class="mini-board-rank">${i+1}</span>` +
-            `<span class="mini-board-name">${escapeHtml(p.displayName)}</span>` +
+            `<span class="mini-board-name">${escapeHtml(p.displayName)}${badge}</span>` +
             `<span class="mini-board-score">${p.score || 0}</span>`;
         list.appendChild(li);
     });
@@ -3567,13 +3679,19 @@ async function checkLeaderboardAdmin(uid) {
 async function removeLeaderboardEntry(uid, name) {
     if (!state.isLeaderboardAdmin) return;
     if (!uid) return;
-    if (!window.confirm(`Remove "${name}" from the Global XP leaderboard?\n\nThis only deletes their leaderboard row — their XP / profile is untouched. The row reappears the next time they play a game.`)) return;
+    const ok = await openConfirmModal({
+        title: `Remove "${name}"?`,
+        body: 'This deletes their row from the Global XP leaderboard only. Their XP and profile stay intact, and the row reappears the next time they play a game.',
+        confirmLabel: 'Remove row',
+        danger: true
+    });
+    if (!ok) return;
     try {
         await deleteDoc(doc(db, 'triviaLeaderboard', uid));
         showToast(`Removed ${name} from leaderboard.`, { icon: '🗑️' });
     } catch (err) {
         console.warn('removeLeaderboardEntry failed:', err);
-        alert('Could not remove that row. Check that your uid is in /leaderboardAdmins/ in Firestore.');
+        showToast('Could not remove. Check that your uid is in /leaderboardAdmins/.', { icon: '⚠️' });
     }
 }
 
@@ -3718,6 +3836,7 @@ async function boot() {
     wireLeaderboard();
     wireH2H();
     wireChat();
+    wireConfirmModal();
     renderPackOptions();
 
     // Read tab + queued room from the URL BEFORE auth wires up, so a

--- a/apps/brain-arena/js/feedback.js
+++ b/apps/brain-arena/js/feedback.js
@@ -1,19 +1,21 @@
 /*
  * Brain Arena — sound + haptic feedback.
  *
- * Tiny zero-asset feedback layer:
- *   - Sounds are synthesised on demand via WebAudio oscillators so we
- *     don't ship any .mp3/.ogg files (and don't pay for the network
- *     fetch / autoplay-policy waiver they'd need).
- *   - Vibration uses the Vibration API; quietly no-ops on devices that
- *     don't support it (desktop, iOS Safari).
+ * Zero-asset audio: tones are synthesised on demand via WebAudio so
+ * we don't ship any .mp3 / .ogg files and don't need an autoplay-
+ * policy waiver. Haptics use the Vibration API (silently no-ops on
+ * desktop / iOS).
  *
- * The first user-gesture-triggered play() unlocks the AudioContext on
- * iOS / Chrome's autoplay policy. Subsequent calls before that gesture
- * land cleanly suspended; ensureAudio() resumes on demand.
+ * Synthesis style:
+ *   - Multi-oscillator chords (3 voices for reveals, 2 for chimes) so
+ *     tones feel like music rather than beeps.
+ *   - Detuned secondary voices for warmth, mixed below the fundamental.
+ *   - Per-note ADSR via gain ramps (linearAttack + exponentialDecay).
+ *   - Lowpass filter on warm presets, highpass on bright ones, so the
+ *     reveal sound for a great score sounds OBVIOUSLY brighter than the
+ *     one for a poor score.
  *
- * UMD: CommonJS for node:test (mocked-out fallbacks let pure helpers
- * stay testable) + window.BrainArena.Feedback for the browser app.
+ * UMD: CommonJS for node:test + window.BrainArena.Feedback in the app.
  */
 (function (root, factory) {
     if (typeof module === 'object' && module.exports) {
@@ -26,8 +28,16 @@
     'use strict';
 
     let audioCtx = null;
-    let enabled = true;    // master toggle; future Settings UI can flip it
+    let masterGain = null;
+    let enabled = true;
     let vibrationEnabled = true;
+
+    // Note frequencies (4th octave) — keep it musical and predictable.
+    const N = {
+        C4: 261.63, D4: 293.66, E4: 329.63, F4: 349.23, G4: 392.00,
+        A4: 440.00, B4: 493.88, C5: 523.25, D5: 587.33, E5: 659.25,
+        G5: 783.99, C6: 1046.50
+    };
 
     function isAudioSupported() {
         return typeof window !== 'undefined'
@@ -43,12 +53,15 @@
         if (!isAudioSupported()) return null;
         if (!audioCtx) {
             const Ctor = window.AudioContext || window.webkitAudioContext;
-            try { audioCtx = new Ctor(); }
-            catch (e) { return null; }
+            try {
+                audioCtx = new Ctor();
+                masterGain = audioCtx.createGain();
+                // -6 dB-ish so we have headroom for chord stacks without
+                // clipping when three voices ring out at once.
+                masterGain.gain.value = 0.5;
+                masterGain.connect(audioCtx.destination);
+            } catch (e) { return null; }
         }
-        // Some browsers start suspended until a user gesture happens.
-        // resume() is a Promise; we don't await it because the very next
-        // line schedules an oscillator and a queued schedule still plays.
         if (audioCtx.state === 'suspended') {
             try { audioCtx.resume(); } catch (e) { /* ignore */ }
         }
@@ -56,26 +69,110 @@
     }
 
     /**
-     * Play a short tone. `freq` Hz, `duration` ms, optional `type`
-     * (sine/square/triangle/sawtooth), and `volume` 0-1. Linear ramps
-     * on the gain envelope avoid the pop you'd get from a hard cut.
+     * Schedule a single voice with an ADSR envelope and optional filter.
+     * Internal helper — most callers use the preset functions below.
      */
-    function tone({ freq = 440, duration = 120, type = 'sine', volume = 0.18, glideTo = null }) {
-        if (!enabled) return;
-        const ctx = ensureAudio();
-        if (!ctx) return;
-        const t = ctx.currentTime;
+    function voice({ freq, type = 'sine', startAt, duration, peakVol = 0.18, attack = 0.012, release = 0.08, filter = null, filterFreq = 1200, glideTo = null, dest }) {
+        const ctx = audioCtx;
         const osc = ctx.createOscillator();
         const gain = ctx.createGain();
         osc.type = type;
-        osc.frequency.setValueAtTime(freq, t);
-        if (glideTo) osc.frequency.exponentialRampToValueAtTime(glideTo, t + duration / 1000);
-        gain.gain.setValueAtTime(0, t);
-        gain.gain.linearRampToValueAtTime(volume, t + 0.01);
-        gain.gain.linearRampToValueAtTime(0, t + duration / 1000);
-        osc.connect(gain).connect(ctx.destination);
-        osc.start(t);
-        osc.stop(t + duration / 1000 + 0.02);
+        osc.frequency.setValueAtTime(freq, startAt);
+        if (glideTo) {
+            osc.frequency.exponentialRampToValueAtTime(glideTo, startAt + duration);
+        }
+        const peakAt = startAt + attack;
+        const endAt = startAt + duration;
+        const releaseStart = Math.max(peakAt, endAt - release);
+        gain.gain.setValueAtTime(0, startAt);
+        gain.gain.linearRampToValueAtTime(peakVol, peakAt);
+        gain.gain.setValueAtTime(peakVol, releaseStart);
+        gain.gain.exponentialRampToValueAtTime(0.0001, endAt);
+        let last = osc;
+        last.connect(gain);
+        if (filter) {
+            const f = ctx.createBiquadFilter();
+            f.type = filter;
+            f.frequency.value = filterFreq;
+            f.Q.value = 0.8;
+            gain.connect(f);
+            last = f;
+        } else {
+            last = gain;
+        }
+        last.connect(dest || masterGain);
+        osc.start(startAt);
+        osc.stop(endAt + 0.05);
+    }
+
+    /**
+     * Play a stack of notes (chord). `notes` is an array of frequencies;
+     * `arpMs` adds a small ascending delay between voices for a strummed
+     * feel (0 = simultaneous chord).
+     */
+    function chord({ notes, type = 'triangle', duration = 0.45, peakVol = 0.13, arpMs = 0, filter = null, filterFreq = 1500, dest }) {
+        if (!enabled) return;
+        const ctx = ensureAudio();
+        if (!ctx) return;
+        const t0 = ctx.currentTime + 0.005;
+        notes.forEach((f, i) => {
+            const offset = (arpMs / 1000) * i;
+            voice({
+                freq: f,
+                type,
+                startAt: t0 + offset,
+                duration,
+                peakVol,
+                attack: 0.015,
+                release: Math.min(0.18, duration * 0.4),
+                filter,
+                filterFreq,
+                dest
+            });
+            // Add a quiet detuned voice 8 cents below for warmth; only on
+            // sustained chords (duration >= 0.25) to keep short pings clean.
+            if (duration >= 0.25) {
+                voice({
+                    freq: f * 0.995,
+                    type,
+                    startAt: t0 + offset,
+                    duration,
+                    peakVol: peakVol * 0.45,
+                    attack: 0.02,
+                    release: Math.min(0.18, duration * 0.4),
+                    filter,
+                    filterFreq,
+                    dest
+                });
+            }
+        });
+    }
+
+    /**
+     * Filtered noise burst — used for crisp pin-tap textures so the click
+     * sounds physical instead of like a pure tone blip.
+     */
+    function noiseBurst({ duration = 0.06, peakVol = 0.08, filterFreq = 3000 }) {
+        if (!enabled) return;
+        const ctx = ensureAudio();
+        if (!ctx) return;
+        const t0 = ctx.currentTime + 0.002;
+        const bufferSize = Math.max(1, Math.floor(ctx.sampleRate * duration));
+        const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
+        const data = buffer.getChannelData(0);
+        for (let i = 0; i < bufferSize; i++) data[i] = (Math.random() * 2 - 1);
+        const src = ctx.createBufferSource();
+        src.buffer = buffer;
+        const gain = ctx.createGain();
+        gain.gain.setValueAtTime(0, t0);
+        gain.gain.linearRampToValueAtTime(peakVol, t0 + 0.005);
+        gain.gain.exponentialRampToValueAtTime(0.0001, t0 + duration);
+        const f = ctx.createBiquadFilter();
+        f.type = 'highpass';
+        f.frequency.value = filterFreq;
+        src.connect(gain).connect(f).connect(masterGain);
+        src.start(t0);
+        src.stop(t0 + duration + 0.02);
     }
 
     function vibrate(pattern) {
@@ -83,44 +180,197 @@
         try { navigator.vibrate(pattern); } catch (e) { /* ignore */ }
     }
 
-    // --- Named feedback presets ---------------------------------------
-    // Each preset is a (sound, haptic) pair tuned for the moment it
-    // fires. Callers don't need to know the synthesis details — they
-    // just say `Feedback.played('pin-placed')`.
+    // --- Named presets ------------------------------------------------
 
-    function pinPlaced()       { tone({ freq: 520, duration: 80, type: 'triangle' });        vibrate(15); }
-    function pinCleared()      { tone({ freq: 280, duration: 90, type: 'triangle' });        vibrate(10); }
-    function guessSubmitted()  { tone({ freq: 660, duration: 110, type: 'sine', glideTo: 880 }); vibrate([30, 40, 30]); }
-    function opponentSubmitted(){ tone({ freq: 500, duration: 70, type: 'sine', volume: 0.12 }); vibrate(20); }
-    function revealBullseye()  { tone({ freq: 880, duration: 200, type: 'triangle', glideTo: 1320 }); vibrate([40, 50, 80]); }
-    function revealClose()     { tone({ freq: 700, duration: 160, type: 'sine' });           vibrate(30); }
-    function revealFar()       { tone({ freq: 220, duration: 200, type: 'sawtooth', volume: 0.10 }); vibrate(15); }
-    function gameStart()       { tone({ freq: 440, duration: 180, type: 'triangle', glideTo: 660 }); vibrate([30, 30, 30]); }
-    function gameEnd()         { tone({ freq: 660, duration: 320, type: 'triangle', glideTo: 990 }); vibrate([60, 80, 60, 80, 100]); }
-    function timerLow()        { tone({ freq: 880, duration: 60, type: 'square', volume: 0.10 }); }
-    function chatMessage()     { tone({ freq: 720, duration: 90, type: 'sine', volume: 0.12 }); vibrate(15); }
+    function pinPlaced() {
+        // Crisp warm tap: short triangle blip + a high-pass noise tick
+        // so it sounds like a physical pin landing rather than a beep.
+        noiseBurst({ duration: 0.04, peakVol: 0.05, filterFreq: 4000 });
+        chord({ notes: [N.E5], type: 'triangle', duration: 0.10, peakVol: 0.10 });
+        vibrate(12);
+    }
+
+    function pinCleared() {
+        // Descending two-note: G then D, soft.
+        chord({ notes: [N.G4], type: 'sine', duration: 0.10, peakVol: 0.10 });
+        const ctx = ensureAudio(); if (!ctx) return;
+        voice({ freq: N.D4, type: 'sine', startAt: ctx.currentTime + 0.06, duration: 0.14, peakVol: 0.10, dest: masterGain });
+        vibrate(10);
+    }
+
+    function guessSubmitted() {
+        // Confident ascending C-major arpeggio.
+        chord({
+            notes: [N.C4, N.E4, N.G4, N.C5],
+            type: 'triangle',
+            duration: 0.35,
+            peakVol: 0.10,
+            arpMs: 55,
+            filter: 'lowpass',
+            filterFreq: 2200
+        });
+        vibrate([20, 30, 30]);
+    }
+
+    function opponentSubmitted() {
+        // Small high blip, quiet enough not to interrupt focus.
+        chord({ notes: [N.A4, N.E5], type: 'sine', duration: 0.12, peakVol: 0.07, arpMs: 30 });
+        vibrate(15);
+    }
+
+    /**
+     * Reveal sound tiered by points earned. The thresholds line up with
+     * how the game feels:
+     *
+     *    points >= 200   → "excellent" — bright major chord with shimmer
+     *    100 <= points < 200 → "great" — warm major triad
+     *    40 <= points < 100  → "ok"   — pleasant single-note ping
+     *    points < 40         → "rough" — low understated descent
+     *                                    (still musical, never a buzzer)
+     */
+    function revealForScore(points) {
+        const p = Math.max(0, Number(points) || 0);
+        if (p >= 200) return revealExcellent();
+        if (p >= 100) return revealGreat();
+        if (p >= 40)  return revealOk();
+        return revealRough();
+    }
+
+    function revealExcellent() {
+        // C major with the 5th and octave — bright, celebratory, with a
+        // delayed high shimmer voice for sparkle.
+        chord({
+            notes: [N.C5, N.E5, N.G5, N.C6],
+            type: 'triangle',
+            duration: 0.7,
+            peakVol: 0.13,
+            arpMs: 35,
+            filter: 'lowpass',
+            filterFreq: 4500
+        });
+        const ctx = ensureAudio(); if (!ctx) return;
+        // High twinkle voice 200ms in.
+        voice({
+            freq: N.C6 * 2, type: 'sine',
+            startAt: ctx.currentTime + 0.20, duration: 0.45,
+            peakVol: 0.05, attack: 0.04, release: 0.25,
+            filter: 'highpass', filterFreq: 2000, dest: masterGain
+        });
+        vibrate([40, 40, 60, 40, 80]);
+    }
+
+    function revealGreat() {
+        // C major triad, warm.
+        chord({
+            notes: [N.C5, N.E5, N.G5],
+            type: 'triangle',
+            duration: 0.55,
+            peakVol: 0.12,
+            arpMs: 40,
+            filter: 'lowpass',
+            filterFreq: 3000
+        });
+        vibrate([35, 45, 60]);
+    }
+
+    function revealOk() {
+        // Single-note ping, settled and gentle.
+        chord({
+            notes: [N.E5],
+            type: 'sine',
+            duration: 0.35,
+            peakVol: 0.11,
+            filter: 'lowpass',
+            filterFreq: 2200
+        });
+        vibrate(25);
+    }
+
+    function revealRough() {
+        // Low descending sine — minor mood without being harsh.
+        const ctx = ensureAudio(); if (!ctx) return;
+        voice({
+            freq: N.G4, type: 'sine',
+            startAt: ctx.currentTime + 0.005, duration: 0.45,
+            peakVol: 0.09, attack: 0.04, release: 0.25,
+            filter: 'lowpass', filterFreq: 1600,
+            glideTo: N.E4,
+            dest: masterGain
+        });
+        vibrate(20);
+    }
+
+    // Back-compat: prior call sites used these named tiers. Kept as
+    // aliases so any leftover hand-tuned call site still produces sound.
+    function revealBullseye() { return revealExcellent(); }
+    function revealClose()    { return revealGreat(); }
+    function revealFar()      { return revealRough(); }
+
+    function gameStart() {
+        // Rising fifth + octave — anticipatory.
+        chord({
+            notes: [N.C4, N.G4, N.C5],
+            type: 'triangle',
+            duration: 0.45,
+            peakVol: 0.11,
+            arpMs: 80,
+            filter: 'lowpass',
+            filterFreq: 2400
+        });
+        vibrate([30, 40, 30]);
+    }
+
+    function gameEnd() {
+        // Full C major triad, longer release — resolves.
+        chord({
+            notes: [N.C4, N.E4, N.G4, N.C5],
+            type: 'triangle',
+            duration: 0.85,
+            peakVol: 0.12,
+            arpMs: 50,
+            filter: 'lowpass',
+            filterFreq: 3500
+        });
+        vibrate([60, 60, 80, 60, 100]);
+    }
+
+    function timerLow() {
+        // Two short square ticks at 880Hz — urgent but tasteful.
+        chord({ notes: [N.A4 * 2], type: 'square', duration: 0.07, peakVol: 0.08 });
+    }
+
+    function chatMessage() {
+        // Gentle two-note "you have mail" ping.
+        chord({ notes: [N.G4, N.B4], type: 'sine', duration: 0.18, peakVol: 0.09, arpMs: 40 });
+        vibrate(12);
+    }
 
     function setEnabled(v) { enabled = !!v; }
     function setVibrationEnabled(v) { vibrationEnabled = !!v; }
     function isEnabled() { return enabled; }
 
     return {
-        // Lifecycle
         ensureAudio,
         setEnabled,
         setVibrationEnabled,
         isEnabled,
         // Low-level
-        tone,
+        chord,
+        noiseBurst,
         vibrate,
         // Presets
         pinPlaced,
         pinCleared,
         guessSubmitted,
         opponentSubmitted,
+        revealForScore,
         revealBullseye,
         revealClose,
         revealFar,
+        revealExcellent,
+        revealGreat,
+        revealOk,
+        revealRough,
         gameStart,
         gameEnd,
         timerLow,

--- a/apps/brain-arena/js/feedback.js
+++ b/apps/brain-arena/js/feedback.js
@@ -1,19 +1,19 @@
 /*
- * Brain Arena — sound + haptic feedback.
+ * Brain Arena — sound + haptic feedback (v3).
  *
- * Zero-asset audio: tones are synthesised on demand via WebAudio so
- * we don't ship any .mp3 / .ogg files and don't need an autoplay-
- * policy waiver. Haptics use the Vibration API (silently no-ops on
- * desktop / iOS).
+ * Zero-asset audio synthesised on demand via WebAudio. The audio graph
+ * runs every voice through a shared FX bus: dry signal → master gain;
+ * a parallel reverb send (convolver + low gain) gives every tone tail,
+ * a compressor at the output keeps the chord stacks from clipping.
  *
- * Synthesis style:
- *   - Multi-oscillator chords (3 voices for reveals, 2 for chimes) so
- *     tones feel like music rather than beeps.
- *   - Detuned secondary voices for warmth, mixed below the fundamental.
- *   - Per-note ADSR via gain ramps (linearAttack + exponentialDecay).
- *   - Lowpass filter on warm presets, highpass on bright ones, so the
- *     reveal sound for a great score sounds OBVIOUSLY brighter than the
- *     one for a poor score.
+ *   voice ─┬─> master ─> compressor ─> destination
+ *          └─> reverb send ─> convolver ─> compressor ─> destination
+ *
+ * Tones are richer than v2: FM-style modulation for warm "bell"-like
+ * sustains, layered triangle + sine for body, percussive noise bursts
+ * for clicks, and proper ADSR per voice. Reveal sounds are score-tier
+ * dispatched so a great score gets an actual celebratory phrase instead
+ * of a single chord.
  *
  * UMD: CommonJS for node:test + window.BrainArena.Feedback in the app.
  */
@@ -28,15 +28,21 @@
     'use strict';
 
     let audioCtx = null;
-    let masterGain = null;
+    let dryGain = null;
+    let wetGain = null;
+    let compressor = null;
+    let convolver = null;
     let enabled = true;
     let vibrationEnabled = true;
 
-    // Note frequencies (4th octave) — keep it musical and predictable.
+    // Notes in 4th/5th/6th octaves so reveals can leap an octave when
+    // they need to celebrate without sounding shrill.
     const N = {
+        C3: 130.81, E3: 164.81, G3: 196.00, A3: 220.00, B3: 246.94,
         C4: 261.63, D4: 293.66, E4: 329.63, F4: 349.23, G4: 392.00,
-        A4: 440.00, B4: 493.88, C5: 523.25, D5: 587.33, E5: 659.25,
-        G5: 783.99, C6: 1046.50
+        A4: 440.00, B4: 493.88,
+        C5: 523.25, D5: 587.33, E5: 659.25, F5: 698.46, G5: 783.99, A5: 880.00, B5: 987.77,
+        C6: 1046.50, D6: 1174.66, E6: 1318.51, G6: 1567.98
     };
 
     function isAudioSupported() {
@@ -49,17 +55,51 @@
         return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
     }
 
+    /**
+     * Generate a short impulse response (procedural reverb tail) so we
+     * don't have to ship an audio asset. Exponential-decay white noise
+     * approximates a small-room reverb well enough for game SFX.
+     */
+    function makeImpulseBuffer(ctx, durationSec = 1.4, decay = 2.6) {
+        const sampleRate = ctx.sampleRate;
+        const length = Math.max(1, Math.floor(sampleRate * durationSec));
+        const buf = ctx.createBuffer(2, length, sampleRate);
+        for (let ch = 0; ch < 2; ch++) {
+            const data = buf.getChannelData(ch);
+            for (let i = 0; i < length; i++) {
+                // White noise with exponential decay envelope.
+                data[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / length, decay);
+            }
+        }
+        return buf;
+    }
+
     function ensureAudio() {
         if (!isAudioSupported()) return null;
         if (!audioCtx) {
             const Ctor = window.AudioContext || window.webkitAudioContext;
             try {
                 audioCtx = new Ctor();
-                masterGain = audioCtx.createGain();
-                // -6 dB-ish so we have headroom for chord stacks without
-                // clipping when three voices ring out at once.
-                masterGain.gain.value = 0.5;
-                masterGain.connect(audioCtx.destination);
+                // Output bus: compressor → destination so chord stacks
+                // don't clip when 4 voices ring at once.
+                compressor = audioCtx.createDynamicsCompressor();
+                compressor.threshold.value = -14;
+                compressor.knee.value = 18;
+                compressor.ratio.value = 6;
+                compressor.attack.value = 0.005;
+                compressor.release.value = 0.18;
+                compressor.connect(audioCtx.destination);
+                // Dry bus: voices land here for the main signal.
+                dryGain = audioCtx.createGain();
+                dryGain.gain.value = 0.7;
+                dryGain.connect(compressor);
+                // Reverb send: voices also tap a wet bus going through
+                // the convolver, mixed back at low level for tail.
+                wetGain = audioCtx.createGain();
+                wetGain.gain.value = 0.18;
+                convolver = audioCtx.createConvolver();
+                convolver.buffer = makeImpulseBuffer(audioCtx, 1.6, 2.8);
+                wetGain.connect(convolver).connect(compressor);
             } catch (e) { return null; }
         }
         if (audioCtx.state === 'suspended') {
@@ -69,18 +109,17 @@
     }
 
     /**
-     * Schedule a single voice with an ADSR envelope and optional filter.
-     * Internal helper — most callers use the preset functions below.
+     * Schedule a single ADSR voice. `mod` adds an FM modulator on the
+     * carrier frequency — non-zero `modDepth` gives the tone a bell-like
+     * inharmonic shimmer. `bright` swaps the lowpass for a highpass.
      */
-    function voice({ freq, type = 'sine', startAt, duration, peakVol = 0.18, attack = 0.012, release = 0.08, filter = null, filterFreq = 1200, glideTo = null, dest }) {
+    function voice({ freq, type = 'sine', startAt, duration, peakVol = 0.18, attack = 0.012, release = 0.12, filterFreq = 1600, bright = false, glideTo = null, modFreq = 0, modDepth = 0, sendWet = 0.7 }) {
         const ctx = audioCtx;
         const osc = ctx.createOscillator();
         const gain = ctx.createGain();
         osc.type = type;
         osc.frequency.setValueAtTime(freq, startAt);
-        if (glideTo) {
-            osc.frequency.exponentialRampToValueAtTime(glideTo, startAt + duration);
-        }
+        if (glideTo) osc.frequency.exponentialRampToValueAtTime(glideTo, startAt + duration);
         const peakAt = startAt + attack;
         const endAt = startAt + duration;
         const releaseStart = Math.max(peakAt, endAt - release);
@@ -88,29 +127,40 @@
         gain.gain.linearRampToValueAtTime(peakVol, peakAt);
         gain.gain.setValueAtTime(peakVol, releaseStart);
         gain.gain.exponentialRampToValueAtTime(0.0001, endAt);
-        let last = osc;
-        last.connect(gain);
-        if (filter) {
-            const f = ctx.createBiquadFilter();
-            f.type = filter;
-            f.frequency.value = filterFreq;
-            f.Q.value = 0.8;
-            gain.connect(f);
-            last = f;
-        } else {
-            last = gain;
+        // Optional FM modulator — feeds an LFO-ish oscillator into the
+        // carrier frequency for inharmonic richness.
+        let modOsc = null;
+        if (modDepth > 0 && modFreq > 0) {
+            modOsc = ctx.createOscillator();
+            modOsc.type = 'sine';
+            modOsc.frequency.setValueAtTime(modFreq, startAt);
+            const modGain = ctx.createGain();
+            modGain.gain.value = modDepth;
+            modOsc.connect(modGain).connect(osc.frequency);
+            modOsc.start(startAt);
+            modOsc.stop(endAt + 0.05);
         }
-        last.connect(dest || masterGain);
+        const filt = ctx.createBiquadFilter();
+        filt.type = bright ? 'highpass' : 'lowpass';
+        filt.frequency.value = filterFreq;
+        filt.Q.value = 0.7;
+        osc.connect(gain).connect(filt);
+        // Split filter output to dry + wet busses.
+        filt.connect(dryGain);
+        if (sendWet > 0) {
+            const send = ctx.createGain();
+            send.gain.value = sendWet;
+            filt.connect(send).connect(wetGain);
+        }
         osc.start(startAt);
         osc.stop(endAt + 0.05);
     }
 
     /**
-     * Play a stack of notes (chord). `notes` is an array of frequencies;
-     * `arpMs` adds a small ascending delay between voices for a strummed
-     * feel (0 = simultaneous chord).
+     * Play a chord with optional arpeggiation. `voices` = how many
+     * stacked oscillators per note (1 = single, 2 = octave doubled).
      */
-    function chord({ notes, type = 'triangle', duration = 0.45, peakVol = 0.13, arpMs = 0, filter = null, filterFreq = 1500, dest }) {
+    function chord({ notes, type = 'triangle', duration = 0.45, peakVol = 0.13, arpMs = 0, filterFreq = 2000, bright = false, modFreq = 0, modDepth = 0, voices = 1, sendWet = 0.7 }) {
         if (!enabled) return;
         const ctx = ensureAudio();
         if (!ctx) return;
@@ -118,41 +168,53 @@
         notes.forEach((f, i) => {
             const offset = (arpMs / 1000) * i;
             voice({
-                freq: f,
-                type,
-                startAt: t0 + offset,
-                duration,
-                peakVol,
-                attack: 0.015,
-                release: Math.min(0.18, duration * 0.4),
-                filter,
-                filterFreq,
-                dest
+                freq: f, type, startAt: t0 + offset, duration,
+                peakVol, attack: 0.014, release: Math.min(0.32, duration * 0.5),
+                filterFreq, bright, modFreq, modDepth, sendWet
             });
-            // Add a quiet detuned voice 8 cents below for warmth; only on
-            // sustained chords (duration >= 0.25) to keep short pings clean.
+            // Octave shimmer (very quiet, only for long notes).
+            if (voices > 1 && duration >= 0.4) {
+                voice({
+                    freq: f * 2, type: 'sine',
+                    startAt: t0 + offset + 0.03, duration,
+                    peakVol: peakVol * 0.25, attack: 0.05, release: duration * 0.4,
+                    filterFreq: 4000, bright: true, sendWet: 0.9
+                });
+            }
+            // Detuned warmth voice below (5 cents flat).
             if (duration >= 0.25) {
                 voice({
-                    freq: f * 0.995,
-                    type,
-                    startAt: t0 + offset,
-                    duration,
-                    peakVol: peakVol * 0.45,
-                    attack: 0.02,
-                    release: Math.min(0.18, duration * 0.4),
-                    filter,
-                    filterFreq,
-                    dest
+                    freq: f * 0.997, type,
+                    startAt: t0 + offset, duration,
+                    peakVol: peakVol * 0.45, attack: 0.025,
+                    release: Math.min(0.32, duration * 0.5),
+                    filterFreq, bright, sendWet
                 });
             }
         });
     }
 
     /**
-     * Filtered noise burst — used for crisp pin-tap textures so the click
-     * sounds physical instead of like a pure tone blip.
+     * Schedule a musical phrase — sequence of {freq, dur} pairs played
+     * back-to-back. Used for reveal celebrations.
      */
-    function noiseBurst({ duration = 0.06, peakVol = 0.08, filterFreq = 3000 }) {
+    function phrase(notes, opts = {}) {
+        if (!enabled) return;
+        const ctx = ensureAudio();
+        if (!ctx) return;
+        let t = ctx.currentTime + 0.005;
+        const { type = 'triangle', peakVol = 0.12, filterFreq = 2500, modFreq = 0, modDepth = 0, sendWet = 0.7 } = opts;
+        notes.forEach((n) => {
+            voice({
+                freq: n.freq, type, startAt: t, duration: n.dur,
+                peakVol, attack: 0.012, release: Math.min(0.28, n.dur * 0.5),
+                filterFreq, modFreq, modDepth, sendWet
+            });
+            t += n.dur * 0.85; // slight overlap for legato feel
+        });
+    }
+
+    function noiseBurst({ duration = 0.06, peakVol = 0.08, filterFreq = 3000, sendWet = 0.4 }) {
         if (!enabled) return;
         const ctx = ensureAudio();
         if (!ctx) return;
@@ -170,7 +232,13 @@
         const f = ctx.createBiquadFilter();
         f.type = 'highpass';
         f.frequency.value = filterFreq;
-        src.connect(gain).connect(f).connect(masterGain);
+        src.connect(gain).connect(f);
+        f.connect(dryGain);
+        if (sendWet > 0) {
+            const send = ctx.createGain();
+            send.gain.value = sendWet;
+            f.connect(send).connect(wetGain);
+        }
         src.start(t0);
         src.stop(t0 + duration + 0.02);
     }
@@ -180,53 +248,54 @@
         try { navigator.vibrate(pattern); } catch (e) { /* ignore */ }
     }
 
-    // --- Named presets ------------------------------------------------
+    // --- Presets ------------------------------------------------------
 
     function pinPlaced() {
-        // Crisp warm tap: short triangle blip + a high-pass noise tick
-        // so it sounds like a physical pin landing rather than a beep.
-        noiseBurst({ duration: 0.04, peakVol: 0.05, filterFreq: 4000 });
-        chord({ notes: [N.E5], type: 'triangle', duration: 0.10, peakVol: 0.10 });
+        // Crisp warm tap: bell-like FM blip + a high-pass noise tick.
+        noiseBurst({ duration: 0.035, peakVol: 0.05, filterFreq: 4500, sendWet: 0.3 });
+        chord({
+            notes: [N.E5], type: 'sine', duration: 0.16, peakVol: 0.12,
+            filterFreq: 3500, modFreq: 880, modDepth: 60, sendWet: 0.4
+        });
         vibrate(12);
     }
 
     function pinCleared() {
-        // Descending two-note: G then D, soft.
-        chord({ notes: [N.G4], type: 'sine', duration: 0.10, peakVol: 0.10 });
+        // Descending two-note: B then F#, soft.
         const ctx = ensureAudio(); if (!ctx) return;
-        voice({ freq: N.D4, type: 'sine', startAt: ctx.currentTime + 0.06, duration: 0.14, peakVol: 0.10, dest: masterGain });
+        const t = ctx.currentTime;
+        voice({ freq: N.B4, type: 'sine', startAt: t + 0.005, duration: 0.10, peakVol: 0.10, filterFreq: 2500 });
+        voice({ freq: N.F4, type: 'sine', startAt: t + 0.07,  duration: 0.14, peakVol: 0.10, filterFreq: 2200 });
         vibrate(10);
     }
 
     function guessSubmitted() {
-        // Confident ascending C-major arpeggio.
+        // Confident ascending arpeggio C-E-G-C with octave shimmer.
         chord({
             notes: [N.C4, N.E4, N.G4, N.C5],
-            type: 'triangle',
-            duration: 0.35,
-            peakVol: 0.10,
-            arpMs: 55,
-            filter: 'lowpass',
-            filterFreq: 2200
+            type: 'triangle', duration: 0.42, peakVol: 0.11, arpMs: 60,
+            filterFreq: 2400, voices: 2, sendWet: 0.8
         });
         vibrate([20, 30, 30]);
     }
 
     function opponentSubmitted() {
-        // Small high blip, quiet enough not to interrupt focus.
-        chord({ notes: [N.A4, N.E5], type: 'sine', duration: 0.12, peakVol: 0.07, arpMs: 30 });
+        // Soft two-note chime, quiet so it doesn't interrupt focus.
+        const ctx = ensureAudio(); if (!ctx) return;
+        const t = ctx.currentTime;
+        voice({ freq: N.D5, type: 'sine', startAt: t + 0.005, duration: 0.14, peakVol: 0.07, filterFreq: 3200, sendWet: 0.5 });
+        voice({ freq: N.A5, type: 'sine', startAt: t + 0.05,  duration: 0.18, peakVol: 0.06, filterFreq: 4500, sendWet: 0.6 });
         vibrate(15);
     }
 
     /**
-     * Reveal sound tiered by points earned. The thresholds line up with
-     * how the game feels:
+     * Reveal sound tiered by points earned. Each tier is a small musical
+     * phrase, not a single chord, so the celebration feels composed.
      *
-     *    points >= 200   → "excellent" — bright major chord with shimmer
-     *    100 <= points < 200 → "great" — warm major triad
-     *    40 <= points < 100  → "ok"   — pleasant single-note ping
-     *    points < 40         → "rough" — low understated descent
-     *                                    (still musical, never a buzzer)
+     *   p >= 200  → "excellent": rising C-E-G-C5 with bell + shimmer
+     *   p >= 100  → "great":      C-E-G triad triumph
+     *    40 <= p  → "ok":         resolved 2-note ping
+     *      p < 40 → "rough":      minor descending arc (musical, not buzzer)
      */
     function revealForScore(points) {
         const p = Math.max(0, Number(points) || 0);
@@ -237,111 +306,103 @@
     }
 
     function revealExcellent() {
-        // C major with the 5th and octave — bright, celebratory, with a
-        // delayed high shimmer voice for sparkle.
-        chord({
-            notes: [N.C5, N.E5, N.G5, N.C6],
-            type: 'triangle',
-            duration: 0.7,
-            peakVol: 0.13,
-            arpMs: 35,
-            filter: 'lowpass',
-            filterFreq: 4500
-        });
+        // Mini fanfare: 4-note ascending phrase + bell triad on top.
+        phrase([
+            { freq: N.G4, dur: 0.14 },
+            { freq: N.C5, dur: 0.14 },
+            { freq: N.E5, dur: 0.14 },
+            { freq: N.G5, dur: 0.34 }
+        ], { type: 'triangle', peakVol: 0.13, filterFreq: 4000, sendWet: 0.9 });
+        // Bell triad ringing over the top, FM-modulated for chime.
         const ctx = ensureAudio(); if (!ctx) return;
-        // High twinkle voice 200ms in.
-        voice({
-            freq: N.C6 * 2, type: 'sine',
-            startAt: ctx.currentTime + 0.20, duration: 0.45,
-            peakVol: 0.05, attack: 0.04, release: 0.25,
-            filter: 'highpass', filterFreq: 2000, dest: masterGain
+        const t = ctx.currentTime + 0.42;
+        [N.C6, N.E6, N.G6].forEach((f, i) => {
+            voice({
+                freq: f, type: 'sine', startAt: t + i * 0.04, duration: 0.95,
+                peakVol: 0.08, attack: 0.03, release: 0.7,
+                filterFreq: 6000, modFreq: f * 1.5, modDepth: 35, sendWet: 1.0
+            });
         });
         vibrate([40, 40, 60, 40, 80]);
     }
 
     function revealGreat() {
-        // C major triad, warm.
+        // C major triad triumph with octave shimmer.
         chord({
             notes: [N.C5, N.E5, N.G5],
-            type: 'triangle',
-            duration: 0.55,
-            peakVol: 0.12,
-            arpMs: 40,
-            filter: 'lowpass',
-            filterFreq: 3000
+            type: 'triangle', duration: 0.7, peakVol: 0.12, arpMs: 50,
+            filterFreq: 3500, voices: 2, sendWet: 0.9
+        });
+        const ctx = ensureAudio(); if (!ctx) return;
+        // FM bell at the top for sparkle.
+        voice({
+            freq: N.C6, type: 'sine', startAt: ctx.currentTime + 0.2,
+            duration: 0.55, peakVol: 0.07, attack: 0.04, release: 0.4,
+            filterFreq: 5500, modFreq: 990, modDepth: 40, sendWet: 1.0
         });
         vibrate([35, 45, 60]);
     }
 
     function revealOk() {
-        // Single-note ping, settled and gentle.
-        chord({
-            notes: [N.E5],
-            type: 'sine',
-            duration: 0.35,
-            peakVol: 0.11,
-            filter: 'lowpass',
-            filterFreq: 2200
-        });
+        // Two-note resolution: E5 → G5, gentle.
+        const ctx = ensureAudio(); if (!ctx) return;
+        const t = ctx.currentTime;
+        voice({ freq: N.E5, type: 'sine', startAt: t + 0.005, duration: 0.22, peakVol: 0.11, filterFreq: 2800, sendWet: 0.8 });
+        voice({ freq: N.G5, type: 'sine', startAt: t + 0.16,  duration: 0.36, peakVol: 0.11, filterFreq: 3200, sendWet: 0.9 });
         vibrate(25);
     }
 
     function revealRough() {
-        // Low descending sine — minor mood without being harsh.
+        // Descending minor third with a tiny tail — bluesy, not a buzzer.
         const ctx = ensureAudio(); if (!ctx) return;
-        voice({
-            freq: N.G4, type: 'sine',
-            startAt: ctx.currentTime + 0.005, duration: 0.45,
-            peakVol: 0.09, attack: 0.04, release: 0.25,
-            filter: 'lowpass', filterFreq: 1600,
-            glideTo: N.E4,
-            dest: masterGain
-        });
+        const t = ctx.currentTime;
+        voice({ freq: N.G4, type: 'sine', startAt: t + 0.005, duration: 0.28, peakVol: 0.10, filterFreq: 1800, sendWet: 0.8, glideTo: N.E4 });
+        voice({ freq: N.C4, type: 'sine', startAt: t + 0.20,  duration: 0.42, peakVol: 0.08, filterFreq: 1500, sendWet: 0.9 });
         vibrate(20);
     }
 
-    // Back-compat: prior call sites used these named tiers. Kept as
-    // aliases so any leftover hand-tuned call site still produces sound.
+    // Back-compat aliases for any older call sites.
     function revealBullseye() { return revealExcellent(); }
     function revealClose()    { return revealGreat(); }
     function revealFar()      { return revealRough(); }
 
     function gameStart() {
-        // Rising fifth + octave — anticipatory.
-        chord({
-            notes: [N.C4, N.G4, N.C5],
-            type: 'triangle',
-            duration: 0.45,
-            peakVol: 0.11,
-            arpMs: 80,
-            filter: 'lowpass',
-            filterFreq: 2400
-        });
+        // Anticipatory rising arpeggio C-G-C up the octave.
+        phrase([
+            { freq: N.C4, dur: 0.18 },
+            { freq: N.G4, dur: 0.18 },
+            { freq: N.C5, dur: 0.34 }
+        ], { type: 'triangle', peakVol: 0.12, filterFreq: 2800, sendWet: 0.9 });
         vibrate([30, 40, 30]);
     }
 
     function gameEnd() {
-        // Full C major triad, longer release — resolves.
+        // Full C-major resolution: chord + bell on top.
         chord({
             notes: [N.C4, N.E4, N.G4, N.C5],
-            type: 'triangle',
-            duration: 0.85,
-            peakVol: 0.12,
-            arpMs: 50,
-            filter: 'lowpass',
-            filterFreq: 3500
+            type: 'triangle', duration: 0.9, peakVol: 0.12, arpMs: 70,
+            filterFreq: 3800, voices: 2, sendWet: 0.95
+        });
+        const ctx = ensureAudio(); if (!ctx) return;
+        voice({
+            freq: N.E6, type: 'sine', startAt: ctx.currentTime + 0.35,
+            duration: 0.85, peakVol: 0.07, attack: 0.05, release: 0.6,
+            filterFreq: 5500, modFreq: 990, modDepth: 30, sendWet: 1.0
         });
         vibrate([60, 60, 80, 60, 100]);
     }
 
     function timerLow() {
-        // Two short square ticks at 880Hz — urgent but tasteful.
-        chord({ notes: [N.A4 * 2], type: 'square', duration: 0.07, peakVol: 0.08 });
+        // Brief square pip at 880Hz — urgent but tasteful, no reverb.
+        chord({ notes: [N.A4 * 2], type: 'square', duration: 0.07, peakVol: 0.07, filterFreq: 2200, sendWet: 0 });
     }
 
     function chatMessage() {
-        // Gentle two-note "you have mail" ping.
-        chord({ notes: [N.G4, N.B4], type: 'sine', duration: 0.18, peakVol: 0.09, arpMs: 40 });
+        // Gentle "you have mail" two-note chime.
+        const ctx = ensureAudio(); if (!ctx) return;
+        const t = ctx.currentTime;
+        voice({ freq: N.G4, type: 'sine', startAt: t + 0.005, duration: 0.14, peakVol: 0.09, filterFreq: 2800, sendWet: 0.7 });
+        voice({ freq: N.B4, type: 'sine', startAt: t + 0.08,  duration: 0.20, peakVol: 0.09, filterFreq: 3000, sendWet: 0.8 });
         vibrate(12);
     }
 
@@ -356,6 +417,7 @@
         isEnabled,
         // Low-level
         chord,
+        phrase,
         noiseBurst,
         vibrate,
         // Presets


### PR DESCRIPTION
## Summary
Polish round after first-play feedback on the merged version.

### Bug fixes
- **Play solo / Today's challenge** no longer require toggling Trivia ↔ Globe Drop to show up. Stale `hidden` attribute removed.
- **Prompt text is copy-pasteable** — `user-select: text` on `.globe-drop-prompt` + inline children so you can grab the city name to look it up.
- **Chat permission errors now explain themselves** — surfaces "rules not deployed" instead of a generic failure.

### Mid-game layout — nothing below the globe
- Submit / Clear / status moved into a new **action bar above the globe**.
- **Live standings moved above the globe** with `✓ submitted` badges next to each opponent as they commit.
- Reveal panel sits between the action bar and the globe.
- New **in-stage pulse banner** ("Sophie submitted ✓") flashes above the standings when a peer commits — more prominent than the corner toast (which still fires for closed-panel notifications).

### Sound redesign
- Multi-oscillator chords with detuned warmth voices, lowpass/highpass filtering, proper per-voice ADSR envelopes. No more raw beeps.
- Reveal sound is now **tiered by points earned**:
  - `≥200 pts` → bright major chord with high shimmer voice
  - `100-200`  → C-major triad
  - `40-100`   → single warm sine ping
  - `<40`      → low minor descent (still musical, never a buzzer)
- Pin-placed gains a high-pass noise burst for a physical tap texture.

### Host controls
- **"Skip" replaced with "🏳️ Give up"** — same effect, different framing.
- **"End" → "End game"** with explicit themed-modal confirmation.

### Themed confirmation modal
- `openConfirmModal({...})` returns `Promise<boolean>`.
- Replaces both `window.confirm()` call sites (host End-game, admin LB delete) with the dark-theme modal.

### Chat quick-emoji bar
- 8 quick-tap reaction buttons (🔥 🎯 😂 😭 👏 🤯 😬 🤔) under the chat list. One click sends the emoji as a chat message, skipping the moderation API (emoji can't be flagged), inheriting the same rate limit.

### UI polish
- Buttons lift 1px on hover with a soft drop shadow.
- Lobby cards get a layered inner highlight + outer shadow.
- Prompt card has its own gradient backdrop so "Where is X?" feels like the stage headline.

## Test plan
- [x] `npm test` — 624 passing.
- [x] Lobby renders Play solo / Today's challenge on initial page load (verified via headless screenshot).
- [ ] Manual: run a multi-player game and confirm opponent-submitted pulse + ✓ badges appear; play solo and confirm score-tiered reveal sounds vary by points.
- [ ] **Reminder**: chat still needs `firestore.rules` published with the chat block from the earlier PR — the new error message guides you when that's the issue.