### PR TITLE
feat: maptap-rivals share card + streak callout, plus 5 football-h2h tracker improvements

### DIFF
--- a/apps/football-h2h/css/refresh.css
+++ b/apps/football-h2h/css/refresh.css
@@ -860,3 +860,249 @@ body.football-h2h-tracker .stats-tab-content.active#h2h-stats::before {
     content: "";
     display: none;
 }
+
+/* ---------- Feature 1: Current streak badge ---------- */
+
+body.football-h2h-tracker .streak-row {
+    margin-bottom: 0.25rem;
+}
+
+body.football-h2h-tracker .streak-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.45rem 1rem;
+    border-radius: 999px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    border: 1px solid var(--fh-border-strong);
+    background: var(--fh-surface-2);
+    color: var(--fh-muted);
+}
+
+body.football-h2h-tracker .streak-badge.streak-win {
+    background: var(--fh-good-soft);
+    border-color: rgba(52, 211, 153, 0.45);
+    color: var(--fh-good);
+}
+
+body.football-h2h-tracker .streak-badge.streak-lose {
+    background: var(--fh-bad-soft);
+    border-color: rgba(248, 113, 113, 0.45);
+    color: var(--fh-bad);
+}
+
+body.football-h2h-tracker .streak-badge.streak-none {
+    opacity: 0.6;
+}
+
+/* ---------- Feature 2: Recent form strip ---------- */
+
+body.football-h2h-tracker .form-strip-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: var(--fh-surface);
+    border: 1px solid var(--fh-border);
+    border-radius: var(--fh-radius);
+    padding: 0.85rem 1.2rem;
+    margin-bottom: 1rem;
+    box-shadow: var(--fh-shadow-lift);
+}
+
+body.football-h2h-tracker .form-strip-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+body.football-h2h-tracker .form-strip-name {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--fh-muted);
+    min-width: 80px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: right;
+}
+
+body.football-h2h-tracker .form-strip-dots {
+    display: flex;
+    gap: 0.3rem;
+}
+
+body.football-h2h-tracker .form-dot {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #fff;
+    cursor: default;
+}
+
+body.football-h2h-tracker .form-dot-w {
+    background: var(--fh-good);
+}
+
+body.football-h2h-tracker .form-dot-l {
+    background: var(--fh-bad);
+}
+
+body.football-h2h-tracker .form-dot-d {
+    background: var(--fh-warn);
+}
+
+/* ---------- Feature 3: Match note in table ---------- */
+
+body.football-h2h-tracker .game-note {
+    font-style: italic;
+    font-size: 0.72rem;
+    color: var(--fh-muted);
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 140px;
+}
+
+body.football-h2h-tracker .sidebar-note-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: 0.5rem;
+}
+
+body.football-h2h-tracker .sidebar-note-section label {
+    font-size: 0.78rem;
+    color: var(--fh-muted);
+}
+
+/* ---------- Feature 4: Team matchup lookup ---------- */
+
+body.football-h2h-tracker .matchup-lookup {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+body.football-h2h-tracker .matchup-selects {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+body.football-h2h-tracker .matchup-select-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    flex: 1;
+    min-width: 120px;
+}
+
+body.football-h2h-tracker .matchup-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--fh-muted);
+}
+
+body.football-h2h-tracker .matchup-select {
+    background: var(--fh-surface-2);
+    border: 1px solid var(--fh-border);
+    border-radius: 10px;
+    color: var(--fh-text);
+    padding: 0.45rem 0.7rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+body.football-h2h-tracker .matchup-vs {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--fh-muted-2);
+    padding-top: 1.2rem;
+    flex-shrink: 0;
+}
+
+body.football-h2h-tracker .matchup-result {
+    background: var(--fh-surface-2);
+    border: 1px solid var(--fh-border);
+    border-radius: var(--fh-radius-sm);
+    padding: 0.8rem 1rem;
+}
+
+body.football-h2h-tracker .matchup-result-grid {
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+body.football-h2h-tracker .matchup-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.15rem;
+    flex: 1;
+}
+
+body.football-h2h-tracker .matchup-stat-label {
+    font-size: 0.68rem;
+    color: var(--fh-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    font-weight: 600;
+}
+
+body.football-h2h-tracker .matchup-stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--fh-text);
+    font-variant-numeric: tabular-nums;
+}
+
+body.football-h2h-tracker .matchup-stat-draw .matchup-stat-value {
+    color: var(--fh-warn);
+    font-size: 1.3rem;
+}
+
+body.football-h2h-tracker .matchup-games-played {
+    width: 100%;
+    text-align: center;
+    font-size: 0.72rem;
+    color: var(--fh-muted-2);
+    margin-top: 0.25rem;
+}
+
+body.football-h2h-tracker .matchup-no-data {
+    color: var(--fh-muted);
+    font-size: 0.85rem;
+}
+
+/* ---------- Feature 5: Session summary modal ---------- */
+
+body.football-h2h-tracker .session-summary-text {
+    font-family: "Menlo", "Consolas", "Courier New", monospace;
+    font-size: 0.82rem;
+    line-height: 1.7;
+    color: var(--fh-text);
+    background: var(--fh-surface-2);
+    border: 1px solid var(--fh-border);
+    border-radius: 8px;
+    padding: 0.9rem 1rem;
+    white-space: pre-wrap;
+    max-height: 360px;
+    overflow-y: auto;
+}
+
+body.football-h2h-tracker .sidebar-action-btn.summary-btn {
+    width: 100%;
+    margin-bottom: 0.5rem;
+}

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -175,6 +175,10 @@
                         <span class="action-text">Redo</span>
                     </button>
                 </div>
