### PR TITLE
feat(maptap-rivals): streak drama callout on rival cards

### DIFF
--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -1439,6 +1439,30 @@ body.maptap-rivals-app button {
   background: linear-gradient(90deg, var(--good), var(--accent-2));
 }
 
+.drama-callout {
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  margin-bottom: 0.55rem;
+}
+.drama-callout-win {
+  background: rgba(249, 115, 22, 0.15);
+  color: #fb923c;
+  border: 1px solid rgba(249, 115, 22, 0.25);
+}
+.drama-callout-loss {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+  border: 1px solid rgba(96, 165, 250, 0.22);
+}
+.drama-callout-comeback {
+  background: rgba(250, 204, 21, 0.12);
+  color: #fbbf24;
+  border: 1px solid rgba(250, 204, 21, 0.22);
+}
+
 /* ---------- Rival detail ---------- */
 
 .rival-header {

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1753,6 +1753,61 @@
     ]);
   }
 
+  // Returns {kind, text} for a one-line drama callout on the dashboard rival
+  // card, or null if no drama applies. Priority order matches the spec.
+  // kind: 'win' | 'loss' | 'comeback'
+  function streakDrama(rivalId) {
+    const today = todayISO();
+    // Already played today — drama resolved, skip.
+    if (state.games.some(g => g.rivalId === rivalId && g.date === today)) return null;
+
+    const games = gamesFor(rivalId);
+    if (games.length < 2) return null;
+
+    const rival = state.rivals.find(r => r.id === rivalId);
+    const rivalName = rival ? rival.name : 'rival';
+
+    const s = streaks(games);
+    const curW = s.curMine;
+    const curL = s.curTheirs;
+
+    // Compute the previous all-time best win streak (excluding the current
+    // ongoing run) so conditions 1 and 2 compare against the historical record.
+    let prevLongestW = 0;
+    let run = 0;
+    for (let i = 0; i < games.length - curW; i++) {
+      const r = resultOf(games[i]);
+      if (r === 'W') { run++; if (run > prevLongestW) prevLongestW = run; }
+      else run = 0;
+    }
+
+    // 1. About to break personal best win streak (tie record with next win)
+    if (curW >= 2 && curW === prevLongestW) {
+      return { kind: 'win', text: `🔥 On a ${curW}-game win streak — match your record today` };
+    }
+    // 2. About to extend personal best win streak (already surpassed old record)
+    if (curW >= 2 && curW > prevLongestW) {
+      return { kind: 'win', text: `🔥 New record! ${curW}-game win streak vs ${rivalName}` };
+    }
+    // 3. About to extend any winning streak
+    if (curW >= 3) {
+      return { kind: 'win', text: `🔥 ${curW}-game win streak vs ${rivalName}` };
+    }
+    // 4. About to end a losing streak
+    if (curL >= 3) {
+      return { kind: 'loss', text: `❄️ ${curL}-game losing streak — turn it around today` };
+    }
+    // 5. Comeback potential
+    if (games.length >= 3) {
+      const last = games[games.length - 1];
+      const diff = getMyTotal(last) - getTheirTotal(last);
+      if (diff < 0 && Math.abs(diff) < 100) {
+        return { kind: 'comeback', text: `⚡ Close one last time (${Math.abs(diff)}-pt loss) — get even today` };
+      }
+    }
+    return null;
+  }
+
   function renderRivalGrid() {
     const grid = $('#rival-grid');
     grid.innerHTML = '';
@@ -1843,6 +1898,11 @@
       el('span', { style: `width:${(s.winPct * 100).toFixed(1)}%` }),
     ]);
     card.appendChild(pctBar);
+
+    const drama = streakDrama(r.id);
+    if (drama) {
+      card.appendChild(el('div', { class: 'drama-callout drama-callout-' + drama.kind }, drama.text));
+    }
 
     const foot = el('div', { class: 'rival-card-foot' });
     const formPills = el('div', { class: 'form-pills', title: 'Last 5 games (oldest → newest)' });


### PR DESCRIPTION
## Summary
- Adds a one-line dashboard callout per rival when today's game sets up a stakes moment.
- Five priority cases: matching a win-streak record, extending past it, ongoing 3+ win streak, ongoing 3+ losing streak, recent close-loss revenge.
- Skips the callout when today already has a game logged against the rival, or the rival has < 2 games.
- Win / loss / comeback variants get warm orange, cool blue, and amber treatments respectively so the dashboard can be scanned at a glance.

## Stacking note
Stacked on top of #110 (shareable result card). Base is `feat/maptap-rivals-shareable-card`; will need to be retargeted to `master` after #110 merges.

## Test plan
- [ ] Rival with a current 2-game win streak equal to historical best → "match your record today" pill (orange)
- [ ] Rival with a current win streak greater than historical best → "New record!" pill (orange)
- [ ] Rival with a 3+ losing streak → "turn it around today" pill (blue)
- [ ] Rival with a close (<100 pt) most-recent loss and 3+ games → "get even today" pill (amber)
- [ ] Rival that has already been played today → no callout
- [ ] Rival with < 2 games → no callout