### PR TITLE
ci(rising-seasons): widen refresh budget and speed up provider fetch

### DIFF
--- a/.github/workflows/refresh-rising-seasons.yml
+++ b/.github/workflows/refresh-rising-seasons.yml
@@ -32,10 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     # Cold first pass after a TMDB schema change (cast back-fill,
     # per-season tvdbId + overview fetch, providers back-fill) re-fetches
-    # tens of thousands of entries at ~8 req/s and needs ~130 min end-to-end.
-    # Incremental subsequent runs are typically well under 15 min, so this
-    # ceiling only matters on the cold pass after a schema bump.
-    timeout-minutes: 180
+    # tens of thousands of entries and, in practice, needs ~3–4 hours
+    # end-to-end. Incremental subsequent runs are typically well under
+    # 15 min, so this ceiling only matters on the cold pass after a
+    # schema bump.
+    timeout-minutes: 240
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/apps/rising-seasons/scripts/enrich-providers.js
+++ b/apps/rising-seasons/scripts/enrich-providers.js
@@ -15,7 +15,7 @@ const path = require('path');
 
 const DATA_DIR = path.join(__dirname, '..', 'data');
 const CACHE_FILE = path.join(DATA_DIR, 'tmdb-cache.json');
-const REQUEST_INTERVAL_MS = 165;
+const REQUEST_INTERVAL_MS = 100;
 const TOKEN = process.env.TMDB_TOKEN || process.env.TMDB_BEARER_TOKEN;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));


### PR DESCRIPTION
## Summary

The 180-min ceiling from #127 still cancelled the cold-pass refresh because `enrich-providers.js` processes its ~25k entry backlog at a hardcoded ~6 req/s (`REQUEST_INTERVAL_MS=165`). Combined with the per-season details fetch that runs first, the cold pass needs more time than 180 min allows.

Two changes:

- **`apps/rising-seasons/scripts/enrich-providers.js`**: drop `REQUEST_INTERVAL_MS` from 165 to 100 ms (~10 req/s, still comfortably under TMDB's 50/s ceiling).
- **`.github/workflows/refresh-rising-seasons.yml`**: raise `timeout-minutes` 180 → 240 to give schema-migration cold passes real headroom.

Incremental daily runs (well under 15 min) are unaffected — this only matters until the new `cast` / `seasonOverviews` / `providers` fields finish backfilling across the cache.

## Test plan

- [x] `npm test` — 697/697 pass
- [ ] After merge: `gh workflow run refresh-rising-seasons.yml`, then watch the run — should complete successfully and open the auto-merge PR for the refreshed `data.json`