+                <button class="sidebar-action-btn summary-btn" onclick="showSessionSummary()" aria-label="Session summary">
+                    <span class="action-icon">📋</span>
+                    <span class="action-text">Session Summary</span>
+                </button>
                 <div class="action-buttons" id="sidebar-action-buttons">
                     <button class="sidebar-action-btn export-btn" onclick="exportData()" aria-label="Export data">
                         <span class="action-icon">📤</span>
@@ -314,6 +318,14 @@
                         </div>
                     </div>
 
+                    <!-- Current Streak Row -->
+                    <h3 class="h2h-section-title">Current Streak</h3>
+                    <div class="streak-row" id="streakRow">
+                        <div class="streak-badge" id="streakBadge">
+                            <span class="streak-text" id="streakText">—</span>
+                        </div>
+                    </div>
+
                     <!-- 90 Minute Wins Row -->
                     <h3 class="h2h-section-title">90 Minute Wins</h3>
                     <div class="stats-grid h2h-row">
@@ -357,6 +369,29 @@
                             <div class="stat-value" id="penaltyShootouts">0</div>
                         </div>
                     </div>
+
+                    <!-- Team Matchup Lookup -->
+                    <h3 class="h2h-section-title" style="margin-top: 1.5rem;">Team Matchup</h3>
+                    <div class="matchup-lookup">
+                        <div class="matchup-selects">
+                            <div class="matchup-select-group">
+                                <label class="matchup-label" id="matchupP1Label">Player 1's Team</label>
+                                <select id="matchupTeam1" class="matchup-select" onchange="updateMatchupResult()">
+                                    <option value="">— any —</option>
+                                </select>
+                            </div>
+                            <span class="matchup-vs">vs</span>
+                            <div class="matchup-select-group">
+                                <label class="matchup-label" id="matchupP2Label">Player 2's Team</label>
+                                <select id="matchupTeam2" class="matchup-select" onchange="updateMatchupResult()">
+                                    <option value="">— any —</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="matchup-result" id="matchupResult" style="display: none;">
+                            <div class="matchup-result-grid" id="matchupResultGrid"></div>
+                        </div>
+                    </div>
                 </section>
 
                 <!-- Player Stats Tab Content -->
@@ -374,6 +409,18 @@
                         </table>
                     </div>
                 </section>
+            </div>
+
+            <!-- Recent Form Strip -->
+            <div class="form-strip-section" id="formStripSection" style="display: none;">
+                <div class="form-strip-row">
+                    <span class="form-strip-name" id="formStrip1Name">Player 1</span>
+                    <div class="form-strip-dots" id="formStrip1Dots"></div>
+                </div>
+                <div class="form-strip-row">
+                    <span class="form-strip-name" id="formStrip2Name">Player 2</span>
+                    <div class="form-strip-dots" id="formStrip2Dots"></div>
+                </div>
             </div>
 
             <!-- Game History Table -->

--- a/apps/football-h2h/js/football-h2h.js
+++ b/apps/football-h2h/js/football-h2h.js
@@ -799,6 +799,14 @@ function editGame(id) {
             placeholder: player2TeamInfo.teamType === 'Other' ? 'Enter team name' : undefined,
             maxlength: player2TeamInfo.teamType === 'Other' ? 15 : undefined,
             hidden: player2TeamInfo.teamType === 'Ultimate Team'
+        },
+        {
+            id: 'note',
+            type: 'text',
+            label: 'Note (optional)',
+            value: game.note || '',
+            placeholder: 'e.g. First session back',
+            maxlength: 80
         }
     ];
     
@@ -912,6 +920,7 @@ function editGame(id) {
                 }
             }
             
+            const noteValue = (formData.note || '').trim() || undefined;
             const updatedGame = {
                 ...game,
                 player1Goals: player1Goals,
@@ -919,7 +928,8 @@ function editGame(id) {
                 player1Team: player1Team,
                 player2Team: player2Team,
                 penaltyWinner: penaltyWinner,
-                dateTime: newDateTime.toISOString()
+                dateTime: newDateTime.toISOString(),
+                ...(noteValue ? { note: noteValue } : { note: undefined })
             };
             
             // Update the game in the array
@@ -1629,9 +1639,10 @@ function renderGamesTableWithData(gamesData) {
             }
         }
         
