### PR TITLE
feat(arena): 10 improvements — share cards, streaks, spectator mode, H2H, mobile UX

### DIFF
--- a/apps/arena/css/styles.css
+++ b/apps/arena/css/styles.css
@@ -1665,6 +1665,18 @@ select option { background: var(--surface); color: var(--text); }
   text-align: center;
 }
 
+.room-spectator-banner {
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0.85rem;
+  background: rgba(168, 85, 247, 0.10);
+  border: 1px solid rgba(168, 85, 247, 0.35);
+  border-radius: 8px;
+  color: var(--violet-2);
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+}
+
 /* Globe-drop layout — top-mounted live standings */
 .globe-drop-status { display: none; }
 

--- a/apps/arena/css/styles.css
+++ b/apps/arena/css/styles.css
@@ -1821,6 +1821,34 @@ select option { background: var(--surface); color: var(--text); }
   .globe-drop-fab span { display: none; }
 }
 
+/* Mobile: fixed bottom pill for the submit button so players don't
+   need to scroll below the globe. Overlays the canvas; the Clear
+   button stays in the FAB stack (top-right) since it's secondary.
+   Only activates on narrow viewports (≤768px). */
+@media (max-width: 768px) {
+  #globe-drop-submit-btn {
+    position: fixed;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 200;
+    height: 48px;
+    padding: 0 2rem;
+    border-radius: 999px;
+    font-size: 0.95rem;
+    min-width: 180px;
+    box-shadow: 0 4px 24px rgba(34, 211, 238, 0.45), 0 2px 8px rgba(0,0,0,0.5);
+    /* Override the FAB-stack absolute positioning context */
+    top: auto;
+    right: auto;
+  }
+  /* Add bottom padding to the map wrap so the fixed pill doesn't
+     cover the bottom of the globe on short screens. */
+  .globe-drop-map-wrap {
+    padding-bottom: 4rem;
+  }
+}
+
 /* Mini-board variant pinned above the globe with submit-state badges.
    Generous bottom margin gives live standings breathing room before
    the next section (globe / previous round scores) begins. */
@@ -3085,6 +3113,20 @@ select option { background: var(--surface); color: var(--text); }
   white-space: nowrap;
 }
 
+/* Pending (not yet submitted) — a subtle pulsing left border so it's
+   obvious at a glance who is still thinking. Only applied during the
+   Globe Drop asking phase; removed when the player locks in. */
+.mini-board-row.is-pending {
+  border-left: 2px solid rgba(168, 85, 247, 0.55);
+}
+.mini-board-row.is-pending .mini-board-rank {
+  animation: mb-rank-pulse 1.6s ease-in-out infinite;
+}
+@keyframes mb-rank-pulse {
+  0%, 100% { opacity: 0.85; }
+  50%       { opacity: 0.35; }
+}
+
 /* Submitted indicator — green tint on the name span PLUS a small ✓
    sliding in next to it. No "submitted" word, no toast, no badge
    chrome. The tint reads at a glance even at a distance; the ✓ is
@@ -3094,6 +3136,14 @@ select option { background: var(--surface); color: var(--text); }
   border-radius: 6px;
   padding: 0.05rem 0.4rem;
   box-shadow: 0 0 10px rgba(16, 185, 129, 0.18) inset;
+}
+/* Settled state removes the pending pulse cleanly. */
+.mini-board-row.is-answered.is-pending {
+  border-left-color: transparent;
+}
+.mini-board-row.is-answered .mini-board-rank {
+  animation: none;
+  opacity: 0.85;
 }
 .mini-board-check {
   display: inline-flex;
@@ -3157,7 +3207,19 @@ select option { background: var(--surface); color: var(--text); }
 
 /* ---------- Stage: end ---------- */
 
-.end-head { text-align: center; margin-bottom: 1.6rem; }
+.end-head {
+  text-align: center;
+  margin-bottom: 1.6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+.end-share-btn {
+  gap: 0.4rem;
+  opacity: 0.85;
+}
+.end-share-btn:hover { opacity: 1; }
 
 /* Solo-only hero block. Replaces the podium / standings table for
    single-player runs since there's nothing to rank against. */

--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -345,6 +345,9 @@
         <p class="room-paused-banner" id="room-paused-banner" hidden>
           <span aria-hidden="true">⏸</span> Game paused by host.
         </p>
+        <p class="room-spectator-banner" id="room-spectator-banner" hidden>
+          <span aria-hidden="true">👁</span> Spectating — joining next round automatically.
+        </p>
 
         <!-- Chat side panel. Slides in from the right when toggled.
              Subscribes to triviaRooms/{code}/chat on enterRoom and

--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -386,6 +386,9 @@
             <header class="room-settings-head">
               <h3>Room settings</h3>
               <span class="room-settings-hint" id="room-settings-hint" hidden>Host can change settings</span>
+              <!-- Host-only: switch game type while still in lobby. Hidden once the
+                   game starts (status changes to 'playing'). -->
+              <button type="button" class="btn btn-ghost btn-sm room-settings-game-type-btn" id="room-switch-game-type-btn" hidden></button>
             </header>
 
             <!-- Read-only summary (always rendered; visibility flipped
@@ -393,6 +396,10 @@
                  open). -->
             <dl class="room-settings-list" id="room-settings-view">
               <div class="room-settings-item">
+                <dt>Game type</dt>
+                <dd id="room-settings-game-type">—</dd>
+              </div>
+              <div class="room-settings-item" id="room-settings-item-round-type">
                 <dt>Round type</dt>
                 <dd id="room-settings-round-type">—</dd>
               </div>

--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -658,6 +658,15 @@
         <section class="stage stage-end" id="stage-end" hidden>
           <header class="end-head">
             <p id="end-summary"></p>
+            <!-- Share result card — generates a canvas image of the
+                 final standings and triggers a download / Web Share. -->
+            <button type="button" class="btn btn-ghost btn-sm end-share-btn" id="end-share-btn" hidden>
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/>
+                <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+              </svg>
+              Share result
+            </button>
           </header>
 
           <!-- Guest-only sign-up CTA. Shown for anonymous users on the

--- a/apps/arena/js/app.js
+++ b/apps/arena/js/app.js
@@ -1125,12 +1125,86 @@ function wireGameTypeToggle() {
                     el.hidden = el.dataset.gameType !== type;
                 }
             });
