### PR TITLE
fix(rising-seasons): full-width sparklines + aligned axis labels

### DIFF
--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -1875,10 +1875,17 @@ button.shape-tag.is-clickable:hover {
 }
 
 .show-season {
+  /* Sparkline is the whole point — give it its own full-width row at all
+     breakpoints. Top row keeps S# / meta / Avg compact; bottom row is a
+     full-bleed spark. */
   display: grid;
-  grid-template-columns: 56px 1fr 110px auto;
-  gap: 0.85rem;
-  align-items: center;
+  grid-template-columns: 56px 1fr auto;
+  grid-template-areas:
+    "num   meta  stats"
+    "spark spark spark";
+  column-gap: 0.85rem;
+  row-gap: 0.55rem;
+  align-items: start;
   padding: 0.7rem 0.9rem;
   background: var(--surface-2);
   border: 1px solid var(--border);
@@ -1902,6 +1909,7 @@ button.shape-tag.is-clickable:hover {
 }
 
 .show-season .ss-num {
+  grid-area: num;
   font-weight: 600;
   font-size: 1rem;
   color: var(--text);
@@ -1909,6 +1917,7 @@ button.shape-tag.is-clickable:hover {
 }
 
 .show-season .ss-meta {
+  grid-area: meta;
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -1924,15 +1933,22 @@ button.shape-tag.is-clickable:hover {
   margin-top: 0.2rem;
 }
 
+/* The actual grid child is the wrapper (.ss-spark-wrap), not the SVG —
+   grid-area must live here so the spark row spans full card width. */
+.show-season .ss-spark-wrap {
+  grid-area: spark;
+  width: 100%;
+}
 .show-season .ss-spark {
   width: 100%;
-  height: 36px;
+  height: 48px;
   background: var(--surface);
   border-radius: 4px;
   display: block;
 }
 
 .show-season .ss-stats {
+  grid-area: stats;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1951,26 +1967,13 @@ button.shape-tag.is-clickable:hover {
 }
 
 @media (max-width: 560px) {
-  /* The season-trend sparkline is the whole point of the app — restore
-     it on mobile by stacking the row into two grid rows. Top row keeps
-     S# / meta / stats compact; bottom row is a full-width spark. */
+  /* Tighter S# column + row gap on phones; the 2-row grid layout itself is
+     defined at the base level so the spark always spans full width. */
   .show-season {
     grid-template-columns: 48px 1fr auto;
-    grid-template-areas:
-      "num   meta  stats"
-      "spark spark spark";
     row-gap: 0.45rem;
-    align-items: start;
   }
-  .show-season .ss-num   { grid-area: num; }
-  .show-season .ss-meta  { grid-area: meta; }
-  .show-season .ss-stats { grid-area: stats; }
-  .show-season .ss-spark {
-    grid-area: spark;
-    display: block;
-    width: 100%;
-    height: 44px;
-  }
+  .show-season .ss-spark { height: 44px; }
 }
 
 .curve {
@@ -3271,14 +3274,25 @@ body.advanced-drawer-open {
     right: 0.4rem;
   }
 
-  /* List view rows — already tight; just give the watch button a
-     bigger circular tap target. */
+  /* List view rows — stack the sparkline onto its own full-width row
+     below poster+text, same pattern as the mobile season cards. The
+     desktop 4-col layout (`56px 1fr 240px 36px`) squeezed the curve
+     into a 40px sliver because the mobile rule only defined 3 columns
+     and grid auto-flow trapped the spark in the 40px watch slot. */
   .row {
     grid-template-columns: 56px 1fr 40px;
+    grid-template-areas:
+      "poster main  watch"
+      "curve  curve curve";
     column-gap: 0.85rem;
     row-gap: 0.55rem;
     padding: 0.7rem 0.85rem;
+    align-items: start;
   }
+  .row-poster        { grid-area: poster; }
+  .row-main          { grid-area: main; }
+  .row .curve-wrap   { grid-area: curve; }
+  .row-watch         { grid-area: watch; align-self: center; }
   .row-curve { height: 48px; }
   .row-watch {
     width: 2.5rem;
@@ -4121,8 +4135,13 @@ body.advanced-drawer-open {
     0 0 2px rgba(8, 10, 16, 0.95),
     0 0 3px rgba(8, 10, 16, 0.7);
 }
-.spark-axis-label-top { top: 0.15rem; }
-.spark-axis-label-bot { bottom: 0.1rem; }
+/* JS sets `top: <yPct>%` for both labels so they line up with the actual
+   y-coordinate of the max/min on the curve (drawCurve pads the Y range
+   beyond min/max). translateY(-50%) centers the label vertically on the
+   y line so it overlays the curve at the right height rather than
+   overflowing above/below the wrap. */
+.spark-axis-label-top,
+.spark-axis-label-bot { top: 0; bottom: auto; transform: translateY(-50%); }
 
 /* #5 Sticky filter bar — frosted-glass strip that drops in once the
    main filter section scrolls off. Echoes the main toolbar (dark

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -1504,20 +1504,17 @@ body.rising-seasons-app button {
 }
 
 .card-body {
-  padding: 0.85rem 1rem 1rem;
-  /* Grid so the curve always sits at its own row, regardless of how many
-     lines the chip row above takes. Row order matches DOM source:
+  padding: 0.85rem 1rem 0.55rem;
+  /* Grid so the chip row absorbs any extra vertical height — keeps the
+     sparkline (a sibling of card-body, not a child) at the same y across
+     cards of varying chip-row line counts. Row order matches DOM source:
        1. card-head    (title + season)
        2. card-meta    (year + genres)
-       3. card-shapes  (1fr — absorbs any extra vertical space so the
-                        curve doesn't drift down when chips wrap)
-       4. .curve       (sparkline, fixed height)
-       5. card-stats   (single horizontal line)
+       3. card-shapes  (1fr — absorbs leftover vertical space)
      Since .results-grid stretches all cards in a row to the same height,
-     the 1fr region resolves to the same value across siblings — putting
-     every sparkline at the identical y from the top of its card. */
+     the 1fr region resolves to the same value across siblings. */
   display: grid;
-  grid-template-rows: auto auto 1fr auto auto;
+  grid-template-rows: auto auto 1fr;
   row-gap: 0.55rem;
   flex: 1;
 }
@@ -1977,13 +1974,10 @@ button.shape-tag.is-clickable:hover {
 }
 
 .curve {
-  /* The card body that wraps this SVG has 1rem of horizontal padding, so a
-     plain width:100% would leave the yellow line drawn 1rem inset from the
-     card's left/right edges. Extend the curve out past that padding with
-     negative margins so the line literally starts at the card edges. */
-  width: calc(100% + 2rem);
-  margin-left: -1rem;
-  margin-right: -1rem;
+  /* .curve-wrap is a direct child of .card now (no parent padding to
+     bleed out of), so the SVG sits at the full card width with no
+     negative margins. */
+  width: 100%;
   height: 70px;
   background:
     radial-gradient(ellipse 60% 50% at 50% 100%, rgba(245, 197, 24, 0.06), transparent 70%),
@@ -2185,6 +2179,11 @@ button.shape-tag.is-clickable:hover {
   font-variant-numeric: tabular-nums;
   color: var(--muted);
   line-height: 1.3;
+}
+/* .card-stats is now a direct child of .card (was inside .card-body), so
+   it needs its own horizontal padding to match the body's text gutter. */
+.card > .card-stats {
+  padding: 0.4rem 1rem 0.85rem;
 }
 .card-stats > span,
 .row-stats > span {
@@ -3220,21 +3219,40 @@ body.advanced-drawer-open {
   }
   .results-grid.list-view { gap: 0.55rem; }
 
+  /* Mobile cards: two-column grid so the poster sits on the left next to
+     the text, but the sparkline + stats span the full card width below.
+     Previously the card was a horizontal flex row and the curve was
+     trapped inside .card-body — visually appearing as a thin chart strip
+     squeezed into the right-hand text column. */
   .card {
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: 104px 1fr;
+    grid-template-areas:
+      "poster body"
+      "curve  curve"
+      "stats  stats";
     align-items: stretch;
-    min-height: 156px;
+    min-height: auto;
   }
   .card-poster {
-    flex: 0 0 104px;
+    grid-area: poster;
+    flex: none;
     width: 104px;
     aspect-ratio: 2 / 3;
   }
   .card-body {
-    flex: 1 1 auto;
+    grid-area: body;
+    flex: none;
     min-width: 0;
-    padding: 0.7rem 0.85rem 0.8rem;
-    gap: 0.45rem;
+    padding: 0.7rem 0.85rem 0.6rem;
+    row-gap: 0.45rem;
+  }
+  .card .curve-wrap { grid-area: curve; }
+  .card-stats {
+    grid-area: stats;
+    gap: 0.55rem;
+    font-size: 0.72rem;
+    padding: 0.5rem 0.85rem 0.7rem;
   }
   .card-head { gap: 0.4rem; }
   .card-title {
@@ -3245,26 +3263,12 @@ body.advanced-drawer-open {
   .card-meta { font-size: 0.72rem; gap: 0.45rem; }
   .card-shapes { gap: 0.25rem; }
   .card .curve { height: 48px; }
-  .card-stats {
-    gap: 0.55rem;
-    font-size: 0.72rem;
-  }
   /* Watch toggle is roomier so it's easier to thumb-tap on the corner. */
   .card .watch-toggle {
     width: 2.25rem;
     height: 2.25rem;
     top: 0.4rem;
     right: 0.4rem;
-  }
-  /* Mobile cards go horizontal (poster | body), so the desktop edge-bleed
-     trick would push the curve into the poster on the left. Match the
-     mobile card-body padding (0.85rem) on the right only, and leave the
-     left edge flush with the body's left padding so the line still feels
-     edge-anchored on the side it can be. */
-  .card .curve {
-    margin-left: 0;
-    margin-right: -0.85rem;
-    width: calc(100% + 0.85rem);
   }
 
   /* List view rows — already tight; just give the watch button a
@@ -4081,22 +4085,44 @@ body.advanced-drawer-open {
 }
 
 /* #4 Mini sparkline min/max axis labels (cards + row sparklines)
-   — small but deliberate: tabular digits, dark halo via paint-order so
+   — small but deliberate: tabular digits, dark halo via text-shadow so
    they stay legible on top of the gold curve, brightness held below
-   the Avg score so the eye reads Avg first. */
+   the Avg score so the eye reads Avg first.
+
+   Rendered as HTML spans absolutely-positioned over a .curve-wrap rather
+   than SVG <text>, because the parent SVG uses preserveAspectRatio="none"
+   and would otherwise stretch inline text horizontally and squish it
+   vertically on narrow mobile widths (the "9.2" rendered as a huge wide
+   blob over the chart). HTML labels keep CSS font-size on every viewport. */
+.curve-wrap {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+.curve-wrap > .curve { width: 100%; margin: 0; }
+.spark-axis-labels {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
 .spark-axis-label {
+  position: absolute;
+  left: 0.3rem;
   font-size: 11px;
-  fill: rgba(241, 243, 248, 0.82);
+  line-height: 1;
+  color: rgba(241, 243, 248, 0.82);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, "Inter", system-ui, sans-serif;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.01em;
-  pointer-events: none;
-  paint-order: stroke fill;
-  stroke: rgba(8, 10, 16, 0.78);
-  stroke-width: 2px;
-  stroke-linejoin: round;
+  /* Dark halo so the digits stay legible over the gold curve area. */
+  text-shadow:
+    0 0 2px rgba(8, 10, 16, 0.95),
+    0 0 2px rgba(8, 10, 16, 0.95),
+    0 0 3px rgba(8, 10, 16, 0.7);
 }
+.spark-axis-label-top { top: 0.15rem; }
+.spark-axis-label-bot { bottom: 0.1rem; }
 
 /* #5 Sticky filter bar — frosted-glass strip that drops in once the
    main filter section scrolls off. Echoes the main toolbar (dark

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -572,17 +572,19 @@
           <span class="card-genres"></span>
         </div>
         <div class="card-shapes"></div>
+      </div>
+      <div class="curve-wrap">
         <svg class="curve" viewBox="0 0 300 80" preserveAspectRatio="none" aria-hidden="true">
           <path class="curve-area" />
           <path class="curve-line" />
           <g class="curve-dots"></g>
         </svg>
-        <div class="card-stats">
-          <span class="stat-climb"></span>
-          <span class="stat-avg"></span>
-          <span class="stat-runtime"></span>
-          <span class="stat-votes"></span>
-        </div>
+      </div>
+      <div class="card-stats">
+        <span class="stat-climb"></span>
+        <span class="stat-avg"></span>
+        <span class="stat-runtime"></span>
+        <span class="stat-votes"></span>
       </div>
     </article>
   </template>
@@ -608,10 +610,12 @@
           <span class="stat-votes"></span>
         </div>
       </div>
-      <svg class="row-curve" viewBox="0 0 200 56" preserveAspectRatio="none" aria-hidden="true">
-        <path class="curve-area" />
-        <path class="curve-line" />
-      </svg>
+      <div class="curve-wrap row-curve-wrap">
+        <svg class="row-curve" viewBox="0 0 200 56" preserveAspectRatio="none" aria-hidden="true">
+          <path class="curve-area" />
+          <path class="curve-line" />
+        </svg>
+      </div>
       <button type="button" class="watch-toggle row-watch" aria-pressed="false" aria-label="Mark as watched" title="Mark as watched">
         <span class="watch-icon" aria-hidden="true">✓</span>
       </button>

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -2249,7 +2249,7 @@ function drawCurveAnnotations(svg, episodes, shapes) {
 // differ on mobile, which would stretch inline <text> into the distorted
 // "huge wide digits over the chart" look the legacy implementation had.
 // HTML labels stay at exactly the CSS font-size on every viewport.
-function drawMiniAxisLabels(svg, ratings /*, padY, W, H */) {
+function drawMiniAxisLabels(svg, ratings, padY, W, H) {
   const wrap = svg.parentElement && svg.parentElement.classList.contains('curve-wrap')
     ? svg.parentElement
     : null;
@@ -2261,15 +2261,27 @@ function drawMiniAxisLabels(svg, ratings /*, padY, W, H */) {
   const max = Math.max(...ratings);
   if (max - min < 0.3) return;
 
+  // Place each label at the actual y of its value on the curve. drawCurve
+  // pads the Y range (lo = min - 0.3, hi = max + 0.3) so the line doesn't
+  // touch the chart edges; positioning labels at the wrap's edges left a
+  // visible gap between "7.5" and where 7.5 actually lives on the curve.
+  const lo = Math.max(0, min - 0.3);
+  const hi = Math.min(10, max + 0.3);
+  const span = Math.max(0.1, hi - lo);
+  const yMaxPct = ((padY + (1 - (max - lo) / span) * (H - 2 * padY)) / H) * 100;
+  const yMinPct = ((padY + (1 - (min - lo) / span) * (H - 2 * padY)) / H) * 100;
+
   overlay = document.createElement('div');
   overlay.className = 'spark-axis-labels';
   overlay.setAttribute('aria-hidden', 'true');
   const top = document.createElement('span');
   top.className = 'spark-axis-label spark-axis-label-top';
   top.textContent = max.toFixed(1);
+  top.style.top = `${yMaxPct.toFixed(2)}%`;
   const bot = document.createElement('span');
   bot.className = 'spark-axis-label spark-axis-label-bot';
   bot.textContent = min.toFixed(1);
+  bot.style.top = `${yMinPct.toFixed(2)}%`;
   overlay.append(top, bot);
   wrap.appendChild(overlay);
 }

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -2243,37 +2243,35 @@ function drawCurveAnnotations(svg, episodes, shapes) {
 // Lightweight min/max labels for non-axis sparklines (card + row + show-modal
 // per-season sparks). Skipped when the rating range is too narrow for labels
 // to be informative — flat curves don't benefit from "8.0 / 8.1".
-function drawMiniAxisLabels(svg, ratings, padY, W, H) {
-  // Remove any previous labels so re-renders don't duplicate.
-  const existing = svg.querySelector('.spark-axis-labels');
-  if (existing) existing.remove();
+//
+// Rendered as HTML spans on a sibling overlay rather than SVG <text> nodes:
+// the parent SVG uses preserveAspectRatio="none" so the X and Y scales
+// differ on mobile, which would stretch inline <text> into the distorted
+// "huge wide digits over the chart" look the legacy implementation had.
+// HTML labels stay at exactly the CSS font-size on every viewport.
+function drawMiniAxisLabels(svg, ratings /*, padY, W, H */) {
+  const wrap = svg.parentElement && svg.parentElement.classList.contains('curve-wrap')
+    ? svg.parentElement
+    : null;
+  if (!wrap) return; // older render paths without a wrapper — skip silently
+  let overlay = wrap.querySelector(':scope > .spark-axis-labels');
+  if (overlay) overlay.remove();
   if (!ratings || ratings.length === 0) return;
   const min = Math.min(...ratings);
   const max = Math.max(...ratings);
   if (max - min < 0.3) return;
 
-  const NS = 'http://www.w3.org/2000/svg';
-  const g = document.createElementNS(NS, 'g');
-  g.setAttribute('class', 'spark-axis-labels');
-  // Hug the left chart edge with a small, deliberate 3-unit gutter. Top
-  // label baseline sits just inside padY so the glyphs touch the top of
-  // the plot area; bottom label baseline sits 2 units off the floor so
-  // the digits visually rest on the bottom edge.
-  const x = 3;
-  const top = document.createElementNS(NS, 'text');
-  top.setAttribute('class', 'spark-axis-label');
-  top.setAttribute('x', x);
-  top.setAttribute('y', padY + 8);
-  top.setAttribute('text-anchor', 'start');
+  overlay = document.createElement('div');
+  overlay.className = 'spark-axis-labels';
+  overlay.setAttribute('aria-hidden', 'true');
+  const top = document.createElement('span');
+  top.className = 'spark-axis-label spark-axis-label-top';
   top.textContent = max.toFixed(1);
-  const bot = document.createElementNS(NS, 'text');
-  bot.setAttribute('class', 'spark-axis-label');
-  bot.setAttribute('x', x);
-  bot.setAttribute('y', H - 2);
-  bot.setAttribute('text-anchor', 'start');
+  const bot = document.createElement('span');
+  bot.className = 'spark-axis-label spark-axis-label-bot';
   bot.textContent = min.toFixed(1);
-  g.append(top, bot);
-  svg.appendChild(g);
+  overlay.append(top, bot);
+  wrap.appendChild(overlay);
 }
 
 // Attach mousemove / touchmove to the modal curve SVG and show a floating
@@ -3111,6 +3109,11 @@ function buildShowSeasonRow(m, bestSeason, worstSeason) {
     meta.appendChild(shapeRow);
   }
 
+  // Wrap the SVG so HTML min/max labels can overlay it without going
+  // through the SVG's preserveAspectRatio="none" stretch (which distorts
+  // inline <text> on narrow mobile widths).
+  const sparkWrap = document.createElement('div');
+  sparkWrap.className = 'curve-wrap ss-spark-wrap';
   const sparkSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   sparkSvg.setAttribute('class', 'ss-spark curve');
   sparkSvg.setAttribute('viewBox', '0 0 200 36');
@@ -3120,6 +3123,7 @@ function buildShowSeasonRow(m, bestSeason, worstSeason) {
     path.setAttribute('class', cls);
     sparkSvg.appendChild(path);
   }
+  sparkWrap.appendChild(sparkSvg);
   drawCurve(sparkSvg, m.episodes, 200, 36, 0);
 
   const stats = document.createElement('div');
@@ -3150,7 +3154,7 @@ function buildShowSeasonRow(m, bestSeason, worstSeason) {
     stats.appendChild(w);
   }
 
-  li.append(num, meta, sparkSvg, stats);
+  li.append(num, meta, sparkWrap, stats);
   li.addEventListener('click', () => openModal(m));
   li.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' || e.key === ' ') {


### PR DESCRIPTION
## Summary
Three related sparkline fixes that surfaced together while testing the prior mobile-card sparkline change at wider viewports and on the list view.

- **Show-modal "All seasons" list**: desktop grid locked the spark to a 110px column. Promoted the 2-row layout (`"num meta stats" / "spark spark spark"`) to the base style at all widths, and moved `grid-area: spark` from the inner SVG to the actual grid child (`.ss-spark-wrap`).
- **Mini axis labels** (max/min rating on every sparkline): were pinned to the top/bottom of `.curve-wrap` but `drawCurve` pads the Y range by 0.3 above/below, so e.g. "7.5" sat ~8% above where 7.5 actually appears. `drawMiniAxisLabels` now computes each label's y-percent with the same formula `drawCurve` uses and writes it inline; CSS uses `translateY(-50%)` to center the label on its y-line.
- **List-view rows on mobile**: the desktop 4-col grid is `56px 1fr 240px 36px` but the ≤600px override only declared 3 columns, so auto-flow trapped the curve in the 40px watch-toggle slot. Added grid template areas so the curve gets its own full-width row, mirroring the mobile card pattern.

## Test plan
- [x] `npm test` — 697/697 pass
- [x] Show-modal "All seasons" list at 900px (desktop) and 400px (mobile): each season's spark spans the full row width
- [x] Mini axis labels overlay the curve at the correct y-altitude in grid cards, list rows, and modal seasons
- [x] List-view rows at 415px (mobile): spark spans full row below poster+text+watch
- [ ] Spot-check on a real phone after deploy