+        const noteHtml = game.note ? `<div class="game-note">${escapeHtml(game.note)}</div>` : '';
         row.innerHTML = `
             <td class="game-number">${game.gameNumber}</td>
-            <td class="game-date">${formattedDate}<br><small>${formattedTime}</small></td>
+            <td class="game-date">${formattedDate}<br><small>${formattedTime}</small>${noteHtml}</td>
             <td class="player-score player1-score ${player1ScoreClass}">
                 <span class="score-number">${game.player1Goals}</span>${player1PenaltyText}
             </td>
@@ -1820,6 +1831,9 @@ function updateStatisticsWithData(gamesData) {
     }
 
     renderPlayerStatsTab(gamesData);
+    renderStreakBadge(gamesData);
+    renderFormStrip(gamesData);
+    populateMatchupDropdowns();
 }
 
 // Descriptor for each row in the Player Stats comparison table. `direction`
@@ -2031,6 +2045,252 @@ function switchStatsTab(tabName, { fromHash = false } = {}) {
     }
 }
 
+// ── Feature 1: Streak badge ────────────────────────────────────────────────
+
+function renderStreakBadge(gamesData) {
+    const badge = document.getElementById('streakBadge');
+    const text = document.getElementById('streakText');
+    if (!badge || !text) return;
+
+    const api = window.FootballPlayerStats;
+    if (!api) return;
+
+    const p1Results = api.matchResultsInOrder(gamesData, 'player1Goals', 'player2Goals', 1);
+    const p2Results = api.matchResultsInOrder(gamesData, 'player2Goals', 'player1Goals', 2);
+    const s1 = api.computeMatchStreaks(p1Results);
+    const s2 = api.computeMatchStreaks(p2Results);
+
+    badge.className = 'streak-badge';
+
+    if (s1.currentWinningStreak > 0) {
+        const n = s1.currentWinningStreak;
+        text.textContent = `${player1Name} – ${n} match winning streak`;
+        badge.classList.add('streak-win');
+    } else if (s2.currentWinningStreak > 0) {
+        const n = s2.currentWinningStreak;
+        text.textContent = `${player2Name} – ${n} match winning streak`;
+        badge.classList.add('streak-win');
+    } else if (s1.currentLosingStreak > 0) {
+        const n = s1.currentLosingStreak;
+        text.textContent = `${player1Name} – ${n} match losing streak`;
+        badge.classList.add('streak-lose');
+    } else if (s2.currentLosingStreak > 0) {
+        const n = s2.currentLosingStreak;
+        text.textContent = `${player2Name} – ${n} match losing streak`;
+        badge.classList.add('streak-lose');
+    } else {
+        text.textContent = 'No current streak';
+        badge.classList.add('streak-none');
+    }
+}
+
+// ── Feature 2: Recent form strip ──────────────────────────────────────────
+
+function renderFormStrip(gamesData) {
+    const section = document.getElementById('formStripSection');
+    if (!section) return;
+
+    if (gamesData.length === 0) {
+        section.style.display = 'none';
+        return;
+    }
+
+    section.style.display = 'flex';
+
+    const api = window.FootballPlayerStats;
+    if (!api) return;
+
+    function buildDots(results) {
+        const last5 = results.slice(-5);
+        const container = document.createDocumentFragment();
+        for (const r of last5) {
+            const dot = document.createElement('span');
+            dot.className = 'form-dot form-dot-' + (r === 'W' ? 'w' : r === 'L' ? 'l' : 'd');
+            dot.textContent = r === null ? '?' : r;
+            dot.title = r === 'W' ? 'Win' : r === 'L' ? 'Loss' : r === 'D' ? 'Draw' : 'Unknown';
+            container.appendChild(dot);
+        }
+        return container;
+    }
+
+    const p1Results = api.matchResultsInOrder(gamesData, 'player1Goals', 'player2Goals', 1);
+    const p2Results = api.matchResultsInOrder(gamesData, 'player2Goals', 'player1Goals', 2);
+
+    const dots1 = document.getElementById('formStrip1Dots');
+    const dots2 = document.getElementById('formStrip2Dots');
+    const name1 = document.getElementById('formStrip1Name');
+    const name2 = document.getElementById('formStrip2Name');
+
+    if (name1) name1.textContent = player1Name;
+    if (name2) name2.textContent = player2Name;
+    if (dots1) { dots1.innerHTML = ''; dots1.appendChild(buildDots(p1Results)); }
+    if (dots2) { dots2.innerHTML = ''; dots2.appendChild(buildDots(p2Results)); }
+}
+
+// ── Feature 4: Team matchup lookup ────────────────────────────────────────
+
+function populateMatchupDropdowns() {
+    const sel1 = document.getElementById('matchupTeam1');
+    const sel2 = document.getElementById('matchupTeam2');
+    const lbl1 = document.getElementById('matchupP1Label');
+    const lbl2 = document.getElementById('matchupP2Label');
+    if (!sel1 || !sel2) return;
+
+    if (lbl1) lbl1.textContent = player1Name + "'s Team";
+    if (lbl2) lbl2.textContent = player2Name + "'s Team";
+
+    const allGames = window.games || [];
+    const teams1 = [...new Set(allGames.map(g => g.player1Team).filter(Boolean))].sort();
+    const teams2 = [...new Set(allGames.map(g => g.player2Team).filter(Boolean))].sort();
+
+    function rebuild(sel, teams) {
+        const current = sel.value;
+        sel.innerHTML = '<option value="">— any —</option>';
+        for (const t of teams) {
+            const opt = document.createElement('option');
+            opt.value = t;
+            opt.textContent = t;
+            if (t === current) opt.selected = true;
+            sel.appendChild(opt);
+        }
+    }
+
+    rebuild(sel1, teams1);
+    rebuild(sel2, teams2);
+    updateMatchupResult();
+}
+
+function updateMatchupResult() {
+    const sel1 = document.getElementById('matchupTeam1');
+    const sel2 = document.getElementById('matchupTeam2');
+    const result = document.getElementById('matchupResult');
+    const grid = document.getElementById('matchupResultGrid');
+    if (!sel1 || !sel2 || !result || !grid) return;
+
+    const t1 = sel1.value;
+    const t2 = sel2.value;
+
+    if (!t1 && !t2) {
+        result.style.display = 'none';
+        return;
+    }
+
+    const allGames = window.games || [];
+    const filtered = allGames.filter(g => {
+        const match1 = !t1 || g.player1Team === t1;
+        const match2 = !t2 || g.player2Team === t2;
+        return match1 && match2;
+    });
+
+    let p1Wins = 0, p2Wins = 0, draws = 0;
+    for (const g of filtered) {
+        if (g.player1Goals > g.player2Goals) {
+            p1Wins++;
+        } else if (g.player2Goals > g.player1Goals) {
+            p2Wins++;
+        } else if (g.penaltyWinner === 1) {
+            p1Wins++;
+        } else if (g.penaltyWinner === 2) {
+            p2Wins++;
+        } else {
+            draws++;
+        }
+    }
+
+    if (filtered.length === 0) {
+        grid.innerHTML = '<span class="matchup-no-data">No games found for this matchup</span>';
+    } else {
+        grid.innerHTML = `
+            <div class="matchup-stat"><span class="matchup-stat-label">${escapeHtml(player1Name)}</span><span class="matchup-stat-value">${p1Wins}</span></div>
+            <div class="matchup-stat matchup-stat-draw"><span class="matchup-stat-label">Draws</span><span class="matchup-stat-value">${draws}</span></div>
+            <div class="matchup-stat"><span class="matchup-stat-label">${escapeHtml(player2Name)}</span><span class="matchup-stat-value">${p2Wins}</span></div>
+            <div class="matchup-games-played">from ${filtered.length} game${filtered.length !== 1 ? 's' : ''}</div>
+        `;
+    }
+
+    result.style.display = 'block';
+}
+
+// ── Feature 5: Session summary ────────────────────────────────────────────
+
+function buildSessionSummaryText(gamesData) {
+    const p1 = player1Name;
+    const p2 = player2Name;
+
+    if (gamesData.length === 0) {
+        return `${p1} vs ${p2} — No games recorded.`;
+    }
+
+    const lines = [];
+    let totalGoals = 0;
+    let p1Wins = 0, p2Wins = 0, draws = 0;
+
+    for (const g of gamesData) {
+        totalGoals += g.player1Goals + g.player2Goals;
+        const scoreStr = `${g.player1Goals}–${g.player2Goals}`;
+        let suffix = '';
+        if (g.player1Goals === g.player2Goals) {
+            if (g.penaltyWinner === 1) { p1Wins++; suffix = ` (${p1} wins pens)`; }
+            else if (g.penaltyWinner === 2) { p2Wins++; suffix = ` (${p2} wins pens)`; }
+            else { draws++; suffix = ' (draw)'; }
+        } else if (g.player1Goals > g.player2Goals) {
+            p1Wins++;
+        } else {
+            p2Wins++;
+        }
+        const dateStr = g.dateTime ? new Date(g.dateTime).toLocaleDateString() : '';
+        const noteStr = g.note ? ` — ${g.note}` : '';
+        lines.push(`${scoreStr}${suffix} (${dateStr})${noteStr}`);
+    }
+
+    let winner = '';
+    if (p1Wins > p2Wins) winner = `Winner of the session: ${p1}`;
+    else if (p2Wins > p1Wins) winner = `Winner of the session: ${p2}`;
+    else winner = 'Session result: level';
+
+    const header = `${p1} vs ${p2}`;
+    const record = `${p1}: ${p1Wins}W  ${p2}: ${p2Wins}W  Draws: ${draws}`;
+    const goals = `Total goals: ${totalGoals}`;
+
+    return [header, record, goals, winner, '', ...lines].join('\n');
+}
+
+function showSessionSummary() {
+    const filteredGames = window.getFilteredGames ? window.getFilteredGames() : (window.games || []);
+
+    const summaryText = buildSessionSummaryText(filteredGames);
+
+    const content = `
+        <div class="session-summary-text" id="sessionSummaryText">${escapeHtml(summaryText).replace(/\n/g, '<br>')}</div>
+    `;
+
+    const modal = createModal({
+        icon: '📋',
+        title: 'Session Summary',
+        content,
+        buttons: [
+            {
+                id: 'copy-summary-btn',
+                text: 'Copy',
+                type: 0,
+                onClick: () => {
+                    navigator.clipboard.writeText(summaryText).then(() => {
+                        showToast('Summary copied!', 'success');
+                    });
+                    return false;
+                },
+                closeOnClick: false
+            },
+            {
+                id: 'close-summary-btn',
+                text: 'Close',
+                type: 1,
+                onClick: () => {}
+            }
+        ]
+    });
+}
+
 // Export player names, teams data and functions to global scope
 window.player1Name = player1Name;
 window.player2Name = player2Name;
@@ -2069,6 +2329,8 @@ window.savePlayerIcons = savePlayerIcons;
 window.checkEditModalForDraw = checkEditModalForDraw;
 window.updateEditModalTeamOptions = updateEditModalTeamOptions;
 window.updateEditModalTeamOptionsHandler = updateEditModalTeamOptionsHandler;
+window.updateMatchupResult = updateMatchupResult;
+window.showSessionSummary = showSessionSummary;
 
 // Duplicate definitions of loadPlayers / savePlayers / loadPlayerIcons /
 // savePlayerIcons / updatePlayerName / openIconSelector / closeIconSelector /

--- a/apps/football-h2h/js/sidebar.js
+++ b/apps/football-h2h/js/sidebar.js
@@ -661,6 +661,11 @@ function generateSidebarGameInputs() {
                     <option value="draw">No Winner (Draw)</option>
                 </select>
             </div>
+            <div class="sidebar-note-section">
+                <label for="sidebar-game-note">Note (optional):</label>
+                <input type="text" id="sidebar-game-note" class="sidebar-player-input"
+                       placeholder="e.g. First session back" maxlength="80">
+            </div>
         </div>
         <div class="sidebar-game-teams">
             <div class="sidebar-player-input">
@@ -869,6 +874,8 @@ function submitSidebarGame() {
         );
     }
     
+    const noteValue = (document.getElementById('sidebar-game-note')?.value || '').trim() || undefined;
+
     // Create game object
     const newGame = {
         id: Date.now(),
@@ -878,7 +885,8 @@ function submitSidebarGame() {
         player2Team: player2Team || 'Unknown',
         penaltyWinner: penaltyWinner,
         dateTime: gameDate.toISOString(),
-        gameNumber: window.games ? window.games.length + 1 : 1
+        gameNumber: window.games ? window.games.length + 1 : 1,
+        ...(noteValue ? { note: noteValue } : {})
     };
     
     // Add to games

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -2048,6 +2048,46 @@ tr:focus-within .icon-btn {
   box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.22);
 }
 
+.icon-btn-share:hover {
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent-2);
+}
+.icon-btn-share:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+/* Inline toast that appears next to the share button after copying. */
+.share-toast {
+  display: inline-block;
+  margin-left: 0.35rem;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  background: var(--surface-3);
+  border: 1px solid var(--border-strong);
+  color: var(--good);
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+  pointer-events: none;
+  animation: share-toast-in 0.15s ease;
+}
+@keyframes share-toast-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Post-save share button in the paste actions bar */
+.paste-share-btn {
+  height: 2.6rem;
+  font-size: 0.85rem;
+  gap: 0.35rem;
+}
+.paste-share-icon {
+  display: inline-flex;
+  align-items: center;
+}
+.paste-share-icon svg { width: 14px; height: 14px; }
+
 .history-controls {
   display: flex;
   flex-wrap: wrap;

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -1439,6 +1439,30 @@ body.maptap-rivals-app button {
   background: linear-gradient(90deg, var(--good), var(--accent-2));
 }
 
+.drama-callout {
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  margin-bottom: 0.55rem;
+}
+.drama-callout-win {
+  background: rgba(249, 115, 22, 0.15);
+  color: #fb923c;
+  border: 1px solid rgba(249, 115, 22, 0.25);
+}
+.drama-callout-loss {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+  border: 1px solid rgba(96, 165, 250, 0.22);
+}
+.drama-callout-comeback {
+  background: rgba(250, 204, 21, 0.12);
+  color: #fbbf24;
+  border: 1px solid rgba(250, 204, 21, 0.22);
+}
+
 /* ---------- Rival detail ---------- */
 
 .rival-header {

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -298,6 +298,7 @@
                 <th>Result</th>
                 <th>Note</th>
                 <th></th>
+                <th></th>
               </tr>
             </thead>
             <tbody></tbody>
@@ -410,6 +411,7 @@
               <th>Rounds</th>
               <th>Result</th>
               <th>Note</th>
+              <th></th>
               <th></th>
             </tr>
           </thead>

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -91,6 +91,12 @@
     '<path d="M21 12a9 9 0 0 1-15 6.7L3 16"/>' +
     '<path d="M3 21v-5h5"/>' +
     '</svg>';
+  const ICON_SHARE =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">' +
+    '<path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/>' +
+    '<polyline points="16 6 12 2 8 6"/>' +
+    '<line x1="12" y1="2" x2="12" y2="15"/>' +
+    '</svg>';
 
   // Render the Note cell. "synced from MapTap" — which would otherwise repeat
   // on most rows — collapses to a tiny sync icon with a tooltip. Manual
@@ -941,6 +947,113 @@
     else if (state.view === 'history') renderHistory();
   }
 
+  // ---------- share / result card ----------
+
+  // Build the streak line for the share text. Uses games for the rival
+  // *up to and including* the game being shared so the streak reflects
+  // the state right after that result, not the current live streak.
+  function streakUpTo(game) {
+    const all = gamesFor(game.rivalId);
+    const idx = all.findIndex(g => g.id === game.id);
+    if (idx < 0) return null;
+    const slice = all.slice(0, idx + 1);
+    const s = streaks(slice);
+    if (s.curMine >= 2) return { kind: 'W', len: s.curMine };
+    if (s.curTheirs >= 2) return { kind: 'L', len: s.curTheirs };
+    return null;
+  }
+
+  function buildShareText(g, rival) {
+    const myT = getMyTotal(g);
+    const theirT = getTheirTotal(g);
+    const diff = myT - theirT;
+    const meName = state.me || 'Me';
+    const rivalName = rival ? rival.name : 'Rival';
+
+    const winnerScore = diff >= 0 ? myT : theirT;
+    const loserScore  = diff >= 0 ? theirT : myT;
+    const margin = Math.abs(diff);
+    const result = diff > 0 ? 'you won' : diff < 0 ? 'they won' : 'tie';
+
+    const winnerSquare = '🟩'; // green
+    const loserSquare  = '⬜';       // white
+    const tieSquare    = '⬛';       // black (tie)
+
+    let lines = [];
+    lines.push(`MapTap Rivals — ${meName} vs ${rivalName}`);
+    lines.push(g.date);
+    lines.push('');
+
+    if (diff > 0) {
+      lines.push(`${winnerSquare} ${winnerScore} — ${loserScore} ${loserSquare}  (${result} by ${margin})`);
+    } else if (diff < 0) {
+      lines.push(`${loserSquare} ${loserScore} — ${winnerScore} ${winnerSquare}  (${result} by ${margin})`);
+    } else {
+      lines.push(`${tieSquare} ${myT} — ${theirT} ${tieSquare}  (tie)`);
+    }
+
+    if (hasLocs(g)) {
+      lines.push('Round scores:');
+      const myRound    = g.myScores.map((m, i) => resultLoc(m, g.theirScores[i]));
+      const theirRound = g.theirScores.map((t, i) => resultLoc(t, g.myScores[i]));
+      const toEmoji = r => r === 'W' ? winnerSquare : r === 'L' ? loserSquare : tieSquare;
+      lines.push(myRound.map(toEmoji).join('') + '  ' + meName);
+      lines.push(theirRound.map(toEmoji).join('') + '  ' + rivalName);
+    }
+
+    const sk = streakUpTo(g);
+    if (sk) {
+      const streakEmoji = sk.kind === 'W' ? '🔥' : '❄️';
+      const who = sk.kind === 'W' ? 'win' : 'loss';
+      lines.push('');
+      lines.push(`${streakEmoji} ${sk.len}-game ${who} streak`);
+    }
+
+    lines.push('shevato.com/apps/maptap-rivals');
+    return lines.join('\n');
+  }
+
+  // Show a transient toast anchored to `anchorEl`. Cleans itself up after
+  // 2.5 s, or immediately if share succeeds via native sheet (no toast needed).
+  function showShareToast(anchorEl, msg) {
+    const existing = anchorEl.parentNode && anchorEl.parentNode.querySelector('.share-toast');
+    if (existing) existing.remove();
+    const toast = el('span', { class: 'share-toast', role: 'status', 'aria-live': 'polite' }, msg);
+    anchorEl.insertAdjacentElement('afterend', toast);
+    setTimeout(() => { if (toast.parentNode) toast.remove(); }, 2500);
+  }
+
+  async function shareGame(g, rival, btn) {
+    const text = buildShareText(g, rival);
+    if (navigator.share) {
+      try {
+        await navigator.share({ text });
+        return;
+      } catch (_) {
+        // User cancelled or share failed — fall through to clipboard.
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      showShareToast(btn, 'Copied — paste anywhere');
+    } catch (_) {
+      showShareToast(btn, 'Copy failed');
+    }
+  }
+
+  function shareCell(g, rival) {
+    return el('td', { class: 'row-action-cell' }, [
+      el('button', {
+        type: 'button',
+        class: 'icon-btn icon-btn-share',
+        title: 'Share result',
+        'aria-label': 'Share result',
+        html: ICON_SHARE,
+        onclick: function () { shareGame(g, rival, this); },
+      }),
+    ]);
+  }
+
   // ---------- dashboard view ----------
   function renderDashboard() {
     renderProfileCard();
@@ -1515,13 +1628,14 @@
 
     let w = 0, l = 0, t = 0;
     const now = Date.now();
+    const savedGames = [];
     for (const { rival, theirs } of targets) {
       const myT = mine.computedTotal;
       const theirT = theirs.computedTotal;
       const diff = myT - theirT;
       if (diff > 0) w++; else if (diff < 0) l++; else t++;
 
-      state.games.push({
+      const newGame = {
         id: uid(),
         rivalId: rival.id,
         date,
@@ -1531,7 +1645,9 @@
         theirScore: theirT,
         note: '',
         createdAt: now,
-      });
+      };
+      state.games.push(newGame);
+      savedGames.push({ game: newGame, rival });
     }
     persistGames();
 
@@ -1558,8 +1674,9 @@
     refreshPasteMineUI();
     refreshAllPasteResults();
 
-    // Confirmation summary on the bottom bar
+    // Confirmation summary on the bottom bar + share buttons (one per rival).
     const summary = $('#paste-summary');
+    const pasteActions = $('#paste-actions');
     if (summary) {
       summary.classList.remove('is-ready', 'is-error');
       summary.classList.add('is-success');
@@ -1568,6 +1685,21 @@
       if (l) wlt.push(`${l}L`);
       if (t) wlt.push(`${t}T`);
       summary.textContent = `Saved ${targets.length} game${targets.length === 1 ? '' : 's'} · ${wlt.join(' · ') || 'no result'}`;
+    }
+    if (pasteActions) {
+      pasteActions.querySelectorAll('.paste-share-btn').forEach(b => b.remove());
+      savedGames.forEach(({ game, rival }) => {
+        const shareBtn = el('button', {
+          type: 'button',
+          class: 'btn btn-ghost paste-share-btn',
+          title: `Share result vs ${rival.name}`,
+        }, [
+          el('span', { html: ICON_SHARE, class: 'paste-share-icon' }),
+          `Share vs ${rival.name}`,
+        ]);
+        shareBtn.addEventListener('click', function () { shareGame(game, rival, this); });
+        pasteActions.appendChild(shareBtn);
+      });
     }
 
     // Refresh the dashboard tiles + summary so saved games land immediately.
@@ -1904,6 +2036,7 @@
         el('td', { class: 'rounds-cell' }, [makeRoundDots(g)]),
         el('td', {}, [el('span', { class: 'result-badge ' + r }, r)]),
         noteCell(g),
+        shareCell(g, rival),
         deleteCell(g),
       ]));
     });
@@ -2835,6 +2968,7 @@
         el('td', { class: 'rounds-cell' }, [makeRoundDots(g)]),
         el('td', {}, [el('span', { class: 'result-badge ' + r }, r)]),
         noteCell(g),
+        shareCell(g, rival || null),
         deleteCell(g),
       ]));
     });

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1753,6 +1753,61 @@
     ]);
   }
 
+  // Returns {kind, text} for a one-line drama callout on the dashboard rival
+  // card, or null if no drama applies. Priority order matches the spec.
+  // kind: 'win' | 'loss' | 'comeback'
+  function streakDrama(rivalId) {
+    const today = todayISO();
+    // Already played today — drama resolved, skip.
+    if (state.games.some(g => g.rivalId === rivalId && g.date === today)) return null;
+
+    const games = gamesFor(rivalId);
+    if (games.length < 2) return null;
+
+    const rival = state.rivals.find(r => r.id === rivalId);
+    const rivalName = rival ? rival.name : 'rival';
+
+    const s = streaks(games);
+    const curW = s.curMine;
+    const curL = s.curTheirs;
+
+    // Compute the previous all-time best win streak (excluding the current
+    // ongoing run) so conditions 1 and 2 compare against the historical record.
+    let prevLongestW = 0;
+    let run = 0;
+    for (let i = 0; i < games.length - curW; i++) {
+      const r = resultOf(games[i]);
+      if (r === 'W') { run++; if (run > prevLongestW) prevLongestW = run; }
+      else run = 0;
+    }
+
+    // 1. About to break personal best win streak (tie record with next win)
+    if (curW >= 2 && curW === prevLongestW) {
+      return { kind: 'win', text: `🔥 On a ${curW}-game win streak — match your record today` };
+    }
+    // 2. About to extend personal best win streak (already surpassed old record)
+    if (curW >= 2 && curW > prevLongestW) {
+      return { kind: 'win', text: `🔥 New record! ${curW}-game win streak vs ${rivalName}` };
+    }
+    // 3. About to extend any winning streak
+    if (curW >= 3) {
+      return { kind: 'win', text: `🔥 ${curW}-game win streak vs ${rivalName}` };
+    }
+    // 4. About to end a losing streak
+    if (curL >= 3) {
+      return { kind: 'loss', text: `❄️ ${curL}-game losing streak — turn it around today` };
+    }
+    // 5. Comeback potential
+    if (games.length >= 3) {
+      const last = games[games.length - 1];
+      const diff = getMyTotal(last) - getTheirTotal(last);
+      if (diff < 0 && Math.abs(diff) < 100) {
+        return { kind: 'comeback', text: `⚡ Close one last time (${Math.abs(diff)}-pt loss) — get even today` };
+      }
+    }
+    return null;
+  }
+
   function renderRivalGrid() {
     const grid = $('#rival-grid');
     grid.innerHTML = '';
@@ -1843,6 +1898,11 @@
       el('span', { style: `width:${(s.winPct * 100).toFixed(1)}%` }),
     ]);
     card.appendChild(pctBar);
+
+    const drama = streakDrama(r.id);
+    if (drama) {
+      card.appendChild(el('div', { class: 'drama-callout drama-callout-' + drama.kind }, drama.text));
+    }
 
     const foot = el('div', { class: 'rival-card-foot' });
     const formPills = el('div', { class: 'form-pills', title: 'Last 5 games (oldest → newest)' });


### PR DESCRIPTION
## Summary

This PR bundles two maptap-rivals additions and five football-h2h tracker improvements.

### maptap-rivals
- **Shareable per-day result card** — Wordle/GeoGuessr-style share snippet with totals, per-round result squares, and current streak. Triggers from a share icon on every history/rival-games row plus inline "Share vs X" buttons after saving today's scores. Uses `navigator.share` when available, falls back to clipboard with an inline "Copied — paste anywhere" toast.
- **Streak drama callout on rival cards** — One-line dashboard callout per rival when today's game sets up a stakes-y moment: matching/breaking a win-streak record, snapping a losing streak, or avenging a close loss. Skips when the rival has already been played today or has fewer than two games. Win, loss, and comeback variants get distinct warm/cool/amber treatments.

### football-h2h
- **Current streak badge on the H2H tab** — e.g. "Jordan – 3 match winning streak", wired into the existing match-streak helpers.
- **Recent form strip** — each player's last five W/D/L results as colored dots above the game history table.
- **Optional match notes / session label** — small italic line under the date in the history table. Backward-compatible with games that don't have a note.
- **Team matchup lookup in General Stats** — pick a team for each player and see the H2H record filtered to that specific pairing.
- **Session Summary share card** — sidebar button opens a copyable modal with today's (or the active date filter's) scorelines, goal totals, and session winner.

## Share format (maptap-rivals)
```
MapTap Rivals — Nikita vs Alex
2026-05-21