+            saveLobbySettings();
         });
     });
 }
 
+const LOBBY_SETTINGS_KEY = 'arena.lobby.lastSettings';
+
+function saveLobbySettings() {
+    try {
+        const overrideTimer = !!$('#create-globe-drop-timer-override').checked;
+        const settings = {
+            gameType: state.selectedGameType,
+            roundType: $('#create-globe-drop-round-type').value,
+            difficulty: $('#create-globe-drop-difficulty').value,
+            locationsCount: $('#create-locations-count').value,
+            timerOverride: overrideTimer,
+            timerSec: overrideTimer ? $('#create-globe-drop-time').value : null,
+            questionsCount: $('#create-questions-count').value,
+            triviaTimeSec: $('#create-trivia-time').value
+        };
+        localStorage.setItem(LOBBY_SETTINGS_KEY, JSON.stringify(settings));
+    } catch (e) { /* localStorage may be unavailable */ }
+}
+
+function restoreLobbySettings() {
+    try {
+        const raw = localStorage.getItem(LOBBY_SETTINGS_KEY);
+        if (!raw) return;
+        const s = JSON.parse(raw);
+
+        // Restore game type toggle first so the correct fields show.
+        if (s.gameType === 'trivia' || s.gameType === 'globe-drop') {
+            const btn = $(`.game-type-btn[data-game-type="${s.gameType}"]`);
+            if (btn) btn.click();
+        }
+
+        if (s.roundType) {
+            const el = $('#create-globe-drop-round-type');
+            if (el) el.value = s.roundType;
+        }
+        if (s.difficulty) {
+            const el = $('#create-globe-drop-difficulty');
+            if (el) el.value = s.difficulty;
+        }
+        if (s.locationsCount) {
+            const el = $('#create-locations-count');
+            if (el) el.value = s.locationsCount;
+        }
+        if (s.timerOverride) {
+            const tog = $('#create-globe-drop-timer-override');
+            if (tog) {
+                tog.checked = true;
+                $('#create-globe-drop-time-field').hidden = false;
+            }
+            if (s.timerSec) {
+                const el = $('#create-globe-drop-time');
+                if (el) el.value = s.timerSec;
+            }
+        }
+        if (s.questionsCount) {
+            const el = $('#create-questions-count');
+            if (el) el.value = s.questionsCount;
+        }
+        if (s.triviaTimeSec) {
+            const el = $('#create-trivia-time');
+            if (el) el.value = s.triviaTimeSec;
+        }
+    } catch (e) { /* ignore corrupt localStorage */ }
+}
+
 function wireLobby() {
     wireGameTypeToggle();
+
+    // Restore previously used settings on mount.
+    restoreLobbySettings();
+
+    // Save settings on any field change so the last selection survives reload.
+    $$('#lobby-panel select, #lobby-panel input[type="checkbox"]').forEach((el) => {
+        el.addEventListener('change', saveLobbySettings);
+    });
 
     $('#create-private-toggle').addEventListener('change', (e) => {
         const wantsPrivate = e.target.checked;
@@ -1190,6 +1264,8 @@ function wireLobby() {
     if (settingsCancel) settingsCancel.addEventListener('click', () => closeRoomSettingsEditor());
     const settingsSave = $('#room-settings-save');
     if (settingsSave) settingsSave.addEventListener('click', () => saveRoomSettings());
+    const switchGameTypeBtn = $('#room-switch-game-type-btn');
+    if (switchGameTypeBtn) switchGameTypeBtn.addEventListener('click', () => switchRoomGameType());
     const endAgainHandler = () => {
         // Solo: skip the accept gate, restart immediately.
         const playMode = (state.roomData && state.roomData.playMode) || 'multi';
@@ -1729,6 +1805,7 @@ async function maybeResetForNewRound() {
         await updateDoc(doc(db, 'triviaRooms', state.roomCode, 'players', state.user.uid), {
             score: 0,
             streak: 0,
+            globeDropStreak: 0,
             round: roomRound,
             currentAnswerIndex: null,
             currentGuess: null,
@@ -2390,34 +2467,55 @@ function renderRoomSettings(isHost) {
     const panel = $('#room-settings');
     if (!panel) return;
     const room = state.roomData || {};
-    if (room.gameType !== 'globe-drop') {
-        panel.hidden = true;
-        return;
-    }
+    const canEdit = isHost && room.status === 'lobby';
+
+    // Show the panel for both game types — trivia rooms need the game-type
+    // display and the switch button even though they have no GlobeDrop fields.
     panel.hidden = false;
 
-    const roundType = room.roundType || 'capitals';
-    const meta = GlobeDropLocations.ROUND_TYPES[roundType] || GlobeDropLocations.ROUND_TYPES.capitals;
-    setText($('#room-settings-round-type'), meta.label || roundType);
+    // Game type display row — always populated regardless of game type.
+    const gameTypeEl = $('#room-settings-game-type');
+    if (gameTypeEl) {
+        setText(gameTypeEl, room.gameType === 'globe-drop' ? 'Globe Drop' : 'Trivia');
+    }
 
-    const diffKey = room.difficulty || 'medium';
-    const diff = GlobeDropScoring.difficultySettings(diffKey);
-    setText($('#room-settings-difficulty'), diff.label || diffKey);
+    // Globe Drop-specific settings rows — hide for trivia rooms.
+    const isGlobeDrop = room.gameType === 'globe-drop';
+    const roundTypeItem = $('#room-settings-item-round-type');
+    if (roundTypeItem) roundTypeItem.hidden = !isGlobeDrop;
+    const diffEl = document.querySelector('.room-settings-item:has(#room-settings-difficulty)');
 
-    setText($('#room-settings-locations'), String(room.totalQuestions || 0));
+    if (isGlobeDrop) {
+        const roundType = room.roundType || 'capitals';
+        const meta = GlobeDropLocations.ROUND_TYPES[roundType] || GlobeDropLocations.ROUND_TYPES.capitals;
+        setText($('#room-settings-round-type'), meta.label || roundType);
 
-    const seconds = Math.round((room.questionTimeMs || diff.timerSec * 1000) / 1000);
-    setText($('#room-settings-timer'), `${seconds}s`);
+        const diffKey = room.difficulty || 'medium';
+        const diff = GlobeDropScoring.difficultySettings(diffKey);
+        setText($('#room-settings-difficulty'), diff.label || diffKey);
+
+        setText($('#room-settings-locations'), String(room.totalQuestions || 0));
+
+        const seconds = Math.round((room.questionTimeMs || diff.timerSec * 1000) / 1000);
+        setText($('#room-settings-timer'), `${seconds}s`);
+    }
+
+    // Switch game type button — host only, lobby only.
+    const switchBtn = $('#room-switch-game-type-btn');
+    if (switchBtn) {
+        switchBtn.hidden = !canEdit;
+        if (canEdit) {
+            switchBtn.textContent = isGlobeDrop ? 'Switch to Trivia' : 'Switch to Globe Drop';
+        }
+    }
 
     const editBtn = $('#room-settings-edit-btn');
     const hint = $('#room-settings-hint');
     const editForm = $('#room-settings-edit');
     const view = $('#room-settings-view');
 
-    // Edit affordances visible only to host AND only while the room is
-    // still in lobby state (settings are locked once playing starts).
-    const canEdit = isHost && room.status === 'lobby';
-    if (editBtn) editBtn.hidden = !canEdit;
+    // Edit affordances visible only for globe-drop host in lobby.
+    if (editBtn) editBtn.hidden = !(canEdit && isGlobeDrop);
     if (hint) hint.hidden = !(isHost && !canEdit);
     // Whenever the form isn't open, keep it hidden (show summary).
     if (editForm && !state.roomSettingsEditing) {
@@ -2521,6 +2619,33 @@ async function saveRoomSettings() {
     } finally {
         if (saveBtn) saveBtn.disabled = false;
         if (cancelBtn) cancelBtn.disabled = false;
+    }
+}
+
+/**
+ * Toggle the room's game type between 'globe-drop' and 'trivia' while the
+ * room is still in the lobby. Writes atomically to the room doc — only the
+ * gameType field changes, the player list is untouched.
+ */
+async function switchRoomGameType() {
+    if (!state.user || !state.roomCode || !state.roomData) return;
+    if (state.roomData.hostUid !== state.user.uid) return;
+    if (state.roomData.status !== 'lobby') return;
+
+    const current = state.roomData.gameType || 'globe-drop';
+    const next = current === 'globe-drop' ? 'trivia' : 'globe-drop';
+
+    const switchBtn = $('#room-switch-game-type-btn');
+    if (switchBtn) switchBtn.disabled = true;
+    try {
+        await updateDoc(doc(db, 'triviaRooms', state.roomCode), { gameType: next });
+        // Also update state.selectedGameType so the local create-form toggle
+        // stays in sync on subsequent room-settings renders.
+        state.selectedGameType = next;
+    } catch (err) {
+        console.warn('switchRoomGameType failed:', err);
+    } finally {
+        if (switchBtn) switchBtn.disabled = false;
     }
 }
 
@@ -3571,10 +3696,16 @@ function renderMiniBoardGlobeDrop(currentQuestionId) {
         const pts = rec && typeof rec.points === 'number' ? rec.points : 0;
         return (p.score || 0) - pts;
     };
+    // Carry each player's globeDropStreak from the Firestore doc so the
+    // streak chip renders correctly in the mini-board.
+    const playerStreak = (p) => {
+        const full = state.roomPlayers.find((rp) => rp.uid === p.uid);
+        return full ? (full.globeDropStreak || 0) : 0;
+    };
     const ranked = Scoring.rankPlayers(state.roomPlayers.map((p) => ({
         displayName: p.displayName,
         score: adjustedScore(p),
-        streak: 0, // GlobeDrop doesn't use streaks (yet)
+        streak: p.globeDropStreak || 0,
         uid: p.uid,
         answeredThisQuestion: currentQuestionId != null
             && p.currentAnsweredFor === currentQuestionId
@@ -3586,13 +3717,15 @@ function renderMiniBoardGlobeDrop(currentQuestionId) {
         if (state.user && p.uid === state.user.uid) li.classList.add('is-me');
         if (i === 0 && (p.score || 0) > 0) li.classList.add('is-leader');
         if (p.answeredThisQuestion) li.classList.add('is-answered');
-        // Answered state: a small green ✓ sits inline next to the
-        // player's name. No "submitted" word, no badge chrome — the
-        // pseudo-element on .is-answered .mini-board-check renders the
-        // ✓ glyph and animates in.
+        // Surface bullseye streak >= 2 — same treatment as trivia streaks.
+        const streak = Number(p.streak) || 0;
+        const streakChip = streak >= 2
+            ? `<span class="mini-board-streak" title="${streak} bullseyes in a row">🎯${streak}</span>`
+            : '';
         li.innerHTML =
             `<span class="mini-board-rank">${i+1}</span>` +
             `<span class="mini-board-name">${escapeHtml(p.displayName)}</span>` +
+            streakChip +
             `<span class="mini-board-check" aria-label="submitted"></span>` +
             `<span class="mini-board-score">${p.score || 0}</span>`;
         list.appendChild(li);
@@ -3741,6 +3874,18 @@ async function submitGuess() {
             if (!snap.exists()) return;
             const cur = snap.data();
             if (cur.currentAnsweredFor === loc.id) return; // already submitted
+
+            // Globe Drop streak: consecutive bullseyes (basePoints >= 98) add a
+            // multiplier on top of the distance/continent score.
+            const prevStreak = cur.globeDropStreak || 0;
+            const isBullseye = basePoints >= 98;
+            const newStreak = isBullseye ? prevStreak + 1 : 0;
+            const cappedStreak = Math.min(newStreak, Config.GLOBE_DROP_STREAK_MULTIPLIER_CAP);
+            const streakMult = 1 + cappedStreak * Config.GLOBE_DROP_STREAK_MULTIPLIER_STEP;
+            // Only apply the streak bonus when there is at least one prior
+            // bullseye in the run (cappedStreak >= 2 means the second+ in a row).
+            const finalPoints = cappedStreak >= 2 ? Math.round(points * streakMult) : points;
+
             // Append a per-location record so the recap can show actual
             // vs guess + distance + points for every play.
             const guessRecord = {
@@ -3755,13 +3900,14 @@ async function submitGuess() {
                 distanceKm: distance,
                 basePoints,
                 multiplier: typeof loc.multiplier === 'number' ? loc.multiplier : 1,
-                points
+                points: finalPoints
             };
             tx.update(pref, {
                 currentGuess: guess,
                 currentAnswerAt: serverTimestamp(),
                 currentAnsweredFor: loc.id,
-                score: (cur.score || 0) + points,
+                score: (cur.score || 0) + finalPoints,
+                globeDropStreak: newStreak,
                 answers: [...(Array.isArray(cur.answers) ? cur.answers : []), guessRecord],
                 lastSeen: serverTimestamp()
             });

--- a/apps/arena/js/app.js
+++ b/apps/arena/js/app.js
@@ -1258,6 +1258,8 @@ function wireLobby() {
     // as a fresh start since guest stats were never persisted anyway.
     const endGuestCtaBtn = $('#end-guest-cta-btn');
     if (endGuestCtaBtn) endGuestCtaBtn.addEventListener('click', () => openSignInPrompt());
+    const endShareBtn = $('#end-share-btn');
+    if (endShareBtn) endShareBtn.addEventListener('click', () => shareResultCard());
     const settingsEditBtn = $('#room-settings-edit-btn');
     if (settingsEditBtn) settingsEditBtn.addEventListener('click', () => openRoomSettingsEditor());
     const settingsCancel = $('#room-settings-cancel');
@@ -3567,15 +3569,24 @@ function drawGlobeDropReveal(loc, me, { showOthers = true } = {}) {
         state.globe.polygonsData(feat ? [feat] : []);
     });
 
-    // Pan + zoom into the correct location. Altitude 0.6 puts the
-    // country's outline at roughly half the viewport — close enough
-    // for borders to read, far enough that the city pin doesn't get
-    // lost under the chrome. 1400ms tween matches globe.gl's default
-    // easing for a smooth fly-in. Guarded so the local + global
-    // reveal don't fight each other's tweens for the same question.
+    // Cinematic camera pan into the correct location. We do a two-phase
+    // tween: first pull back slightly from the player's current altitude
+    // (200ms, gives visual context), then arc into the target at 0.6
+    // altitude (1400ms). The two-phase approach prevents an abrupt jump
+    // when the player is zoomed close and the target is far away.
+    // Guarded by lastCameraTarget so local → global doesn't re-fire.
     const camTarget = `${loc.id}:${loc.lat.toFixed(3)},${loc.lng.toFixed(3)}`;
     if (state.lastCameraTarget !== camTarget) {
-        state.globe.pointOfView({ lat: loc.lat, lng: loc.lng, altitude: 0.6 }, 1400);
+        const curPov = state.globe.pointOfView();
+        const pullbackAlt = Math.max(curPov.altitude, 1.2);
+        // Phase 1: pull back (200ms)
+        state.globe.pointOfView({ lat: curPov.lat, lng: curPov.lng, altitude: pullbackAlt }, 200);
+        // Phase 2: fly to target (1400ms), delayed so phase 1 settles
+        setTimeout(() => {
+            if (state.globe && state.lastCameraTarget === camTarget) {
+                state.globe.pointOfView({ lat: loc.lat, lng: loc.lng, altitude: 0.6 }, 1400);
+            }
+        }, 220);
         state.lastCameraTarget = camTarget;
     }
 
@@ -3711,12 +3722,27 @@ function renderMiniBoardGlobeDrop(currentQuestionId) {
             && p.currentAnsweredFor === currentQuestionId
             && p.currentGuess != null
     })));
+    // Determine the current phase so we can show the pending pulse only during
+    // the asking window (not during reveal when everyone's result is locked).
+    const startMs = state.roomData && state.roomData.questionStartedAt && state.roomData.questionStartedAt.toMillis
+        ? state.roomData.questionStartedAt.toMillis() : null;
+    const revealMs = state.roomData && state.roomData.revealStartedAt && state.roomData.revealStartedAt.toMillis
+        ? state.roomData.revealStartedAt.toMillis() : null;
+    const currentPhase = globeDropPhase(startMs, Date.now(), revealMs, currentAskingDurationMs());
+    const isAskingPhase = currentPhase === 'asking';
+
     ranked.forEach((p, i) => {
         const li = document.createElement('li');
         li.className = 'mini-board-row';
         if (state.user && p.uid === state.user.uid) li.classList.add('is-me');
         if (i === 0 && (p.score || 0) > 0) li.classList.add('is-leader');
-        if (p.answeredThisQuestion) li.classList.add('is-answered');
+        if (p.answeredThisQuestion) {
+            li.classList.add('is-answered');
+        } else if (isAskingPhase && currentQuestionId) {
+            // Idle during the asking window: subtle pulse so the host can
+            // see who still needs to submit without it being distracting.
+            li.classList.add('is-pending');
+        }
         // Surface bullseye streak >= 2 — same treatment as trivia streaks.
         const streak = Number(p.streak) || 0;
         const streakChip = streak >= 2
@@ -4608,6 +4634,10 @@ async function renderEndStage(isHost) {
         setText($('#end-summary'), 'No scores recorded.');
     }
 
+    // Share result button — visible on the end stage for all game types.
+    const shareBtn = $('#end-share-btn');
+    if (shareBtn) shareBtn.hidden = false;
+
     // Full per-question/per-location recap (free for everyone)
     renderEndRecap();
 
@@ -4720,6 +4750,144 @@ async function writeEndOfGameStats(me, didWin) {
         await maybeWriteH2HPairs();
     } catch (err) {
         console.warn('End-of-game profile write failed:', err);
+    }
+}
+
+/**
+ * Generate and download (or Web Share) a canvas result card for the
+ * current finished game. Card includes: game type, top score, and the
+ * final standings for all players.
+ */
+async function shareResultCard() {
+    if (!state.roomData || !state.roomPlayers) return;
+    const btn = $('#end-share-btn');
+    if (btn) btn.disabled = true;
+
+    try {
+        const W = 600, H = 340;
+        const canvas = document.createElement('canvas');
+        canvas.width = W;
+        canvas.height = H;
+        const ctx = canvas.getContext('2d');
+
+        // Background gradient
+        const bg = ctx.createLinearGradient(0, 0, W, H);
+        bg.addColorStop(0, '#06070d');
+        bg.addColorStop(1, '#0e1220');
+        ctx.fillStyle = bg;
+        ctx.fillRect(0, 0, W, H);
+
+        // Accent border top
+        const topBar = ctx.createLinearGradient(0, 0, W, 0);
+        topBar.addColorStop(0, '#22d3ee');
+        topBar.addColorStop(1, '#a855f7');
+        ctx.fillStyle = topBar;
+        ctx.fillRect(0, 0, W, 3);
+
+        // Title
+        ctx.font = 'bold 22px "Space Grotesk", sans-serif';
+        ctx.fillStyle = '#eef2ff';
+        const gameType = state.roomData.gameType === 'globe-drop' ? 'Globe Drop' : 'Trivia';
+        ctx.fillText(`Arena — ${gameType}`, 28, 40);
+
+        // Date
+        ctx.font = '13px "Outfit", sans-serif';
+        ctx.fillStyle = '#8b95b3';
+        const dateStr = new Date().toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+        ctx.fillText(dateStr, 28, 62);
+
+        // Ranked players
+        const ranked = Scoring.rankPlayers(state.roomPlayers.map((p) => ({
+            displayName: p.displayName,
+            score: p.score || 0,
+            streak: p.streak || 0,
+            uid: p.uid
+        })));
+        const medals = ['🥇', '🥈', '🥉'];
+        const rowH = 44;
+        const startY = 90;
+        ranked.slice(0, 5).forEach((p, i) => {
+            const y = startY + i * rowH;
+            const isWinner = i === 0;
+
+            // Row background for winner
+            if (isWinner) {
+                ctx.fillStyle = 'rgba(251,191,36,0.08)';
+                ctx.beginPath();
+                ctx.roundRect(20, y - 8, W - 40, rowH - 4, 8);
+                ctx.fill();
+            }
+
+            // Medal or rank number
+            if (medals[i]) {
+                ctx.font = '20px serif';
+                ctx.fillText(medals[i], 28, y + 18);
+            } else {
+                ctx.font = 'bold 14px "JetBrains Mono", monospace';
+                ctx.fillStyle = '#22d3ee';
+                ctx.fillText(String(i + 1), 32, y + 18);
+            }
+
+            // Name
+            ctx.font = isWinner ? 'bold 16px "Outfit", sans-serif' : '15px "Outfit", sans-serif';
+            ctx.fillStyle = isWinner ? '#fbbf24' : '#eef2ff';
+            const maxNameW = 340;
+            let name = p.displayName || 'Player';
+            while (ctx.measureText(name).width > maxNameW && name.length > 1) name = name.slice(0, -1);
+            if (name !== p.displayName) name += '…';
+            ctx.fillText(name, 68, y + 18);
+
+            // Score pill
+            ctx.font = 'bold 14px "JetBrains Mono", monospace';
+            ctx.fillStyle = isWinner ? '#fbbf24' : '#22d3ee';
+            const scoreStr = String(p.score);
+            const scoreW = ctx.measureText(scoreStr).width;
+            ctx.fillText(scoreStr, W - 48 - scoreW / 2, y + 18);
+        });
+
+        // Footer
+        ctx.font = '12px "Outfit", sans-serif';
+        ctx.fillStyle = '#5b6585';
+        ctx.fillText('shevato.com/apps/arena', 28, H - 16);
+
+        // Gradient cyan line bottom-right
+        const footerBar = ctx.createLinearGradient(W - 200, 0, W, 0);
+        footerBar.addColorStop(0, 'transparent');
+        footerBar.addColorStop(1, '#22d3ee');
+        ctx.fillStyle = footerBar;
+        ctx.fillRect(W - 200, H - 3, 200, 3);
+
+        const filename = `arena-result-${Date.now()}.png`;
+        const dataUrl = canvas.toDataURL('image/png');
+
+        if (navigator.share && navigator.canShare) {
+            // Attempt Web Share API (mobile)
+            try {
+                const res = await fetch(dataUrl);
+                const blob = await res.blob();
+                const file = new File([blob], filename, { type: 'image/png' });
+                if (navigator.canShare({ files: [file] })) {
+                    await navigator.share({
+                        files: [file],
+                        title: `Arena ${gameType} results`,
+                        text: ranked[0] ? `${ranked[0].displayName} won with ${ranked[0].score} points!` : 'Check out the results!'
+                    });
+                    return;
+                }
+            } catch (_) { /* fall through to download */ }
+        }
+
+        // Fallback: download
+        const a = document.createElement('a');
+        a.href = dataUrl;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    } catch (err) {
+        console.warn('shareResultCard failed:', err);
+    } finally {
+        if (btn) btn.disabled = false;
     }
 }
 

--- a/apps/arena/js/app.js
+++ b/apps/arena/js/app.js
@@ -1654,11 +1654,14 @@ async function joinRoom() {
     }
 
     const displayName = (state.profile && state.profile.displayName) || deriveInitialDisplayName();
-    await joinPlayer(code, displayName, /* isHost */ false);
+    // Mark the player as a spectator if they're joining mid-game so the UI
+    // can show a "Spectating — joining next round" banner and gate submitting.
+    const isSpectator = data.status === 'playing';
+    await joinPlayer(code, displayName, /* isHost */ false, isSpectator ? (data.currentQuestionIndex || 0) : -1);
     enterRoom(code);
 }
 
-async function joinPlayer(code, displayName, isHost) {
+async function joinPlayer(code, displayName, isHost, joinedAtQuestionIndex) {
     const pref = doc(db, 'triviaRooms', code, 'players', state.user.uid);
     // Pull the room's current round so we don't carry stale "joinedAt round 1"
     // markers into round 2+. We can't write across players, so each player
@@ -1668,7 +1671,33 @@ async function joinPlayer(code, displayName, isHost) {
         const roomSnap = await getDoc(doc(db, 'triviaRooms', code));
         if (roomSnap.exists()) currentRound = roomSnap.data().round || 1;
     } catch (e) { /* fall back to 1 */ }
-    await setDoc(pref, {
+
+    // Check for an existing player doc written by beforeUnloadCleanup — if
+    // disconnectedAt is within the grace window, restore the player's
+    // score/streak/answers instead of resetting them to 0.
+    let existingSnap = null;
+    try { existingSnap = await getDoc(pref); } catch (e) { /* ignore */ }
+    const existing = existingSnap && existingSnap.exists() ? existingSnap.data() : null;
+    const now = Date.now();
+    const withinGrace = existing
+        && typeof existing.disconnectedAt === 'number'
+        && (now - existing.disconnectedAt) < DISCONNECT_GRACE_MS;
+
+    if (withinGrace) {
+        // Reconnect path: clear the disconnectedAt flag and refresh lastSeen.
+        // Score, streak, answers, and currentAnsweredFor are preserved.
+        await updateDoc(pref, {
+            displayName: String(displayName).slice(0, Config.MAX_DISPLAY_NAME),
+            disconnectedAt: deleteField(),
+            lastSeen: serverTimestamp()
+        });
+        return;
+    }
+
+    // joinedAtQuestionIndex >= 0 means the player joined mid-game and should
+    // spectate the current question (gate: their joinedAtQuestionIndex === the
+    // room's currentQuestionIndex at join time). -1 = joined at lobby, full participant.
+    const doc_data = {
         uid: state.user.uid,
         displayName: String(displayName).slice(0, Config.MAX_DISPLAY_NAME),
         isHost: !!isHost,
@@ -1681,7 +1710,11 @@ async function joinPlayer(code, displayName, isHost) {
         currentAnswerAt: null,
         currentAnsweredFor: null,
         answers: []
-    }, { merge: true });
+    };
+    if (typeof joinedAtQuestionIndex === 'number' && joinedAtQuestionIndex >= 0) {
+        doc_data.joinedAtQuestionIndex = joinedAtQuestionIndex;
+    }
+    await setDoc(pref, doc_data, { merge: true });
 }
 
 function openSignInPrompt() {
@@ -1820,6 +1853,8 @@ async function maybeResetForNewRound() {
     }
 }
 
+const DISCONNECT_GRACE_MS = 30000; // 30-second rejoin window
+
 async function beforeUnloadCleanup() {
     if (!state.roomCode || !state.user) return;
     // Keep the player doc when the room is already in the post-match
@@ -1829,8 +1864,17 @@ async function beforeUnloadCleanup() {
     // renderRoom routes status=finished → renderEndStage.
     if (state.roomData && state.roomData.status === 'finished') return;
     try {
-        await deleteDoc(doc(db, 'triviaRooms', state.roomCode, 'players', state.user.uid));
-    } catch (e) { /* best-effort */ }
+        // Write disconnectedAt timestamp instead of deleting the doc.
+        // If the player reloads within DISCONNECT_GRACE_MS, joinPlayer
+        // detects the grace window and restores their score/streak rather
+        // than treating them as a fresh joiner. After the grace period
+        // elapses without reconnect, the host's TTL sweep (or the next
+        // joinPlayer call) cleans up the orphaned doc.
+        await updateDoc(doc(db, 'triviaRooms', state.roomCode, 'players', state.user.uid), {
+            disconnectedAt: Date.now(),
+            lastSeen: serverTimestamp()
+        });
+    } catch (e) { /* best-effort; deletion still happens via joinPlayer on fresh join */ }
 }
 
 /**
@@ -2414,6 +2458,20 @@ function renderRoom() {
         && !state.rematchInFlight) {
         playAgain();
     }
+    // Spectator banner — shown when the local player joined mid-game and the
+    // current question is the one they joined on (joinedAtQuestionIndex === currentQuestionIndex).
+    // As soon as the host advances to the next question the index increments
+    // and the banner disappears — the player is now a full participant.
+    const spectatorBanner = $('#room-spectator-banner');
+    if (spectatorBanner) {
+        const mePlayer = state.user ? state.roomPlayers.find((p) => p.uid === state.user.uid) : null;
+        const joinedAtQIdx = mePlayer && typeof mePlayer.joinedAtQuestionIndex === 'number'
+            ? mePlayer.joinedAtQuestionIndex : -1;
+        const curQIdx = typeof room.currentQuestionIndex === 'number' ? room.currentQuestionIndex : -1;
+        const isSpectating = playing && joinedAtQIdx >= 0 && curQIdx <= joinedAtQIdx;
+        spectatorBanner.hidden = !isSpectating;
+    }
+
     const banner = $('#room-paused-banner');
     if (banner) {
         banner.hidden = !room.paused;
@@ -3861,6 +3919,13 @@ async function submitGuess() {
     if (!loc) return;
     if (!state.pendingGuess) return;
     if (state.submittedQuestionId === loc.id) return;
+    // Block submission while spectating (joined mid-game on this question).
+    const mePlayer = state.roomPlayers.find((p) => p.uid === state.user.uid);
+    const joinedAtQIdx = mePlayer && typeof mePlayer.joinedAtQuestionIndex === 'number'
+        ? mePlayer.joinedAtQuestionIndex : -1;
+    const curQIdx = typeof state.roomData.currentQuestionIndex === 'number'
+        ? state.roomData.currentQuestionIndex : -1;
+    if (joinedAtQIdx >= 0 && curQIdx <= joinedAtQIdx) return;
 
     const startMs = state.roomData.questionStartedAt && state.roomData.questionStartedAt.toMillis
         ? state.roomData.questionStartedAt.toMillis() : null;
@@ -4960,6 +5025,7 @@ async function maybeWriteH2HPairs() {
         const aScore = me.score || 0;
         const bScore = opp.score || 0;
         try {
+            const gameType = state.roomData.gameType || 'trivia';
             await runTransaction(db, async (tx) => {
                 const ref = doc(db, 'triviaH2H', key);
                 const snap = await tx.get(ref);
@@ -4967,13 +5033,18 @@ async function maybeWriteH2HPairs() {
                 const winsA = (cur.winsA || 0) + (aScore > bScore ? 1 : 0);
                 const winsB = (cur.winsB || 0) + (bScore > aScore ? 1 : 0);
                 const ties = (cur.ties || 0) + (aScore === bScore ? 1 : 0);
+                // Track game-type breakdown so the H2H view can show
+                // per-mode records when the pair has played multiple modes.
+                const prevGameTypes = (cur.gameTypes && typeof cur.gameTypes === 'object') ? cur.gameTypes : {};
+                const prevTypeCount = prevGameTypes[gameType] || 0;
                 tx.set(ref, {
                     uidA, uidB,
                     displayNameA: me.displayName || 'Player',
                     displayNameB: opp.displayName || 'Player',
                     winsA, winsB, ties,
                     gamesPlayed: (cur.gamesPlayed || 0) + 1,
-                    lastPlayedAt: serverTimestamp()
+                    lastPlayedAt: serverTimestamp(),
+                    gameTypes: { ...prevGameTypes, [gameType]: prevTypeCount + 1 }
                 }, { merge: true });
             });
         } catch (err) {

--- a/apps/arena/js/config.js
+++ b/apps/arena/js/config.js
@@ -133,6 +133,14 @@
         // Default round size dropdown for GlobeDrop (locations per game).
         GLOBE_DROP_LOCATIONS_DEFAULT: 5,
 
+        // Globe Drop bullseye streak. A streak increments when a player earns
+        // base score >= 98 (near-perfect guess). Consecutive bullseyes add a
+        // multiplier capped at GLOBE_DROP_STREAK_MULTIPLIER_CAP consecutive
+        // bullseyes. The multiplier is applied on top of the distance/continent
+        // score so a hot streak can meaningfully swing the leaderboard.
+        GLOBE_DROP_STREAK_MULTIPLIER_STEP: 0.1,   // +10% per consecutive bullseye
+        GLOBE_DROP_STREAK_MULTIPLIER_CAP: 5,       // capped at 5 in a row (=> 1.5x)
+
         // Cap on small-island-nation entries per playlist. Without this,
         // luck-of-the-shuffle can pack three Maldives-class capitals into
         // a 5-location game and turn it into "name the Caribbean specks".


### PR DESCRIPTION
## Summary

10 targeted improvements to the Arena app across Globe Drop and Trivia, covering UX polish, mobile usability, real-time collaboration, and multiplayer state management.

## Changes

**UI / UX**

1. **Live player avatars in Globe Drop mini-scoreboard** — rows for players who haven't submitted yet get an `.is-pending` class: a violet left border + pulsing rank number. Clears cleanly to `.is-answered` (green name tint + ✓) on submit.

2. **Cinematic camera pan on Globe Drop reveal** — two-phase tween: pull back to `max(currentAlt, 1.2)` in 200ms, then arc to the correct lat/lng at 0.6 altitude in 1400ms. The `lastCameraTarget` guard prevents re-firing when local→global reveal happens for the same question.

3. **Mobile: fixed bottom submit pill** — on viewports ≤768px, the submit button becomes `position:fixed` at the bottom of the screen (with safe-area inset), so players never need to scroll below the globe. Clear pin stays in the top-right FAB stack.

4. **Share result card** — "Share result" button in the end-stage header generates a 600×340 canvas card (gradient background, medal standings, accent bars) and triggers `navigator.share` on mobile or PNG download as fallback.

5. **Persist lobby settings** — host's game type, round type, difficulty, location count, timer, and trivia time persist to `localStorage` under `arena.lobby.lastSettings`. Restored on form mount; saved on every field change.

**Non-UI**

6. **Latecomer spectator mode** — joining while `status === 'playing'` writes `joinedAtQuestionIndex` to the player doc. A violet "Spectating — joining next round automatically" banner appears. Submitting guesses is blocked for the current round; the ban lifts automatically when `currentQuestionIndex` advances.

7. **Host can change game type mid-lobby** — a "Switch to Trivia / Switch to Globe Drop" button appears in the room settings header for the host while `status === 'lobby'`. One atomic `updateDoc` on `gameType` — player list untouched.

8. **Globe Drop bullseye streaks** — consecutive near-perfect guesses (basePoints ≥ 98) earn a streak multiplier (+10% per bullseye in a row, capped at 5, matching trivia's shape). Constants `GLOBE_DROP_STREAK_MULTIPLIER_STEP` / `CAP` added to `config.js`. Stored as `globeDropStreak` on the player doc; mini-scoreboard shows `🎯N` chip for N ≥ 2.

9. **Room-level H2H history with game-type tracking** — the existing `triviaH2H` pair transaction now also writes a `gameTypes` map (`{ 'globe-drop': N, 'trivia': M }`) so per-mode records are available for future display. The end-recap W-D-L banner already surfaces the lifetime record in 2-player rooms.

10. **Disconnect/resume recovery** — `beforeUnloadCleanup` writes `disconnectedAt: Date.now()` to the player doc instead of deleting it. `joinPlayer` detects a doc with `disconnectedAt` within 30s and skips score/streak/answers reset — only clears `disconnectedAt` and refreshes `lastSeen`. Explicit "Leave room" still deletes the doc immediately.

## How to test

1. **Live player avatar pulse (feature 1)** — Open a Globe Drop room with 2 players. While one player is thinking (hasn't placed a pin), their row in the "Live standings" mini-board should show a pulsing rank number and a violet left border. After they submit, the border and pulse disappear; the row gets a green tint and ✓.

2. **Cinematic reveal pan (feature 2)** — Start a Globe Drop game, submit a guess. On reveal, watch the globe camera: it should briefly pull back (zoom out) then arc smoothly to the correct location. The tween should feel like a two-step fly-in rather than a single jump.

3. **Mobile submit pill (feature 3)** — Open the Arena app on a phone (or set Chrome DevTools to 390px viewport). Start a Globe Drop game and place a pin. The "Submit guess" button should appear as a pill anchored to the bottom of the screen, always visible without scrolling.

4. **Share result card (feature 4)** — Finish any game. On the end-stage, a "Share result" button appears in the header. Click it. On mobile, the OS share sheet should open with a PNG card. On desktop, a PNG file should download. The card should show player standings with medal emoji.

5. **Persist lobby settings (feature 5)** — Configure the create-room form (e.g. switch to Trivia, change locations to 7). Reload the page. The same selections should still be active.

6. **Spectator mode (feature 6)** — Have Player A start a Globe Drop game. While the question is active, have Player B join with `?room=CODE`. Player B should see a violet "Spectating — joining next round automatically" banner. Player B should not be able to submit a guess for the current round. When the next round starts, the banner disappears and Player B can guess.

7. **Host game type switch (feature 7)** — Create a Globe Drop room and wait in the lobby. In the room settings panel, a "Switch to Trivia" button should appear (host only). Click it. The room settings should update to show "Trivia" as game type. The player list should remain unchanged. Clicking "Start game" should launch Trivia.

8. **Globe Drop streaks (feature 8)** — In a Globe Drop game, get two consecutive near-perfect scores (base ≥ 98, i.e. < ~50km off). After the second bullseye, the mini-scoreboard should show a `🎯2` chip next to your name. A third bullseye upgrades it to `🎯3` and the earned points should increase by the streak multiplier.

9. **H2H history (feature 9)** — Play a 2-player Globe Drop game to completion. The end-recap should show a W-D-L record in the "Head to head" banner. Play again (rematch). The record should increment. In Firestore console, check `triviaH2H/{pairKey}` — the `gameTypes` map should include `{ 'globe-drop': N }`.

10. **Disconnect/resume recovery (feature 10)** — Join a Globe Drop room. While the game is in progress, close the tab and reopen it within 30 seconds (refresh or navigate back to the same URL). Rejoin the room with the same account. Your score, streak, and answers should be restored — not reset to 0.