### PR TITLE
feat(maptap-rivals): composite rivalry score on leaderboard

### DIFF
--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -2055,6 +2055,36 @@ body.maptap-rivals-app button {
 .delta-neg { color: var(--bad); font-variant-numeric: tabular-nums; font-weight: 600; }
 .delta-zero { color: var(--muted); font-variant-numeric: tabular-nums; }
 
+/* Leaderboard sortable column headers */
+.lb-th-sortable {
+  cursor: pointer;
+  user-select: none;
+}
+.lb-th-sortable:hover {
+  color: var(--text);
+}
+.lb-th-sorted {
+  color: var(--accent-2);
+}
+.lb-th-sorted::after {
+  content: ' \25BC'; /* down triangle */
+  font-size: 0.55rem;
+  vertical-align: middle;
+  opacity: 0.7;
+}
+/* Rivalry score tooltip trigger */
+.lb-th-hint {
+  font-size: 0.65rem;
+  color: var(--muted-2);
+  cursor: help;
+  border-bottom: 1px dotted currentColor;
+}
+/* Rivalry score data cells — tabular numerics, same weight as Win % */
+.lb-rivalry-score {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Row action — compact icon button that sits muted until the row is
    hovered/focused, like Linear / Notion table actions. */
 .icon-btn,

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -344,7 +344,8 @@
               <th>W</th>
               <th>L</th>
               <th>T</th>
-              <th>Win %</th>
+              <th id="lb-th-winpct" class="lb-th-sortable lb-th-sorted" tabindex="0" role="button" aria-sort="descending">Win %</th>
+              <th id="lb-th-rivalry" class="lb-th-sortable" tabindex="0" role="button" aria-sort="none">Rivalry <span class="lb-th-hint" title="Rivalry score blends win rate, total games played, recency of results, and average margin. Higher = you are winning the rivalry.">(?)</span></th>
               <th>Avg Δ</th>
               <th>Streak</th>
               <th>Form</th>

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -265,6 +265,7 @@
     view: 'dashboard',
     matrixSelection: load(KEY.MATRIX_SEL, null), // string[] of rivalIds, or null = "all"
     matrixTab: 'record',           // overridden by URL hash on first paint
+    lbSort: 'winpct',              // 'winpct' | 'rivalry'
     historyFilters: { rival: 'all', result: 'all' },
     historyPage: 1,
     historyPageSize: 25,
@@ -416,6 +417,41 @@
     return state.games
       .filter(g => g.rivalId === rivalId)
       .sort((a, b) => a.date.localeCompare(b.date) || a.createdAt - b.createdAt);
+  }
+
+  // Composite rivalry score — single number summarising how the rivalry is
+  // going. Blends win rate, volume confidence, recency, and average margin.
+  //
+  // Formula (one line):
+  //   score = min(1, games/10) * 50 * (recencyWinRate + recencyMarginRate)
+  //
+  // recencyWinRate    = Σ(outcome * 0.95^rank) / Σ(0.95^rank)
+  //                     outcome: W=+1, L=−1, T=0; rank 0 = newest game
+  // recencyMarginRate = Σ((myTotal − theirTotal)/1000 * 0.95^rank) / Σ(0.95^rank)
+  //
+  // Positive = you are winning the rivalry; negative = they are.
+  function rivalryScore(rivalId) {
+    const games = gamesFor(rivalId);
+    const n = games.length;
+    if (n === 0) return 0;
+    const volume = Math.min(1, n / 10);
+    let weightSum = 0;
+    let winSum = 0;
+    let marginSum = 0;
+    for (let i = 0; i < n; i++) {
+      const rank = n - 1 - i; // rank 0 = newest (games is oldest-first)
+      const decay = Math.pow(0.95, rank);
+      const g = games[i];
+      const my = getMyTotal(g);
+      const their = getTheirTotal(g);
+      const outcome = my > their ? 1 : my < their ? -1 : 0;
+      winSum    += outcome * decay;
+      marginSum += ((my - their) / 1000) * decay;
+      weightSum += decay;
+    }
+    const recencyWinRate    = winSum    / weightSum;
+    const recencyMarginRate = marginSum / weightSum;
+    return volume * 50 * (recencyWinRate + recencyMarginRate);
   }
 
   function resultOf(g) {
@@ -2566,7 +2602,27 @@
       return;
     }
     $('#leaderboard-empty').hidden = true;
-    summaries.sort((a, b) => b.winPct - a.winPct || b.total - a.total);
+
+    // Annotate each summary with its rivalry score so we compute it once.
+    summaries.forEach(s => { s._rivalryScore = rivalryScore(s.rival.id); });
+
+    if (state.lbSort === 'rivalry') {
+      summaries.sort((a, b) => b._rivalryScore - a._rivalryScore || b.total - a.total);
+    } else {
+      summaries.sort((a, b) => b.winPct - a.winPct || b.total - a.total);
+    }
+
+    // Update sort-active state on the column headers.
+    const thWinPct  = $('#lb-th-winpct');
+    const thRivalry = $('#lb-th-rivalry');
+    if (thWinPct) {
+      thWinPct.classList.toggle('lb-th-sorted', state.lbSort === 'winpct');
+      thWinPct.setAttribute('aria-sort', state.lbSort === 'winpct' ? 'descending' : 'none');
+    }
+    if (thRivalry) {
+      thRivalry.classList.toggle('lb-th-sorted', state.lbSort === 'rivalry');
+      thRivalry.setAttribute('aria-sort', state.lbSort === 'rivalry' ? 'descending' : 'none');
+    }
 
     summaries.forEach((s, i) => {
       const avgDiff = s.total ? (s.cumDiff / s.total) : 0;
@@ -2593,6 +2649,13 @@
       tr.appendChild(el('td', { style: 'color:var(--bad);font-weight:600' }, String(s.losses)));
       tr.appendChild(el('td', { style: 'color:var(--tie)' }, String(s.ties)));
       tr.appendChild(el('td', { style: 'font-weight:600' }, `${(s.winPct * 100).toFixed(1)}%`));
+
+      const rs = s._rivalryScore;
+      const rsFormatted = (rs > 0 ? '+' : '') + rs.toFixed(1);
+      tr.appendChild(el('td', {
+        class: 'lb-rivalry-score ' + (rs > 0 ? 'delta-pos' : rs < 0 ? 'delta-neg' : 'delta-zero'),
+      }, rsFormatted));
+
       tr.appendChild(el('td', { class: avgDiff > 0 ? 'delta-pos' : avgDiff < 0 ? 'delta-neg' : 'delta-zero' },
         (avgDiff > 0 ? '+' : '') + avgDiff.toFixed(1)));
       const streakCell = el('td', {});
@@ -4441,6 +4504,27 @@
       state.rivalGamesPage++;
       renderRival();
     });
+
+    // leaderboard sort headers
+    function makeLbSortHandler(sortKey) {
+      return function (e) {
+        if (e.type === 'keydown' && e.key !== 'Enter' && e.key !== ' ') return;
+        if (e.type === 'keydown') e.preventDefault();
+        if (state.lbSort === sortKey) return;
+        state.lbSort = sortKey;
+        if (state.view === 'leaderboard') renderLeaderboard();
+      };
+    }
+    const lbThWinPct  = $('#lb-th-winpct');
+    const lbThRivalry = $('#lb-th-rivalry');
+    if (lbThWinPct) {
+      lbThWinPct.addEventListener('click',   makeLbSortHandler('winpct'));
+      lbThWinPct.addEventListener('keydown', makeLbSortHandler('winpct'));
+    }
+    if (lbThRivalry) {
+      lbThRivalry.addEventListener('click',   makeLbSortHandler('rivalry'));
+      lbThRivalry.addEventListener('keydown', makeLbSortHandler('rivalry'));
+    }
 
     // cross-tab / sync changes
     window.addEventListener('storage', onExternalStorage);


### PR DESCRIPTION
## Summary
- Adds a single-number Rivalry column to the leaderboard blending win rate, total games played, recency-weighted decay, and average margin.
- Positive = you're winning the rivalry; negative = they are.
- Both Win % and Rivalry headers are click-to-sort; the active one is highlighted with a ▼.
- A `(?)` hint on the Rivalry header has a native tooltip explaining the formula in plain English.
- Win % remains the default sort on first load.

## Formula
\`score = min(1, games/10) × 50 × (recencyWinRate + recencyMarginRate)\`
where both rates use exponential decay `0.95 ^ rank` (rank 0 = newest), and margin is `(myTotal − theirTotal) / 1000` per game.

## Test plan
- [ ] Leaderboard renders a Rivalry column after Win %
- [ ] Click Rivalry header → table sorts by Rivalry score, header highlights and gains ▼
- [ ] Click Win % header → sort reverts to win %
- [ ] Hover the (?) → tooltip explains the formula
- [ ] Negative scores render with the bad/red color
- [ ] Default sort on first load is Win % (regression check)