### PR TITLE
fix(arena): edge-to-edge visual + a11y pass on Globe Drop

### DIFF
--- a/apps/arena/css/styles.css
+++ b/apps/arena/css/styles.css
@@ -304,7 +304,7 @@ body.brain-arena-app button {
 
 .view-tabs {
   display: inline-flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.4rem;
   justify-content: center;
   align-items: center;
@@ -375,6 +375,10 @@ body.brain-arena-app button {
     0 0 28px rgba(168, 85, 247, 0.30);
 }
 
+@media (max-width: 480px) {
+  .view-tab, .view-tab:hover { padding: 0.5rem 0.65rem; font-size: 0.82rem; gap: 0.3rem; }
+}
+
 .view { display: none; }
 .view.is-active { display: block; }
 
@@ -404,7 +408,7 @@ body.brain-arena-app button {
 .auth-gate .link-btn {
   background: none;
   border: none;
-  color: var(--accent, #6aa7ff);
+  color: var(--accent);
   text-decoration: underline;
   cursor: pointer;
   font: inherit;
@@ -412,12 +416,12 @@ body.brain-arena-app button {
 }
 .auth-gate .link-btn:hover,
 .auth-gate .link-btn:focus-visible {
-  color: var(--accent-strong, #8bbcff);
+  color: var(--cyan-2);
 }
 
 .lobby-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1.4rem;
   /* Let each card size to its own content height. Without this, the
      Join card stretches to match the much taller Create card and
@@ -629,7 +633,7 @@ select option { background: var(--surface); color: var(--text); }
   outline-offset: 3px;
 }
 
-.lobby-cta { align-self: stretch; height: 42px; }
+.lobby-cta { align-self: stretch; --ctrl-h: 42px; }
 
 #join-code {
   text-transform: uppercase;
@@ -642,6 +646,7 @@ select option { background: var(--surface); color: var(--text); }
 
 .join-error {
   margin: 0;
+  min-height: 1.2rem;
   color: var(--bad);
   font-size: 0.85rem;
 }
@@ -1063,8 +1068,8 @@ select option { background: var(--surface); color: var(--text); }
 .globe-drop-prompt-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  justify-content: flex-start;
+  gap: 0.75rem;
   margin: 0 0 1.1rem;
   padding: 1.3rem 1.5rem;
   /* scrollIntoView({block:'start'}) anchors element top to viewport
@@ -1179,6 +1184,15 @@ select option { background: var(--surface); color: var(--text); }
   gap: 0.7rem;
   margin-top: 0.7rem;
   flex-wrap: wrap;
+  overflow: hidden;
+  max-height: 200px;
+  visibility: visible;
+  transition: max-height 0.28s ease, visibility 0.28s ease, margin-top 0.28s ease;
+}
+.lobby-solo-actions.is-hidden {
+  max-height: 0;
+  visibility: hidden;
+  margin-top: 0;
 }
 /* Gradient-bordered ghost — transparent fill on a dark surface, with
    the border itself being a cyan→violet gradient via double-bg trick
@@ -1724,8 +1738,9 @@ select option { background: var(--surface); color: var(--text); }
 }
 /* Hide the whole stack until a pin is placed. The Clear button is the
    pin-placed signal (hidden becomes false on pin-drop); when it's
-   absent, the entire FAB stack collapses. */
-.globe-drop-fab-stack:not(:has(#globe-drop-clear-btn:not([hidden]))) {
+   absent, the entire FAB stack collapses.
+   .fab-pinned is a JS fallback class for browsers that don't support :has(). */
+.globe-drop-fab-stack:not(:has(#globe-drop-clear-btn:not([hidden]))):not(.fab-pinned) {
   display: none;
 }
 @keyframes globe-fab-in {
@@ -1857,7 +1872,7 @@ select option { background: var(--surface); color: var(--text); }
   /* Add bottom padding to the map wrap so the fixed pill doesn't
      cover the bottom of the globe on short screens. */
   .globe-drop-map-wrap {
-    padding-bottom: 4rem;
+    padding-bottom: calc(4rem + env(safe-area-inset-bottom, 0px));
   }
 }
 
@@ -1870,6 +1885,9 @@ select option { background: var(--surface); color: var(--text); }
    player score chips. Sits next to / under the cumulative live
    standings — same visual family, muted treatment so it reads as
    reference detail not the headline. */
+.rounds-history-board:not([hidden]) {
+  animation: stage-fade 0.35s ease-out both;
+}
 .rounds-history-board {
   margin: 0 0 1.6rem;
   padding: 0.9rem 1.1rem 0.95rem;
@@ -1915,7 +1933,7 @@ select option { background: var(--surface); color: var(--text); }
      scans vertically without zig-zagging. Narrow viewports collapse
      to a stacked layout via the media query below. */
   display: grid;
-  grid-template-columns: auto 14ch 1fr;
+  grid-template-columns: auto minmax(0, 14ch) 1fr;
   align-items: center;
   gap: 0.55rem 0.75rem;
   padding: 0.4rem 0.6rem;
@@ -2039,7 +2057,7 @@ select option { background: var(--surface); color: var(--text); }
     0 1px 0 rgba(255, 255, 255, 0.04) inset,
     0 24px 60px rgba(2, 6, 23, 0.6),
     0 0 32px rgba(34, 211, 238, 0.10);
-  z-index: 50;
+  z-index: 210;
   animation: ba-chat-in 240ms cubic-bezier(0.22, 1, 0.36, 1);
   overflow: hidden;
 }
@@ -2070,6 +2088,22 @@ select option { background: var(--surface); color: var(--text); }
   letter-spacing: 0.01em;
   color: var(--text);
 }
+.room-chat-game-live {
+  margin: 0;
+  padding: 0.4rem 0.95rem;
+  background: rgba(34, 211, 238, 0.08);
+  border-bottom: 1px solid rgba(34, 211, 238, 0.18);
+  color: var(--cyan-2);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  animation: chat-live-pulse 2s ease-in-out infinite;
+}
+@keyframes chat-live-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.6; }
+}
+
 .room-chat-list {
   list-style: none;
   margin: 0;
@@ -2455,7 +2489,7 @@ select option { background: var(--surface); color: var(--text); }
 }
 @media (max-width: 540px) {
   .h2h-picker { grid-template-columns: 1fr; }
-  .h2h-versus { text-align: center; padding: 0.15rem 0; }
+  .h2h-versus { text-align: center; padding: 0.15rem 0; width: 58px; margin: 0 auto; }
   .h2h-result { grid-template-columns: 1fr; }
   .h2h-record-pill { order: -1; }   /* lifetime pill above the cards on mobile */
 }
@@ -2574,15 +2608,17 @@ select option { background: var(--surface); color: var(--text); }
   flex: 1;
   min-width: 0;
 }
-.globe-drop-reveal-distance strong { color: var(--accent-2); }
-.globe-drop-reveal-distance.is-pulse strong {
+.globe-drop-reveal-distance strong { color: var(--violet-2); }
+.globe-drop-reveal-distance strong {
   display: inline-block;
+}
+.globe-drop-reveal-distance.is-pulse strong {
   animation: gd-score-pulse 700ms cubic-bezier(0.18, 0.84, 0.32, 1) both;
 }
 @keyframes gd-score-pulse {
   0%   { transform: translateY(8px) scale(0.85); opacity: 0; }
-  35%  { transform: translateY(-2px) scale(1.35); opacity: 1; color: var(--accent-2); }
-  60%  { transform: translateY(0) scale(1.08); }
+  35%  { transform: translateY(-2px) scale(1.15); opacity: 1; }
+  60%  { transform: translateY(0) scale(1.05); }
   100% { transform: translateY(0) scale(1); }
 }
 
@@ -3149,6 +3185,10 @@ select option { background: var(--surface); color: var(--text); }
   padding: 0.05rem 0.4rem;
   box-shadow: 0 0 10px rgba(16, 185, 129, 0.18) inset;
 }
+/* When both me + pending: remove the violet border (the cyan shimmer is enough). */
+.mini-board-row.is-me.is-pending {
+  border-left-color: transparent;
+}
 /* Settled state removes the pending pulse cleanly. */
 .mini-board-row.is-answered.is-pending {
   border-left-color: transparent;
@@ -3215,6 +3255,8 @@ select option { background: var(--surface); color: var(--text); }
     border-left: 0;
     border-top: 1px solid rgba(148, 163, 184, 0.10);
   }
+  /* When 5+ players, save space: hide the name, show rank + score only. */
+  .mini-board-list.is-crowded .mini-board-name { display: none; }
 }
 
 /* ---------- Stage: end ---------- */
@@ -3991,6 +4033,9 @@ select option { background: var(--surface); color: var(--text); }
      rooms overflow on narrow viewports. The mask is a no-op when
      nothing overflows — at desktop widths the table fits and no
      fade is visible. */
+  /* Mask applied only when content overflows (class set by JS). */
+}
+.end-recap-table-wrap.has-overflow {
   -webkit-mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 48px), transparent 100%);
           mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 48px), transparent 100%);
 }
