### PR TITLE
fix(rising-seasons): retry empty/null cast in TMDB back-fill

### DIFF
--- a/apps/rising-seasons/scripts/enrich-tmdb.js
+++ b/apps/rising-seasons/scripts/enrich-tmdb.js
@@ -260,16 +260,22 @@ async function fetchSeasonExtras(tmdbId, seasonNumber) {
     }
   }
 
-  // Back-fill cast for entries resolved before fetchCast existed, AND
-  // re-fetch entries cached before person.id was added (so cast cards
-  // can link to TMDB person pages). null result is recorded so we
-  // don't retry forever. Entries with a populated cast that already
-  // carry id on the first cast member are left alone.
+  // Back-fill cast for entries resolved before fetchCast existed, entries
+  // where a prior fetchCast errored (cast === null) or returned no credits
+  // (cast === []), and entries cached before person.id was added (so cast
+  // cards can link to TMDB person pages). Brand-new shows often resolve on
+  // TMDB before any cast credits are posted, and pinning their cache row
+  // to null/[] permanently would leave them without a cast strip even
+  // after TMDB fills the credits in — so we retry these every refresh.
+  // Entries with a populated cast that already carry id on the first cast
+  // member are left alone.
   const castBackfill = uniqueSeries.filter((id) => {
     const e = cache[id];
     if (!e || !e.id || e.notFound || e.error) return false;
     if (!('cast' in e)) return true;
-    if (Array.isArray(e.cast) && e.cast.length > 0 && e.cast[0].id == null) return true;
+    if (e.cast === null) return true;
+    if (Array.isArray(e.cast) && e.cast.length === 0) return true;
+    if (Array.isArray(e.cast) && e.cast[0].id == null) return true;
     return false;
   });
   if (castBackfill.length > 0) {


### PR DESCRIPTION
## Summary
- The cast back-fill in `apps/rising-seasons/scripts/enrich-tmdb.js` only re-fetched entries whose `cast` field was missing. Once a row was written with `cast: null` (prior `fetchCast` threw) or `cast: []` (TMDB returned no credits), it stayed pinned forever — even though the GitHub Actions cache restore preserves the row across refreshes.
- This is exactly what happened to Spider-Noir (`seriesId=tt30460310`, `tmdbId=220102`). TMDB now serves 9 cast members for that show, but our cache row recorded an empty/null result on an earlier refresh and the back-fill skipped it on every subsequent run.
- The predicate now also retries `cast === null` and `cast.length === 0`. Brand-new shows that initially had no TMDB credits will heal on the next refresh once TMDB fills them in.

## Cost
- One extra TMDB call per cache row that has ever returned empty/null cast (rate-limited at 100 ms). Bounded by the population of "TMDB has the show but no credits yet" entries — currently small.

## Test plan
- [x] `npm test` — 697/697 pass
- [ ] After merge, trigger `Refresh Rising Seasons data` workflow via `workflow_dispatch`, confirm Spider-Noir's `show-modal-extras.json` entry gets populated and the modal renders a cast strip on the live site