### PR TITLE
fix(maptap-rivals): share button always copies to clipboard

### DIFF
--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1025,14 +1025,6 @@
 
   async function shareGame(g, rival, btn) {
     const text = buildShareText(g, rival);
-    if (navigator.share) {
-      try {
-        await navigator.share({ text });
-        return;
-      } catch (_) {
-        // User cancelled or share failed — fall through to clipboard.
-      }
-    }
     try {
       await navigator.clipboard.writeText(text);
       showShareToast(btn, 'Copied — paste anywhere');


### PR DESCRIPTION
## Summary
- Removes the `navigator.share` path so every share button (history table, rival-games table, post-save "Share vs X" buttons) consistently copies the snippet to the clipboard.
- The native share sheet fragmented the UX between platforms; clipboard-paste works the same everywhere.

## Test plan
- [ ] Click share button on a history table row → snippet copied + "Copied — paste anywhere" toast
- [ ] Click share button on a rival detail row → same behavior
- [ ] Post-save "Share vs X" button → same behavior
- [ ] On mobile, no native share sheet appears