🟩 735 — 650 ⬜  (you won by 85)
Round scores:
🟩🟩⬜🟩⬜  Nikita
⬜⬜🟩⬜🟩  Alex

🔥 4-game win streak
shevato.com/apps/maptap-rivals
```

## Test plan

### maptap-rivals — shareable card
- [ ] Save a new day's scores → "Share vs {Rival}" buttons appear in the paste-actions bar
- [ ] Click a share button on the history table → snippet copied + toast appears
- [ ] Click a share button on a rival-games row → snippet copied + toast appears
- [ ] On mobile, native share sheet opens instead of clipboard fallback
- [ ] Share text for a tie game uses ⬛ squares
- [ ] Share text omits the streak line when streak < 2

### maptap-rivals — streak drama callout
- [ ] Rival with a 3-win streak shows a "matching record" callout before today's game
- [ ] Rival with a current losing streak shows a "snap the streak" variant
- [ ] After a close loss to a rival, the next day shows the comeback variant
- [ ] Rivals with fewer than two games or who have already been played today show no callout

### football-h2h
- [ ] H2H tab shows the current streak badge with the leading player's name and length
- [ ] Form strip shows the last five W/D/L dots per player above the history table
- [ ] Add Game form accepts an optional note; it renders as an italic line under the date in history
- [ ] Editing a game lets you change or remove the note
- [ ] General Stats team matchup dropdowns filter the H2H record correctly
- [ ] Session Summary button opens a modal honoring the active date filter; Copy button copies formatted text
