### PR TITLE
fix(maptap-rivals): floating clipboard confirmation toast

### DIFF
--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -2105,24 +2105,28 @@ tr:focus-within .icon-btn {
   box-shadow: 0 0 0 2px var(--accent-soft);
 }
 
-/* Inline toast that appears next to the share button after copying. */
+/* Floating clipboard-confirmation pill — bottom center, doesn't affect layout. */
 .share-toast {
-  display: inline-block;
-  margin-left: 0.35rem;
-  padding: 0.18rem 0.55rem;
+  position: fixed;
+  left: 50%;
+  bottom: 1.75rem;
+  transform: translateX(-50%);
+  padding: 0.5rem 1rem;
   border-radius: 999px;
   background: var(--surface-3);
   border: 1px solid var(--border-strong);
   color: var(--good);
-  font-size: 0.72rem;
+  font-size: 0.8rem;
   font-weight: 600;
   white-space: nowrap;
   pointer-events: none;
-  animation: share-toast-in 0.15s ease;
+  z-index: 9999;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  animation: share-toast-in 0.18s ease;
 }
 @keyframes share-toast-in {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; transform: translate(-50%, 6px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
 }
 
 /* Post-save share button in the paste actions bar */

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -1013,21 +1013,22 @@
     return lines.join('\n');
   }
 
-  // Show a transient toast anchored to `anchorEl`. Cleans itself up after
-  // 2.5 s, or immediately if share succeeds via native sheet (no toast needed).
-  function showShareToast(anchorEl, msg) {
-    const existing = anchorEl.parentNode && anchorEl.parentNode.querySelector('.share-toast');
+  // Floating, body-level confirmation that doesn't reflow the table the
+  // share button lives in. Replaces any prior toast so rapid clicks don't
+  // stack up multiple pills.
+  function showShareToast(_anchorEl, msg) {
+    const existing = document.querySelector('.share-toast');
     if (existing) existing.remove();
-    const toast = el('span', { class: 'share-toast', role: 'status', 'aria-live': 'polite' }, msg);
-    anchorEl.insertAdjacentElement('afterend', toast);
-    setTimeout(() => { if (toast.parentNode) toast.remove(); }, 2500);
+    const toast = el('div', { class: 'share-toast', role: 'status', 'aria-live': 'polite' }, msg);
+    document.body.appendChild(toast);
+    setTimeout(() => { if (toast.parentNode) toast.remove(); }, 2000);
   }
 
   async function shareGame(g, rival, btn) {
     const text = buildShareText(g, rival);
     try {
       await navigator.clipboard.writeText(text);
-      showShareToast(btn, 'Copied — paste anywhere');
+      showShareToast(btn, 'Copied to clipboard');
     } catch (_) {
       showShareToast(btn, 'Copy failed');
     }


### PR DESCRIPTION
## Summary
- Per user feedback, the previous inline pill ("Copied — paste anywhere") anchored next to the share button and reflowed the table cell it lived in.
- Replaces it with a single body-level "Copied to clipboard" toast pinned to the bottom-center of the viewport. Table layout no longer shifts.
- Auto-dismisses after 2 s; rapid clicks replace rather than stack.

## Test plan
- [ ] Click share on a history row → snippet copied, floating toast appears at bottom-center, table layout unchanged
- [ ] Same on a rival detail row
- [ ] Same on post-save "Share vs X" button
- [ ] Toast auto-dismisses after ~2s; clicking another share button replaces it instead of stacking