@@ -4087,7 +4132,7 @@ select option { background: var(--surface); color: var(--text); }
 }
 .recap-score-meta {
   display: block;
-  font-family: var(--font);
+  font-family: inherit;
   font-weight: 500;
   font-size: 0.72rem;
   color: var(--muted);
@@ -4784,8 +4829,8 @@ body.premium-disabled [data-action="open-premium"] { display: none !important; }
   position: absolute;
   top: 0.6rem;
   right: 0.6rem;
-  width: 26px;
-  height: 26px;
+  width: 36px;
+  height: 36px;
   padding: 0;
   border-radius: 6px;
   border: 0;
@@ -4845,6 +4890,18 @@ body.premium-disabled [data-action="open-premium"] { display: none !important; }
 }
 .premium-modal-price strong { font-size: 1.15rem; }
 
+/* Focus-visible outlines for interactive elements missing them */
+.room-code-copy:focus-visible,
+.game-type-btn:focus-visible,
+.pick-cat-btn:focus-visible,
+.answer-btn:focus-visible,
+.globe-drop-ready-btn:focus-visible,
+.room-chat-quick-btn:focus-visible,
+.modal-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* ---------- Responsive ---------- */
 
 @media (max-width: 540px) {
@@ -4856,4 +4913,11 @@ body.premium-disabled [data-action="open-premium"] { display: none !important; }
   .game-timer { width: 54px; height: 54px; }
   .game-timer-num { font-size: 0.95rem; }
   .question-card { padding: 1.1rem 1rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -161,11 +161,11 @@
               <label class="lobby-field" data-game-type="globe-drop">
                 <span>Round type</span>
                 <select id="create-globe-drop-round-type" title="Pick the location pool used to seed each round.">
-                  <option value="capitals" selected title="One capital per country. Variety guaranteed.">World capitals (REST Countries)</option>
-                  <option value="countries" title="Guess each country at its geographic centroid — bigger sense of scale, less precision.">Countries (guess the country centroid)</option>
-                  <option value="major-cities" title="Wikidata cities with population over 2 million.">Major cities (Wikidata, pop &gt; 2M)</option>
-                  <option value="top-cities-by-country" title="Top-population 10% of each country's cities (variety across regions, harder picks).">Top cities by country (top 10% of each)</option>
-                  <option value="landmarks" title="UNESCO World Heritage sites worldwide.">World landmarks (UNESCO sites)</option>
+                  <option value="capitals" selected>World capitals (one per country, variety guaranteed)</option>
+                  <option value="countries">Countries (guess the geographic centroid)</option>
+                  <option value="major-cities">Major cities (pop &gt; 2M)</option>
+                  <option value="top-cities-by-country">Top cities by country (top 10%, harder)</option>
+                  <option value="landmarks">World landmarks (UNESCO sites)</option>
                 </select>
               </label>
               <label class="lobby-field" data-game-type="globe-drop">
@@ -279,7 +279,7 @@
             <div class="lobby-form">
               <label class="lobby-field">
                 <span>Room code</span>
-                <input type="text" id="join-code" maxlength="7" placeholder="ABCDE" autocomplete="off" spellcheck="false" inputmode="latin" autocapitalize="characters">
+                <input type="text" id="join-code" maxlength="5" placeholder="ABCDE" autocomplete="off" spellcheck="false" inputmode="latin" autocapitalize="characters">
               </label>
               <label class="lobby-field" id="join-password-field" hidden>
                 <span>Password</span>
@@ -361,20 +361,21 @@
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
             </button>
           </header>
+          <p class="room-chat-game-live" id="room-chat-game-live" hidden><span aria-hidden="true">🎮</span> Game in progress</p>
           <ul class="room-chat-list" id="room-chat-list" aria-live="polite"></ul>
           <p class="room-chat-empty" id="room-chat-empty">No messages yet. Say something.</p>
           <!-- Quick-tap emoji bar — one click sends that emoji as a
                message, no typing required. Skips moderation since
                emoji-only messages can't contain profanity. -->
           <div class="room-chat-quick" aria-label="Quick reactions">
-            <button type="button" class="room-chat-quick-btn" data-emoji="🔥">🔥</button>
-            <button type="button" class="room-chat-quick-btn" data-emoji="🎯">🎯</button>
-            <button type="button" class="room-chat-quick-btn" data-emoji="😂">😂</button>
-            <button type="button" class="room-chat-quick-btn" data-emoji="😭">😭</button>
-            <button type="button" class="room-chat-quick-btn" data-emoji="👏">👏</button>
-            <button type="button" class="room-chat-quick-btn" data-emoji="🤯">🤯</button>
-            <button type="button" class="room-chat-quick-btn" data-emoji="😬">😬</button>
-            <button type="button" class="room-chat-quick-btn" data-emoji="🤔">🤔</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="🔥" title="Send 🔥" aria-label="Send fire reaction">🔥</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="🎯" title="Send 🎯" aria-label="Send bullseye reaction">🎯</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="😂" title="Send 😂" aria-label="Send laughing reaction">😂</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="😭" title="Send 😭" aria-label="Send crying reaction">😭</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="👏" title="Send 👏" aria-label="Send clapping reaction">👏</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="🤯" title="Send 🤯" aria-label="Send mind-blown reaction">🤯</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="😬" title="Send 😬" aria-label="Send grimace reaction">😬</button>
+            <button type="button" class="room-chat-quick-btn" data-emoji="🤔" title="Send 🤔" aria-label="Send thinking reaction">🤔</button>
           </div>
           <form class="room-chat-form" id="room-chat-form" autocomplete="off">
             <input type="text" id="room-chat-input" maxlength="280" placeholder="Type a message…" aria-label="Chat message">
@@ -393,7 +394,7 @@
               <span class="room-settings-hint" id="room-settings-hint" hidden>Host can change settings</span>
               <!-- Host-only: switch game type while still in lobby. Hidden once the
                    game starts (status changes to 'playing'). -->
-              <button type="button" class="btn btn-ghost btn-sm room-settings-game-type-btn" id="room-switch-game-type-btn" hidden></button>
+              <button type="button" class="btn btn-ghost btn-sm room-settings-game-type-btn" id="room-switch-game-type-btn" hidden aria-label="Switch game type"></button>
             </header>
 
             <!-- Read-only summary (always rendered; visibility flipped
@@ -617,7 +618,7 @@
                 <button type="button" class="btn btn-ghost btn-sm" id="globe-drop-ready-btn">
                   <span aria-hidden="true">⏭</span> Ready
                 </button>
-                <span class="globe-drop-ready-status" id="globe-drop-ready-status"></span>
+                <span class="globe-drop-ready-status" id="globe-drop-ready-status" aria-live="polite"></span>
               </div>
             </section>
 
@@ -625,13 +626,13 @@
             <!-- Status element kept (display:none) so JS callsites don't
                  crash. Action bar removed by request — phase feedback
                  lives in the reveal panel + visual pin. -->
-            <p class="answer-status globe-drop-status" id="globe-drop-status" aria-live="polite" hidden></p>
+            <p class="answer-status globe-drop-status" id="globe-drop-status" hidden></p>
             <!-- Wrapper holds the globe + overlay UI as siblings; globe.gl
                  owns the inner contents of #globe-drop-map (canvas) so
                  the FAB stack + timer overlay MUST live outside that
                  element or they get wiped during scene init. -->
             <div class="globe-drop-map-wrap">
-              <div id="globe-drop-map" class="globe-drop-map" aria-label="World globe for guessing"></div>
+              <div id="globe-drop-map" class="globe-drop-map" role="img" aria-label="Interactive 3D world globe — click to place your guess pin"></div>
               <!-- In-globe timer ring (top-left overlay). Drives the
                    countdown visualization for the current question. -->
               <div class="game-timer globe-drop-timer-overlay" id="globe-drop-timer" data-state="asking">
@@ -645,11 +646,11 @@
                    until #globe-drop-clear-btn loses its [hidden] (i.e.
                    a pin has been placed). -->
               <div class="globe-drop-fab-stack" id="globe-drop-fab-stack">
-                <button type="button" class="globe-drop-fab globe-drop-fab-ghost" id="globe-drop-clear-btn" hidden>
+                <button type="button" class="globe-drop-fab globe-drop-fab-ghost" id="globe-drop-clear-btn" hidden aria-label="Clear pin">
                   <svg class="globe-drop-fab-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
                   <span>Clear pin</span>
                 </button>
-                <button type="button" class="globe-drop-fab globe-drop-fab-primary" id="globe-drop-submit-btn" disabled>
+                <button type="button" class="globe-drop-fab globe-drop-fab-primary" id="globe-drop-submit-btn" disabled aria-label="Submit guess">
                   <svg class="globe-drop-fab-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 5 5L20 7"/></svg>
                   <span>Submit guess</span>
                 </button>
@@ -706,8 +707,8 @@
             </div>
           </div>
 
-          <!-- Podium top 3 -->
-          <div class="podium" id="podium" aria-label="Top three"></div>
+          <!-- Podium top 3. aria-label set dynamically by JS. -->
+          <div class="podium" id="podium"></div>
 
           <!-- Full scoreboard -->
           <div class="end-board-wrap">
@@ -717,7 +718,7 @@
                   <th>#</th>
                   <th>Player</th>
                   <th>Score</th>
-                  <th>Streak</th>
+                  <th id="end-board-streak-header">Streak</th>
                 </tr>
               </thead>
               <tbody id="end-board-body"></tbody>
@@ -1007,13 +1008,13 @@
 
   <!-- Premium modal -->
   <div class="modal" id="premium-modal" role="dialog" aria-modal="true" aria-labelledby="premium-modal-title" hidden>
-    <div class="modal-backdrop" data-close="modal"></div>
+    <div class="modal-backdrop" data-close="modal" aria-label="Close dialog"></div>
     <article class="modal-panel modal-panel-sm">
       <button type="button" class="modal-close" data-close="modal" aria-label="Close">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
       </button>
       <h2 id="premium-modal-title"><span aria-hidden="true">✨</span> Arena Premium</h2>
-      <p class="premium-modal-price"><strong>$5 one-time</strong> (no subscription).</p>
+      <p class="premium-modal-price" id="premium-modal-price"><strong id="premium-modal-price-value">$5 one-time</strong> (no subscription).</p>
       <ul class="premium-list">
         <li><span aria-hidden="true">📦</span> Upload custom question packs</li>
         <li><span aria-hidden="true">📊</span> Detailed post-game stats (accuracy, response time, category breakdown)</li>
@@ -1032,7 +1033,7 @@
        title/body/labels in and returns a Promise<boolean>. Replaces
        window.confirm() so confirmations match the dark theme. -->
   <div class="modal" id="confirm-modal" role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title" hidden>
-    <div class="modal-backdrop" data-confirm-close></div>
+    <div class="modal-backdrop" data-confirm-close aria-label="Close dialog"></div>
     <article class="modal-panel modal-panel-sm">
       <button type="button" class="modal-close" data-confirm-close aria-label="Close">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>

--- a/apps/arena/js/app.js
+++ b/apps/arena/js/app.js
@@ -233,7 +233,21 @@ function wireConfirmModal() {
     document.getElementById('confirm-modal-cancel').addEventListener('click', () => closeConfirmModal(false));
     document.getElementById('confirm-modal-confirm').addEventListener('click', () => closeConfirmModal(true));
     document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && !modal.hasAttribute('hidden')) closeConfirmModal(false);
+        if (e.key === 'Escape' && !modal.hasAttribute('hidden')) { closeConfirmModal(false); return; }
+        // Focus trap: cycle Tab/Shift+Tab within the modal's focusable elements.
+        if (e.key === 'Tab' && !modal.hasAttribute('hidden')) {
+            const focusables = Array.from(modal.querySelectorAll(
+                'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+            )).filter((el) => !el.disabled && !el.hasAttribute('hidden'));
+            if (!focusables.length) return;
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+            if (e.shiftKey) {
+                if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+            } else {
+                if (document.activeElement === last) { e.preventDefault(); first.focus(); }
+            }
+        }
     });
 }
 
@@ -806,6 +820,8 @@ function openPremiumModal() {
     // instead of flashing a half-styled hidden modal at the user.
     if (!Config.PREMIUM_UI_ENABLED) return;
     const modal = $('#premium-modal');
+    const priceEl = document.getElementById('premium-modal-price-value');
+    if (priceEl) priceEl.textContent = Config.PREMIUM_PRICE_DISPLAY;
     show(modal);
     modal.removeAttribute('hidden');
 }
@@ -1122,7 +1138,13 @@ function wireGameTypeToggle() {
             // Show/hide trivia-only vs globe-drop-only form fields.
             $$('[data-game-type]').forEach((el) => {
                 if (!el.matches('.game-type-btn') && el.dataset.gameType) {
-                    el.hidden = el.dataset.gameType !== type;
+                    const shouldHide = el.dataset.gameType !== type;
+                    // .lobby-solo-actions uses a CSS transition instead of hidden.
+                    if (el.classList.contains('lobby-solo-actions')) {
+                        el.classList.toggle('is-hidden', shouldHide);
+                    } else {
+                        el.hidden = shouldHide;
+                    }
                 }
             });
             saveLobbySettings();
@@ -1819,10 +1841,12 @@ function flashStagePulse(message) {
     // run on first mount, so swapping the element resets them.
     const replacement = el.cloneNode(true);
     el.parentNode.replaceChild(replacement, el);
-    // Hide after the animation finishes; the keyframes already fade it
-    // out, but we want the element fully out of layout so the next pulse
-    // renders cleanly.
-    setTimeout(() => { try { replacement.setAttribute('hidden', ''); } catch (_) {} }, 3000);
+    // Hide once the gd-pulse-out animation ends so the element leaves layout cleanly.
+    replacement.addEventListener('animationend', (e) => {
+        if (e.animationName === 'gd-pulse-out') {
+            try { replacement.hidden = true; } catch (_) {}
+        }
+    });
 }
 
 // When the host bumps the room's `round` (Play Again), every client notices
@@ -2088,6 +2112,9 @@ function openChatPanel() {
     if (panel) panel.hidden = false;
     chatState.unreadSince = chatState.messages.length;
     updateChatBadge();
+    // Show "Game in progress" banner when a game is actively running.
+    const liveBanner = document.getElementById('room-chat-game-live');
+    if (liveBanner) liveBanner.hidden = !(state.roomData && state.roomData.status === 'playing');
     // Focus the input on open — feels conversational.
     const input = $('#room-chat-input');
     if (input) setTimeout(() => input.focus(), 50);
@@ -3190,6 +3217,15 @@ function loadCountryFeaturesIndex() {
     return countryFeaturesIndexPromise;
 }
 
+function setClearBtnVisible(visible) {
+    const btn = document.getElementById('globe-drop-clear-btn');
+    if (!btn) return;
+    btn.hidden = !visible;
+    // Fallback for browsers that don't support :has() — toggle class on the stack.
+    const stack = document.getElementById('globe-drop-fab-stack');
+    if (stack) stack.classList.toggle('fab-pinned', visible);
+}
+
 function onGlobeClick(lat, lng) {
     // Only respond when we're in a live GlobeDrop game and haven't locked
     // in this question yet. We do NOT block on phase === 'asking' here —
@@ -3215,7 +3251,7 @@ function onGlobeClick(lat, lng) {
     state.pendingGuess = { lat, lng };
     drawMyPinOnly(lat, lng);
     $('#globe-drop-submit-btn').disabled = false;
-    $('#globe-drop-clear-btn').hidden = false;
+    setClearBtnVisible(true);
     setText($('#globe-drop-status'), 'Pin placed. Submit when you\'re sure.');
     $('#globe-drop-status').classList.remove('is-correct', 'is-wrong');
     Feedback.pinPlaced();
@@ -3406,7 +3442,7 @@ function renderGlobeDropStage() {
             state.lastCameraTarget = null;        // re-arm the reveal-pan guard
             state.pendingGuess = null;
             $('#globe-drop-submit-btn').disabled = true;
-            $('#globe-drop-clear-btn').hidden = true;
+            setClearBtnVisible(false);
             $('#globe-drop-reveal').hidden = true;
             const triviaEl = $('#globe-drop-reveal-trivia');
             // Clear the text in addition to hiding so a stale entry can
@@ -3426,7 +3462,7 @@ function renderGlobeDropStage() {
         const meSubmitted = !!(me && me.currentAnsweredFor === loc.id && me.currentGuess);
         if (meSubmitted) {
             $('#globe-drop-submit-btn').disabled = true;
-            $('#globe-drop-clear-btn').hidden = true;
+            setClearBtnVisible(false);
         }
 
         // Three reveal states:
@@ -3532,11 +3568,16 @@ function renderReadyBar(phase) {
     const statusEl = $('#globe-drop-ready-status');
     if (statusEl) {
         const readyCount = players.filter((p) => p.readyAfterQId === loc.id).length;
-        const pips = players.map((p) => {
-            const isReady = p.readyAfterQId === loc.id;
-            return `<span class="ready-pip${isReady ? ' is-ready' : ''}">${escapeHtml(p.displayName || 'Player')}</span>`;
-        }).join('');
-        statusEl.innerHTML = `${pips} <small>${readyCount}/${players.length} ${isLast ? 'finishing' : 'ready'}</small>`;
+        const label = isLast ? 'finishing' : 'ready';
+        if (players.length > 4) {
+            statusEl.innerHTML = `<small>${readyCount}/${players.length} ${label}</small>`;
+        } else {
+            const pips = players.map((p) => {
+                const isReady = p.readyAfterQId === loc.id;
+                return `<span class="ready-pip${isReady ? ' is-ready' : ''}">${escapeHtml(p.displayName || 'Player')}</span>`;
+            }).join('');
+            statusEl.innerHTML = `${pips} <small>${readyCount}/${players.length} ${label}</small>`;
+        }
     }
 }
 
@@ -3746,6 +3787,7 @@ function drawGlobeDropReveal(loc, me, { showOthers = true } = {}) {
 function renderMiniBoardGlobeDrop(currentQuestionId) {
     const list = $('#mini-board-list-globe-drop');
     list.innerHTML = '';
+    list.classList.toggle('is-crowded', state.roomPlayers && state.roomPlayers.length > 4);
     // Anti-peek: if I haven't submitted the current round, redact each
     // opponent's contribution from THIS round so I can't infer their
     // distance/score before I've committed mine. The reveal phase
@@ -3949,7 +3991,7 @@ async function submitGuess() {
     // snapshot round-trip. We mirror the guess into our local roomPlayers
     // copy so drawGlobeDropReveal can find it.
     $('#globe-drop-submit-btn').disabled = true;
-    $('#globe-drop-clear-btn').hidden = true;
+    setClearBtnVisible(false);
     const myEntry = state.roomPlayers.find((p) => p.uid === state.user.uid);
     if (myEntry) {
         myEntry.currentGuess = guess;
@@ -4018,7 +4060,7 @@ function clearMyPin() {
         state.globe.polygonsData([]);
     }
     $('#globe-drop-submit-btn').disabled = true;
-    $('#globe-drop-clear-btn').hidden = true;
+    setClearBtnVisible(false);
     setText($('#globe-drop-status'), '');
 }
 
@@ -4654,23 +4696,28 @@ async function renderEndStage(isHost) {
     }
     const medals = ['🥇', '🥈', '🥉'];
     const slotOrder = [1, 0, 2]; // visual: 2nd, 1st, 3rd
-    if (!isSoloMode) for (const orderIdx of slotOrder) {
-        if (!ranked[orderIdx]) {
-            podium.appendChild(document.createElement('div'));
-            continue;
+    if (!isSoloMode) {
+        podium.setAttribute('aria-label', `Top ${Math.min(ranked.length, 3)}`);
+        for (const orderIdx of slotOrder) {
+            if (!ranked[orderIdx]) continue;
+            const p = ranked[orderIdx];
+            const slot = document.createElement('div');
+            slot.className = `podium-slot podium-slot-${orderIdx+1}`;
+            slot.innerHTML =
+                `<span class="podium-medal">${medals[orderIdx]}</span>` +
+                `<span class="podium-name" title="${escapeHtml(p.displayName)}">${escapeHtml(p.displayName)}</span>` +
+                `<span class="podium-score">${p.score}</span>` +
+                `<div class="podium-block">${orderIdx+1}</div>`;
+            podium.appendChild(slot);
         }
-        const p = ranked[orderIdx];
-        const slot = document.createElement('div');
-        slot.className = `podium-slot podium-slot-${orderIdx+1}`;
-        slot.innerHTML =
-            `<span class="podium-medal">${medals[orderIdx]}</span>` +
-            `<span class="podium-name">${escapeHtml(p.displayName)}</span>` +
-            `<span class="podium-score">${p.score}</span>` +
-            `<div class="podium-block">${orderIdx+1}</div>`;
-        podium.appendChild(slot);
     }
 
     // Full board
+    const streakHeader = $('#end-board-streak-header');
+    if (streakHeader) {
+        const isGlobeDrop = state.roomData && state.roomData.gameType === 'globe-drop';
+        streakHeader.textContent = isGlobeDrop ? 'Bullseye streak' : 'Streak';
+    }
     const body = $('#end-board-body');
     body.innerHTML = '';
     ranked.forEach((p, i) => {
@@ -5101,9 +5148,13 @@ async function renderEndRecapH2H(players) {
     const banner = document.getElementById('end-recap-h2h');
     if (!banner) return;
     banner.hidden = true;
-    if (!state.user || !Array.isArray(players) || players.length !== 2) return;
-    const me = players.find((p) => p.uid === state.user.uid);
-    const opp = players.find((p) => p.uid !== state.user.uid);
+    if (!state.user || !Array.isArray(players)) return;
+    // Show when exactly 2 players have recorded answers (works even when a 3rd player left).
+    const withAnswers = players.filter((p) => p && Array.isArray(p.answers) && p.answers.length > 0);
+    const twoPlayers = withAnswers.length === 2 ? withAnswers : (players.length === 2 ? players : null);
+    if (!twoPlayers) return;
+    const me = twoPlayers.find((p) => p.uid === state.user.uid);
+    const opp = twoPlayers.find((p) => p.uid !== state.user.uid);
     if (!me || !opp) return;
     const key = h2hPairKey(me.uid, opp.uid);
     if (!key) return;
@@ -5335,6 +5386,11 @@ function renderEndRecap() {
     setText($('#end-recap-sub'),
         `${questions.length} ${qNoun} · comparing ${columns.length} player${columns.length === 1 ? '' : 's'}`);
     section.hidden = false;
+    // Apply the scroll-fade mask only when the table actually overflows.
+    const tableWrap = document.querySelector('.end-recap-table-wrap');
+    if (tableWrap) {
+        tableWrap.classList.toggle('has-overflow', tableWrap.scrollWidth > tableWrap.clientWidth);
+    }
 }
 
 function computeGlobeDropAggregates(columns, answersByUid) {


### PR DESCRIPTION
## Summary

Sweep of 43 issues from an edge-to-edge audit of Arena's Globe Drop feature — lobby, in-game, results, modals, responsive, theming, animation, and edge cases.

### a11y
- Global `prefers-reduced-motion` clamp
- `:focus-visible` rings on `.room-code-copy`, `.game-type-btn`, `.pick-cat-btn`, `.answer-btn`, `.globe-drop-ready-btn`, `.room-chat-quick-btn`, `.modal-close`
- Focus trap on confirm modal; `aria-label` on modal backdrops
- `aria-label` on Clear/Submit FABs, quick-emoji buttons, game-type switch
- `aria-live="polite"` on ready-status; spurious `aria-live` removed from permanently hidden status `<p>`
- Podium `aria-label` set dynamically; `title` on truncated names
- Globe gets `role="img"` and a descriptive aria-label

### Mobile / responsive
- Chat panel raised above the fixed submit pill (z-index 210)
- `.globe-drop-map-wrap` padding uses `env(safe-area-inset-bottom)`
- `.view-tabs` no longer wraps (padding shrinks at ≤480px)
- Ready-bar collapses to `N/M ready` past 4 players
- Mini-board hides names on mobile when crowded (`.is-crowded`)
- Lobby grid min-col lowered to 260px

### Theming
- Reveal-distance score uses `--violet-2` (WCAG AA)
- `.recap-score-meta` undefined `var(--font)` → `inherit`
- `.auth-gate .link-btn` hover uses `--cyan-2`; stray `#6aa7ff` fallback removed

### Polish
- End-board "Streak" → "Bullseye streak" for Globe Drop
- Podium no longer renders an empty 3rd slot in 2-player games
- H2H banner handles mid-game departures (matches on players with answers)
- End-recap mask only fades when the table actually overflows
- `#join-code` `maxlength` matches `ROOM_CODE_LENGTH` (5)
- Premium price rendered from `Config.PREMIUM_PRICE_DISPLAY` instead of hardcoded
- Prompt row aligns correctly when difficulty chip is absent
- Rounds-history board gets the same `stage-fade` entrance the rest of the stage uses
- Stage pulse hides on `animationend` instead of a 3s timeout
- Score-pulse `<strong>` uses `inline-block` + calmer 1.15× peak (no inline reflow)
- Solo-action toggle uses CSS transition instead of snapping
- Round-type dropdown hints inlined so they survive native mobile selects

### Compat
- `.fab-pinned` JS fallback class alongside the `:has()` selector

## Test plan

- [x] `npm test` — 697/697 passing
- [x] Screenshot-verified lobby at 1280px and 390px
- [ ] Walk through the in-game flow on a deploy preview (mobile + desktop)
- [ ] Confirm chat panel + submit pill stacking on a real iPhone
- [ ] Confirm reduced-motion OS toggle silences animations on the deploy preview
- [ ] End-of-game podium and recap with 2-player and 3-player rooms