### PR TITLE
feat(rising-seasons): two surprise-me modes — all filtered vs popular

### DIFF
--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -585,6 +585,14 @@ body.rising-seasons-app button {
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset, var(--shadow-lift);
 }
 
+/* Surprise group — two adjacent buttons sharing a labeled boundary:
+   primary "Surprise me" (random across all filtered) + secondary
+   "Popular pick" (random across the top 50 by current sort). */
+.surprise-group {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0.35rem;
+}
 /* Soften the Surprise CTA — was the heaviest element on the bar,
    competing with active filter pills. Now reads as a secondary action
    that's still clearly the primary yellow surface, just less shouty. */
@@ -596,6 +604,22 @@ body.rising-seasons-app button {
   filter: saturate(0.92);
 }
 .filter-row.primary .surprise:hover { filter: saturate(1) brightness(1.04); }
+.filter-row.primary .surprise-popular {
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  padding: 0 0.75rem;
+  /* Sits next to the primary yellow Surprise me — quieter so the
+     primary stays clearly primary, but visible enough to discover. */
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: rgba(231, 233, 238, 0.85);
+}
+.filter-row.primary .surprise-popular:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.22);
+  color: #ffffff;
+}
 
 /* Tighter horizontal padding on the buttons inside the slimmer toolbar
    so the labels don't crowd the rounded edges at the smaller height. */

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -204,10 +204,18 @@
           <button type="button" class="btn view-btn" data-view="grid" aria-pressed="true" aria-label="Grid view" title="Grid view">▦</button>
           <button type="button" class="btn view-btn" data-view="list" aria-pressed="false" aria-label="List view" title="List view">☰</button>
         </div>
-        <button class="btn btn-primary surprise" id="surprise" type="button" title="Pick one at random">
-          <span aria-hidden="true">🎲</span>
-          <span>Surprise me</span>
-        </button>
+        <div class="surprise-group" role="group" aria-label="Random pick">
+          <button class="btn btn-primary surprise" id="surprise" type="button"
+                  title="Random pick across every season matching your filters">
+            <span aria-hidden="true">🎲</span>
+            <span>Surprise me</span>
+          </button>
+          <button class="btn btn-ghost surprise-popular" id="surprisePopular" type="button"
+                  title="Random pick from the 50 most-watched seasons matching your filters">
+            <span aria-hidden="true">🔥</span>
+            <span>Popular pick</span>
+          </button>
+        </div>
       </div>
 
       <div class="quick-filters-row">

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -105,6 +105,7 @@ const els = {
   modalWatchBtn: document.getElementById('modalWatchBtn'),
   modalReroll: document.getElementById('modalReroll'),
   modalViewShow: document.getElementById('modalViewShow'),
+  surprisePopular: document.getElementById('surprisePopular'),
   showModal: document.getElementById('showModal'),
   showModalTitle: document.getElementById('showModalTitle'),
   showModalSubtitle: document.getElementById('showModalSubtitle'),
@@ -1244,9 +1245,16 @@ function syncResetButton() {
     : 'No filters are currently active';
 }
 
-function surprisePick() {
+// Two surprise modes:
+//   'any'     — true random across every filtered season.
+//   'popular' — random from the top 50 by current sort (popularity by
+//               default), so the user always lands on something with
+//               enough audience to have an opinion about.
+// Reroll inside the modal honors whichever mode the user clicked.
+function surprisePick(mode = 'any') {
   if (filtered.length === 0) return null;
-  return filtered[Math.floor(Math.random() * Math.min(filtered.length, 50))];
+  const pool = mode === 'popular' ? Math.min(filtered.length, 50) : filtered.length;
+  return filtered[Math.floor(Math.random() * pool)];
 }
 
 // --- shared shape-tag + best-badge helpers ---
@@ -1894,7 +1902,10 @@ function openModal(m, opts = {}) {
       modalState.lastFocus = document.activeElement;
     }
   }
-  modalState.surprise = !!opts.surprise;
+  // Carry the surprise mode forward so the in-modal Reroll button can
+  // re-pick from the same pool the user originally chose.
+  modalState.surprise = opts.surprise === true ? 'any' :
+                        (opts.surprise === 'any' || opts.surprise === 'popular' ? opts.surprise : false);
   // Origin tracker — when set, closeModal reopens the changelog so the
   // user lands back in the "What's new" list they were browsing.
   modalState.fromChangelog = opts.fromChangelog === true || inheritedFromChangelog;
@@ -2867,13 +2878,23 @@ function bindEvents() {
   });
 
   els.surprise.addEventListener('click', () => {
-    const pick = surprisePick();
-    if (pick) openModal(pick, { surprise: true });
+    const pick = surprisePick('any');
+    if (pick) openModal(pick, { surprise: 'any' });
   });
 
+  if (els.surprisePopular) {
+    els.surprisePopular.addEventListener('click', () => {
+      const pick = surprisePick('popular');
+      if (pick) openModal(pick, { surprise: 'popular' });
+    });
+  }
+
+  // Reroll inherits whichever mode opened the modal — 'any' or 'popular' —
+  // so the dice button feels consistent with the entry point.
   els.modalReroll.addEventListener('click', () => {
-    const pick = surprisePick();
-    if (pick) openModal(pick, { surprise: true });
+    const mode = modalState.surprise || 'any';
+    const pick = surprisePick(mode);
+    if (pick) openModal(pick, { surprise: mode });
   });
 
   els.resetFilters.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
The old "Surprise me" always picked from the top 50 by current sort, regardless of where the user was in the result set. Useful but limited, and the logic wasn't visible anywhere in the UI.

Now there are two buttons side by side:
- **🎲 Surprise me** (primary, yellow) — random pick across *every* season matching the active filters.
- **🔥 Popular pick** (secondary, ghost) — random pick from the 50 most-watched matches (the old behavior).

Both have explicit `title` tooltips describing the pool they draw from, so the logic is one hover away.

## Why two buttons (not a dropdown)
- Discoverability — both options are visible, no menu to open
- Single click for either mode — no extra component to build
- Clear visual hierarchy keeps the primary CTA primary; the secondary is intentionally muted

## Reroll
`modalState.surprise` now stores the mode string (`'any'` | `'popular'`), so the in-modal **Roll again** button re-picks from the same pool the user originally chose — consistent with their entry point.

## Test plan
- [x] `npm test` — 673/673 passing
- [x] Screenshot: desktop toolbar shows both buttons; mobile wraps them sensibly
- [ ] Smoke test: click each button, verify modal opens; click Reroll inside, verify it stays in the same mode
- [ ] Hover each button, verify the tooltip text matches the documented logic