### PR TITLE
feat(rising-seasons): drop the 100-vote build floor

### DIFF
--- a/apps/rising-seasons/DATA_README.md
+++ b/apps/rising-seasons/DATA_README.md
@@ -82,10 +82,8 @@ gh run watch
 {
   "builtAt": "2026-05-11T18:24:00.000Z",
   "minEpisodes": 3,                                       // build-time threshold
-  "minVotes": 100,                                        // build-time threshold
-  "relaxedGenres": ["Reality-TV", "Game-Show", "Talk-Show"], // genres that get the lower floor below
-  "relaxedMinVotes": 10,                                  // per-episode vote floor for relaxed-genre series
-  "count": 16510,                                         // total matching seasons
+  "minVotes": 5,                                          // build-time threshold
+  "count": 64877,                                         // total matching seasons
   "shapeCounts": {
     "rollercoaster": 3551, "big-finale": 2999, "rebound": 2783,
     "mid-peak": 1105, "bad-finale": 1041, "slow-burn": 873,
@@ -183,19 +181,19 @@ Notes:
 
 `build-data.js` accepts these env vars:
 
-| Var               | Default                              | Effect                                                                                            |
-| ----------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `MIN_EPISODES`    | `3`                                  | Skip seasons with fewer rated episodes                                                            |
-| `MIN_VOTES`       | `100`                                | Every episode must have ≥ this many votes                                                         |
-| `RELAX_GENRES`    | `Reality-TV,Game-Show,Talk-Show`     | Series tagged with any of these IMDb genres use the relaxed floor below                           |
-| `RELAX_MIN_VOTES` | `10`                                 | Per-episode vote floor for relaxed-genre series (reality episodes rarely clear 100 votes on IMDb) |
+| Var            | Default | Effect                                    |
+| -------------- | ------- | ----------------------------------------- |
+| `MIN_EPISODES` | `3`     | Skip seasons with fewer rated episodes    |
+| `MIN_VOTES`    | `5`     | Every episode must have ≥ this many votes |
 
-The browser UI applies its own (typically stricter) defaults on top, so
-build wide and let users narrow in the UI.
+The vote floor is deliberately low so older shows, foreign series, reality
+TV, and short-run formats are not filtered out at build time. The browser
+UI exposes its own minimum-votes filter and popularity sort, so build wide
+and let users narrow in the UI.
 
 ## Repo size considerations
 
-`data.json` is ~26 MB after both enrichment passes (posters + providers).
+`data.json` is ~85 MB after both enrichment passes (posters + providers).
 Weekly commits will grow git history by roughly a few MB/week (most fields
 are stable; only ratings, votes, and counts change). If history bloat
 becomes an issue, options:

--- a/apps/rising-seasons/README.md
+++ b/apps/rising-seasons/README.md
@@ -94,14 +94,12 @@ The app degrades gracefully without each layer:
 
 Pass via env vars to `build-data.js`:
 
-| Var               | Default                              | Meaning                                                                                            |
-| ----------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| `MIN_EPISODES`    | `3`                                  | Skip seasons with fewer rated episodes                                                             |
-| `MIN_VOTES`       | `100`                                | Every episode must have at least this many votes                                                   |
-| `RELAX_GENRES`    | `Reality-TV,Game-Show,Talk-Show`     | Series tagged with any of these genres use the lower floor below                                   |
-| `RELAX_MIN_VOTES` | `10`                                 | Per-episode vote floor for relaxed-genre series (reality episodes rarely clear 100 votes on IMDb)  |
+| Var            | Default | Meaning                                          |
+| -------------- | ------- | ------------------------------------------------ |
+| `MIN_EPISODES` | `3`     | Skip seasons with fewer rated episodes           |
+| `MIN_VOTES`    | `5`     | Every episode must have at least this many votes |
 
-The browser UI applies its own (stricter) defaults on top, so building wide and filtering narrow in the UI is the easy path.
+The default vote floor is deliberately low — IMDb's per-episode vote counts can be tiny for older shows, foreign series, reality TV, and short-run formats, and a high floor at build time wipes them out. The browser UI exposes its own minimum-votes filter and a popularity-sorted view, so building wide and filtering narrow in the UI is the easy path.
 
 ## Viewing locally
 

--- a/apps/rising-seasons/scripts/build-data.js
+++ b/apps/rising-seasons/scripts/build-data.js
@@ -18,13 +18,11 @@
 // Output: apps/rising-seasons/data.json
 //
 // Tunables (env vars):
-//   MIN_EPISODES     (default 4)   — minimum rated episodes per season
-//   MIN_VOTES        (default 100) — every episode must have at least this many votes
-//   RELAX_GENRES     (default "Reality-TV,Game-Show,Talk-Show") — comma-list of
-//                                    IMDb genres whose series get the lower floor below
-//   RELAX_MIN_VOTES  (default 10)  — per-episode vote floor for the relaxed-genre series.
-//                                    Reality/competition episodes typically draw 10-50
-//                                    IMDb votes, so the standard 100 wipes them out.
+//   MIN_EPISODES     (default 3)  — minimum rated episodes per season
+//   MIN_VOTES        (default 5)  — every episode must have at least this many votes.
+//                                   Set low so reality, foreign, and short-run shows are
+//                                   not filtered out at build time. The browser UI exposes
+//                                   its own (stricter) vote and popularity filters on top.
 
 const fs = require('fs');
 const path = require('path');
@@ -42,12 +40,7 @@ const TMDB_CACHE = path.join(DATA_DIR, 'tmdb-cache.json');
 // short seasons will be emitted as shape-less rows under the parent show
 // rather than appearing as their own pattern hits.
 const MIN_EPISODES = parseInt(process.env.MIN_EPISODES || '3', 10);
-const MIN_VOTES = parseInt(process.env.MIN_VOTES || '100', 10);
-const RELAX_GENRES = (process.env.RELAX_GENRES ?? 'Reality-TV,Game-Show,Talk-Show')
-  .split(',')
-  .map((s) => s.trim())
-  .filter(Boolean);
-const RELAX_MIN_VOTES = parseInt(process.env.RELAX_MIN_VOTES || '10', 10);
+const MIN_VOTES = parseInt(process.env.MIN_VOTES || '5', 10);
 const SERIES_TYPES = new Set(['tvSeries', 'tvMiniSeries']);
 
 function openTsv(filename) {
@@ -232,8 +225,6 @@ function loadTmdbCache() {
   const matches = findMatches(series, episodes, {
     minEpisodes: MIN_EPISODES,
     minVotes: MIN_VOTES,
-    relaxedGenres: new Set(RELAX_GENRES),
-    relaxedMinVotes: RELAX_MIN_VOTES,
   });
   const shapedCount = matches.reduce((n, m) => n + (m.shapes.length > 0 ? 1 : 0), 0);
   console.log(`${matches.length.toLocaleString()} seasons (${shapedCount.toLocaleString()} with at least one shape)`);
@@ -344,8 +335,6 @@ function loadTmdbCache() {
     builtAt: new Date().toISOString(),
     minEpisodes: MIN_EPISODES,
     minVotes: MIN_VOTES,
-    relaxedGenres: RELAX_GENRES,
-    relaxedMinVotes: RELAX_MIN_VOTES,
     count: matches.length,
     shapeCounts,
     genres,

--- a/apps/rising-seasons/scripts/match.js
+++ b/apps/rising-seasons/scripts/match.js
@@ -192,32 +192,18 @@ function detectShapes(episodes) {
 //
 // Filters:
 //   minEpisodes — skip seasons with fewer rated episodes than this.
-//   minVotes    — every episode must have at least this many votes (low-vote
-//                 ratings are noisy and not meaningful).
-//   relaxedGenres / relaxedMinVotes — apply a lower per-episode vote floor
-//                 when the series is tagged with any of these genres.
-//                 Reality/competition shows get a fraction of the per-episode
-//                 votes scripted shows do, so the standard floor wipes them
-//                 out entirely; a relaxed floor lets them surface.
+//   minVotes    — every episode must have at least this many votes. The
+//                 default is intentionally low; the browser UI applies its
+//                 own (stricter) vote and popularity filters on top.
 function findMatches(seriesById, episodesBySeries, opts = {}) {
   const minEpisodes = opts.minEpisodes ?? 4;
-  const minVotes = opts.minVotes ?? 100;
-  const relaxedGenres = opts.relaxedGenres instanceof Set
-    ? opts.relaxedGenres
-    : new Set(opts.relaxedGenres || []);
-  const relaxedMinVotes = opts.relaxedMinVotes ?? minVotes;
+  const minVotes = opts.minVotes ?? 5;
 
   const seasons = []; // { seriesId, season, eps, shapes, minSeasonVotes }
 
   for (const [seriesId, bySeason] of episodesBySeries) {
     const meta = seriesById.get(seriesId);
     if (!meta) continue;
-    let floor = minVotes;
-    if (relaxedGenres.size > 0 && meta.genres) {
-      for (const g of meta.genres) {
-        if (relaxedGenres.has(g)) { floor = relaxedMinVotes; break; }
-      }
-    }
     for (const [season, eps] of bySeason) {
       if (eps.length < minEpisodes) continue;
       eps.sort((a, b) => a.episode - b.episode);
@@ -226,7 +212,7 @@ function findMatches(seriesById, episodesBySeries, opts = {}) {
       for (const e of eps) {
         if (e.votes < minSeasonVotes) minSeasonVotes = e.votes;
       }
-      if (minSeasonVotes < floor) continue;
+      if (minSeasonVotes < minVotes) continue;
 
       const shapes = detectShapes(eps);
       seasons.push({ seriesId, season, eps, shapes, minSeasonVotes });

--- a/apps/rising-seasons/tests/match.test.js
+++ b/apps/rising-seasons/tests/match.test.js
@@ -308,40 +308,6 @@ test('findMatches drops seasons whose lowest-vote episode is under minVotes', ()
   assert.equal(findMatches(series, episodes, { minVotes: 25 }).length, 1);
 });
 
-test('findMatches applies relaxedMinVotes only to series in relaxedGenres', () => {
-  const series = new Map([
-    ['ttReal',   { title: 'Cook-Off',  year: 2020, type: 'tvSeries', genres: ['Reality-TV'] }],
-    ['ttDrama',  { title: 'Big Drama', year: 2020, type: 'tvSeries', genres: ['Drama'] }],
-  ]);
-  // Both seasons have a low-vote episode (15) — well below the standard 100.
-  const episodes = new Map([
-    ['ttReal',  new Map([[1, [ep(1, 7.0, 15), ep(2, 7.2, 5000), ep(3, 7.4, 5000), ep(4, 7.5, 5000)]]])],
-    ['ttDrama', new Map([[1, [ep(1, 7.0, 15), ep(2, 7.2, 5000), ep(3, 7.4, 5000), ep(4, 7.5, 5000)]]])],
-  ]);
-  const matches = findMatches(series, episodes, {
-    minVotes: 100,
-    relaxedGenres: new Set(['Reality-TV']),
-    relaxedMinVotes: 10,
-  });
-  assert.equal(matches.length, 1);
-  assert.equal(matches[0].seriesId, 'ttReal');
-});
-
-test('findMatches accepts relaxedGenres as an array', () => {
-  const series = new Map([
-    ['ttGame', { title: 'Quiz Show', year: 2021, type: 'tvSeries', genres: ['Game-Show'] }],
-  ]);
-  const episodes = new Map([
-    ['ttGame', new Map([[1, [ep(1, 7.0, 20), ep(2, 7.2, 20), ep(3, 7.4, 20), ep(4, 7.5, 20)]]])],
-  ]);
-  const matches = findMatches(series, episodes, {
-    minVotes: 100,
-    relaxedGenres: ['Game-Show'],
-    relaxedMinVotes: 10,
-  });
-  assert.equal(matches.length, 1);
-});
-
 test('findMatches skips series missing from the metadata map', () => {
   const series = new Map();
   const episodes = new Map([


### PR DESCRIPTION
## Summary
- Lower default `MIN_VOTES` from 100 to 5 and drop `RELAX_GENRES` / `RELAX_MIN_VOTES` entirely from `build-data.js` and `match.js`.
- ~48k previously-excluded seasons now surface in `data.json` (**16,575 → 64,877**). IMDb's own ratings dump already excludes titles with very few votes, so a `MIN_VOTES=5` floor is effectively "no floor."
- Updated `README.md`, `DATA_README.md`, and `tests/match.test.js` (dropped the two RELAX-specific tests).

## Why
**Married... with Children S1** (and a long tail of similar shows) was being filtered out at build time. IMDb attaches an unaired-pilot entry as S1E0 with 77 votes, which dragged the whole season below the 100-vote floor under the old `every-episode-must-clear-floor` rule. Many other older / foreign / reality / short-run seasons hit the same trap. The UI already has its own minimum-votes filter and popularity sort, so the build can hand it the full IMDb catalog and let users narrow client-side.

## Test plan
- [x] `npm test` — 668/668 passing on this branch.
- [x] `npm run build:rising-seasons` — completes in ~26s, writes 64,877 seasons.
- [x] Confirm `Married... with Children S1` appears in `data.json` (all 11 seasons now present, was 10).
- [ ] Smoke-test the live site after deploy: load time, shape-chip counts, popularity sort.

## Size note
`data.json` grows from ~29 MB to ~86 MB. GitHub warns about files over 50 MB but does not block the push; Netlify will still serve it. If size becomes a concern, the `DATA_README.md` "Repo size considerations" section lists options (orphan data branch, build at deploy, Git LFS).