### PR TITLE
feat(maptap-rivals): form guide column on leaderboard

### DIFF
--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -1413,6 +1413,31 @@ body.maptap-rivals-app button {
 .form-pill.L { background: var(--bad); color: var(--bad-ink); }
 .form-pill.T { background: var(--tie); color: #1a1d24; }
 
+.leaderboard-form {
+  display: inline-flex;
+  gap: 2px;
+  align-items: center;
+}
+.lb-form-pill {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.58rem;
+  font-weight: 700;
+  color: #fff;
+}
+.lb-form-W { background: var(--good); color: var(--good-ink); }
+.lb-form-L { background: var(--bad); color: var(--bad-ink); }
+.lb-form-T { background: var(--tie); color: #1a1d24; }
+.lb-form-empty {
+  background: transparent;
+  border: 1px solid var(--border);
+  opacity: 0.35;
+}
+
 .streak-tag {
   display: inline-flex;
   align-items: center;

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -347,6 +347,7 @@
               <th>Win %</th>
               <th>Avg Δ</th>
               <th>Streak</th>
+              <th>Form</th>
             </tr>
           </thead>
           <tbody></tbody>

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -2606,6 +2606,27 @@
       const streakCell = el('td', {});
       streakCell.innerHTML = streakHtml;
       tr.appendChild(streakCell);
+
+      const formCell = el('td', {});
+      const formWrap = el('div', { class: 'leaderboard-form' });
+      const FORM_SLOTS = 5;
+      const padCount = FORM_SLOTS - s.recent5.length;
+      for (let p = 0; p < padCount; p++) {
+        formWrap.appendChild(el('span', { class: 'lb-form-pill lb-form-empty' }));
+      }
+      s.recent5.forEach(g => {
+        const r = resultOf(g);
+        const myT = getMyTotal(g);
+        const theirT = getTheirTotal(g);
+        const label = r === 'W' ? 'Win' : r === 'L' ? 'Loss' : 'Tie';
+        formWrap.appendChild(el('span', {
+          class: 'lb-form-pill lb-form-' + r,
+          title: `${label} ${myT}–${theirT} (${g.date})`,
+        }, r));
+      });
+      formCell.appendChild(formWrap);
+      tr.appendChild(formCell);
+
       tbody.appendChild(tr);
     });
   }


### PR DESCRIPTION
## Summary
- Adds a 5-pill Form column to the leaderboard showing each rival's last five W/L/T results.
- Oldest on the left, newest on the right. Rivals with fewer than 5 games get muted empty slots on the left so the column stays the same width across rows.
- Each pill tooltip shows the result, score, and date.

## Test plan
- [ ] Leaderboard renders a Form column after Streak with 5 pills per row
- [ ] Tooltip on a W pill reads e.g. "Win 520–440 (2026-05-20)"
- [ ] Rivals with < 5 games render muted placeholder pills on the left
- [ ] Dashboard rival cards' form pills are unchanged