### PR TITLE
feat(rising-seasons): cast strip + app deep-link on show pages

### DIFF
--- a/apps/rising-seasons/css/show-page.css
+++ b/apps/rising-seasons/css/show-page.css
@@ -284,6 +284,51 @@ a.shape-badge:hover {
 .rec-shape-badge { font-size: 11px; }
 .rec-see-all { margin: 14px 0 0; font-size: 14px; }
 
+/* --- Cast strip --- */
+.show-cast {
+  margin: 32px 0 0; padding-top: 24px; border-top: 1px solid var(--border);
+}
+.show-cast h2 { font-size: 20px; margin: 0 0 14px; }
+.cast-list {
+  display: flex; gap: 14px; overflow-x: auto;
+  margin: 0; padding: 4px 0 10px; list-style: none;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+}
+.cast-list::-webkit-scrollbar { height: 6px; }
+.cast-list::-webkit-scrollbar-track { background: transparent; }
+.cast-list::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18); border-radius: 999px;
+}
+.cast-card { flex: 0 0 90px; }
+.cast-card-inner {
+  display: flex; flex-direction: column; gap: 6px; text-align: center;
+  text-decoration: none; color: var(--text);
+  transition: transform 0.15s;
+}
+a.cast-card-inner:hover { transform: translateY(-2px); color: var(--text); }
+a.cast-card-inner:hover .cast-name { color: var(--accent); }
+.cast-photo {
+  width: 90px; aspect-ratio: 2 / 3; border-radius: 10px;
+  background: var(--panel); position: relative; overflow: hidden;
+  box-shadow: 0 0 0 1px var(--border) inset;
+}
+.cast-photo img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.cast-photo-fallback {
+  position: absolute; inset: 0; display: flex; align-items: center;
+  justify-content: center; font-size: 24px; font-weight: 600;
+  color: var(--muted);
+  background: linear-gradient(135deg, #1f2c4d 0%, #2d1f4d 100%);
+}
+.cast-name {
+  font-size: 13px; font-weight: 600; line-height: 1.25;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.cast-character {
+  font-size: 12px; color: var(--muted); line-height: 1.25;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+
 /* --- Sticky CTA banner --- */
 .sticky-cta-banner {
   position: fixed; bottom: 0; left: 0; right: 0; z-index: 200;

--- a/apps/rising-seasons/scripts/build-show-pages.js
+++ b/apps/rising-seasons/scripts/build-show-pages.js
@@ -16,6 +16,7 @@ const { renderShowsSitemap } = require('./render-sitemap.js');
 
 const ROOT = path.join(__dirname, '..');
 const DATA_FILE = path.join(ROOT, 'data.json');
+const EXTRAS_FILE = path.join(ROOT, 'data', 'show-modal-extras.json');
 const SHOWS_DIR = path.join(ROOT, 'shows');
 const SITEMAP_FILE = path.join(ROOT, 'sitemap-shows.xml');
 
@@ -30,6 +31,13 @@ function main() {
   const series = groupBySeries(data.matches);
   console.log(`[build-show-pages] ${series.length} unique series · ${data.matches.length} seasons · builtAt=${data.builtAt}`);
 
+  // Cast lives in show-modal-extras.json (build-data.js strips it out of
+  // data.json's matches), keyed by seriesId. Load it so each show page can
+  // render the same top-billed cast strip the in-app modal shows. Missing
+  // file is non-fatal — pages just render without cast.
+  const extras = fs.existsSync(EXTRAS_FILE) ? JSON.parse(fs.readFileSync(EXTRAS_FILE, 'utf8')) : {};
+  let castCount = 0;
+
   // Build shape → series lookup for recommendations panel.
   const shapeIndex = buildShapeIndex(series);
 
@@ -43,7 +51,9 @@ function main() {
     fs.mkdirSync(dir, { recursive: true });
     const { dominantShape, dominantShapeSlug } = computeDominantShape(s);
     const relatedShows = computeRelatedShows(s, dominantShape, shapeIndex, 4);
-    const html = renderShowPage({ ...s, builtAt: data.builtAt, dominantShape, dominantShapeSlug, relatedShows });
+    const cast = extras[s.seriesId] && extras[s.seriesId].cast ? extras[s.seriesId].cast : null;
+    if (cast) castCount++;
+    const html = renderShowPage({ ...s, cast, builtAt: data.builtAt, dominantShape, dominantShapeSlug, relatedShows });
     fs.writeFileSync(path.join(dir, 'index.html'), html);
     pageCount++;
     if (pageCount % 1000 === 0) {
@@ -58,7 +68,7 @@ function main() {
   fs.writeFileSync(SITEMAP_FILE, renderShowsSitemap(series.map(toIndexEntry), data.builtAt));
 
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);
-  console.log(`[build-show-pages] wrote ${pageCount} show pages + index + sitemap in ${elapsed}s`);
+  console.log(`[build-show-pages] wrote ${pageCount} show pages (${castCount} with cast) + index + sitemap in ${elapsed}s`);
 }
 
 // data.json's `matches` is a flat list of seasons. Group them by series

--- a/apps/rising-seasons/scripts/render-show-page.js
+++ b/apps/rising-seasons/scripts/render-show-page.js
@@ -31,7 +31,7 @@ const SHAPE_LABELS = {
 // Build a single static HTML page for one TV series, given every season's
 // data (already grouped from data.json's flat `matches` array). Returns a
 // complete HTML string.
-function renderShowPage({ seriesId, title, year, type, genres, seriesRating, seriesVotes, poster, overview, language, providers, tmdbId, seasons, builtAt, dominantShape, dominantShapeSlug, relatedShows }) {
+function renderShowPage({ seriesId, title, year, type, genres, seriesRating, seriesVotes, poster, overview, language, providers, tmdbId, cast, seasons, builtAt, dominantShape, dominantShapeSlug, relatedShows }) {
   const path = `/apps/rising-seasons/shows/${showPath(title, seriesId)}/`;
   const canonical = `${SITE}${path}`;
   const numberOfSeasons = seasons.length;
@@ -83,7 +83,7 @@ ${jsonLd(buildBreadcrumbs(title, path))}
 
   <!-- TVSeries -->
   <script type="application/ld+json">
-${jsonLd(buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, cleanOverview, genres, seriesRating, seriesVotes, seasons, tmdbId }))}
+${jsonLd(buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, cleanOverview, genres, seriesRating, seriesVotes, seasons, tmdbId, cast }))}
   </script>
 
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📈%3C/text%3E%3C/svg%3E">
@@ -133,12 +133,14 @@ ${jsonLd(buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, clea
         </dl>
         <div class="hero-actions">
           ${renderPrimaryCtaBtn(dominantShape, dominantShapeSlug)}
-          <a class="app-btn" href="/apps/rising-seasons/">Open Rising Seasons app →</a>
+          <a class="app-btn" href="/apps/rising-seasons/#show=${escapeHtml(seriesId)}">Open in Rising Seasons app →</a>
           <a class="secondary-btn" href="https://www.imdb.com/title/${seriesId}/" rel="noopener" target="_blank">View on IMDb</a>
         </div>
         ${renderFreshnessLine(builtAt, seasons.length)}
       </div>
     </section>
+
+    ${renderCast(cast)}
 
     <section class="seasons" aria-labelledby="seasons-heading">
       <h2 id="seasons-heading">Seasons</h2>
@@ -165,6 +167,36 @@ function renderHeroPoster(posterUrl, title) {
     return '<div class="show-poster poster-placeholder" aria-hidden="true"></div>';
   }
   return `<img class="show-poster" src="${escapeHtml(posterUrl)}" alt="${escapeHtml(`${title} poster`)}" width="300" height="450" loading="eager" decoding="async">`;
+}
+
+// Top-billed cast strip. `cast` is the array stashed on the series by
+// enrich-tmdb.js — each entry is { id, name, character, profile_path }.
+// Mirrors the in-app show modal's cast cards (same class names) so the
+// shared .cast-* styling applies. Returns '' when there's no cast so the
+// section is omitted entirely.
+const TMDB_PROFILE = 'https://image.tmdb.org/t/p/w185';
+function renderCast(cast) {
+  if (!Array.isArray(cast) || cast.length === 0) return '';
+  const cards = cast.map((person) => {
+    const photo = person.profile_path
+      ? `<img src="${escapeHtml(`${TMDB_PROFILE}${person.profile_path}`)}" alt="" width="90" height="135" loading="lazy" decoding="async">`
+      : `<div class="cast-photo-fallback" aria-hidden="true">${escapeHtml((person.name || '?').charAt(0).toUpperCase())}</div>`;
+    const inner = `<div class="cast-photo">${photo}</div>
+          <span class="cast-name">${escapeHtml(person.name || '')}</span>
+          ${person.character ? `<span class="cast-character">${escapeHtml(person.character)}</span>` : ''}`;
+    // Whole card links to the TMDB person page when we have an id, matching
+    // the app modal. Falls back to a non-interactive card otherwise.
+    const body = Number.isFinite(person.id)
+      ? `<a class="cast-card-inner" href="https://www.themoviedb.org/person/${person.id}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(`View ${person.name || 'cast member'} on TMDB`)}">${inner}</a>`
+      : `<div class="cast-card-inner">${inner}</div>`;
+    return `<li class="cast-card">${body}</li>`;
+  }).join('\n      ');
+  return `<section class="show-cast" aria-labelledby="cast-heading">
+      <h2 id="cast-heading">Cast</h2>
+      <ul class="cast-list">
+      ${cards}
+      </ul>
+    </section>`;
 }
 
 function renderSeasonSection(season, seriesId) {
@@ -307,7 +339,7 @@ function buildBreadcrumbs(title, path) {
   };
 }
 
-function buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, cleanOverview, genres, seriesRating, seriesVotes, seasons, tmdbId }) {
+function buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, cleanOverview, genres, seriesRating, seriesVotes, seasons, tmdbId, cast }) {
   const sameAs = [`https://www.imdb.com/title/${seriesId}/`];
   if (tmdbId) sameAs.push(`https://www.themoviedb.org/tv/${tmdbId}`);
   const schema = {
@@ -322,6 +354,13 @@ function buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, clea
   if (cleanOverview) schema.description = cleanOverview;
   if (posterUrl) schema.image = posterUrl;
   if (genres && genres.length) schema.genre = genres;
+  if (Array.isArray(cast) && cast.length) {
+    schema.actor = cast.map((p) => {
+      const person = { '@type': 'Person', name: p.name };
+      if (Number.isFinite(p.id)) person.sameAs = `https://www.themoviedb.org/person/${p.id}`;
+      return person;
+    });
+  }
   if (seriesRating) {
     schema.aggregateRating = {
       '@type': 'AggregateRating',

--- a/apps/rising-seasons/tests/render-show-page.test.js
+++ b/apps/rising-seasons/tests/render-show-page.test.js
@@ -155,10 +155,11 @@ test('renderShowPage hero-actions has three buttons: shape CTA, app-btn, IMDb li
   assert.ok(html.includes('class="primary-btn"'));
   assert.ok(html.includes('class="app-btn"'));
   assert.ok(html.includes('class="secondary-btn"'));
-  // app-btn links to the base app URL with no hash
+  // app-btn deep-links into the app, opening this show's modal via #show=
   const appBtnIdx = html.indexOf('class="app-btn"');
-  const appBtnSnippet = html.slice(appBtnIdx - 60, appBtnIdx + 80);
-  assert.ok(appBtnSnippet.includes('href="/apps/rising-seasons/"'));
+  const appBtnSnippet = html.slice(appBtnIdx - 60, appBtnIdx + 120);
+  assert.ok(appBtnSnippet.includes(`href="/apps/rising-seasons/#show=${BREAKING_BAD.seriesId}"`));
+  assert.ok(appBtnSnippet.includes('Open in Rising Seasons app'));
   // app-btn does NOT carry the shape hash (that's the primary-btn's job)
   assert.ok(!appBtnSnippet.includes('#shape='));
   // Order: primary-btn appears before app-btn, app-btn before secondary-btn
@@ -170,8 +171,32 @@ test('renderShowPage app-btn is present even when show has no dominant shape', (
   const html = renderShowPage({ ...BREAKING_BAD, dominantShape: null, dominantShapeSlug: null, relatedShows: [] });
   assert.ok(html.includes('class="app-btn"'));
   const appBtnIdx = html.indexOf('class="app-btn"');
-  const snippet = html.slice(appBtnIdx - 60, appBtnIdx + 80);
-  assert.ok(snippet.includes('href="/apps/rising-seasons/"'));
+  const snippet = html.slice(appBtnIdx - 60, appBtnIdx + 120);
+  assert.ok(snippet.includes(`href="/apps/rising-seasons/#show=${BREAKING_BAD.seriesId}"`));
+});
+
+test('renderShowPage renders a cast strip when cast is provided', () => {
+  const cast = [
+    { id: 17419, name: 'Bryan Cranston', character: 'Walter White', profile_path: '/bran.jpg' },
+    { id: 134531, name: 'Aaron Paul', character: 'Jesse Pinkman', profile_path: null },
+  ];
+  const html = renderShowPage({ ...BREAKING_BAD, cast, dominantShape: 'rising', dominantShapeSlug: 'rising', relatedShows: [] });
+  assert.ok(html.includes('<h2 id="cast-heading">Cast</h2>'));
+  assert.ok(html.includes('class="cast-name">Bryan Cranston'));
+  assert.ok(html.includes('class="cast-character">Walter White'));
+  // Member with a TMDB id links out to their person page.
+  assert.ok(html.includes('https://www.themoviedb.org/person/17419'));
+  // Member without a profile_path gets the initial fallback, not a broken img.
+  assert.ok(html.includes('class="cast-photo-fallback"'));
+  // Cast feeds the TVSeries JSON-LD actor list for SEO.
+  assert.ok(html.includes('"actor"'));
+  assert.ok(html.includes('"name": "Bryan Cranston"'));
+});
+
+test('renderShowPage omits the cast section when there is no cast', () => {
+  const html = renderShowPage({ ...BREAKING_BAD, cast: null, dominantShape: 'rising', dominantShapeSlug: 'rising', relatedShows: [] });
+  assert.ok(!html.includes('id="cast-heading"'));
+  assert.ok(!html.includes('"actor"'));
 });
 
 test('groupBySeries backfills series-level fields from any season', () => {


### PR DESCRIPTION
## What

Two additions to the static per-show pages in Rising Seasons (the SEO landing pages under `/apps/rising-seasons/shows/`):

1. **Cast strip** — a new "Cast" section showing the top-billed cast (photo, name, character), each card linking to the actor's TMDB person page. Mirrors the cast strip already shown in the in-app show modal.
2. **Deep-link into the app** — the hero button changed from *"Open Rising Seasons app →"* (which dropped you on the app home) to *"Open in Rising Seasons app →"*, now linking to `/apps/rising-seasons/#show=<seriesId>` so the app opens directly on that show's modal. The `#show=` hash was already handled by `app.js`.

## How

- **Cast data**: `build-data.js` strips `cast` out of `data.json`'s `matches` and stashes it in `data/show-modal-extras.json` (keyed by seriesId). The show-page build never saw it, so `build-show-pages.js` now loads that extras file and passes each series' cast to the renderer. Missing file/entry is non-fatal — the section is simply omitted.
- **Renderer** (`render-show-page.js`): new `renderCast()` reuses the modal's `.cast-*` class names; section is omitted entirely when a show has no cast. Cast also feeds the `TVSeries` JSON-LD `actor` array for SEO. Self-contained `.cast-*` styles added to `show-page.css` (the static pages don't load the app's `styles.css`).

## Verification

- `npm test` — all 699 pass (added 2 cast tests; updated 2 app-btn tests for the new deep-link URL).
- Full `build:rising-seasons:pages` regenerated all 33,921 pages (27,921 with cast) with no errors.
- Screenshot-verified on desktop (1280px) and mobile (390px): cast strip renders with photos + horizontal scroll on mobile, and the hero button reads "Open in Rising Seasons app →".

## Notes

- `apps/rising-seasons/shows/` is build-generated and gitignored — no generated pages are committed; Netlify regenerates them from `data.json` at build time.