### PR TITLE
fix(rising-seasons): sync changelog with current data.json + chain build steps

### DIFF
--- a/apps/rising-seasons/scripts/build-changelog.js
+++ b/apps/rising-seasons/scripts/build-changelog.js
@@ -45,12 +45,13 @@ function loadJsonFromFile(p) {
 // path doesn't exist in that ref (first-ever build, fresh checkout, etc).
 function loadJsonFromGit(ref, relPath, repoRoot) {
   try {
-    // 64 MiB is well above any plausible JSON we ship (data.json sits at
-     // ~30 MiB) and well below the previous 512 MiB cap that wasted RAM
-     // on memory-constrained CI runners.
+    // 256 MiB headroom for the post-lower-vote-floor era — data.json
+     // grew from ~30 MB to ~85 MB after MIN_VOTES dropped to 5. The
+     // previous 64 MiB cap was silently truncating, making the "prev"
+     // load return null and treating every season as freshly added.
     const buf = execFileSync('git', ['show', `${ref}:${relPath}`], {
       cwd: repoRoot,
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: 256 * 1024 * 1024,
     });
     return JSON.parse(buf.toString('utf8'));
   } catch {

--- a/apps/rising-seasons/scripts/build-data.js
+++ b/apps/rising-seasons/scripts/build-data.js
@@ -344,4 +344,20 @@ function loadTmdbCache() {
   }));
   const seconds = ((Date.now() - t0) / 1000).toFixed(1);
   console.log(`Wrote ${OUT_FILE} in ${seconds}s`);
+
+  // Diff against the previously-committed data.json and update changelog.json
+  // so the "What's new" footer chip stays in sync. The footer guards the chip
+  // on `latest.builtAt === dataset.builtAt`, so writing a new data.json without
+  // also writing a matching changelog entry silently hides the chip.
+  // Skip when explicitly opted out (e.g., test fixtures, dry runs).
+  if (process.env.SKIP_CHANGELOG !== '1') {
+    try {
+      const { execFileSync } = require('child_process');
+      execFileSync(process.execPath,
+        [path.join(__dirname, 'build-changelog.js')],
+        { stdio: 'inherit', cwd: path.join(__dirname, '..', '..', '..') });
+    } catch (err) {
+      console.warn(`build-changelog step failed: ${err.message}`);
+    }
+  }
 })();


### PR DESCRIPTION
## Summary
The "What's new" chip (next to "Last updated") vanished from PROD after PR #100 because the rebuilt `data.json` didn't get a matching `changelog.json` entry. The footer guards the chip on exact `builtAt` match — when the two files disagree, the chip is suppressed rather than display stale counts.

Three changes:

1. **Regenerated the missing changelog entry.** Diff is between the pre-floor-drop refresh (`c302da0`, 16,582 seasons) and the current build (64,877 seasons). Result: `+48,306 added · −11 dropped`. This restores the chip immediately.

2. **Bumped `build-changelog.js` maxBuffer from 64 MiB → 256 MiB.** `data.json` grew from ~30 MB to ~85 MB after `MIN_VOTES` dropped. The old cap was silently truncating `git show HEAD:data.json`, making the prev-side load return `null` and treating every season as freshly added — explaining the magnitude of the diff but also why a manual re-run wasn't trivial.

3. **Chained `build-changelog.js` into `build-data.js`.** Manual builds and the bot's nightly workflow both regenerate the changelog automatically now, so the two files can't desync. Opt-out via `SKIP_CHANGELOG=1` for fixture / dry-run cases.

## Test plan
- [x] `node build-changelog.js --prev /tmp/rs-prev-data.json` — wrote 11 entries, latest `builtAt` matches current `data.json`
- [x] `npm test` — 668/668 passing
- [x] Visual: footer renders `Last updated May 21, 2026 · +48306 new · −11 dropped · WHAT'S NEW ▾`
- [ ] Smoke test on Netlify preview deploy

## Notes
- The `+48306` doesn't carry a thousands separator — pre-existing chip behavior, not changed here.
- The big diff (~290k lines added to `changelog.json`) is the new entry's per-season added/removed list. One-time reconciliation; future incremental updates will be small.