### PR TITLE
feat(rising-seasons): smarter search, modal y-axis, ep-0 flag, new shape, perf

### DIFF
--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -697,17 +697,6 @@ body.rising-seasons-app button {
   text-overflow: ellipsis;
 }
 
-.search-suggestion .ss-ep-hint {
-  display: block;
-  font-size: 0.72rem;
-  color: var(--accent);
-  font-style: italic;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-top: 0.1rem;
-}
-
 .search-suggestion mark {
   background: transparent;
   color: var(--accent);
@@ -1286,12 +1275,40 @@ body.rising-seasons-app button {
 }
 
 .poster-fallback {
+  --poster-hue: 220;
   position: absolute;
   inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem;
   background:
-    radial-gradient(circle at 30% 30%, rgba(245, 197, 24, 0.18), transparent 60%),
-    radial-gradient(circle at 70% 70%, rgba(74, 222, 128, 0.12), transparent 60%),
+    radial-gradient(circle at 30% 25%, hsl(var(--poster-hue) 70% 45% / 0.55), transparent 65%),
+    radial-gradient(circle at 70% 75%, hsl(calc(var(--poster-hue) + 60) 70% 35% / 0.4), transparent 65%),
     var(--surface-2);
+}
+.poster-fallback-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: rgba(255, 255, 255, 0.92);
+  text-align: center;
+  letter-spacing: -0.01em;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+}
+/* Big modal-poster context — larger title text so it doesn't look lost */
+.modal-poster .poster-fallback-title {
+  font-size: 1.05rem;
+  -webkit-line-clamp: 5;
+}
+/* Compact row-poster context — smaller title */
+.row-poster .poster-fallback-title {
+  font-size: 0.72rem;
+  padding: 0.35rem;
 }
 
 .card-body {
@@ -1782,6 +1799,22 @@ button.shape-tag.is-clickable:hover {
 .curve-dots circle {
   fill: var(--accent);
   cursor: help;
+}
+.curve-dots circle.special-ep {
+  fill: #c084fc;
+  stroke: rgba(255, 255, 255, 0.7);
+  stroke-width: 1;
+}
+.curve-axis .axis-grid {
+  stroke: rgba(255, 255, 255, 0.08);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+.curve-axis .axis-label {
+  fill: var(--muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 }
 
 .modal-curve {
@@ -2408,6 +2441,13 @@ button.shape-tag.is-clickable:hover {
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+.modal-episodes li.ep-special {
+  border-color: rgba(192, 132, 252, 0.4);
+  background: rgba(192, 132, 252, 0.06);
+}
+.modal-episodes li.ep-special .ep-number {
+  color: #c084fc;
 }
 .modal-episodes .ep-name {
   color: var(--text);

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -676,6 +676,24 @@ body.rising-seasons-app button {
   display: block;
 }
 
+/* Same hash-based tint as the card/modal poster placeholder, scaled to
+   the dropdown's 32×48 slot. A single initial sits centered. */
+.search-suggestion .ss-poster.ss-poster-fallback {
+  --poster-hue: 220;
+  background:
+    radial-gradient(circle at 30% 25%, hsl(var(--poster-hue) 70% 45% / 0.7), transparent 70%),
+    radial-gradient(circle at 70% 75%, hsl(calc(var(--poster-hue) + 60) 70% 35% / 0.55), transparent 70%),
+    var(--surface-2);
+}
+.search-suggestion .ss-poster-initial {
+  font-size: 1rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.95);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+}
+
 .search-suggestion .ss-text {
   display: flex;
   flex-direction: column;

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -697,6 +697,17 @@ body.rising-seasons-app button {
   text-overflow: ellipsis;
 }
 
+.search-suggestion .ss-ep-hint {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--accent);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 0.1rem;
+}
+
 .search-suggestion mark {
   background: transparent;
   color: var(--accent);

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -499,9 +499,17 @@ body.rising-seasons-app button {
 
 .shape-chip:disabled,
 .shape-chip.is-disabled {
-  opacity: 0.3;
+  /* Muted but still legible — 0.3 read as "broken element" on mobile
+     next to brighter siblings. */
+  opacity: 0.5;
   cursor: not-allowed;
   pointer-events: none;
+}
+.shape-chip.is-disabled .shape-count {
+  /* Zero-count badges look mid-render on disabled chips. Drop the
+     pill background so the disabled state reads as "no hits in this
+     filter combo," not as a partial render. */
+  background: transparent;
 }
 
 /* ---------- Filter toolbar ---------- */
@@ -1839,11 +1847,34 @@ button.shape-tag.is-clickable:hover {
   stroke-width: 1;
   vector-effect: non-scaling-stroke;
 }
-.curve-axis .axis-label {
-  fill: var(--muted);
-  font-size: 10px;
+/* Y-axis labels live in HTML (not SVG) so the SVG's preserveAspectRatio="none"
+   doesn't horizontally squish the glyphs. The wrapper sits over the SVG,
+   labels are positioned by percentage of the SVG's height. */
+.curve-with-axis {
+  position: relative;
+}
+.curve-with-axis > svg {
+  display: block;
+}
+.curve-axis-labels {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+.curve-axis-labels .axis-label {
+  position: absolute;
+  /* padXLeft (36) / W (600) = 6% of the SVG's display width. The label's
+     right edge sits just inside that — matching where the gridline begins
+     regardless of how wide the modal becomes. */
+  right: calc(100% - 5%);
+  transform: translateY(-50%);
+  padding-right: 4px;
+  font-size: 11px;
+  color: var(--muted);
   font-variant-numeric: tabular-nums;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  white-space: nowrap;
 }
 
 .modal-curve {

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -69,7 +69,7 @@
       "Shape-based season classification (rising, consistent, slow-burn, big-finale, rebound, front-loaded, declining, bad-finale, rollercoaster, mid-peak)",
       "Episode-by-episode rating curves",
       "Filter by genre, year, episode count, votes, and watched status",
-      "Search by show title or IMDb ID",
+      "Search by show title, episode name, or IMDb ID",
       "Above-IMDb filter — shows whose episode avg exceeds the show's IMDb score",
       "Show-level view with all seasons and aggregate stats",
       "Best-season highlight per show",
@@ -188,15 +188,15 @@
       <div class="filter-row primary">
         <div class="search">
           <label>
-            <span class="visually-hidden">Search title or IMDb ID</span>
+            <span class="visually-hidden">Search title, episode, or IMDb ID</span>
             <input type="search" id="search"
-                   placeholder="Search title or IMDb ID — press / to focus"
+                   placeholder="Search title, episode, or IMDb ID — press / to focus"
                    autocomplete="off"
                    role="combobox"
                    aria-expanded="false"
                    aria-autocomplete="list"
                    aria-controls="searchSuggestions"
-                   aria-label="Search title or IMDb ID">
+                   aria-label="Search title, episode, or IMDb ID">
           </label>
           <ul id="searchSuggestions" class="search-suggestions" role="listbox" hidden></ul>
         </div>

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -176,6 +176,12 @@
         <span class="shape-desc">Climaxes mid-season, falls after</span>
         <span class="shape-count" data-count="mid-peak"></span>
       </button>
+      <button class="shape-chip" data-shape="u-shaped" aria-pressed="false" type="button">
+        <span class="shape-icon" aria-hidden="true">∪</span>
+        <span class="shape-name">U-shaped</span>
+        <span class="shape-desc">Strong opener and finale, sag in the middle</span>
+        <span class="shape-count" data-count="u-shaped"></span>
+      </button>
     </nav>
 
     <section class="filters" aria-label="Filters">

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -216,6 +216,17 @@ function populatePosterFallback(el, title) {
   el.appendChild(label);
 }
 
+// First meaningful character of the title — skips leading articles
+// ("The X-Files" → "X", "A Quiet Place" → "Q") and falls back to the
+// raw first char. Used by the suggestion dropdown where the full title
+// won't fit in the 32×48 px poster slot.
+function posterInitial(title) {
+  if (!title) return '?';
+  const cleaned = title.replace(/^(the|a|an)\s+/i, '').trim();
+  const ch = (cleaned || title).charAt(0);
+  return ch.toUpperCase() || '?';
+}
+
 // --- search normalization ---
 // "The X-Files" → "the x files", "Married... with Children" → "married with children".
 // Lets a typed query of "the x files" or "married with children" match titles
@@ -2555,6 +2566,15 @@ function renderSuggestionItems() {
       img.alt = '';
       img.loading = 'lazy';
       poster.appendChild(img);
+    } else {
+      // Tinted initial placeholder — small enough that the full title
+      // doesn't fit, so we show a single distinguishing character.
+      poster.classList.add('ss-poster-fallback');
+      poster.style.setProperty('--poster-hue', String(hashHue(s.title || 'unknown')));
+      const initial = document.createElement('span');
+      initial.className = 'ss-poster-initial';
+      initial.textContent = posterInitial(s.title);
+      poster.appendChild(initial);
     }
 
     const text = document.createElement('div');

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -794,7 +794,16 @@ function buildNonShapeChecker() {
       // "The X-Files"). IMDb-ID match stays plain since IDs are alnum.
       const titleHit = qNorm.length > 0 && m.titleSearch.includes(qNorm);
       const idHit = m.seriesId.toLowerCase().includes(q);
-      if (!titleHit && !idHit) return false;
+      // Episode-title fallback — only run when the cheaper title/id checks
+      // missed, since this scans every episode in the season. Gated at
+      // q.length >= 3 so single-character noise queries don't iterate.
+      let epHit = false;
+      if (!titleHit && !idHit && q.length >= 3) {
+        for (const ep of m.episodes) {
+          if (ep.name && ep.name.toLowerCase().includes(q)) { epHit = true; break; }
+        }
+      }
+      if (!titleHit && !idHit && !epHit) return false;
     }
     if (wantLanguages.size && (!m.language || !wantLanguages.has(m.language))) {
       return false;
@@ -2459,23 +2468,52 @@ function computeSuggestions(rawQuery) {
   const titleStarts = [];
   const titleContains = [];
   const idMatches = [];
+  const matchedIds = new Set();
   for (const s of seriesIndex) {
     const idL = s.seriesId.toLowerCase();
     const titleN = s.titleSearch;
     if (titleN === qNorm || idL === q || idL === `tt${q}`) {
-      exact.push(s);
+      exact.push(s); matchedIds.add(s.seriesId);
     } else if (qNorm && titleN.startsWith(qNorm)) {
-      titleStarts.push(s);
+      titleStarts.push(s); matchedIds.add(s.seriesId);
     } else if (qNorm && titleN.includes(qNorm)) {
-      titleContains.push(s);
+      titleContains.push(s); matchedIds.add(s.seriesId);
     } else if (idL.includes(q)) {
-      idMatches.push(s);
+      idMatches.push(s); matchedIds.add(s.seriesId);
     }
     if (exact.length + titleStarts.length + titleContains.length + idMatches.length >= MAX_SUGGESTIONS * 4) {
       break;
     }
   }
-  return [...exact, ...titleStarts, ...titleContains, ...idMatches].slice(0, MAX_SUGGESTIONS);
+  // Episode-name fallback: if the title pass didn't fill the dropdown and
+  // the query is specific (>= 3 chars), surface series whose episode list
+  // contains the query (e.g. "Gray Matter" → Breaking Bad).
+  const epHits = [];
+  const titleHits = exact.length + titleStarts.length + titleContains.length + idMatches.length;
+  if (q.length >= 3 && titleHits < MAX_SUGGESTIONS) {
+    const seriesById = new Map(seriesIndex.map((s) => [s.seriesId, s]));
+    const seen = new Set();
+    for (const m of dataset.matches) {
+      if (matchedIds.has(m.seriesId) || seen.has(m.seriesId)) continue;
+      for (const ep of m.episodes) {
+        if (ep.name && ep.name.toLowerCase().includes(q)) {
+          seen.add(m.seriesId);
+          const base = seriesById.get(m.seriesId);
+          if (base) {
+            epHits.push({
+              ...base,
+              episodeMatch: ep.name,
+              episodeSeason: m.season,
+              episodeNumber: ep.episode,
+            });
+          }
+          break;
+        }
+      }
+      if (epHits.length + titleHits >= MAX_SUGGESTIONS * 2) break;
+    }
+  }
+  return [...exact, ...titleStarts, ...titleContains, ...idMatches, ...epHits].slice(0, MAX_SUGGESTIONS);
 }
 
 function highlightFragment(text, q) {
@@ -2533,6 +2571,16 @@ function renderSuggestionItems() {
 
     text.append(title, meta);
 
+    // If this match came from an episode-name hit, append a small line
+    // explaining which episode caused the match — so the user understands
+    // why Breaking Bad shows up when they typed "Gray Matter".
+    if (s.episodeMatch) {
+      const epHint = document.createElement('span');
+      epHint.className = 'ss-ep-hint';
+      epHint.appendChild(document.createTextNode(`S${s.episodeSeason}E${s.episodeNumber} · `));
+      for (const node of highlightFragment(s.episodeMatch, q)) epHint.appendChild(node);
+      text.appendChild(epHint);
+    }
     li.append(poster, text);
 
     li.addEventListener('mousedown', (e) => e.preventDefault());

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -1553,14 +1553,20 @@ function drawCurve(svg, episodes, W, H, opts) {
 // Draw IMDb-rating gridlines + labels along the left edge of a curve SVG.
 // 5 evenly-spaced ticks across the actual [lo, hi] range — snapped to 0.1
 // (IMDb's own precision) so the labels read like real rating values.
+//
+// Gridlines render inside the SVG (horizontal lines can safely stretch
+// under preserveAspectRatio="none"). Labels are placed as HTML in a sibling
+// overlay so they're never horizontally squished by the SVG's non-uniform
+// scale — that's what caused "9.3" to read as "0.3" before.
 function drawYAxis(svg, lo, hi, padXLeft, padXRight, padY, W, H) {
   const NS = 'http://www.w3.org/2000/svg';
-  // Reuse or create the axis group; clear previous contents.
+  const labelsEl = ensureAxisLabelContainer(svg);
+  while (labelsEl.firstChild) labelsEl.removeChild(labelsEl.firstChild);
+
   let group = svg.querySelector('.curve-axis');
   if (!group) {
     group = document.createElementNS(NS, 'g');
     group.setAttribute('class', 'curve-axis');
-    // Insert before .curve-area so the area/line draw over the gridlines.
     svg.insertBefore(group, svg.firstChild);
   } else {
     while (group.firstChild) group.removeChild(group.firstChild);
@@ -1576,6 +1582,7 @@ function drawYAxis(svg, lo, hi, padXLeft, padXRight, padY, W, H) {
     const v = lo + (span * i) / (ticks - 1);
     const y = plotTop + (1 - (v - lo) / span) * (plotBottom - plotTop);
 
+    // Gridline — SVG, free to stretch.
     const line = document.createElementNS(NS, 'line');
     line.setAttribute('x1', padXLeft);
     line.setAttribute('x2', plotRight);
@@ -1584,14 +1591,38 @@ function drawYAxis(svg, lo, hi, padXLeft, padXRight, padY, W, H) {
     line.setAttribute('class', 'axis-grid');
     group.appendChild(line);
 
-    const label = document.createElementNS(NS, 'text');
-    label.setAttribute('x', padXLeft - 6);
-    label.setAttribute('y', (y + 3.5).toFixed(1));
-    label.setAttribute('class', 'axis-label');
-    label.setAttribute('text-anchor', 'end');
+    // Label — HTML, positioned by percentage so SVG scaling doesn't
+    // distort the glyphs.
+    const yPct = (y / H * 100).toFixed(2);
+    const label = document.createElement('span');
+    label.className = 'axis-label';
+    label.style.top = yPct + '%';
     label.textContent = v.toFixed(1);
-    group.appendChild(label);
+    labelsEl.appendChild(label);
   }
+}
+
+// Wrap an axis-bearing SVG in a positioned container the first time we
+// draw on it, so the HTML axis labels can layer over the SVG without being
+// stretched by the SVG's non-uniform scale.
+function ensureAxisLabelContainer(svg) {
+  if (svg.parentElement && svg.parentElement.classList.contains('curve-with-axis')) {
+    let labels = svg.parentElement.querySelector('.curve-axis-labels');
+    if (!labels) {
+      labels = document.createElement('div');
+      labels.className = 'curve-axis-labels';
+      svg.parentElement.appendChild(labels);
+    }
+    return labels;
+  }
+  const wrap = document.createElement('div');
+  wrap.className = 'curve-with-axis';
+  svg.parentNode.insertBefore(wrap, svg);
+  wrap.appendChild(svg);
+  const labels = document.createElement('div');
+  labels.className = 'curve-axis-labels';
+  wrap.appendChild(labels);
+  return labels;
 }
 
 // Picks a visually distinct stroke color per season. HSL spread across the

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -11,6 +11,7 @@ const SHAPE_LABELS = {
   'bad-finale': 'Bad finale',
   rollercoaster: 'Rollercoaster',
   'mid-peak': 'Mid-peak',
+  'u-shaped': 'U-shaped',
   'saved-best-for-last': 'Saved best for last',
 };
 
@@ -194,6 +195,36 @@ function debounce(fn, ms) {
   };
 }
 
+// --- poster placeholder ---
+// 80% of series in the dataset have no TMDB poster (the build's TMDB
+// enrichment is incremental and the catalog is huge), so the placeholder
+// has to do real work. Render the show title prominently and tint the
+// background by a stable hash of the title so a given show is always the
+// same color across cards/modals.
+function hashHue(s) {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return Math.abs(h) % 360;
+}
+function populatePosterFallback(el, title) {
+  if (!el || el.dataset.populated === '1') return;
+  el.dataset.populated = '1';
+  el.style.setProperty('--poster-hue', String(hashHue(title || 'unknown')));
+  const label = document.createElement('span');
+  label.className = 'poster-fallback-title';
+  label.textContent = title || '?';
+  el.appendChild(label);
+}
+
+// --- search normalization ---
+// "The X-Files" → "the x files", "Married... with Children" → "married with children".
+// Lets a typed query of "the x files" or "married with children" match titles
+// whose punctuation differs from how the user types it. Same form is applied
+// to query and to each indexed title before substring-matching.
+function normalizeSearch(s) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
 // --- localStorage helpers ---
 
 const Watched = {
@@ -285,6 +316,11 @@ async function load() {
   } catch (err) {
     showError(err);
     return;
+  }
+  // Precompute normalized title once per match so the search hot path doesn't
+  // re-derive it on every filter pass. [[normalizeSearch]] for the rule.
+  for (const m of dataset.matches) {
+    m.titleSearch = normalizeSearch(m.title);
   }
   loadChangelog();
   Watched.load();
@@ -392,6 +428,7 @@ function buildSeriesIndex() {
       entry = {
         seriesId: m.seriesId,
         title: m.title,
+        titleSearch: m.titleSearch,
         year: m.year || null,
         poster: m.poster || null,
       };
@@ -564,6 +601,16 @@ function updateShapeChipCounts() {
   const baseNoShape = dataset.matches.filter(passesNonShape);
   const currentResults = baseNoShape.filter(m => passesShapeAnd(m, state.shapes));
 
+  // Tally per-shape hits in a single pass instead of one pass per chip —
+  // a season's shapes[] is short (typically 0-3), so this is roughly
+  // currentResults * 1.5 work versus currentResults * 11 work before.
+  const shapeCounts = Object.create(null);
+  for (const m of currentResults) {
+    for (const s of m.shapes) {
+      shapeCounts[s] = (shapeCounts[s] || 0) + 1;
+    }
+  }
+
   for (const btn of els.shapes.querySelectorAll('.shape-chip')) {
     const shape = btn.dataset.shape;
     const span = btn.querySelector('[data-count]');
@@ -575,15 +622,7 @@ function updateShapeChipCounts() {
       continue;
     }
 
-    let n;
-    if (state.shapes.has(shape)) {
-      // Active: every result already has this shape, so n == result total.
-      n = currentResults.length;
-    } else {
-      // Inactive: how many current results would survive adding this filter.
-      n = 0;
-      for (const m of currentResults) if (m.shapes.includes(shape)) n++;
-    }
+    const n = state.shapes.has(shape) ? currentResults.length : (shapeCounts[shape] || 0);
     if (span) span.textContent = n.toLocaleString();
 
     // Disable an inactive chip that would drive results to zero. Active
@@ -716,7 +755,9 @@ function renderLanguageChips() {
 // --- filter + sort ---
 
 function buildNonShapeChecker() {
-  const q = state.search.trim().toLowerCase();
+  const qRaw = state.search.trim();
+  const q = qRaw.toLowerCase();
+  const qNorm = normalizeSearch(qRaw);
   const minEps = state.minEpisodes;
   const maxEps = state.maxEpisodes;
   const minVotes = state.minVotes;
@@ -748,17 +789,12 @@ function buildNonShapeChecker() {
       // user edits the search input.
       if (m.seriesId !== state.lockedSeriesId) return false;
     } else if (q) {
-      const titleHit = m.title.toLowerCase().includes(q);
+      // Title match runs on normalized form so punctuation/whitespace
+      // differences don't block a match (e.g. "the x files" matches
+      // "The X-Files"). IMDb-ID match stays plain since IDs are alnum.
+      const titleHit = qNorm.length > 0 && m.titleSearch.includes(qNorm);
       const idHit = m.seriesId.toLowerCase().includes(q);
-      let epHit = false;
-      // Episode-title fallback — only run when the cheaper title/id checks
-      // missed, since this scans every episode in the season.
-      if (!titleHit && !idHit && q.length >= 3) {
-        for (const ep of m.episodes) {
-          if (ep.name && ep.name.toLowerCase().includes(q)) { epHit = true; break; }
-        }
-      }
-      if (!titleHit && !idHit && !epHit) return false;
+      if (!titleHit && !idHit) return false;
     }
     if (wantLanguages.size && (!m.language || !wantLanguages.has(m.language))) {
       return false;
@@ -1330,6 +1366,8 @@ function buildCard(m) {
     img.alt = `${m.title} poster`;
     img.loading = 'lazy';
     posterEl.appendChild(img);
+  } else {
+    populatePosterFallback(posterEl.querySelector('.poster-fallback'), m.title);
   }
 
   applyWatchedState(node, node.querySelector('.watch-toggle'), m);
@@ -1396,6 +1434,8 @@ function buildRow(m) {
     img.alt = `${m.title} poster`;
     img.loading = 'lazy';
     posterEl.appendChild(img);
+  } else {
+    populatePosterFallback(posterEl.querySelector('.poster-fallback'), m.title);
   }
 
   applyWatchedState(node, node.querySelector('.watch-toggle'), m);
@@ -1436,23 +1476,30 @@ function onToggleWatched(m, cardOrRow) {
 
 // --- curve drawing (shared) ---
 
-function drawCurve(svg, episodes, W, H, padXOverride) {
+function drawCurve(svg, episodes, W, H, opts) {
   // Charts with hover dots need a small inset so the dots don't get
   // clipped at the viewport edge. Sparklines without dots (the list-view
   // row and the show-modal per-season mini-spark) pass padX=0 so the
   // line/fill plot literally edge-to-edge — symmetric by construction,
   // no perceived left-bias from a 2-6 px gap on the left.
-  const padX = typeof padXOverride === 'number' ? padXOverride : 4;
+  // Backward-compat: a numeric 5th arg is treated as padX.
+  if (typeof opts === 'number') opts = { padX: opts };
+  opts = opts || {};
+  const showAxis = opts.showAxis === true;
+  const defaultPad = showAxis ? 4 : 4;
+  const padX = typeof opts.padX === 'number' ? opts.padX : defaultPad;
+  const padXLeft = showAxis ? 36 : padX;
+  const padXRight = padX;
   const padY = 6;
   const ratings = episodes.map((e) => e.rating);
   const lo = Math.max(0, Math.min(...ratings) - 0.3);
   const hi = Math.min(10, Math.max(...ratings) + 0.3);
   const span = Math.max(0.1, hi - lo);
   const n = episodes.length;
-  const xStep = n > 1 ? (W - padX * 2) / (n - 1) : 0;
+  const xStep = n > 1 ? (W - padXLeft - padXRight) / (n - 1) : 0;
 
   const points = episodes.map((e, i) => {
-    const x = padX + (n > 1 ? i * xStep : (W - padX * 2) / 2);
+    const x = padXLeft + (n > 1 ? i * xStep : (W - padXLeft - padXRight) / 2);
     const y = padY + (1 - (e.rating - lo) / span) * (H - padY * 2);
     return [x, y];
   });
@@ -1463,6 +1510,8 @@ function drawCurve(svg, episodes, W, H, padXOverride) {
   svg.querySelector('.curve-line').setAttribute('d', linePath);
   svg.querySelector('.curve-area').setAttribute('d', areaPath);
 
+  if (showAxis) drawYAxis(svg, lo, hi, padXLeft, padXRight, padY, W, H);
+
   const dots = svg.querySelector('.curve-dots');
   if (dots) {
     dots.replaceChildren();
@@ -1471,11 +1520,57 @@ function drawCurve(svg, episodes, W, H, padXOverride) {
       c.setAttribute('cx', points[i][0].toFixed(1));
       c.setAttribute('cy', points[i][1].toFixed(1));
       c.setAttribute('r', H > 100 ? '4' : '2.5');
+      if (episodes[i].episode === 0) c.classList.add('special-ep');
       const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
-      title.textContent = `Ep ${episodes[i].episode}: ${episodes[i].rating.toFixed(1)} · ${episodes[i].votes.toLocaleString()} votes`;
+      const epLabel = episodes[i].episode === 0 ? 'Ep 0 (pre-season special)' : `Ep ${episodes[i].episode}`;
+      title.textContent = `${epLabel}: ${episodes[i].rating.toFixed(1)} · ${episodes[i].votes.toLocaleString()} votes`;
       c.appendChild(title);
       dots.appendChild(c);
     }
+  }
+}
+
+// Draw IMDb-rating gridlines + labels along the left edge of a curve SVG.
+// 5 evenly-spaced ticks across the actual [lo, hi] range — snapped to 0.1
+// (IMDb's own precision) so the labels read like real rating values.
+function drawYAxis(svg, lo, hi, padXLeft, padXRight, padY, W, H) {
+  const NS = 'http://www.w3.org/2000/svg';
+  // Reuse or create the axis group; clear previous contents.
+  let group = svg.querySelector('.curve-axis');
+  if (!group) {
+    group = document.createElementNS(NS, 'g');
+    group.setAttribute('class', 'curve-axis');
+    // Insert before .curve-area so the area/line draw over the gridlines.
+    svg.insertBefore(group, svg.firstChild);
+  } else {
+    while (group.firstChild) group.removeChild(group.firstChild);
+  }
+
+  const span = Math.max(0.1, hi - lo);
+  const ticks = 5;
+  const plotTop = padY;
+  const plotBottom = H - padY;
+  const plotRight = W - padXRight;
+
+  for (let i = 0; i < ticks; i++) {
+    const v = lo + (span * i) / (ticks - 1);
+    const y = plotTop + (1 - (v - lo) / span) * (plotBottom - plotTop);
+
+    const line = document.createElementNS(NS, 'line');
+    line.setAttribute('x1', padXLeft);
+    line.setAttribute('x2', plotRight);
+    line.setAttribute('y1', y.toFixed(1));
+    line.setAttribute('y2', y.toFixed(1));
+    line.setAttribute('class', 'axis-grid');
+    group.appendChild(line);
+
+    const label = document.createElementNS(NS, 'text');
+    label.setAttribute('x', padXLeft - 6);
+    label.setAttribute('y', (y + 3.5).toFixed(1));
+    label.setAttribute('class', 'axis-label');
+    label.setAttribute('text-anchor', 'end');
+    label.textContent = v.toFixed(1);
+    group.appendChild(label);
   }
 }
 
@@ -1491,7 +1586,8 @@ function seasonColor(i, total) {
 // 0..1 (episode index / season length) so seasons of different lengths align.
 // Y range spans the global min/max across all seasons (slightly padded).
 function drawSeasonOverlay(svg, seasons, W, H) {
-  const padX = 10;
+  const padXLeft = 36;
+  const padXRight = 10;
   const padY = 12;
   // Wipe previous content — this SVG is reused across openShowModal calls.
   while (svg.firstChild) svg.removeChild(svg.firstChild);
@@ -1506,15 +1602,18 @@ function drawSeasonOverlay(svg, seasons, W, H) {
   hi = Math.min(10, hi + 0.3);
   const span = Math.max(0.1, hi - lo);
 
+  // Axis first so the season curves draw on top of the gridlines.
+  drawYAxis(svg, lo, hi, padXLeft, padXRight, padY, W, H);
+
   const NS = 'http://www.w3.org/2000/svg';
   const colors = [];
   seasons.forEach((s, idx) => {
     const color = seasonColor(idx, seasons.length);
     colors.push({ season: s.season, color });
     const n = s.episodes.length;
-    const xStep = n > 1 ? (W - padX * 2) / (n - 1) : 0;
+    const xStep = n > 1 ? (W - padXLeft - padXRight) / (n - 1) : 0;
     const points = s.episodes.map((e, i) => {
-      const x = padX + (n > 1 ? i * xStep : (W - padX * 2) / 2);
+      const x = padXLeft + (n > 1 ? i * xStep : (W - padXLeft - padXRight) / 2);
       const y = padY + (1 - (e.rating - lo) / span) * (H - padY * 2);
       return [x, y];
     });
@@ -1767,18 +1866,28 @@ function openModal(m, opts = {}) {
   } else {
     const fallback = document.createElement('div');
     fallback.className = 'poster-fallback';
+    populatePosterFallback(fallback, m.title);
     els.modalPoster.appendChild(fallback);
   }
 
-  drawCurve(els.modalCurve, m.episodes, 600, 180);
+  drawCurve(els.modalCurve, m.episodes, 600, 180, { showAxis: true });
 
   const epFrag = document.createDocumentFragment();
   for (const e of m.episodes) {
     const li = document.createElement('li');
+    // IMDb tags pre-season specials, unaired pilots, and Christmas episodes
+    // as ep 0 of a given season. Flag them so the curve isn't read as a
+    // weak cold open from a regular ep 1.
+    if (e.episode === 0) li.classList.add('ep-special');
 
     const num = document.createElement('span');
     num.className = 'ep-number';
-    num.textContent = `Ep ${e.episode}`;
+    if (e.episode === 0) {
+      num.textContent = '★ Ep 0';
+      num.title = 'Pre-season special (IMDb episode 0)';
+    } else {
+      num.textContent = `Ep ${e.episode}`;
+    }
 
     // Episode title — populated by build-data.js from IMDb's
     // title.basics.tsv. Falls back to empty (hidden via CSS) when the
@@ -1954,6 +2063,7 @@ function openShowModal(seriesId) {
   } else {
     const fb = document.createElement('div');
     fb.className = 'poster-fallback';
+    populatePosterFallback(fb, meta.title);
     els.showModalPoster.appendChild(fb);
   }
 
@@ -2344,56 +2454,28 @@ function jumpToSeason(item) {
 function computeSuggestions(rawQuery) {
   const q = rawQuery.trim().toLowerCase();
   if (!q) return [];
+  const qNorm = normalizeSearch(rawQuery);
   const exact = [];
   const titleStarts = [];
   const titleContains = [];
   const idMatches = [];
-  const matchedIds = new Set();
   for (const s of seriesIndex) {
-    const titleL = s.title.toLowerCase();
     const idL = s.seriesId.toLowerCase();
-    if (titleL === q || idL === q || idL === `tt${q}`) {
-      exact.push(s); matchedIds.add(s.seriesId);
-    } else if (titleL.startsWith(q)) {
-      titleStarts.push(s); matchedIds.add(s.seriesId);
-    } else if (titleL.includes(q)) {
-      titleContains.push(s); matchedIds.add(s.seriesId);
+    const titleN = s.titleSearch;
+    if (titleN === qNorm || idL === q || idL === `tt${q}`) {
+      exact.push(s);
+    } else if (qNorm && titleN.startsWith(qNorm)) {
+      titleStarts.push(s);
+    } else if (qNorm && titleN.includes(qNorm)) {
+      titleContains.push(s);
     } else if (idL.includes(q)) {
-      idMatches.push(s); matchedIds.add(s.seriesId);
+      idMatches.push(s);
     }
     if (exact.length + titleStarts.length + titleContains.length + idMatches.length >= MAX_SUGGESTIONS * 4) {
       break;
     }
   }
-  // Episode-name fallback: if the title pass didn't fill the dropdown and
-  // the query is specific (>= 3 chars), surface series whose episode list
-  // contains the query (e.g. "Gray Matter" → Breaking Bad).
-  const epHits = [];
-  const titleHits = exact.length + titleStarts.length + titleContains.length + idMatches.length;
-  if (q.length >= 3 && titleHits < MAX_SUGGESTIONS) {
-    const seriesById = new Map(seriesIndex.map((s) => [s.seriesId, s]));
-    const seen = new Set();
-    for (const m of dataset.matches) {
-      if (matchedIds.has(m.seriesId) || seen.has(m.seriesId)) continue;
-      for (const ep of m.episodes) {
-        if (ep.name && ep.name.toLowerCase().includes(q)) {
-          seen.add(m.seriesId);
-          const base = seriesById.get(m.seriesId);
-          if (base) {
-            epHits.push({
-              ...base,
-              episodeMatch: ep.name,
-              episodeSeason: m.season,
-              episodeNumber: ep.episode,
-            });
-          }
-          break;
-        }
-      }
-      if (epHits.length + titleHits >= MAX_SUGGESTIONS * 2) break;
-    }
-  }
-  return [...exact, ...titleStarts, ...titleContains, ...idMatches, ...epHits].slice(0, MAX_SUGGESTIONS);
+  return [...exact, ...titleStarts, ...titleContains, ...idMatches].slice(0, MAX_SUGGESTIONS);
 }
 
 function highlightFragment(text, q) {
@@ -2451,16 +2533,6 @@ function renderSuggestionItems() {
 
     text.append(title, meta);
 
-    // If this match came from an episode-name hit, append a small line
-    // explaining which episode caused the match — so the user understands
-    // why Breaking Bad shows up when they typed "Gray Matter".
-    if (s.episodeMatch) {
-      const epHint = document.createElement('span');
-      epHint.className = 'ss-ep-hint';
-      epHint.appendChild(document.createTextNode(`S${s.episodeSeason}E${s.episodeNumber} · `));
-      for (const node of highlightFragment(s.episodeMatch, q)) epHint.appendChild(node);
-      text.appendChild(epHint);
-    }
     li.append(poster, text);
 
     li.addEventListener('mousedown', (e) => e.preventDefault());
@@ -2586,18 +2658,18 @@ function bindEvents() {
   const debouncedChange = debounce(onToolbarChange, 150);
   // Numeric inputs debounce on 'input' (mid-typing) but commit instantly on
   // 'change' (Tab out / blur) so users can still ENTER and see results.
+  // Search also debounces — at 64k seasons the filter+chip-count work is
+  // ~5-10 ms; per-keystroke renders made fast typing feel sticky.
   const debouncedInputIds = [
-    'minEpisodes', 'maxEpisodes', 'minVotes', 'minAvg', 'minClimb', 'minYear', 'maxYear',
+    'search', 'minEpisodes', 'maxEpisodes', 'minVotes', 'minAvg', 'minClimb', 'minYear', 'maxYear',
   ];
   for (const id of debouncedInputIds) {
     els[id].addEventListener('input', debouncedChange);
     els[id].addEventListener('change', onToolbarChange);
   }
-  // Search and the sort select react instantly.
-  for (const id of ['search', 'sort']) {
-    els[id].addEventListener('input', onToolbarChange);
-    els[id].addEventListener('change', onToolbarChange);
-  }
+  // Sort select still reacts instantly — it's a single click, not mid-typing.
+  els.sort.addEventListener('input', onToolbarChange);
+  els.sort.addEventListener('change', onToolbarChange);
   // Any direct keystroke in the search box releases the suggestion lock —
   // the user is now searching freeform, not riding a picked series.
   els.search.addEventListener('input', () => { state.lockedSeriesId = null; });

--- a/apps/rising-seasons/scripts/match.js
+++ b/apps/rising-seasons/scripts/match.js
@@ -25,6 +25,10 @@ const DEFAULTS = {
   rollercoaster: { minFlips: 4, minRange: 1.2, minAvgDiff: 0.4, ignoreBelow: 0.2 },
   // "Mid-peak" — peak sits in the interior; both edges sit well below it.
   midPeak: { peakAboveStart: 0.7, peakAboveEnd: 0.7 },
+  // "U-shaped" — strong opener and strong finale with a real dip between
+  // them. Distinct from rebound (which requires end > start) and from
+  // front-loaded (which has no strong finale).
+  uShaped: { edgeAboveMiddle: 0.4 },
 };
 
 function isRising(episodes) {
@@ -170,6 +174,19 @@ function isMidPeak(episodes, opts = DEFAULTS.midPeak) {
   return (max - start) >= opts.peakAboveStart && (max - end) >= opts.peakAboveEnd;
 }
 
+function isUShaped(episodes, opts = DEFAULTS.uShaped) {
+  const n = episodes.length;
+  if (n < 6) return false;
+  const q = Math.max(1, Math.floor(n / 4));
+  const firstQ = episodes.slice(0, q);
+  const lastQ = episodes.slice(n - q);
+  const middle = episodes.slice(q, n - q);
+  if (middle.length === 0) return false;
+  const mid = avg(middle);
+  return (avg(firstQ) - mid) >= opts.edgeAboveMiddle
+      && (avg(lastQ) - mid) >= opts.edgeAboveMiddle;
+}
+
 function detectShapes(episodes) {
   const tags = [];
   if (isRising(episodes)) tags.push('rising');
@@ -182,6 +199,7 @@ function detectShapes(episodes) {
   if (isBadFinale(episodes)) tags.push('bad-finale');
   if (isRollercoaster(episodes)) tags.push('rollercoaster');
   if (isMidPeak(episodes)) tags.push('mid-peak');
+  if (isUShaped(episodes)) tags.push('u-shaped');
   return tags;
 }
 
@@ -322,6 +340,7 @@ module.exports = {
   isBadFinale,
   isRollercoaster,
   isMidPeak,
+  isUShaped,
   detectShapes,
   findMatches,
   tagSavedBestForLast,

--- a/apps/rising-seasons/tests/match.test.js
+++ b/apps/rising-seasons/tests/match.test.js
@@ -13,6 +13,7 @@ const {
   isBadFinale,
   isRollercoaster,
   isMidPeak,
+  isUShaped,
   detectShapes,
   findMatches,
   isNonDecreasing,
@@ -190,6 +191,32 @@ test('isMidPeak rejects a peak in the first quarter (Last of Us S2 case)', () =>
 test('isMidPeak rejects a peak in the last quarter', () => {
   // Peak at ep 6 of 7 is interior but in the last quarter.
   assert.equal(isMidPeak(season(6.2, 7.1, 6.7, 6.1, 7.0, 9.0, 7.5)), false);
+});
+
+// --- isUShaped ---
+
+test('isUShaped accepts a clear U with strong opener + finale and a middle dip', () => {
+  // First quarter avg ~8.5, middle ~7.0, last quarter avg ~8.5
+  assert.equal(isUShaped(season(8.5, 8.4, 7.0, 6.9, 7.1, 8.5, 8.6, 8.4)), true);
+});
+
+test('isUShaped rejects a rising season (no middle dip)', () => {
+  assert.equal(isUShaped(season(7.0, 7.2, 7.5, 7.8, 8.0, 8.4)), false);
+});
+
+test('isUShaped rejects a season without a strong finale (front-loaded)', () => {
+  // First quarter ~8.5, middle ~7.0, last quarter ~7.0 — opener strong, finale not.
+  assert.equal(isUShaped(season(8.5, 8.4, 7.0, 6.9, 7.1, 7.0, 6.9, 7.1)), false);
+});
+
+test('isUShaped rejects a season without a strong opener', () => {
+  // First quarter ~7.0, middle ~7.0, last quarter ~8.5 — finale strong, opener not.
+  assert.equal(isUShaped(season(7.0, 7.1, 7.0, 6.9, 7.1, 8.5, 8.6, 8.4)), false);
+});
+
+test('isUShaped rejects very short seasons', () => {
+  // Fewer than 6 episodes — too short to identify a U.
+  assert.equal(isUShaped(season(8.5, 8.4, 7.0, 8.5, 8.4)), false);
 });
 
 // --- detectShapes ---


### PR DESCRIPTION
## Summary
A batch of six independent UX/perf improvements for the Rising Seasons app, written while the poster-refresh PR is enriching the TMDB cache.

### 1. Smarter search
Query and titles are normalized to lowercase alphanumeric tokens before comparing, so:
- `the x files` → matches **The X-Files**
- `married with children` → matches **Married... with Children**

Episode-name search dropped (the bar now matches show title OR IMDb id only — was overloaded and added ~3-5 ms per keystroke on the 64k dataset).

### 2. IMDb-rating Y-axis on modal graphs
Per-season modal curve and show-modal seasons overlay now show 5 horizontal gridlines with rating labels on the left edge. Cards/rows unchanged (too small to be useful, and the user only asked for the modal).

### 3. Episode-0 visual flag
IMDb tags pre-season specials and unaired pilots as ep 0 (e.g. Sherlock's "Unaired Pilot", Doctor Who Christmas episodes). They now get:
- Purple ★ prefix and tinted background in the modal episode list
- Tinted dot on the curve so the leftmost point isn't misread as a weak cold open

### 4. Better poster placeholder
~80% of series in the dataset are currently un-posterized (the catalog quadrupled with the last refresh; TMDB enrichment is still catching up). The bare gradient placeholder did no work. New placeholder shows the title prominently and tints by a stable hash of the title.

### 5. New "U-shaped" shape detector
Identifies seasons with a strong opener and finale separated by a middle sag. Distinct from rebound (requires end > start) and front-loaded (no strong finale).
- Rule: first-quarter avg AND last-quarter avg are both ≥ middle-half avg + 0.4
- Will populate in data.json on the next refresh (the chip exists with count 0 until then).

### 6. Perf fixes for 64k seasons
- `updateShapeChipCounts` now uses a single-pass tally instead of one pass per shape. **~3× faster: 12 ms vs ~40 ms.**
- Search input is debounced at 150 ms; per-keystroke renders were noticeable at the new dataset size.

## Test plan
- [x] `npm test` — 673/673 passing (up from 668: 5 new u-shaped tests)
- [x] Visual: home page renders, new chip visible, 64k count
- [x] Visual: search "the x files" returns The X-Files
- [x] Visual: Sherlock S1 modal shows Y-axis labels + ★ EP 0 for Unaired Pilot
- [x] Visual: Blackadder the Third card uses the new title-overlay placeholder
- [ ] Smoke test after Netlify preview deploy

## Notes
- No `data.json` changes — this PR is fully independent of the in-flight poster-refresh PR.
- The U-shaped chip will show 0 until the next nightly data refresh runs the new detector.