### PR TITLE
Rising Seasons: discovery, navigation, visual polish, and SEO batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ apps/gym-tracker/sitemap-exercises.xml
 # Local-only change-notes / site-comparison docs. Kept on disk for
 # reference, not published to the repo.
 .features/
+
+# Transient test-run screenshot evidence (written by the test pipeline,
+# reviewed by the owner, deleted at round close). Never committed.
+.screenshots/

--- a/apps/rising-seasons/README.md
+++ b/apps/rising-seasons/README.md
@@ -32,16 +32,39 @@ A season can match more than one shape — the card shows all of them.
 | Feature                  | What it does                                                                                       |
 | ------------------------ | -------------------------------------------------------------------------------------------------- |
 | Shape filter             | Toggle one or more shape chips; AND across selected shapes.                                        |
-| Genre filter (tri-state) | Click a chip to **require** that genre; click again to **exclude** it (red strike); third click clears. AND across required genres. |
+| Mood presets             | One-tap "Explore by mood" chips that apply a curated filter combination, including shape-anchored picks (Best rebounders, Unmissable finales, Hidden slow-burns, Worst endings). The rail shows the first 6 moods; the rest sit behind a "More moods +N" toggle (an active mood is never hidden). On mobile the whole strip is additionally collapsed behind a toggle pill. |
+| Genre filter (tri-state) | Click a chip to **require** that genre; click again to **exclude** it (red strike); third click clears. AND across required genres. The top 8 genres live as chips in the quick-filters panel (the advanced drawer no longer duplicates them). |
+| Decade filter            | "80s / 90s / 00s / 10s / 20s" quick chips set the year range in one tap (synced with the advanced-drawer year inputs); "All" clears it. |
 | Language filter          | Multi-select chips for the top original languages (TMDB `original_language`).                      |
 | Streaming filter         | Multi-select chips for top US watch providers (Netflix, HBO Max, Prime …).                         |
 | Hidden gems toggle       | Surfaces seasons with avg ≥ 8.0 *and* fewer than 1,000 votes per episode.                          |
 | Episode-title search     | Searching ≥3 chars also matches against episode names — "Gray Matter" → Breaking Bad.              |
 | Compare shows            | "+ Add to compare" on each show, then a floating button opens an overlay chart of season-trajectories for up to 5 series (persisted in localStorage). |
-| Season overlay           | In the show modal, all seasons drawn together on one chart with a legend.                          |
+| Season overlay           | In the show modal, all seasons drawn together on one chart with a legend; clicking a legend entry (the swatch or the S-number) hides/restores that season's line. |
 | Best / worst badges      | Inline pill on the highest- and lowest-rated season of each series (skipped when all seasons tie). |
 | Watched tracking         | Per-season toggle; persists in localStorage; "watched / unwatched" filters and stats.              |
 | Above-IMDb badge         | Marks seasons whose average episode rating beats the show's overall IMDb score.                    |
+| Sort options             | Popularity, season length, rating climb (last vs first), finale rating, season average, most recent, and most volatile (episode-to-episode standard deviation). |
+| More seasons like this   | The season detail modal lists up to 10 related seasons (sharing a shape **and** a genre, same original language, similar average, votes/episode within 10x, different series), ranked by a likeness score (shared shapes, then rating closeness, then votes). The first 4 show; a "6 more" toggle expands the rest. Click one to open it. |
+| More shows like this     | The show modal lists up to 10 shows that share a genre, the same original language, and a similar popularity (votes/episode within 10x), with the closest gap between their IMDb rating and their average episode rating. Same 4 + "N more" pattern; click one to open that show. |
+| Copy link                | A "Copy link" button in the active-filter bar copies the current filtered-view URL to the clipboard whenever any filter is active. |
+
+## Static show pages (SEO)
+
+`scripts/build-show-pages.js` (run via `npm run build:rising-seasons:pages`, and on
+every Netlify deploy through `npm run build:site`) renders one static HTML page per
+series under `apps/rising-seasons/shows/` plus an A-Z index and `sitemap-shows.xml`.
+These are gitignored build artifacts, derived from the committed `data.json`.
+
+Each page (`scripts/render-show-page.js`) emits:
+
+- `BreadcrumbList` and `TVSeries` JSON-LD, plus one `TVSeason` block per season with
+  `aggregateRating` (rating value + vote count), `partOfSeries`, and a `#season-N` URL,
+  so search engines can surface per-season rating data.
+- A season jump nav (`S1 S2 S3 …`) on shows with 4 or more seasons, linking to each
+  `#season-N` anchor.
+- Open Graph and Twitter card meta, including `og:image:alt` and `twitter:label`/`data`
+  pairs that carry the dominant shape and average episode rating into link previews.
 
 ## One-time setup
 

--- a/apps/rising-seasons/css/show-page.css
+++ b/apps/rising-seasons/css/show-page.css
@@ -252,6 +252,35 @@ a.shape-badge:hover {
   margin: 10px 0 0; font-size: 13px; color: var(--muted);
 }
 
+/* --- Season jump nav (Feature 8) --- */
+.season-jump-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0 0 20px;
+  padding: 10px 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+.season-jump-nav a {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: var(--bg-2);
+  color: var(--text);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+.season-jump-nav a:hover {
+  background: var(--shape);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 /* --- Related shows --- */
 .related-shows {
   margin: 32px 0 0; padding-top: 24px; border-top: 1px solid var(--border);
@@ -348,6 +377,94 @@ a.cast-card-inner:hover .cast-name { color: var(--accent); }
   cursor: pointer; padding: 0 4px; line-height: 1; flex-shrink: 0;
 }
 .sticky-cta-close:hover { color: var(--text); }
+
+/* --- Scroll-to-top button ---
+   Fixed to the bottom-right corner of the viewport. The visible state
+   materialises out of the corner (fade + rise + scale); the hidden state
+   removes interactivity so it is never reachable by keyboard or pointer
+   while invisible. Mirrors the .modal-scroll-top design in styles.css
+   but adapted for window scrolling (position:fixed, safe-area insets). */
+.page-scroll-top,
+.page-scroll-top:hover,
+.page-scroll-top:hover:active {
+  position: fixed;
+  bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+  right: calc(1.25rem + env(safe-area-inset-right, 0px));
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  width: auto;
+  height: 42px;
+  min-height: 42px;
+  padding: 0 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(180deg, rgba(56, 62, 82, 0.92), rgba(28, 32, 45, 0.92));
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow:
+    0 6px 20px rgba(0, 0, 0, 0.45),
+    0 0 12px rgba(255, 255, 255, 0.06),
+    0 1px 0 rgba(255, 255, 255, 0.08) inset;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(8px) scale(0.85);
+  transition: opacity 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
+              transform 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
+              background 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
+              border-color 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
+              box-shadow 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
+              bottom 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
+              visibility 0s linear 0.25s;
+}
+.page-scroll-top--visible,
+.page-scroll-top--visible:hover,
+.page-scroll-top--visible:hover:active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+  transition: opacity 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
+              transform 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
+              background 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
+              border-color 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
+              box-shadow 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
+              bottom 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
+              visibility 0s;
+}
+.page-scroll-top svg {
+  display: block;
+  flex-shrink: 0;
+  transition: transform 0.2s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.page-scroll-top--visible:hover {
+  background: linear-gradient(180deg, rgba(72, 79, 102, 0.95), rgba(38, 43, 60, 0.95));
+  border-color: rgba(255, 255, 255, 0.3);
+  transform: translateY(-2px);
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.5),
+    0 0 18px rgba(255, 255, 255, 0.12),
+    0 1px 0 rgba(255, 255, 255, 0.12) inset;
+}
+.page-scroll-top--visible:hover svg {
+  transform: translateY(-1px);
+}
+.page-scroll-top--visible:hover:active {
+  transform: translateY(0) scale(0.95);
+}
+.page-scroll-top:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* --- Mobile --- */
 @media (max-width: 700px) {

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -928,7 +928,7 @@ body.rising-seasons-app button {
               box-shadow 0.18s var(--ease);
 }
 .filter-row.primary .search input::placeholder {
-  color: rgba(231, 233, 238, 0.42);
+  color: rgba(231, 233, 238, 0.62);
   font-weight: 400;
 }
 .filter-row.primary .search input:hover { background-color: rgba(255, 255, 255, 0.025); }
@@ -978,7 +978,7 @@ body.rising-seasons-app button {
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.035);
   border: 1px solid var(--border);
-  color: rgba(243, 244, 246, 0.78);
+  color: rgba(243, 244, 246, 0.88);
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -1032,7 +1032,7 @@ body.rising-seasons-app button {
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(243, 244, 246, 0.78);
+  color: rgba(243, 244, 246, 0.88);
   transition: color 0.15s var(--ease), background 0.15s var(--ease);
 }
 /* The browser draws a default focus ring on <summary> when one of its
@@ -1190,7 +1190,7 @@ body.rising-seasons-app button {
     0 1px 0 rgba(0, 0, 0, 0.18) inset;
 }
 .advanced .filter-row input::placeholder {
-  color: rgba(231, 233, 238, 0.55);
+  color: rgba(231, 233, 238, 0.7);
   font-weight: 400;
 }
 /* Restore the chevron on the slim Sort select (the default arrow gets
@@ -1239,10 +1239,10 @@ body.rising-seasons-app button {
   align-items: center;
   height: 28px;
   padding: 0 0.8rem;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.075);
+  border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 999px;
-  color: var(--text) !important;
+  color: #ffffff !important;
   font: inherit;
   font-size: 0.74rem;
   font-weight: 600;
@@ -1255,9 +1255,19 @@ body.rising-seasons-app button {
   transition: background 0.18s var(--ease), border-color 0.18s var(--ease), color 0.18s var(--ease);
 }
 .genre-chip:hover {
-  background: rgba(255, 255, 255, 0.09);
-  border-color: rgba(255, 255, 255, 0.22);
-  color: var(--text) !important;
+  background: rgba(255, 255, 255, 0.11);
+  border-color: rgba(255, 255, 255, 0.26);
+  color: #ffffff !important;
+}
+/* Pin the pressed-state background (main.css red button:hover:active). */
+.genre-chip:hover:active {
+  background: rgba(255, 255, 255, 0.13);
+}
+.genre-chip[aria-pressed="true"]:hover:active {
+  background: rgba(245, 197, 24, 0.16);
+}
+.genre-chip[data-exclude="true"]:hover:active {
+  background: rgba(248, 113, 113, 0.16);
 }
 .genre-chip[aria-pressed="true"],
 .genre-chip[aria-pressed="true"]:hover {
@@ -1749,7 +1759,7 @@ button.shape-tag.is-clickable:hover {
   line-height: 1;
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: rgba(231, 233, 238, 0.55);
+  color: rgba(231, 233, 238, 0.75);
   font-weight: 600;
   border: 0;
   user-select: none;
@@ -1775,7 +1785,11 @@ button.shape-tag.is-clickable:hover {
 .label-chip[aria-pressed="true"]:focus,
 .label-chip[aria-pressed="true"]:focus-visible {
   outline: 0 !important;
-  border: 0 !important;
+  /* One hairline border we own, pinned across every state with !important
+     so main.css's inset rings can never combine with it. State rules below
+     vary only border-color (also !important, later in the file, so they
+     win this tie). */
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
   box-shadow: none !important;
 }
 
@@ -1787,8 +1801,12 @@ button.shape-tag.is-clickable:hover {
   justify-content: center;
   height: 26px;
   padding: 0 0.65rem;
-  background: transparent;
-  color: var(--text);
+  /* Faint surface + hairline border so inactive options read as quiet
+     controls rather than flat gray text. The color needs !important:
+     main.css paints every button #555555 !important, which silently wins
+     over any non-important color here regardless of specificity. */
+  background: rgba(255, 255, 255, 0.045);
+  color: #ffffff !important;
   font: inherit;
   font-size: 0.76rem;
   font-weight: 600;
@@ -1797,6 +1815,7 @@ button.shape-tag.is-clickable:hover {
   cursor: pointer;
   transition:
     background 0.18s var(--ease),
+    border-color 0.18s var(--ease),
     color 0.18s var(--ease);
   white-space: nowrap;
 }
@@ -1806,12 +1825,22 @@ button.shape-tag.is-clickable:hover {
 .label-chip + .label-chip { margin-left: 0.35rem; }
 .label-chip:hover {
   color: #ffffff !important;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.22) !important;
+}
+/* Pin the pressed-state background too — main.css gives every
+   button:hover:active a translucent red fill otherwise. */
+.label-chip:hover:active {
+  background: rgba(255, 255, 255, 0.1);
+}
+.label-chip[aria-pressed="true"]:hover:active {
+  background: rgba(245, 197, 24, 0.16);
 }
 .label-chip:focus-visible {
-  /* Background-only focus indicator — no outline, no shadow. Cannot
+  /* Background + border focus indicator — no outline, no shadow. Cannot
      possibly extend into the adjacent chip's space. */
   background: rgba(245, 197, 24, 0.2);
+  border-color: rgba(245, 197, 24, 0.45) !important;
   color: var(--accent) !important;
 }
 
@@ -1821,20 +1850,24 @@ button.shape-tag.is-clickable:hover {
    don't draw attention away from the editorial pattern chips. */
 .label-chip[aria-pressed="true"] {
   background: rgba(245, 197, 24, 0.085);
-  color: rgba(245, 197, 24, 0.92);
+  border-color: rgba(245, 197, 24, 0.4) !important;
+  color: rgba(245, 197, 24, 0.92) !important;
   box-shadow: none;
 }
 .label-chip[aria-pressed="true"]:hover {
   background: rgba(245, 197, 24, 0.14);
-  color: var(--accent);
+  border-color: rgba(245, 197, 24, 0.5) !important;
+  color: var(--accent) !important;
 }
 .label-chip-good[aria-pressed="true"] {
   background: rgba(74, 222, 128, 0.085);
-  color: rgba(74, 222, 128, 0.92);
+  border-color: rgba(74, 222, 128, 0.4) !important;
+  color: rgba(74, 222, 128, 0.92) !important;
 }
 .label-chip-good[aria-pressed="true"]:hover {
   background: rgba(74, 222, 128, 0.14);
-  color: var(--good);
+  border-color: rgba(74, 222, 128, 0.5) !important;
+  color: var(--good) !important;
 }
 
 .search-suggestion-empty {
@@ -2094,6 +2127,83 @@ button.shape-tag.is-clickable:hover {
   width: 0.7rem;
   height: 0.7rem;
   border-radius: 2px;
+}
+
+/* Season visibility chips for the overlay chart. Each chip derives its
+   filled active state and swatch glow from --season-color (set inline by
+   openShowModal to the same hue as its chart line), so the controls read
+   as extensions of the chart rather than form inputs. The :hover /
+   :hover:active twins pin every box property against main.css's button
+   styling (gray/red inset rings, red press fill). */
+.overlay-legend-toggle,
+.overlay-legend-toggle:hover,
+.overlay-legend-toggle:hover:active {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  height: 26px;
+  padding: 0 0.7rem 0 0.5rem;
+  background: color-mix(in srgb, var(--season-color, #888) 13%, rgba(16, 19, 28, 0.55));
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  border: 1px solid color-mix(in srgb, var(--season-color, #888) 30%, transparent);
+  border-radius: 999px;
+  color: rgba(248, 249, 252, 0.95) !important;
+  box-shadow: none !important;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.2s var(--ease), border-color 0.2s var(--ease),
+              color 0.2s var(--ease), transform 0.2s var(--ease),
+              opacity 0.2s var(--ease);
+}
+.overlay-legend-toggle:hover {
+  background: color-mix(in srgb, var(--season-color, #888) 22%, rgba(16, 19, 28, 0.55));
+  border-color: color-mix(in srgb, var(--season-color, #888) 48%, transparent);
+  color: #ffffff !important;
+  transform: translateY(-1px);
+}
+.overlay-legend-toggle:hover:active {
+  transform: translateY(0) scale(0.97);
+}
+.overlay-legend-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+/* Hidden season: the chip empties out — glassy neutral surface, quiet
+   label, desaturated swatch — so re-enabling it feels like refilling it. */
+.overlay-legend-toggle--off,
+.overlay-legend-toggle--off:hover,
+.overlay-legend-toggle--off:hover:active {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: rgba(241, 243, 248, 0.45) !important;
+}
+.overlay-legend-toggle--off:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.14);
+  color: rgba(241, 243, 248, 0.7) !important;
+}
+.overlay-legend-toggle--off .overlay-legend-swatch {
+  opacity: 0.35;
+  filter: saturate(0.25);
+  box-shadow: none;
+}
+/* Bigger, glowing color dot inside the toggle chips. (The compare-overlay
+   legend keeps the plain square swatch from the base rule above.) */
+.overlay-legend-toggle .overlay-legend-swatch {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 7px color-mix(in srgb, var(--season-color, transparent) 55%, transparent);
+  transition: opacity 0.2s var(--ease), filter 0.2s var(--ease),
+              box-shadow 0.2s var(--ease);
+}
+.overlay-season-hidden {
+  display: none;
 }
 
 .compare-fab {
@@ -2533,6 +2643,154 @@ button.shape-tag.is-clickable:hover {
   top: 0.85rem;
   right: 0.85rem;
   z-index: 3;
+}
+
+/* Back: the close button's sibling — same 36px glass circle, anchored just
+   left of the ×, with a CSS-drawn left chevron. Only visible while there is
+   a previous modal view to return to (drill-downs via related cards, season
+   rows, or "View show"). Hover mirrors the × (brighten + soft glow) and
+   nudges the chevron left so the affordance reads as "step back". */
+.modal-back,
+.modal-back:hover {
+  position: absolute;
+  top: 0.85rem;
+  right: 3.6rem;
+  z-index: 3;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.85) !important;
+  font-size: 0;
+  line-height: 1;
+  box-shadow:
+    0 4px 14px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(0, 0, 0, 0.35) inset !important;
+  transition: background 0.18s var(--ease), border-color 0.18s var(--ease),
+              color 0.18s var(--ease), transform 0.08s var(--ease),
+              box-shadow 0.18s var(--ease);
+}
+.modal-back[hidden] { display: none; }
+.modal-back::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 9px;
+  height: 9px;
+  border-left: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  border-radius: 1px;
+  /* Chevron's optical center sits right of its geometric center. */
+  transform: translate(calc(-50% + 1.5px), -50%) rotate(45deg);
+  transition: transform 0.2s var(--ease);
+}
+.modal-back:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: #ffffff !important;
+  box-shadow:
+    0 4px 14px rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 0 18px rgba(255, 255, 255, 0.12) !important;
+}
+.modal-back:hover::before {
+  transform: translate(calc(-50% + 0.5px), -50%) rotate(45deg);
+}
+.modal-back:active { transform: scale(0.92); }
+.modal-back:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Floating "back to top": a glass pill (arrow + "Top" label) that sits at
+   the END of the panel content with position:sticky, riding the bottom-right
+   corner of the scrollport without ever leaving the panel's bounds.
+   Colors are pinned on base, hover and active so no sitewide button:hover
+   style can bleed in. Visibility is animated: JS toggles
+   .modal-scroll-top--visible; the hidden state fades + sinks + scales down
+   and removes interactivity (visibility/pointer-events), so the pill
+   materializes out of the corner instead of popping in. */
+.modal-scroll-top,
+.modal-scroll-top:hover,
+.modal-scroll-top:hover:active {
+  position: sticky;
+  bottom: 1.1rem;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  margin-left: auto;
+  width: auto;
+  height: 42px !important;
+  min-height: 42px;
+  padding: 0 0.85rem;
+  border-radius: 999px;
+  /* Gradient glass: brighter top edge catches light over any content
+     (episode rows, cards) for reliable contrast on the dark panel. */
+  background: linear-gradient(180deg, rgba(56, 62, 82, 0.92), rgba(28, 32, 45, 0.92));
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #ffffff !important;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  box-shadow:
+    0 6px 20px rgba(0, 0, 0, 0.45),
+    0 0 12px rgba(255, 255, 255, 0.06),
+    0 1px 0 rgba(255, 255, 255, 0.08) inset !important;
+  /* Hidden resting state: faded, sunk and slightly shrunk. */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(8px) scale(0.85);
+  transition: opacity 0.25s var(--ease), transform 0.25s var(--ease),
+              background 0.18s var(--ease), border-color 0.18s var(--ease),
+              box-shadow 0.18s var(--ease),
+              visibility 0s linear 0.25s;
+}
+.modal-scroll-top--visible,
+.modal-scroll-top--visible:hover,
+.modal-scroll-top--visible:hover:active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+  transition: opacity 0.25s var(--ease), transform 0.25s var(--ease),
+              background 0.18s var(--ease), border-color 0.18s var(--ease),
+              box-shadow 0.18s var(--ease),
+              visibility 0s;
+}
+.modal-scroll-top svg {
+  display: block;
+  flex-shrink: 0;
+  transition: transform 0.2s var(--ease);
+}
+.modal-scroll-top--visible:hover {
+  background: linear-gradient(180deg, rgba(72, 79, 102, 0.95), rgba(38, 43, 60, 0.95));
+  border-color: rgba(255, 255, 255, 0.3);
+  transform: translateY(-2px);
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.5),
+    0 0 18px rgba(255, 255, 255, 0.12),
+    0 1px 0 rgba(255, 255, 255, 0.12) inset !important;
+}
+.modal-scroll-top--visible:hover svg {
+  transform: translateY(-1px);
+}
+.modal-scroll-top--visible:hover:active {
+  transform: translateY(0) scale(0.95);
+}
+.modal-scroll-top:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 /* Reserve space on the header's right side so long titles don't run
    under the absolutely-positioned close button. ~2.75rem clears the
@@ -3736,9 +3994,9 @@ body.advanced-drawer-open {
 /* ---- Mood presets (NUI-5) ---- */
 
 .mood-presets {
-  /* Bottom padding scales 48 → 64 px between mobile and desktop so the
-     mood strip never crowds the filter toolbar below. */
-  padding: 0.5rem 0 clamp(3rem, 5vw, 4rem);
+  /* Tighter bottom padding than the hero above it, so the mood rail reads
+     as the top of the filter stack rather than a separate hero section. */
+  padding: 0.5rem 0 clamp(1.75rem, 3vw, 2.5rem);
   max-width: 48rem;
   margin: 0 auto;
 }
@@ -3755,7 +4013,7 @@ body.advanced-drawer-open {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--muted-2);
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.75rem;
   text-align: center;
 }
 .mood-presets-title::before,
@@ -3764,6 +4022,23 @@ body.advanced-drawer-open {
   flex: 0 1 4rem;
   height: 1px;
   background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.12), transparent);
+}
+
+/* The mood strip is a <details> that ships open. On desktop it reads as a
+   static heading + chips (the summary is not interactive); on mobile the
+   summary becomes a collapse toggle (rules live in the max-width 600px
+   block near the end of this file). app.js syncs the open state to the
+   viewport, since a closed <details> hides its content at the UA level
+   and child CSS cannot force it visible. */
+.mood-collapsible > summary::-webkit-details-marker { display: none; }
+.mood-collapsible > summary::marker { content: ''; }
+@media (min-width: 601px) {
+  .mood-collapsible > summary {
+    cursor: default;
+    pointer-events: none;
+    user-select: none;
+  }
+  .mood-toggle-chevron { display: none; }
 }
 
 .mood-preset-chips {
@@ -3799,26 +4074,36 @@ body.advanced-drawer-open {
 }
 
 .mood-chip:hover {
-  background: rgba(245, 197, 24, 0.06);
-  border-color: rgba(245, 197, 24, 0.32);
+  background: rgba(255, 255, 255, 0.075);
+  border-color: var(--border-strong);
   color: rgba(255, 255, 255, 0.98) !important;
   text-decoration: none !important;
-  transform: scale(1.03);
+  transform: translateY(-1px);
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset,
-              0 4px 14px rgba(245, 197, 24, 0.1);
+              0 4px 12px rgba(0, 0, 0, 0.25);
 }
 
+/* Active preset: a hairline accent border and an accent icon carry the
+   selected state — the label stays white and the surface stays dark, so a
+   pressed mood reads clearly without a heavy yellow fill. */
 .mood-chip[aria-pressed="true"],
 .mood-chip[aria-pressed="true"]:hover {
-  background: rgba(245, 197, 24, 0.12);
-  border-color: rgba(245, 197, 24, 0.45);
-  color: var(--accent) !important;
+  background: rgba(245, 197, 24, 0.05);
+  border-color: rgba(245, 197, 24, 0.5);
+  color: var(--text) !important;
+}
+.mood-chip[aria-pressed="true"] .mood-chip-icon {
+  color: var(--accent);
 }
 
 .mood-chip-icon {
   font-size: 0.78rem;
-  color: var(--accent);
+  color: rgba(231, 233, 238, 0.55);
   font-weight: 700;
+  transition: color 0.18s var(--ease);
+}
+.mood-chip:hover .mood-chip-icon {
+  color: rgba(231, 233, 238, 0.85);
 }
 
 .mood-chip-label {
@@ -3847,9 +4132,66 @@ body.advanced-drawer-open {
   color: rgba(231, 233, 238, 0.75);
 }
 .mood-chip[aria-pressed="true"] .mood-chip-count {
-  background: rgba(245, 197, 24, 0.18);
+  background: rgba(245, 197, 24, 0.14);
   color: var(--accent);
 }
+
+/* ---- Mood overflow toggle (mirrors the shape bar's "More shapes") ---- */
+
+.moods-hidden {
+  display: none !important;
+}
+
+.mood-more-btn[hidden] {
+  display: none;
+}
+
+/* Neutral ghost toggle — quieter than the chips it reveals, so the rail's
+   hierarchy stays: active mood > moods > overflow control. The :hover /
+   :hover:active twins defend against the site theme's red button:hover
+   (same idiom as .shapes-more-btn / .shape-chip). */
+.mood-more-btn,
+.mood-more-btn:hover,
+.mood-more-btn:hover:active {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  height: 30px;
+  padding: 0 0.85rem;
+  background: transparent;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  color: rgba(231, 233, 238, 0.75) !important;
+  box-shadow: none !important;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.18s var(--ease), border-color 0.18s var(--ease),
+              color 0.18s var(--ease);
+}
+
+.mood-more-btn:hover,
+.mood-more-btn:hover:active {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.95) !important;
+}
+
+.mood-more-count {
+  display: inline-flex;
+  align-items: center;
+  height: 17px;
+  padding: 0 0.45rem;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+  color: rgba(231, 233, 238, 0.6);
+}
+.mood-more-count:empty { display: none; }
 
 .mood-chip-desc {
   position: absolute;
@@ -3869,7 +4211,15 @@ body.advanced-drawer-open {
   display: none;
 }
 
-.shapes-more-btn {
+/* The :hover/:hover:active selectors are listed alongside the base rule on
+   purpose — the site theme (assets/css/main.css) paints every button red on
+   hover (`button:hover { color: #ce1b28 !important; box-shadow: inset ... }`)
+   and gives it a red fill while pressed (`button:hover:active`). Touch
+   devices keep :hover stuck on the button after a tap, so without these the
+   label flashed red until the next tap elsewhere. Same idiom as .shape-chip. */
+.shapes-more-btn,
+.shapes-more-btn:hover,
+.shapes-more-btn:hover:active {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -3878,7 +4228,10 @@ body.advanced-drawer-open {
   background: rgba(245, 197, 24, 0.08);
   border: 1px solid rgba(245, 197, 24, 0.28);
   border-radius: 999px;
-  color: var(--accent) !important;
+  /* White label like the other shape chips; the yellow border/background
+     tint (and the count badge) stay as the "expandable" accent. */
+  color: #FFFFFF !important;
+  box-shadow: none !important;
   font: inherit;
   font-size: 0.8rem;
   font-weight: 600;
@@ -3887,7 +4240,8 @@ body.advanced-drawer-open {
   transition: background 0.18s var(--ease), border-color 0.18s var(--ease);
 }
 
-.shapes-more-btn:hover {
+.shapes-more-btn:hover,
+.shapes-more-btn:hover:active {
   background: rgba(245, 197, 24, 0.15);
   border-color: rgba(245, 197, 24, 0.45);
 }
@@ -4521,4 +4875,366 @@ body.advanced-drawer-open {
 .shape-chip.is-hover-intersection .shape-count {
   background: var(--accent-soft);
   color: var(--accent);
+}
+
+/* ======= NEW FEATURES ======= */
+
+/* Feature 2: on mobile the mood presets collapse behind a pill toggle
+   (replaces the original horizontal scroll strip). The summary is styled
+   as a pill that mirrors the quick-filters toggle; app.js collapses the
+   <details> on narrow viewports. */
+@media (max-width: 600px) {
+  .mood-collapsible {
+    text-align: center;
+  }
+  /* Chips inherit the base rule's justify-content: center so the wrapped
+     rows stay centered under the centered toggle pill. */
+  .mood-chip {
+    white-space: normal;
+    height: auto;
+    min-height: 36px;
+    padding: 0.4rem 0.85rem;
+  }
+  .mood-collapsible > summary {
+    cursor: pointer;
+    user-select: none;
+  }
+  /* Border-drawn chevron: points right when closed, down when open. */
+  .mood-toggle-chevron {
+    display: inline-block;
+    width: 0.55rem;
+    height: 0.55rem;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(-45deg) translateY(-1px);
+    transition: transform 0.2s ease;
+    flex-shrink: 0;
+    margin-left: 0.15rem;
+    opacity: 0.75;
+  }
+  .mood-collapsible[open] .mood-toggle-chevron {
+    transform: rotate(45deg) translateY(-2px);
+  }
+  /* The heading becomes the toggle pill; hide its hairline rules. */
+  .mood-presets-title {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid var(--border);
+    color: rgba(243, 244, 246, 0.88);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0;
+    transition: background 0.15s var(--ease), border-color 0.15s var(--ease),
+                color 0.15s var(--ease);
+  }
+  .mood-presets-title::before,
+  .mood-presets-title::after {
+    display: none;
+  }
+  .mood-collapsible > summary:hover {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: var(--border-strong);
+    color: #F3F4F6;
+  }
+  /* Open state: elevated neutral pill with a hairline accent border. The
+     accent is a hint, not a fill, so the open toggle doesn't compete with
+     active filter chips for attention. */
+  .mood-collapsible[open] > summary {
+    background: rgba(255, 255, 255, 0.07);
+    border-color: rgba(245, 197, 24, 0.4);
+    color: #F3F4F6;
+  }
+  .mood-collapsible[open] .mood-preset-chips {
+    margin-top: 0.85rem;
+  }
+}
+
+/* Feature 3: Copy link button in active-filter bar */
+.copy-link-btn {
+  height: var(--ctrl-h-sm);
+  font-size: 0.78rem;
+  padding: 0 0.75rem;
+  margin-left: auto;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Feature 5: More like this section in modal */
+.modal-related {
+  margin-top: 1.5rem;
+}
+
+.related-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+  margin-top: 0.75rem;
+}
+
+.related-row {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.7rem;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.15s var(--ease), border-color 0.15s var(--ease);
+}
+.related-row:hover {
+  background: var(--surface-3);
+  border-color: var(--border-strong);
+}
+.related-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.related-poster {
+  width: 40px;
+  height: 60px;
+  flex-shrink: 0;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--surface-3);
+}
+.related-poster img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.related-poster-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 60px;
+  border-radius: 4px;
+  background: hsl(calc(var(--poster-hue, 220)) 30% 18%);
+  font-size: 1.1rem;
+  color: #fff;
+  font-weight: 700;
+}
+
+.related-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.related-title {
+  font-size: 0.83rem;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.related-season {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+.related-shapes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem;
+}
+
+.related-rating {
+  flex-shrink: 0;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 480px) {
+  .related-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Feature 6: Quick genre row in label-filters panel */
+/* No group-level flex override: the genre group inherits the same wrap
+   behavior as the decade group so the label sits on its own line and the
+   chip row takes the full width (its overflow-x scroll then works on
+   mobile instead of collapsing to a zero-width sliver). */
+.genre-quick-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+@media (max-width: 600px) {
+  /* The group must be pinned to the panel's width — as a content-sized
+     flex item it otherwise grows to fit all 8 chips (≈740px), the row
+     inside it never overflows, and the scroll lands on the panel (which
+     clips). Pinning the group makes the row the overflowing element so
+     its own overflow-x scroll actually works. */
+  .genre-quick-group {
+    width: 100%;
+    min-width: 0;
+  }
+  .genre-quick-row {
+    width: 100%;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.3rem;
+  }
+  .genre-quick-row .genre-chip {
+    flex-shrink: 0;
+  }
+}
+
+/* Feature 9: Decade row in label-filters panel */
+.decade-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+@media (max-width: 600px) {
+  /* Same group-width pin as .genre-quick-group above — without it the
+     decade chips can push the group past the panel width and the row's
+     own scroll never engages. */
+  .decade-group {
+    width: 100%;
+    min-width: 0;
+  }
+  .decade-row {
+    width: 100%;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.3rem;
+  }
+  .decade-row .label-chip {
+    flex-shrink: 0;
+  }
+}
+
+/* Show-modal related-shows section (Tasks C/D) */
+.show-related {
+  margin-top: 1.5rem;
+}
+
+.show-related-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+  margin-top: 0.75rem;
+}
+
+.show-related-row {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.7rem;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.15s var(--ease), border-color 0.15s var(--ease);
+}
+.show-related-row:hover {
+  background: var(--surface-3);
+  border-color: var(--border-strong);
+}
+.show-related-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.show-related-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.show-related-title {
+  font-size: 0.83rem;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.show-related-meta {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+/* "N more" collapsible toggle for both season and show related sections */
+.related-more-toggle {
+  margin-top: 0.5rem;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.related-more-toggle:hover {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+/* Hidden rows revealed by the toggle */
+.related-row-extra,
+.show-related-row-extra {
+  display: none;
+}
+.related-extra-expanded .related-row-extra,
+.show-related-extra-expanded .show-related-row-extra {
+  display: flex;
+}
+
+@media (max-width: 480px) {
+  .show-related-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* External-link arrow on linked episode rows — the same trailing "→" the
+   IMDb/TVDB action buttons carry, so a row that opens imdb.com reads as an
+   outbound link. Absolutely positioned at the row's right edge (survives
+   every breakpoint's grid-template override); the extra right padding keeps
+   the rating/votes column clear of it. Rows without an episode tt id get
+   no arrow (no .has-link class). Declared after the responsive blocks so
+   the padding-right wins over their `padding` shorthands. */
+.modal-episodes li.has-link {
+  padding-right: 2.05rem;
+}
+.modal-episodes li.has-link::after {
+  content: '→';
+  position: absolute;
+  right: 0.7rem;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  pointer-events: none;
+  color: rgba(231, 233, 238, 0.45);
+  font-size: 0.85rem;
+  line-height: 1;
+  transition: color 0.15s var(--ease), transform 0.15s var(--ease);
+}
+.modal-episodes li.has-link:hover::after,
+.modal-episodes li.has-link:focus-within::after {
+  color: var(--accent);
+  transform: translateY(-50%) translateX(2px);
 }

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -216,39 +216,72 @@
     </nav>
 
     <section class="mood-presets" aria-label="Explore by mood">
-      <h2 class="mood-presets-title">Explore by mood</h2>
-      <div class="mood-preset-chips">
-        <a class="mood-chip" href="#minYear=2020&minAvg=8.5&minVotes=1000&sort=avg" title="2020+, avg ≥ 8.5, ≥1,000 votes/episode">
-          <span class="mood-chip-icon" aria-hidden="true">★◉</span>
-          <span class="mood-chip-label">Modern prestige</span>
-          <span class="mood-chip-desc">Recent seasons critics and audiences both love</span>
-          <span class="mood-chip-count"></span>
-        </a>
-        <a class="mood-chip" href="#type=tvMiniSeries&minAvg=8&sort=avg" title="Mini-series only, avg ≥ 8">
-          <span class="mood-chip-icon" aria-hidden="true">❮❯</span>
-          <span class="mood-chip-label">One and done</span>
-          <span class="mood-chip-desc">Top mini-series — one season, full story</span>
-          <span class="mood-chip-count"></span>
-        </a>
-        <a class="mood-chip" href="#above=above&minAvg=8&sort=avg" title="Season avg above the show's IMDb rating, avg ≥ 8">
-          <span class="mood-chip-icon" aria-hidden="true">⇈★</span>
-          <span class="mood-chip-label">Outshines the show</span>
-          <span class="mood-chip-desc">Seasons rated higher than their show overall</span>
-          <span class="mood-chip-count"></span>
-        </a>
-        <a class="mood-chip" href="#minEps=10&minAvg=8&sort=length" title="≥10 episodes, avg ≥ 8, sorted by length">
-          <span class="mood-chip-icon" aria-hidden="true">❯❯❯</span>
-          <span class="mood-chip-label">Marathon material</span>
-          <span class="mood-chip-desc">Long seasons worth committing to</span>
-          <span class="mood-chip-count"></span>
-        </a>
-        <a class="mood-chip" href="#minClimb=1&minAvg=7.5&sort=climb" title="Last episode ≥1 pt higher than the first, avg ≥ 7.5">
-          <span class="mood-chip-icon" aria-hidden="true">↗⇧</span>
-          <span class="mood-chip-label">Biggest glow-ups</span>
-          <span class="mood-chip-desc">Seasons that ended way better than they started</span>
-          <span class="mood-chip-count"></span>
-        </a>
-      </div>
+      <details class="mood-collapsible" open>
+        <summary class="mood-presets-title">
+          <span class="mood-presets-title-text">Explore by mood</span>
+          <span class="mood-toggle-chevron" aria-hidden="true"></span>
+        </summary>
+        <div class="mood-preset-chips">
+          <a class="mood-chip" href="#minYear=2020&minAvg=8.5&minVotes=1000&sort=avg" title="2020+, avg ≥ 8.5, ≥1,000 votes/episode">
+            <span class="mood-chip-icon" aria-hidden="true">★◉</span>
+            <span class="mood-chip-label">Modern prestige</span>
+            <span class="mood-chip-desc">Recent seasons critics and audiences both love</span>
+            <span class="mood-chip-count"></span>
+          </a>
+          <a class="mood-chip" href="#type=tvMiniSeries&minAvg=8&sort=avg" title="Mini-series only, avg ≥ 8">
+            <span class="mood-chip-icon" aria-hidden="true">❮❯</span>
+            <span class="mood-chip-label">One and done</span>
+            <span class="mood-chip-desc">Top mini-series — one season, full story</span>
+            <span class="mood-chip-count"></span>
+          </a>
+          <a class="mood-chip" href="#above=above&minAvg=8&sort=avg" title="Season avg above the show's IMDb rating, avg ≥ 8">
+            <span class="mood-chip-icon" aria-hidden="true">⇈★</span>
+            <span class="mood-chip-label">Outshines the show</span>
+            <span class="mood-chip-desc">Seasons rated higher than their show overall</span>
+            <span class="mood-chip-count"></span>
+          </a>
+          <a class="mood-chip" href="#minEps=10&minAvg=8&sort=length" title="≥10 episodes, avg ≥ 8, sorted by length">
+            <span class="mood-chip-icon" aria-hidden="true">❯❯❯</span>
+            <span class="mood-chip-label">Marathon material</span>
+            <span class="mood-chip-desc">Long seasons worth committing to</span>
+            <span class="mood-chip-count"></span>
+          </a>
+          <a class="mood-chip" href="#minClimb=1&minAvg=7.5&sort=climb" title="Last episode ≥1 pt higher than the first, avg ≥ 7.5">
+            <span class="mood-chip-icon" aria-hidden="true">↗⇧</span>
+            <span class="mood-chip-label">Biggest glow-ups</span>
+            <span class="mood-chip-desc">Seasons that ended way better than they started</span>
+            <span class="mood-chip-count"></span>
+          </a>
+          <a class="mood-chip" href="#shape=rebound&minAvg=7.5&minVotes=500&sort=avg" title="Rebound shape, avg ≥ 7.5, ≥500 votes/episode">
+            <span class="mood-chip-icon" aria-hidden="true">∪★</span>
+            <span class="mood-chip-label">Best rebounders</span>
+            <span class="mood-chip-desc">Shows that dipped, then came back stronger</span>
+            <span class="mood-chip-count"></span>
+          </a>
+          <a class="mood-chip" href="#shape=big-finale&minAvg=8&minVotes=1000&sort=avg" title="Big finale shape, avg ≥ 8, ≥1,000 votes/episode">
+            <span class="mood-chip-icon" aria-hidden="true">⇧★</span>
+            <span class="mood-chip-label">Unmissable finales</span>
+            <span class="mood-chip-desc">Seasons that save the best for the very last episode</span>
+            <span class="mood-chip-count"></span>
+          </a>
+          <a class="mood-chip" href="#shape=slow-burn&minAvg=8&gems=on&sort=avg" title="Slow-burn shape, avg ≥ 8, hidden gems">
+            <span class="mood-chip-icon" aria-hidden="true">🔥💎</span>
+            <span class="mood-chip-label">Hidden slow-burns</span>
+            <span class="mood-chip-desc">Under-the-radar seasons that build to something great</span>
+            <span class="mood-chip-count"></span>
+          </a>
+          <a class="mood-chip" href="#shape=bad-finale&minAvg=7.5&sort=avg" title="Bad finale shape, avg ≥ 7.5">
+            <span class="mood-chip-icon" aria-hidden="true">⇩✗</span>
+            <span class="mood-chip-label">Worst endings</span>
+            <span class="mood-chip-desc">Otherwise solid seasons ruined by the finale</span>
+            <span class="mood-chip-count"></span>
+          </a>
+          <button type="button" class="mood-more-btn" id="moodMoreBtn" aria-expanded="false" hidden>
+            <span class="mood-more-label">More moods</span>
+            <span class="mood-more-count" id="moodMoreCount"></span>
+          </button>
+        </div>
+      </details>
     </section>
 
     <section class="filters" aria-label="Filters">
@@ -303,6 +336,16 @@
         <button type="button" class="advanced-reset" id="resetFilters" hidden>× Clear filters</button>
       </div>
       <div class="label-filters" id="quickFiltersPanel" aria-label="Quick filters">
+        <!-- Feature 6: Quick genre row (top 8 genres, synced with advanced drawer) -->
+        <div class="label-group genre-quick-group" role="group" aria-label="Genre">
+          <span class="label-group-name">Genre</span>
+          <div class="genre-quick-row" id="quickGenreRow"></div>
+        </div>
+        <!-- Feature 9: Decade quick-filter buttons -->
+        <div class="label-group decade-group" role="radiogroup" aria-label="Decade">
+          <span class="label-group-name">Decade</span>
+          <div class="decade-row" id="decadeRow"></div>
+        </div>
         <div class="label-group" role="radiogroup" aria-label="Series type">
           <span class="label-group-name">Type</span>
           <button type="button" class="label-chip" data-filter="seriesType" data-value="all" aria-pressed="true">All</button>
@@ -375,12 +418,9 @@
               <option value="finale">Finale rating</option>
               <option value="avg">Season average rating</option>
               <option value="recent">Most recent</option>
+              <option value="volatility">Most volatile (std dev)</option>
             </select>
           </label>
-        </div>
-        <div class="chip-section">
-          <span class="chip-section-title">Genres</span>
-          <div class="genre-row" id="genres" role="group" aria-label="Filter by genre"></div>
         </div>
         <div class="chip-section">
           <span class="chip-section-title">Language</span>
@@ -447,6 +487,7 @@
     <div class="modal-backdrop" data-close="modal"></div>
     <article class="modal-panel" tabindex="-1">
       <button type="button" class="btn modal-close" data-close="modal" aria-label="Close">×</button>
+      <button type="button" class="btn modal-back" id="modalBack" hidden aria-label="Back to previous view" title="Back"></button>
       <button type="button" class="btn btn-primary modal-reroll" id="modalReroll" hidden>Roll again</button>
       <div class="modal-header">
         <div class="modal-poster" id="modalPoster" aria-hidden="true"></div>
@@ -475,6 +516,14 @@
       </svg>
       <p class="modal-curve-annotation" id="modalCurveAnnotation" hidden></p>
       <ol class="modal-episodes" id="modalEpisodes"></ol>
+      <!-- Feature 5: More seasons like this -->
+      <section class="modal-related" id="modalRelated" hidden>
+        <h3 class="modal-section">More seasons like this</h3>
+        <div class="related-grid"></div>
+      </section>
+      <button type="button" class="btn modal-scroll-top" id="modalScrollTop" aria-label="Scroll back to top" title="Back to top">
+        <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3.5 10 8 5.5 12.5 10"/></svg><span>Top</span>
+      </button>
     </article>
   </div>
 
@@ -483,6 +532,7 @@
     <div class="modal-backdrop" data-close="show-modal"></div>
     <article class="modal-panel" tabindex="-1">
       <button type="button" class="btn modal-close" data-close="show-modal" aria-label="Close">×</button>
+      <button type="button" class="btn modal-back" id="showModalBack" hidden aria-label="Back to previous view" title="Back"></button>
       <div class="modal-header">
         <div class="modal-poster" id="showModalPoster" aria-hidden="true"></div>
         <div class="modal-heading">
@@ -515,6 +565,14 @@
       </section>
       <h3 class="modal-section">All seasons</h3>
       <ol class="show-seasons" id="showModalSeasons"></ol>
+      <!-- Task D: More shows like this -->
+      <section class="show-related" id="showModalRelated" hidden>
+        <h3 class="modal-section">More shows like this</h3>
+        <div class="show-related-grid"></div>
+      </section>
+      <button type="button" class="btn modal-scroll-top" id="showModalScrollTop" aria-label="Scroll back to top" title="Back to top">
+        <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3.5 10 8 5.5 12.5 10"/></svg><span>Top</span>
+      </button>
     </article>
   </div>
 

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -1,5 +1,113 @@
 'use strict';
 
+// --- Feature 7: std dev helper (exported via window for tests) ---
+function computeStdDev(episodes) {
+  const n = episodes.length;
+  if (n === 0) return 0;
+  const ratings = episodes.map((e) => e.rating);
+  const m = ratings.reduce((s, r) => s + r, 0) / n;
+  return Math.sqrt(ratings.reduce((s, r) => s + (r - m) * (r - m), 0) / n);
+}
+
+// --- Feature 5: related-season selection helpers (exported via window for tests) ---
+
+// Likeness score for ranking related seasons.
+// Primary: shared-shape count (desc). Secondary: |avgRating diff| (asc). Tiebreak: minVotes (desc).
+function seasonLikenessScore(m, x) {
+  const sharedShapes = (m.shapes || []).filter((s) => x.shapes && x.shapes.includes(s)).length;
+  const ratingDiff = Math.abs(m.avgRating - x.avgRating);
+  return { sharedShapes, ratingDiff, minVotes: x.minVotes || 0 };
+}
+
+function computeModalRelated(m, matches) {
+  if (!m.shapes || m.shapes.length === 0) return [];
+  const minAvg = m.avgRating - 0.5;
+  const mGenres = m.genres || [];
+  // Same original language only (two unknown languages count as a match);
+  // and a similar-popularity window: votes/episode within one order of
+  // magnitude of the open season (10x either way). Keeps a 60k-votes hit
+  // from suggesting a 400-vote obscurity and vice versa. Skipped when the
+  // open season has no vote data to anchor on.
+  const mLang = m.language || '';
+  const voteAnchor = m.minVotes > 0 ? m.minVotes : 0;
+  return matches
+    .filter((x) => {
+      if (x.seriesId === m.seriesId) return false;
+      if (x.avgRating < minAvg) return false;
+      if ((x.language || '') !== mLang) return false;
+      if (voteAnchor > 0) {
+        const xv = x.minVotes || 0;
+        if (xv < voteAnchor / 10 || xv > voteAnchor * 10) return false;
+      }
+      const xGenres = x.genres || [];
+      if (mGenres.length > 0 && !mGenres.some((g) => xGenres.includes(g))) return false;
+      for (const s of m.shapes) {
+        if (x.shapes && x.shapes.includes(s)) return true;
+      }
+      return false;
+    })
+    .sort((a, b) => {
+      const sa = seasonLikenessScore(m, a);
+      const sb = seasonLikenessScore(m, b);
+      if (sb.sharedShapes !== sa.sharedShapes) return sb.sharedShapes - sa.sharedShapes;
+      if (sa.ratingDiff !== sb.ratingDiff) return sa.ratingDiff - sb.ratingDiff;
+      return sb.minVotes - sa.minVotes;
+    })
+    .slice(0, 10);
+}
+
+// Compute related shows for the show modal.
+// d = mean(season avgRatings) - seriesRating. Requires seriesRating on both shows.
+// Candidates: other series with seriesRating that share at least one genre,
+// have the same original language, and sit within one order of magnitude of
+// the current show's votes/episode (mean of its seasons' minVotes).
+// Sort: |d_current - d_candidate| asc, then shared-genre count desc, then votes desc.
+// Returns up to 10; caller hides section when fewer than 2.
+function computeShowRelated(seriesId, matches) {
+  const bySeriesId = new Map();
+  for (const m of matches) {
+    if (!bySeriesId.has(m.seriesId)) bySeriesId.set(m.seriesId, []);
+    bySeriesId.get(m.seriesId).push(m);
+  }
+  const currentSeasons = bySeriesId.get(seriesId);
+  if (!currentSeasons || currentSeasons.length === 0) return [];
+  const currentMeta = currentSeasons[0];
+  if (typeof currentMeta.seriesRating !== 'number') return [];
+  const meanVotes = (seasons) =>
+    seasons.reduce((s, m) => s + (m.minVotes || 0), 0) / seasons.length;
+  const currentAvg = currentSeasons.reduce((s, m) => s + m.avgRating, 0) / currentSeasons.length;
+  const currentDev = currentAvg - currentMeta.seriesRating;
+  const currentGenres = currentMeta.genres || [];
+  const currentLang = currentMeta.language || '';
+  const voteAnchor = meanVotes(currentSeasons);
+
+  const results = [];
+  for (const [sid, seasons] of bySeriesId) {
+    if (sid === seriesId) continue;
+    const meta = seasons[0];
+    if (typeof meta.seriesRating !== 'number') continue;
+    if ((meta.language || '') !== currentLang) continue;
+    if (voteAnchor > 0) {
+      const xv = meanVotes(seasons);
+      if (xv < voteAnchor / 10 || xv > voteAnchor * 10) continue;
+    }
+    const xGenres = meta.genres || [];
+    const sharedGenreCount = currentGenres.filter((g) => xGenres.includes(g)).length;
+    if (sharedGenreCount === 0) continue;
+    const avg = seasons.reduce((s, m) => s + m.avgRating, 0) / seasons.length;
+    const dev = avg - meta.seriesRating;
+    const devDiff = Math.abs(currentDev - dev);
+    const voteProxy = typeof meta.seriesVotes === 'number' ? meta.seriesVotes : (meta.minVotes || 0);
+    results.push({ meta, avg, devDiff, sharedGenreCount, voteProxy });
+  }
+  results.sort((a, b) => {
+    if (a.devDiff !== b.devDiff) return a.devDiff - b.devDiff;
+    if (b.sharedGenreCount !== a.sharedGenreCount) return b.sharedGenreCount - a.sharedGenreCount;
+    return b.voteProxy - a.voteProxy;
+  });
+  return results.slice(0, 10).map((r) => ({ ...r.meta, _avg: r.avg }));
+}
+
 const SHAPE_LABELS = {
   rising: 'Rising',
   consistent: 'Consistent',
@@ -164,6 +272,11 @@ const els = {
   changelogFreshnessSection: document.getElementById('changelogFreshness'),
   changelogFreshnessContent: document.getElementById('changelogFreshnessContent'),
   activeFilterBar: document.getElementById('activeFilterBar'),
+  quickGenreRow: document.getElementById('quickGenreRow'),
+  decadeRow: document.getElementById('decadeRow'),
+  modalRelated: document.getElementById('modalRelated'),
+  modalBack: document.getElementById('modalBack'),
+  showModalBack: document.getElementById('showModalBack'),
   stickyFilterBar: document.getElementById('stickyFilterBar'),
   stickyShapeRow: document.getElementById('stickyShapeRow'),
   stickySearch: document.getElementById('stickySearch'),
@@ -409,6 +522,8 @@ async function load() {
   // `e.tt`, and `e.runtime` exactly as it did when everything lived in data.json.
   for (const m of dataset.matches) {
     m.titleSearch = normalizeSearch(m.title);
+    // Feature 7: precompute std dev once so the volatility sort is O(1) per comparison.
+    m._stddev = computeStdDev(m.episodes);
     if (extras) {
       const e = extras[m.seriesId];
       if (e) {
@@ -439,9 +554,10 @@ async function load() {
   buildSeriesIndex();
   buildBestSeasonMap();
   buildAboveImdbMap();
-  renderGenreChips();
+  renderQuickGenreRow();
   renderLanguageChips();
   renderProviderChips();
+  renderDecadeRow();
   // Promote each chip's hidden description to a native browser tooltip
   // so the desktop nav stays calm but the teaching content is one
   // hover away.
@@ -634,9 +750,10 @@ function applyStateFromURL() {
   els.sort.value = state.sort;
   syncLabelFiltersAria();
   syncShapeChipsAria();
-  for (const chip of els.genres.querySelectorAll('.genre-chip')) {
+  for (const chip of (els.genres ? els.genres.querySelectorAll('.genre-chip') : [])) {
     syncGenreChipTriState(chip);
   }
+  syncQuickGenreRow();
   for (const chip of els.languages.querySelectorAll('.genre-chip')) {
     chip.setAttribute('aria-pressed', state.languages.has(chip.dataset.language) ? 'true' : 'false');
   }
@@ -658,6 +775,105 @@ function syncLabelFiltersAria() {
     const filter = btn.dataset.filter;
     const val = btn.dataset.value;
     btn.setAttribute('aria-pressed', map[filter] === val ? 'true' : 'false');
+  }
+  syncDecadeRowAria();
+}
+
+// --- Feature 9: Decade quick-filter helpers ---
+
+const DECADE_RANGES = {
+  '80s':  [1980, 1989],
+  '90s':  [1990, 1999],
+  '00s':  [2000, 2009],
+  '10s':  [2010, 2019],
+  '20s':  [2020, 2029],
+};
+
+function activeDecadeKey() {
+  for (const [key, [min, max]] of Object.entries(DECADE_RANGES)) {
+    if (state.minYear === min && state.maxYear === max) return key;
+  }
+  if (state.minYear == null && state.maxYear == null) return 'all';
+  return null;
+}
+
+function syncDecadeRowAria() {
+  const row = els.decadeRow;
+  if (!row) return;
+  const active = activeDecadeKey();
+  for (const btn of row.querySelectorAll('.label-chip')) {
+    btn.setAttribute('aria-pressed', btn.dataset.decade === active ? 'true' : 'false');
+  }
+}
+
+function renderDecadeRow() {
+  const row = els.decadeRow;
+  if (!row) return;
+  const frag = document.createDocumentFragment();
+  const all = document.createElement('button');
+  all.type = 'button';
+  all.className = 'label-chip';
+  all.dataset.decade = 'all';
+  all.textContent = 'All';
+  all.addEventListener('click', () => {
+    state.minYear = null;
+    state.maxYear = null;
+    els.minYear.value = '';
+    els.maxYear.value = '';
+    syncDecadeRowAria();
+    onFilterChange();
+  });
+  frag.appendChild(all);
+  for (const [key, [min, max]] of Object.entries(DECADE_RANGES)) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'label-chip';
+    btn.dataset.decade = key;
+    btn.textContent = key;
+    btn.addEventListener('click', () => {
+      state.minYear = min;
+      state.maxYear = max;
+      els.minYear.value = String(min);
+      els.maxYear.value = String(max);
+      syncDecadeRowAria();
+      onFilterChange();
+    });
+    frag.appendChild(btn);
+  }
+  row.replaceChildren(frag);
+  syncDecadeRowAria();
+}
+
+// --- Feature 6: Quick genre row ---
+
+function renderQuickGenreRow() {
+  const row = els.quickGenreRow;
+  if (!row || !dataset) return;
+  const top8 = (dataset.genres || []).slice(0, 8);
+  const frag = document.createDocumentFragment();
+  for (const g of top8) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'genre-chip';
+    btn.dataset.genre = g.name;
+    btn.dataset.source = 'quick';
+    btn.textContent = g.name;
+    syncGenreChipTriState(btn);
+    btn.addEventListener('click', () => {
+      cycleGenreState(g.name);
+      syncGenreChipTriState(btn);
+      onFilterChange();
+    });
+    frag.appendChild(btn);
+  }
+  row.replaceChildren(frag);
+}
+
+function syncQuickGenreRow() {
+  const row = els.quickGenreRow;
+  if (!row) return;
+  for (const btn of row.querySelectorAll('.genre-chip')) {
+    syncGenreChipTriState(btn);
   }
 }
 
@@ -847,26 +1063,6 @@ function cycleGenreState(name) {
   }
 }
 
-function renderGenreChips() {
-  const top = (dataset.genres || []).slice(0, 14);
-  const frag = document.createDocumentFragment();
-  for (const g of top) {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'genre-chip';
-    btn.dataset.genre = g.name;
-    btn.textContent = g.name;
-    syncGenreChipTriState(btn);
-    btn.addEventListener('click', () => {
-      cycleGenreState(g.name);
-      syncGenreChipTriState(btn);
-      onFilterChange();
-    });
-    frag.appendChild(btn);
-  }
-  els.genres.replaceChildren(frag);
-}
-
 // TMDB stores `original_language` as ISO 639-1 codes (en, ja, ko, ...).
 // The UI shows the English name so users don't need to know codes.
 const LANGUAGE_NAMES = {
@@ -1047,11 +1243,12 @@ function filterAndSort() {
     }
     let primary;
     switch (state.sort) {
-      case 'length': primary = b.episodes.length - a.episodes.length; break;
-      case 'climb':  primary = (b.lastRating - b.firstRating) - (a.lastRating - a.firstRating); break;
-      case 'finale': primary = b.lastRating - a.lastRating; break;
-      case 'avg':    primary = b.avgRating - a.avgRating; break;
-      case 'recent': primary = ((b.seasonYear || b.year) || 0) - ((a.seasonYear || a.year) || 0); break;
+      case 'length':     primary = b.episodes.length - a.episodes.length; break;
+      case 'climb':      primary = (b.lastRating - b.firstRating) - (a.lastRating - a.firstRating); break;
+      case 'finale':     primary = b.lastRating - a.lastRating; break;
+      case 'avg':        primary = b.avgRating - a.avgRating; break;
+      case 'recent':     primary = ((b.seasonYear || b.year) || 0) - ((a.seasonYear || a.year) || 0); break;
+      case 'volatility': primary = (b._stddev || 0) - (a._stddev || 0); break;
       case 'popularity':
       default: {
         // When exactly one shape is selected, boost the most archetypal
@@ -1292,7 +1489,7 @@ function buildEmptyStateSuggestions() {
       label: state.genres.size === 1 ? `Genre: ${[...state.genres][0]}` : `Genres (${state.genres.size})`,
       action: () => {
         state.genres.clear();
-        for (const c of els.genres.querySelectorAll('.genre-chip')) {
+        for (const c of (els.genres ? els.genres.querySelectorAll('.genre-chip') : [])) {
           c.setAttribute('aria-pressed', 'false');
           c.dataset.exclude = 'false';
         }
@@ -1714,8 +1911,49 @@ function syncMoodChipsActive() {
     if (params.has('above')    && state.aboveImdb !== params.get('above'))          match = false;
     if (params.has('gems')     && state.hiddenGems !== params.get('gems'))          match = false;
     if (params.has('sort')     && state.sort !== params.get('sort'))                match = false;
+    if (params.has('shape')) {
+      const chipShapes = new Set(params.get('shape').split(',').filter(Boolean));
+      const stateShapes = state.shapes;
+      if (chipShapes.size !== stateShapes.size) match = false;
+      else for (const s of chipShapes) if (!stateShapes.has(s)) { match = false; break; }
+    }
     chip.setAttribute('aria-pressed', match ? 'true' : 'false');
   }
+  syncMoodOverflow();
+}
+
+// The mood rail shows the first MOOD_CHIP_LIMIT presets; the rest collapse
+// behind a "More moods +N" toggle so the section scales to dozens of moods
+// without dominating the page. An ACTIVE mood is never hidden, even when it
+// sits past the limit — collapsing away the user's current selection would
+// make the pressed state invisible. Same interaction family as the shape
+// bar's "More shapes" overflow.
+const MOOD_CHIP_LIMIT = 6;
+
+function syncMoodOverflow() {
+  const wrap = document.querySelector('.mood-preset-chips');
+  const btn = document.getElementById('moodMoreBtn');
+  if (!wrap || !btn) return;
+  const chips = [...wrap.querySelectorAll('.mood-chip')];
+  // No point trading exactly one hidden chip for a toggle of the same size.
+  if (chips.length <= MOOD_CHIP_LIMIT + 1) {
+    btn.hidden = true;
+    for (const c of chips) c.classList.remove('moods-hidden');
+    return;
+  }
+  const expanded = btn.getAttribute('aria-expanded') === 'true';
+  let hiddenCount = 0;
+  chips.forEach((c, i) => {
+    const hide = !expanded
+      && i >= MOOD_CHIP_LIMIT
+      && c.getAttribute('aria-pressed') !== 'true';
+    c.classList.toggle('moods-hidden', hide);
+    if (hide) hiddenCount++;
+  });
+  btn.hidden = false;
+  btn.querySelector('.mood-more-label').textContent = expanded ? 'Show fewer' : 'More moods';
+  const countEl = document.getElementById('moodMoreCount');
+  if (countEl) countEl.textContent = expanded ? '' : `+${hiddenCount}`;
 }
 
 // Per-mood-chip count. The base set respects user filters that wouldn't
@@ -2524,6 +2762,7 @@ function drawSeasonOverlay(svg, seasons, W, H) {
     path.setAttribute('stroke-linejoin', 'round');
     path.setAttribute('vector-effect', 'non-scaling-stroke');
     path.setAttribute('opacity', '0.85');
+    path.dataset.season = s.season;
     const title = document.createElementNS(NS, 'title');
     title.textContent = `Season ${s.season} — avg ${s.avgRating.toFixed(1)}`;
     path.appendChild(title);
@@ -2703,7 +2942,67 @@ function closeCompareModal() {
 
 // --- modal ---
 
+// --- In-app modal view history ------------------------------------------
+// Drilling through "More seasons/shows like this", season rows, or "View
+// show" stacks up views; the "← Back" button in both modals pops the stack.
+// Kept in-app (not history.pushState) so it composes with the existing
+// replaceState-based filter/URL sync instead of fighting it. The stack
+// clears when the user actually closes a modal (×, backdrop, Esc) — not on
+// the internal close that happens when one modal chains into another.
+
+const modalViewHistory = [];
+
+function currentModalView() {
+  if (!els.modal.hidden && modalState.season) {
+    return { type: 'season', season: modalState.season };
+  }
+  if (!els.showModal.hidden && showModalState.seriesId) {
+    return { type: 'show', seriesId: showModalState.seriesId };
+  }
+  return null;
+}
+
+function modalViewKey(view) {
+  return view.type === 'season'
+    ? `season:${view.season.seriesId}:${view.season.season}`
+    : `show:${view.seriesId}`;
+}
+
+// Record the CURRENT view before a new one replaces it. No-ops when the
+// navigation came from the Back button itself, when no modal is open
+// (fresh open from the result list), or when the "new" view is the one
+// already showing (e.g. a reroll landing on the same season).
+function pushModalHistory(opts, nextKey) {
+  if (opts.fromHistory) return;
+  const prev = currentModalView();
+  if (!prev || modalViewKey(prev) === nextKey) return;
+  modalViewHistory.push(prev);
+  // Safety cap — nobody steps back through more than this anyway.
+  if (modalViewHistory.length > 50) modalViewHistory.shift();
+  syncModalBackButtons();
+}
+
+function clearModalHistory() {
+  modalViewHistory.length = 0;
+  syncModalBackButtons();
+}
+
+function syncModalBackButtons() {
+  const show = modalViewHistory.length > 0;
+  if (els.modalBack) els.modalBack.hidden = !show;
+  if (els.showModalBack) els.showModalBack.hidden = !show;
+}
+
+function goBackModalView() {
+  const prev = modalViewHistory.pop();
+  if (!prev) return;
+  if (prev.type === 'season') openModal(prev.season, { fromHistory: true });
+  else openShowModal(prev.seriesId, { fromHistory: true });
+  syncModalBackButtons();
+}
+
 function openModal(m, opts = {}) {
+  pushModalHistory(opts, `season:${m.seriesId}:${m.season}`);
   const wasOpen = !els.modal.hidden;
   const wasShowOpen = !els.showModal.hidden;
   // Inherit fromChangelog from the show modal we're closing, so closing
@@ -2862,6 +3161,9 @@ function openModal(m, opts = {}) {
   }
   els.modalEpisodes.replaceChildren(epFrag);
 
+  // Feature 5: More like this
+  renderModalRelated(m);
+
   els.modalImdb.href = `https://www.imdb.com/title/${m.seriesId}/episodes/?season=${m.season}`;
 
 
@@ -2886,13 +3188,105 @@ function openModal(m, opts = {}) {
   els.modal.setAttribute('aria-hidden', 'false');
   document.documentElement.style.overflow = 'hidden';
   document.body.style.overflow = 'hidden';
+  const modalPanel = els.modal.querySelector('.modal-panel');
+  if (modalPanel) modalPanel.scrollTop = 0;
   syncModalInert();
   writeStateToURL();
   if (!wasOpen) {
     requestAnimationFrame(() => {
-      const panel = els.modal.querySelector('.modal-panel');
-      if (panel) panel.focus();
+      if (modalPanel) modalPanel.focus();
     });
+  }
+}
+
+// Feature 5: Render "More seasons like this" related seasons in the detail modal.
+// Shows first 4 immediately; extra rows (up to 6 more) are hidden behind a toggle.
+function buildRelatedSeasonRow(r, extraClass) {
+  const row = document.createElement('div');
+  row.className = 'related-row' + (extraClass ? ' ' + extraClass : '');
+  row.tabIndex = 0;
+  row.setAttribute('role', 'button');
+  row.setAttribute('aria-label', `${r.title} season ${r.season}`);
+
+  const posterEl = document.createElement('div');
+  posterEl.className = 'related-poster';
+  if (r.poster) {
+    const img = document.createElement('img');
+    img.src = `https://image.tmdb.org/t/p/w92${r.poster}`;
+    img.alt = '';
+    img.loading = 'lazy';
+    img.width = 40;
+    img.height = 60;
+    posterEl.appendChild(img);
+  } else {
+    posterEl.classList.add('related-poster-fallback');
+    posterEl.style.setProperty('--poster-hue', String(hashHue(r.title)));
+    const init = document.createElement('span');
+    init.textContent = posterInitial(r.title);
+    posterEl.appendChild(init);
+  }
+
+  const info = document.createElement('div');
+  info.className = 'related-info';
+  const title = document.createElement('span');
+  title.className = 'related-title';
+  title.textContent = r.title;
+  const seasonLabel = document.createElement('span');
+  seasonLabel.className = 'related-season';
+  seasonLabel.textContent = `Season ${r.season}`;
+  const shapes = document.createElement('span');
+  shapes.className = 'related-shapes';
+  fillShapeTags(shapes, (r.shapes || []).filter((s) => s !== 'saved-best-for-last'), { clickable: false });
+  info.append(title, seasonLabel, shapes);
+
+  const rating = document.createElement('span');
+  rating.className = 'related-rating';
+  rating.textContent = r.avgRating.toFixed(1);
+
+  row.append(posterEl, info, rating);
+  row.addEventListener('click', () => openModal(r));
+  row.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openModal(r); }
+  });
+  return row;
+}
+
+function renderModalRelated(m) {
+  const container = els.modalRelated;
+  if (!container) return;
+  if (!dataset) { container.hidden = true; return; }
+  const related = computeModalRelated(m, dataset.matches);
+  if (related.length < 2) { container.hidden = true; return; }
+  container.hidden = false;
+  const grid = container.querySelector('.related-grid') || container;
+
+  const visible = related.slice(0, 4);
+  const extra = related.slice(4);
+
+  const frag = document.createDocumentFragment();
+  for (const r of visible) {
+    frag.appendChild(buildRelatedSeasonRow(r, null));
+  }
+  for (const r of extra) {
+    frag.appendChild(buildRelatedSeasonRow(r, 'related-row-extra'));
+  }
+  grid.replaceChildren(frag);
+  grid.classList.remove('related-extra-expanded');
+
+  // Remove any existing toggle before re-rendering
+  const existingToggle = container.querySelector('.related-more-toggle');
+  if (existingToggle) existingToggle.remove();
+
+  if (extra.length > 0) {
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'btn btn-ghost related-more-toggle';
+    toggle.textContent = `${extra.length} more`;
+    toggle.addEventListener('click', () => {
+      const expanded = grid.classList.toggle('related-extra-expanded');
+      toggle.textContent = expanded ? 'Show less' : `${extra.length} more`;
+    });
+    container.appendChild(toggle);
   }
 }
 
@@ -2913,6 +3307,9 @@ function closeModal(opts = {}) {
   const reopenChangelog = !opts.suppressReopen
     && modalState.fromChangelog
     && els.showModal.hidden;
+  // A real close (×, backdrop, Esc) ends the drill-down session; an
+  // internal close chaining into another modal keeps the trail alive.
+  if (!opts.suppressReopen && els.showModal.hidden) clearModalHistory();
   modalState.season = null;
   modalState.lastFocus = null;
   modalState.surprise = false;
@@ -2927,6 +3324,7 @@ function openShowModal(seriesId, opts = {}) {
     .sort((a, b) => a.season - b.season);
   if (seasons.length === 0) return;
 
+  pushModalHistory(opts, `show:${seriesId}`);
   const wasSeasonOpen = !els.modal.hidden;
   // Inherit origin from the season modal we're closing, so closing the
   // show modal still returns the user to the changelog.
@@ -3041,14 +3439,28 @@ function openShowModal(seriesId, opts = {}) {
     const colors = drawSeasonOverlay(els.showModalOverlayCurve, seasons, 600, 200);
     const legendFrag = document.createDocumentFragment();
     for (const { season, color } of colors) {
-      const item = document.createElement('span');
-      item.className = 'overlay-legend-item';
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'overlay-legend-item overlay-legend-toggle';
+      item.setAttribute('aria-pressed', 'true');
+      item.title = `Toggle Season ${season} line`;
+      // Expose the line color to CSS so the chip's filled active state and
+      // swatch glow can derive from the same hue as the chart line.
+      item.style.setProperty('--season-color', color);
       const swatch = document.createElement('span');
       swatch.className = 'overlay-legend-swatch';
       swatch.style.background = color;
       const label = document.createElement('span');
       label.textContent = `S${season}`;
       item.append(swatch, label);
+      item.addEventListener('click', () => {
+        const visible = item.getAttribute('aria-pressed') === 'true';
+        const nowVisible = !visible;
+        item.setAttribute('aria-pressed', String(nowVisible));
+        item.classList.toggle('overlay-legend-toggle--off', !nowVisible);
+        const path = els.showModalOverlayCurve.querySelector(`[data-season="${season}"]`);
+        if (path) path.classList.toggle('overlay-season-hidden', !nowVisible);
+      });
       legendFrag.appendChild(item);
     }
     els.showModalOverlayLegend.replaceChildren(legendFrag);
@@ -3068,15 +3480,18 @@ function openShowModal(seriesId, opts = {}) {
     els.showModalTvdb.hidden = true;
   }
 
+  renderShowRelated(seriesId);
+
   els.showModal.hidden = false;
   els.showModal.setAttribute('aria-hidden', 'false');
   document.documentElement.style.overflow = 'hidden';
   document.body.style.overflow = 'hidden';
+  const showModalPanel = els.showModal.querySelector('.modal-panel');
+  if (showModalPanel) showModalPanel.scrollTop = 0;
   syncModalInert();
   writeStateToURL();
   requestAnimationFrame(() => {
-    const panel = els.showModal.querySelector('.modal-panel');
-    if (panel) panel.focus();
+    if (showModalPanel) showModalPanel.focus();
   });
 }
 
@@ -3177,6 +3592,93 @@ function buildShowSeasonRow(m, bestSeason, worstSeason) {
   return li;
 }
 
+// TASK D: Render "More shows like this" in the show modal.
+// Shows first 4 immediately; extra rows (up to 6 more) behind a toggle.
+function renderShowRelated(seriesId) {
+  const container = document.getElementById('showModalRelated');
+  if (!container) return;
+  if (!dataset) { container.hidden = true; return; }
+  const related = computeShowRelated(seriesId, dataset.matches);
+  if (related.length < 2) { container.hidden = true; return; }
+  container.hidden = false;
+
+  const grid = container.querySelector('.show-related-grid') || container;
+  const visible = related.slice(0, 4);
+  const extra = related.slice(4);
+
+  const frag = document.createDocumentFragment();
+  for (const r of visible) {
+    frag.appendChild(buildShowRelatedRow(r, null));
+  }
+  for (const r of extra) {
+    frag.appendChild(buildShowRelatedRow(r, 'show-related-row-extra'));
+  }
+  grid.replaceChildren(frag);
+  grid.classList.remove('show-related-extra-expanded');
+
+  const existingToggle = container.querySelector('.related-more-toggle');
+  if (existingToggle) existingToggle.remove();
+
+  if (extra.length > 0) {
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'btn btn-ghost related-more-toggle';
+    toggle.textContent = `${extra.length} more`;
+    toggle.addEventListener('click', () => {
+      const expanded = grid.classList.toggle('show-related-extra-expanded');
+      toggle.textContent = expanded ? 'Show less' : `${extra.length} more`;
+    });
+    container.appendChild(toggle);
+  }
+}
+
+function buildShowRelatedRow(r, extraClass) {
+  const row = document.createElement('div');
+  row.className = 'show-related-row' + (extraClass ? ' ' + extraClass : '');
+  row.tabIndex = 0;
+  row.setAttribute('role', 'button');
+  row.setAttribute('aria-label', `${r.title}`);
+
+  const posterEl = document.createElement('div');
+  posterEl.className = 'related-poster';
+  if (r.poster) {
+    const img = document.createElement('img');
+    img.src = `https://image.tmdb.org/t/p/w92${r.poster}`;
+    img.alt = '';
+    img.loading = 'lazy';
+    img.width = 40;
+    img.height = 60;
+    posterEl.appendChild(img);
+  } else {
+    posterEl.classList.add('related-poster-fallback');
+    posterEl.style.setProperty('--poster-hue', String(hashHue(r.title)));
+    const init = document.createElement('span');
+    init.textContent = posterInitial(r.title);
+    posterEl.appendChild(init);
+  }
+
+  const info = document.createElement('div');
+  info.className = 'show-related-info';
+  const title = document.createElement('span');
+  title.className = 'show-related-title';
+  title.textContent = r.title;
+  const yearVal = r.year || '';
+  const imdbPart = typeof r.seriesRating === 'number' ? `IMDb ${r.seriesRating.toFixed(1)}` : '';
+  const avgPart = typeof r._avg === 'number' ? `avg ep ${r._avg.toFixed(1)}` : '';
+  const metaParts = [imdbPart, avgPart, yearVal].filter(Boolean);
+  const meta = document.createElement('span');
+  meta.className = 'show-related-meta';
+  meta.textContent = metaParts.join(' · ');
+  info.append(title, meta);
+
+  row.append(posterEl, info);
+  row.addEventListener('click', () => openShowModal(r.seriesId));
+  row.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openShowModal(r.seriesId); }
+  });
+  return row;
+}
+
 function closeShowModal(opts = {}) {
   if (els.showModal.hidden) return;
   els.showModal.hidden = true;
@@ -3192,6 +3694,8 @@ function closeShowModal(opts = {}) {
   const reopenChangelog = !opts.suppressReopen
     && showModalState.fromChangelog
     && els.modal.hidden;
+  // Same rule as closeModal: only a real close ends the drill-down trail.
+  if (!opts.suppressReopen && els.modal.hidden) clearModalHistory();
   showModalState.seriesId = null;
   showModalState.lastFocus = null;
   showModalState.fromChangelog = false;
@@ -4024,16 +4528,18 @@ function bindEvents() {
     els.sort.value = 'popularity';
     syncLabelFiltersAria();
     syncShapeChipsAria();
-    for (const c of els.genres.querySelectorAll('.genre-chip')) {
+    for (const c of (els.genres ? els.genres.querySelectorAll('.genre-chip') : [])) {
       c.setAttribute('aria-pressed', 'false');
       c.dataset.exclude = 'false';
     }
+    syncQuickGenreRow();
     for (const c of els.languages.querySelectorAll('.genre-chip')) {
       c.setAttribute('aria-pressed', 'false');
     }
     for (const c of els.providers.querySelectorAll('.genre-chip')) {
       c.setAttribute('aria-pressed', 'false');
     }
+    syncDecadeRowAria();
     closeSuggestions();
     writeStateToURL();
     syncResetButton();
@@ -4065,6 +4571,29 @@ function bindEvents() {
   for (const closer of els.showModal.querySelectorAll('[data-close="show-modal"]')) {
     closer.addEventListener('click', closeShowModal);
   }
+  if (els.modalBack) els.modalBack.addEventListener('click', goBackModalView);
+  if (els.showModalBack) els.showModalBack.addEventListener('click', goBackModalView);
+
+  // Floating "back to top" inside the season/show modals — fades/scales in
+  // once the panel is scrolled a screen-ish deep, smooth-scrolls back on
+  // click. Visibility is a class (not [hidden]) so the appearance can
+  // animate; the hidden state also drops visibility/pointer-events so the
+  // button can't be tabbed to or clicked while invisible. The scroll
+  // listener also re-hides it whenever openModal/openShowModal reset
+  // scrollTop to 0 (programmatic scrollTop changes fire scroll events).
+  const SCROLL_TOP_THRESHOLD = 400;
+  const bindModalScrollTop = (modalEl, btn) => {
+    const panel = modalEl && modalEl.querySelector('.modal-panel');
+    if (!panel || !btn) return;
+    panel.addEventListener('scroll', () => {
+      btn.classList.toggle('modal-scroll-top--visible', panel.scrollTop >= SCROLL_TOP_THRESHOLD);
+    }, { passive: true });
+    btn.addEventListener('click', () => {
+      panel.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  };
+  bindModalScrollTop(els.modal, document.getElementById('modalScrollTop'));
+  bindModalScrollTop(els.showModal, document.getElementById('showModalScrollTop'));
   for (const closer of els.compareModal.querySelectorAll('[data-close="compare-modal"]')) {
     closer.addEventListener('click', closeCompareModal);
   }
@@ -4304,6 +4833,30 @@ function renderActiveFilterBar() {
     btn.addEventListener('click', c.remove);
     frag.appendChild(btn);
   }
+
+  // Feature 3: Copy link button — always visible in the active-filter bar.
+  const copyBtn = document.createElement('button');
+  copyBtn.type = 'button';
+  copyBtn.className = 'btn btn-ghost copy-link-btn';
+  copyBtn.textContent = 'Copy link';
+  copyBtn.addEventListener('click', () => {
+    const orig = copyBtn.textContent;
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      navigator.clipboard.writeText(location.href)
+        .then(() => {
+          copyBtn.textContent = 'Copied!';
+          setTimeout(() => { copyBtn.textContent = orig; }, 1800);
+        })
+        .catch(() => {
+          copyBtn.textContent = orig;
+        });
+    } else {
+      try { window.prompt('Copy this link:', location.href); }
+      catch { /* ignore */ }
+    }
+  });
+  frag.appendChild(copyBtn);
+
   bar.replaceChildren(frag);
 }
 
@@ -4374,7 +4927,7 @@ function describeActiveFilters() {
       value: g,
       remove: () => {
         state.genres.delete(g);
-        const btn = els.genres.querySelector(`.genre-chip[data-genre="${cssEscape(g)}"]`);
+        const btn = els.genres && els.genres.querySelector(`.genre-chip[data-genre="${cssEscape(g)}"]`);
         if (btn) syncGenreChipTriState(btn);
         onFilterChange();
       },
@@ -4386,7 +4939,7 @@ function describeActiveFilters() {
       value: g,
       remove: () => {
         state.excludeGenres.delete(g);
-        const btn = els.genres.querySelector(`.genre-chip[data-genre="${cssEscape(g)}"]`);
+        const btn = els.genres && els.genres.querySelector(`.genre-chip[data-genre="${cssEscape(g)}"]`);
         if (btn) syncGenreChipTriState(btn);
         onFilterChange();
       },
@@ -4430,6 +4983,7 @@ function describeActiveFilters() {
       finale: 'Finale',
       avg: 'Avg rating',
       recent: 'Most recent',
+      volatility: 'Most volatile',
     };
     chips.push({
       key: 'Sort',
@@ -4451,6 +5005,7 @@ function numericChip(label, displayValue, field) {
     remove: () => {
       state[field] = null;
       if (els[field]) els[field].value = '';
+      if (field === 'minYear' || field === 'maxYear') syncDecadeRowAria();
       onFilterChange();
     },
   };
@@ -4731,5 +5286,51 @@ window.addEventListener('localStorageSync', (e) => {
     render();
   }, 750);
 });
+
+// "Explore by mood" is a <details> that ships open (desktop shows the chips
+// as a plain always-visible section; its summary is pointer-events:none
+// there). On mobile the summary becomes a real toggle, collapsed by
+// default. CSS alone can't force a closed <details> open (modern engines
+// hide closed-details content via content-visibility, which child rules
+// can't override), so the open state is synced to the viewport here.
+const moodCollapsible = document.querySelector('.mood-collapsible');
+if (moodCollapsible && typeof window.matchMedia === 'function') {
+  const moodMq = window.matchMedia('(max-width: 600px)');
+  const syncMoodCollapsible = () => {
+    // Mobile: start collapsed; desktop: always expanded.
+    moodCollapsible.open = !moodMq.matches;
+  };
+  syncMoodCollapsible();
+  if (typeof moodMq.addEventListener === 'function') {
+    moodMq.addEventListener('change', syncMoodCollapsible);
+  }
+}
+
+// "More moods +N" overflow toggle (see syncMoodOverflow).
+const moodMoreBtn = document.getElementById('moodMoreBtn');
+if (moodMoreBtn) {
+  moodMoreBtn.addEventListener('click', () => {
+    const expanded = moodMoreBtn.getAttribute('aria-expanded') === 'true';
+    moodMoreBtn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+    syncMoodOverflow();
+  });
+  syncMoodOverflow();
+}
+
+// Expose pure helpers for unit tests (node:vm loads this file into a sandbox
+// that provides a `window` stub; same pattern as mario-kart/js/).
+if (typeof window !== 'undefined') {
+  window._rsTestExports = {
+    computeStdDev,
+    computeModalRelated,
+    seasonLikenessScore,
+    computeShowRelated,
+    hasActiveFilters: () => hasActiveFilters(),
+    buildSeasonShareText,
+    activeDecadeKey: () => activeDecadeKey(),
+    DECADE_RANGES,
+    state,
+  };
+}
 
 load();

--- a/apps/rising-seasons/scripts/render-show-page.js
+++ b/apps/rising-seasons/scripts/render-show-page.js
@@ -43,6 +43,22 @@ function renderShowPage({ seriesId, title, year, type, genres, seriesRating, ser
   const posterUrl = poster ? `${TMDB_POSTER}${poster}` : null;
   const ogImage = posterUrl || `${SITE}/images/og-card.png`;
 
+  const dominantShapeLabel = dominantShape ? (SHAPE_LABELS[dominantShape] || dominantShape) : null;
+  const overallAvgRating = computeOverallAvgRating(seasons);
+
+  // Feature 10: richer OG/Twitter meta
+  // When a poster is available, replace the basic alt with a richer one (parens, no em dashes).
+  const ogImageAlt = posterUrl
+    ? escapeHtml(`${title} poster (${dominantShapeLabel || 'TV show'} shape, avg episode ${overallAvgRating})`)
+    : escapeHtml(`${title} poster`);
+  const ogPosterDimensions = posterUrl
+    ? `\n  <meta property="og:image:width" content="500">\n  <meta property="og:image:height" content="750">` : '';
+  const twitterCardMeta = dominantShapeLabel
+    ? `\n  <meta name="twitter:label1" content="Shape">\n  <meta name="twitter:data1" content="${escapeHtml(dominantShapeLabel)}">\n  <meta name="twitter:label2" content="Avg episode rating">\n  <meta name="twitter:data2" content="${escapeHtml(String(overallAvgRating))}">` : '';
+
+  // Feature 4: per-season TVSeason JSON-LD blocks
+  const seasonSchemas = seasons.map((s) => buildTvSeasonSchema(s, title, canonical)).join('\n');
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -65,7 +81,7 @@ function renderShowPage({ seriesId, title, year, type, genres, seriesRating, ser
   <meta property="og:type" content="video.tv_show">
   <meta property="og:url" content="${canonical}">
   <meta property="og:image" content="${ogImage}">
-  <meta property="og:image:alt" content="${escapeHtml(`${title} poster`)}">
+  <meta property="og:image:alt" content="${ogImageAlt}">${ogPosterDimensions}
   <meta property="og:site_name" content="Shevato">
   <meta property="og:locale" content="en_US">
 
@@ -74,7 +90,7 @@ function renderShowPage({ seriesId, title, year, type, genres, seriesRating, ser
   <meta name="twitter:title" content="${escapeHtml(`${title}${yearLabel} — Episode Ratings`)}">
   <meta name="twitter:description" content="${escapeHtml(description)}">
   <meta name="twitter:image" content="${ogImage}">
-  <meta name="twitter:site" content="@shevato">
+  <meta name="twitter:site" content="@shevato">${twitterCardMeta}
 
   <!-- Breadcrumbs -->
   <script type="application/ld+json">
@@ -85,6 +101,9 @@ ${jsonLd(buildBreadcrumbs(title, path))}
   <script type="application/ld+json">
 ${jsonLd(buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, cleanOverview, genres, seriesRating, seriesVotes, seasons, tmdbId, cast }))}
   </script>
+
+  <!-- TVSeason per-season rating blocks -->
+${seasonSchemas}
 
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📈%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="/apps/rising-seasons/css/show-page.css">
@@ -140,6 +159,8 @@ ${jsonLd(buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, clea
       </div>
     </section>
 
+    ${renderSeasonNav(seasons)}
+
     ${renderCast(cast)}
 
     <section class="seasons" aria-labelledby="seasons-heading">
@@ -157,6 +178,7 @@ ${jsonLd(buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, clea
 
   ${renderMoreFooter()}
   ${renderStickyBanner(title, dominantShape, dominantShapeSlug)}
+  ${renderScrollToTop()}
 </body>
 </html>
 `;
@@ -197,6 +219,17 @@ function renderCast(cast) {
       ${cards}
       </ul>
     </section>`;
+}
+
+// Feature 8: season jump nav. Only rendered when there are 4+ seasons.
+function renderSeasonNav(seasons) {
+  if (!seasons || seasons.length < 4) return '';
+  const links = seasons
+    .map((s) => `<a href="#season-${s.season}">S${s.season}</a>`)
+    .join('\n    ');
+  return `<nav class="season-jump-nav" aria-label="Jump to season">
+    ${links}
+  </nav>`;
 }
 
 function renderSeasonSection(season, seriesId) {
@@ -282,7 +315,7 @@ function renderStickyBanner(title, dominantShape, dominantShapeSlug) {
       <span class="sticky-cta-title">${escapeHtml(title)}</span>
       <span class="shape-badge sticky-cta-badge">${escapeHtml(shapeLabel)}</span>
       <a class="primary-btn sticky-cta-btn" href="${escapeHtml(link)}">Explore by shape in the app</a>
-      <button type="button" class="sticky-cta-close" aria-label="Dismiss banner" onclick="sessionStorage.setItem('rs-cta-banner-dismissed','1');document.getElementById('stickyCta').hidden=true;document.body.style.paddingBottom=''">×</button>
+      <button type="button" class="sticky-cta-close" aria-label="Dismiss banner" onclick="sessionStorage.setItem('rs-cta-banner-dismissed','1');document.getElementById('stickyCta').hidden=true;document.body.style.paddingBottom='';var p=document.getElementById('pageScrollTop');if(p)p.style.bottom=''">×</button>
     </div>
   </div>
   <script>
@@ -303,6 +336,44 @@ function renderStickyBanner(title, dominantShape, dominantShapeSlug) {
     check();
   })();
   </script>`;
+}
+
+// Feature 4: build a TVSeason JSON-LD block with aggregateRating.
+function buildTvSeasonSchema(season, seriesTitle, seriesCanonical) {
+  const ratingCount = (season.episodes || []).reduce((sum, ep) => sum + (ep.votes || 0), 0);
+  const ratingValue = parseFloat(season.avgRating.toFixed(1));
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'TVSeason',
+    name: `${seriesTitle} Season ${season.season}`,
+    seasonNumber: season.season,
+    url: `${seriesCanonical}#season-${season.season}`,
+    partOfSeries: {
+      '@type': 'TVSeries',
+      url: seriesCanonical,
+    },
+    aggregateRating: {
+      '@type': 'AggregateRating',
+      ratingValue: String(ratingValue),
+      ratingCount,
+      bestRating: 10,
+      worstRating: 1,
+    },
+  };
+  return `  <script type="application/ld+json">\n${jsonLd(schema)}\n  </script>`;
+}
+
+// Compute mean avgRating across all seasons (weighted by episode count).
+function computeOverallAvgRating(seasons) {
+  if (!seasons || seasons.length === 0) return '0.0';
+  let totalWeight = 0;
+  let weightedSum = 0;
+  for (const s of seasons) {
+    const epCount = (s.episodes || []).length || 1;
+    weightedSum += s.avgRating * epCount;
+    totalWeight += epCount;
+  }
+  return (weightedSum / totalWeight).toFixed(1);
 }
 
 function buildDescription(title, year, n, rating, votes, overview) {
@@ -379,6 +450,49 @@ function buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, clea
   return schema;
 }
 
+function renderScrollToTop() {
+  return `<button
+    type="button"
+    class="page-scroll-top"
+    id="pageScrollTop"
+    aria-label="Scroll back to top"
+    title="Back to top"
+  >
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+      <path d="M3 10.5 L8 5.5 L13 10.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+    Top
+  </button>
+  <script>
+  (function () {
+    var btn = document.getElementById('pageScrollTop');
+    if (!btn) return;
+    // Ride above the sticky CTA banner while it is visible; both elements
+    // are fixed to the bottom and would otherwise overlap at the right
+    // edge (the pill could cover the CTA's dismiss button).
+    function liftAboveCta() {
+      var cta = document.getElementById('stickyCta');
+      if (cta && !cta.hidden) {
+        btn.style.bottom = (cta.offsetHeight + 16) + 'px';
+      } else {
+        btn.style.bottom = '';
+      }
+    }
+    window.addEventListener('scroll', function () {
+      liftAboveCta();
+      if (window.scrollY >= 400) {
+        btn.classList.add('page-scroll-top--visible');
+      } else {
+        btn.classList.remove('page-scroll-top--visible');
+      }
+    }, { passive: true });
+    btn.addEventListener('click', function () {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  })();
+  </script>`;
+}
+
 function jsonLd(obj) {
   return JSON.stringify(obj, null, 2)
     .replace(/<\/(script|style)/gi, '<\\/$1')
@@ -396,4 +510,4 @@ function escapeHtml(s) {
     .replace(/'/g, '&#39;');
 }
 
-module.exports = { renderShowPage, escapeHtml, buildDescription, shapeToSlug, SITE };
+module.exports = { renderShowPage, escapeHtml, buildDescription, shapeToSlug, SITE, buildTvSeasonSchema, renderSeasonNav };

--- a/apps/rising-seasons/tests/app-features.test.js
+++ b/apps/rising-seasons/tests/app-features.test.js
@@ -1,0 +1,557 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// ---------------------------------------------------------------------------
+// Load app.js into a vm context that stubs the browser globals it touches
+// at parse + init time. We stop execution before load() does anything real
+// by making fetch() reject immediately.
+// ---------------------------------------------------------------------------
+
+const APP_JS = fs.readFileSync(path.join(__dirname, '..', 'js', 'app.js'), 'utf8');
+
+function makeContext(extra = {}) {
+  const noopEl = () => {
+    const el = {
+      querySelector() { return noopEl(); },
+      querySelectorAll() { return []; },
+      getAttribute() { return null; },
+      setAttribute() {},
+      removeAttribute() {},
+      addEventListener() {},
+      removeEventListener() {},
+      replaceChildren() {},
+      appendChild() {},
+      insertBefore() {},
+      insertAdjacentElement() {},
+      closest() { return null; },
+      cloneNode() { return noopEl(); },
+      classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } },
+      style: {},
+      dataset: {},
+      hidden: true,
+      textContent: '',
+      value: '',
+      disabled: false,
+      children: [],
+      firstChild: null,
+      childElementCount: 0,
+      // Template element content stub
+      get content() {
+        return {
+          firstElementChild: { cloneNode() { return noopEl(); } },
+        };
+      },
+    };
+    return el;
+  };
+
+  const sandbox = {
+    // Core JS globals
+    console,
+    Date, Math, JSON, Array, Object, Number, String, Boolean,
+    Symbol, Map, Set, Promise, Error, URL, URLSearchParams,
+    setTimeout, clearTimeout, setInterval, clearInterval,
+    requestAnimationFrame: (fn) => setTimeout(fn, 0),
+    parseInt, parseFloat, isFinite, isNaN,
+    encodeURIComponent, decodeURIComponent,
+
+    // Browser globals that app.js accesses at top level
+    window: {},
+    addEventListener() {},
+    removeEventListener() {},
+    scrollTo() {},
+    scrollY: 0,
+    innerWidth: 1024,
+    document: {
+      getElementById: () => noopEl(),
+      querySelector: () => noopEl(),
+      querySelectorAll: () => [],
+      createElement: () => noopEl(),
+      createElementNS: () => noopEl(),
+      createTextNode: (t) => ({ textContent: t }),
+      createDocumentFragment: () => {
+        const frag = { childNodes: [], children: [], childElementCount: 0 };
+        frag.appendChild = () => {};
+        frag.replaceChildren = () => {};
+        return frag;
+      },
+      body: {
+        appendChild() {}, children: [], classList: { contains: () => false, add() {}, remove() {}, toggle() {} }, style: {},
+      },
+      documentElement: { style: {} },
+      activeElement: null,
+      addEventListener() {},
+      removeEventListener() {},
+    },
+    localStorage: (() => {
+      const m = new Map();
+      return {
+        getItem: (k) => (m.has(k) ? m.get(k) : null),
+        setItem: (k, v) => m.set(k, String(v)),
+        removeItem: (k) => m.delete(k),
+        clear: () => m.clear(),
+      };
+    })(),
+    location: { hash: '', href: 'http://localhost/', origin: 'http://localhost/' },
+    history: { replaceState() {} },
+    navigator: { clipboard: null, share: undefined, canShare: undefined },
+    CSS: { escape: (s) => s },
+    IntersectionObserver: class { observe() {} disconnect() {} },
+    matchMedia: () => ({ matches: false, addEventListener() {} }),
+    // Never-settling fetch so load()'s async chain never throws an unhandled rejection.
+    fetch: () => new Promise(() => {}),
+    ...extra,
+  };
+  // window self-reference
+  sandbox.window = sandbox;
+  return vm.createContext(sandbox);
+}
+
+let ctx;
+ctx = makeContext();
+try {
+  vm.runInContext(APP_JS, ctx, { filename: 'app.js' });
+} catch (e) {
+  // Synchronous errors from load() (skeleton/DOM stubs) are expected.
+}
+
+const helpers = ctx._rsTestExports || {};
+
+// ---------------------------------------------------------------------------
+// Feature 7: computeStdDev
+// ---------------------------------------------------------------------------
+
+test('computeStdDev: empty array returns 0', () => {
+  assert.equal(helpers.computeStdDev([]), 0);
+});
+
+test('computeStdDev: single episode returns 0', () => {
+  assert.equal(helpers.computeStdDev([{ rating: 8.0 }]), 0);
+});
+
+test('computeStdDev: [7.0,9.5,6.5,9.0] approx 1.27 (population std dev)', () => {
+  const eps = [7.0, 9.5, 6.5, 9.0].map((r, i) => ({ episode: i + 1, rating: r }));
+  const sd = helpers.computeStdDev(eps);
+  // mean=8, sum_sq=(1+2.25+2.25+1)/4=1.625, sqrt(1.625)=1.2748
+  assert.ok(Math.abs(sd - 1.27) < 0.02, `expected ~1.27, got ${sd}`);
+});
+
+test('computeStdDev: perfectly flat season returns 0', () => {
+  const eps = [8.0, 8.0, 8.0].map((r) => ({ rating: r }));
+  assert.equal(helpers.computeStdDev(eps), 0);
+});
+
+// ---------------------------------------------------------------------------
+// Feature 5: computeModalRelated (updated contract)
+// ---------------------------------------------------------------------------
+
+const mkMatch = (seriesId, season, shapes, avgRating, minVotes = 5000, genres = []) => ({
+  seriesId, season, shapes, avgRating, minVotes, genres,
+});
+
+test('computeModalRelated: excludes same series', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0, 5000, ['Drama']);
+  const matches = [
+    mkMatch('tt001', 2, ['rising'], 8.2, 3000, ['Drama']),
+    mkMatch('tt002', 1, ['rising'], 7.6, 8000, ['Drama']),
+  ];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].seriesId, 'tt002');
+});
+
+test('computeModalRelated: excludes seasons below avgRating - 0.5', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0, 5000, ['Drama']);
+  const matches = [
+    mkMatch('tt002', 1, ['rising'], 7.4, 8000, ['Drama']), // 7.4 < 7.5 — excluded
+    mkMatch('tt003', 1, ['rising'], 7.5, 6000, ['Drama']), // exactly 7.5 — included
+  ];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].seriesId, 'tt003');
+});
+
+test('computeModalRelated: requires shared genre when m has genres', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0, 5000, ['Drama']);
+  const matches = [
+    mkMatch('tt002', 1, ['rising'], 8.0, 8000, ['Comedy']),  // no shared genre
+    mkMatch('tt003', 1, ['rising'], 8.0, 6000, ['Drama']),   // shared genre
+  ];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].seriesId, 'tt003');
+});
+
+test('computeModalRelated: accepts any candidate when m has no genres', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0, 5000, []);
+  const matches = [
+    mkMatch('tt002', 1, ['rising'], 8.0, 8000, ['Comedy']),
+    mkMatch('tt003', 1, ['rising'], 8.0, 6000, []),
+  ];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result.length, 2);
+});
+
+test('computeModalRelated: returns [] when m has no shapes', () => {
+  const m = mkMatch('tt001', 1, [], 8.0, 5000, ['Drama']);
+  const matches = [mkMatch('tt002', 1, ['rising'], 8.0, 5000, ['Drama'])];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result.length, 0);
+});
+
+test('computeModalRelated: requires the same language', () => {
+  const m = { ...mkMatch('tt001', 1, ['rising'], 8.0, 5000, ['Drama']), language: 'en' };
+  const matches = [
+    { ...mkMatch('tt002', 1, ['rising'], 8.0, 5000, ['Drama']), language: 'ja' }, // different
+    { ...mkMatch('tt003', 1, ['rising'], 8.0, 5000, ['Drama']), language: 'en' }, // same
+    mkMatch('tt004', 1, ['rising'], 8.0, 5000, ['Drama']),                        // missing != 'en'
+  ];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].seriesId, 'tt003');
+});
+
+test('computeModalRelated: two unknown languages count as a match', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0, 5000, ['Drama']);
+  const matches = [mkMatch('tt002', 1, ['rising'], 8.0, 5000, ['Drama'])];
+  assert.equal(helpers.computeModalRelated(m, matches).length, 1);
+});
+
+test('computeModalRelated: votes/episode must be within 10x either way', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0, 5000, ['Drama']);
+  const matches = [
+    mkMatch('tt002', 1, ['rising'], 8.0, 499, ['Drama']),    // < 5000/10 — excluded
+    mkMatch('tt003', 1, ['rising'], 8.0, 500, ['Drama']),    // exactly lo — included
+    mkMatch('tt004', 1, ['rising'], 8.0, 50000, ['Drama']),  // exactly hi — included
+    mkMatch('tt005', 1, ['rising'], 8.0, 50001, ['Drama']),  // > 5000*10 — excluded
+  ];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result.map((r) => r.seriesId).sort().join(','), 'tt003,tt004');
+});
+
+test('computeModalRelated: vote window skipped when m has no vote data', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0, 0, ['Drama']);
+  const matches = [mkMatch('tt002', 1, ['rising'], 8.0, 999999, ['Drama'])];
+  assert.equal(helpers.computeModalRelated(m, matches).length, 1);
+});
+
+test('computeModalRelated: returns up to 10 results', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0, 5000, ['Drama']);
+  const matches = Array.from({ length: 15 }, (_, i) =>
+    mkMatch(`tt${100 + i}`, 1, ['rising'], 8.0, 1000 + i, ['Drama']));
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result.length, 10);
+});
+
+test('computeModalRelated: sorted by likeness (more shared shapes first)', () => {
+  const m = mkMatch('tt001', 1, ['rising', 'big-finale'], 8.0, 5000, ['Drama']);
+  const matches = [
+    mkMatch('tt002', 1, ['rising'], 8.0, 9000, ['Drama']),               // 1 shared shape
+    mkMatch('tt003', 1, ['rising', 'big-finale'], 8.0, 5000, ['Drama']), // 2 shared shapes
+  ];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result[0].seriesId, 'tt003', 'more shared shapes ranks first');
+  assert.equal(result[1].seriesId, 'tt002');
+});
+
+test('computeModalRelated: tiebreak on rating diff then minVotes', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0, 5000, ['Drama']);
+  const matches = [
+    mkMatch('tt002', 1, ['rising'], 8.3, 1000, ['Drama']), // diff=0.3, low votes
+    mkMatch('tt003', 1, ['rising'], 8.1, 5000, ['Drama']), // diff=0.1, high votes
+    mkMatch('tt004', 1, ['rising'], 8.1, 3000, ['Drama']), // diff=0.1, lower votes
+  ];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result[0].seriesId, 'tt003', 'closest rating first');
+  assert.equal(result[1].seriesId, 'tt004', 'then higher votes');
+  assert.equal(result[2].seriesId, 'tt002', 'then higher rating diff');
+});
+
+// ---------------------------------------------------------------------------
+// seasonLikenessScore
+// ---------------------------------------------------------------------------
+
+test('seasonLikenessScore: returns correct sharedShapes count', () => {
+  const m = mkMatch('tt001', 1, ['rising', 'big-finale'], 8.0);
+  const x = mkMatch('tt002', 1, ['rising', 'slow-burn'], 8.0);
+  const score = helpers.seasonLikenessScore(m, x);
+  assert.equal(score.sharedShapes, 1);
+});
+
+test('seasonLikenessScore: returns correct ratingDiff', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.5);
+  const x = mkMatch('tt002', 1, ['rising'], 8.0);
+  const score = helpers.seasonLikenessScore(m, x);
+  assert.ok(Math.abs(score.ratingDiff - 0.5) < 0.001);
+});
+
+test('seasonLikenessScore: zero shared shapes when no overlap', () => {
+  const m = mkMatch('tt001', 1, ['rising'], 8.0);
+  const x = mkMatch('tt002', 1, ['slow-burn'], 8.0);
+  const score = helpers.seasonLikenessScore(m, x);
+  assert.equal(score.sharedShapes, 0);
+});
+
+// ---------------------------------------------------------------------------
+// computeShowRelated
+// ---------------------------------------------------------------------------
+
+const mkShowMatch = (seriesId, season, avgRating, seriesRating, genres = [], seriesVotes = 10000) => ({
+  seriesId, season, avgRating, seriesRating, genres, seriesVotes,
+  shapes: ['rising'], minVotes: 1000, episodes: [],
+});
+
+test('computeShowRelated: excludes self', () => {
+  const matches = [
+    mkShowMatch('tt001', 1, 8.5, 8.0, ['Drama']),
+    mkShowMatch('tt002', 1, 8.5, 8.0, ['Drama']),
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.ok(!result.some((r) => r.seriesId === 'tt001'), 'should not include self');
+});
+
+test('computeShowRelated: excludes shows without seriesRating', () => {
+  const matches = [
+    mkShowMatch('tt001', 1, 8.5, 8.0, ['Drama']),
+    { seriesId: 'tt002', season: 1, avgRating: 8.5, genres: ['Drama'], shapes: [], episodes: [], minVotes: 1000 },
+    mkShowMatch('tt003', 1, 8.5, 8.0, ['Drama']),
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.ok(!result.some((r) => r.seriesId === 'tt002'), 'no seriesRating excluded');
+  assert.equal(result.length, 1);
+  assert.equal(result[0].seriesId, 'tt003');
+});
+
+test('computeShowRelated: excludes shows with no shared genre', () => {
+  const matches = [
+    mkShowMatch('tt001', 1, 8.5, 8.0, ['Drama']),
+    mkShowMatch('tt002', 1, 8.5, 8.0, ['Comedy']),  // no shared genre
+    mkShowMatch('tt003', 1, 8.5, 8.0, ['Drama']),
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.ok(!result.some((r) => r.seriesId === 'tt002'));
+  assert.equal(result[0].seriesId, 'tt003');
+});
+
+test('computeShowRelated: returns empty when current show has no seriesRating', () => {
+  const matches = [
+    { seriesId: 'tt001', season: 1, avgRating: 8.5, genres: ['Drama'], shapes: [], episodes: [], minVotes: 1000 },
+    mkShowMatch('tt002', 1, 8.5, 8.0, ['Drama']),
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.equal(result.length, 0);
+});
+
+test('computeShowRelated: requires the same language', () => {
+  const matches = [
+    { ...mkShowMatch('tt001', 1, 8.5, 8.0, ['Drama']), language: 'en' },
+    { ...mkShowMatch('tt002', 1, 8.5, 8.0, ['Drama']), language: 'ja' }, // different
+    { ...mkShowMatch('tt003', 1, 8.5, 8.0, ['Drama']), language: 'en' }, // same
+    mkShowMatch('tt004', 1, 8.5, 8.0, ['Drama']),                        // missing != 'en'
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.equal(result.map((r) => r.seriesId).join(','), 'tt003');
+});
+
+test('computeShowRelated: mean votes/episode must be within 10x either way', () => {
+  // Current show: mean minVotes = 1000 (mkShowMatch default) -> window 100..10000.
+  const matches = [
+    mkShowMatch('tt001', 1, 8.5, 8.0, ['Drama']),
+    { ...mkShowMatch('tt002', 1, 8.5, 8.0, ['Drama']), minVotes: 99 },     // below window
+    { ...mkShowMatch('tt003', 1, 8.5, 8.0, ['Drama']), minVotes: 100 },    // at lo edge
+    { ...mkShowMatch('tt004', 1, 8.5, 8.0, ['Drama']), minVotes: 10000 },  // at hi edge
+    { ...mkShowMatch('tt005', 1, 8.5, 8.0, ['Drama']), minVotes: 10001 },  // above window
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.equal(result.map((r) => r.seriesId).sort().join(','), 'tt003,tt004');
+});
+
+test('computeShowRelated: returns up to 10 results', () => {
+  const matches = [
+    mkShowMatch('tt001', 1, 8.5, 8.0, ['Drama']),
+    ...Array.from({ length: 15 }, (_, i) =>
+      mkShowMatch(`tt${100 + i}`, 1, 8.5, 8.0, ['Drama'], 10000 - i)),
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.ok(result.length <= 10, `got ${result.length}, expected <= 10`);
+});
+
+test('computeShowRelated: orders by deviation similarity (asc devDiff)', () => {
+  // current: avg=8.5, seriesRating=8.0 => d=0.5
+  // tt002: avg=8.6, seriesRating=8.0 => d=0.6, devDiff=0.1  (closer)
+  // tt003: avg=9.0, seriesRating=8.0 => d=1.0, devDiff=0.5  (farther)
+  const matches = [
+    mkShowMatch('tt001', 1, 8.5, 8.0, ['Drama']),
+    mkShowMatch('tt002', 1, 8.6, 8.0, ['Drama']),
+    mkShowMatch('tt003', 1, 9.0, 8.0, ['Drama']),
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.equal(result[0].seriesId, 'tt002', 'closer deviation ranks first');
+  assert.equal(result[1].seriesId, 'tt003');
+});
+
+test('computeShowRelated: tiebreak on shared genre count (desc)', () => {
+  // current: d=0.5 (avg=8.5, seriesRating=8.0), genres=['Drama','Crime']
+  // both candidates same devDiff
+  const current = { seriesId: 'tt001', season: 1, avgRating: 8.5, seriesRating: 8.0, genres: ['Drama', 'Crime'], shapes: [], episodes: [], minVotes: 1000, seriesVotes: 10000 };
+  const cand1 = { seriesId: 'tt002', season: 1, avgRating: 8.5, seriesRating: 8.0, genres: ['Drama'], shapes: [], episodes: [], minVotes: 1000, seriesVotes: 9000 };        // 1 shared genre
+  const cand2 = { seriesId: 'tt003', season: 1, avgRating: 8.5, seriesRating: 8.0, genres: ['Drama', 'Crime'], shapes: [], episodes: [], minVotes: 1000, seriesVotes: 8000 }; // 2 shared genres
+  const result = helpers.computeShowRelated('tt001', [current, cand1, cand2]);
+  assert.equal(result[0].seriesId, 'tt003', 'more shared genres ranks first on tie');
+});
+
+test('computeShowRelated: _avg is set on results', () => {
+  const matches = [
+    mkShowMatch('tt001', 1, 8.5, 8.0, ['Drama']),
+    mkShowMatch('tt002', 1, 8.0, 7.5, ['Drama']),
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.equal(result.length, 1);
+  assert.ok(typeof result[0]._avg === 'number', '_avg should be set');
+  assert.ok(Math.abs(result[0]._avg - 8.0) < 0.001);
+});
+
+// ---------------------------------------------------------------------------
+// Feature 3: hasActiveFilters
+// ---------------------------------------------------------------------------
+
+test('hasActiveFilters: true when shape filter is set', () => {
+  if (!helpers.state) return; // sandbox didn't expose state
+  helpers.state.shapes = new Set(['rising']);
+  assert.equal(helpers.hasActiveFilters(), true);
+});
+
+test('hasActiveFilters: false in fully-default state', () => {
+  if (!helpers.state) return;
+  helpers.state.shapes = new Set();
+  helpers.state.search = '';
+  helpers.state.minEpisodes = null;
+  helpers.state.maxEpisodes = null;
+  helpers.state.minVotes = null;
+  helpers.state.minAvg = null;
+  helpers.state.minClimb = null;
+  helpers.state.minYear = null;
+  helpers.state.maxYear = null;
+  helpers.state.seriesType = 'all';
+  helpers.state.watched = 'all';
+  helpers.state.aboveImdb = 'all';
+  helpers.state.hiddenGems = 'all';
+  helpers.state.poster = 'all';
+  helpers.state.sort = 'popularity';
+  helpers.state.genres = new Set();
+  helpers.state.excludeGenres = new Set();
+  helpers.state.languages = new Set();
+  helpers.state.providers = new Set();
+  assert.equal(helpers.hasActiveFilters(), false);
+});
+
+// ---------------------------------------------------------------------------
+// Feature 1: buildSeasonShareText still returns a string
+// ---------------------------------------------------------------------------
+
+test('buildSeasonShareText: returns a non-empty string', () => {
+  const m = {
+    title: 'Breaking Bad',
+    season: 5,
+    seasonYear: 2013,
+    year: 2008,
+    seriesId: 'tt0903747',
+    shapes: ['rising', 'big-finale'],
+    firstRating: 8.1,
+    lastRating: 9.9,
+    avgRating: 9.0,
+    episodes: [{ rating: 8.1 }, { rating: 9.9 }],
+  };
+  const text = helpers.buildSeasonShareText(m);
+  assert.ok(typeof text === 'string' && text.length > 0);
+  assert.ok(text.includes('Breaking Bad'));
+  assert.ok(text.includes('Season 5'));
+});
+
+// ---------------------------------------------------------------------------
+// Feature 2: New mood chip hrefs parse to expected URL params
+// ---------------------------------------------------------------------------
+
+test('mood chip: Best rebounders href has shape=rebound,minAvg,minVotes,sort', () => {
+  const href = '#shape=rebound&minAvg=7.5&minVotes=500&sort=avg';
+  const p = new URLSearchParams(href.replace(/^#/, ''));
+  assert.equal(p.get('shape'), 'rebound');
+  assert.equal(p.get('minAvg'), '7.5');
+  assert.equal(p.get('minVotes'), '500');
+  assert.equal(p.get('sort'), 'avg');
+});
+
+test('mood chip: Unmissable finales href has shape=big-finale,minAvg=8,minVotes=1000', () => {
+  const href = '#shape=big-finale&minAvg=8&minVotes=1000&sort=avg';
+  const p = new URLSearchParams(href.replace(/^#/, ''));
+  assert.equal(p.get('shape'), 'big-finale');
+  assert.equal(p.get('minAvg'), '8');
+  assert.equal(p.get('minVotes'), '1000');
+});
+
+test('mood chip: Hidden slow-burns href has shape=slow-burn,gems=on', () => {
+  const href = '#shape=slow-burn&minAvg=8&gems=on&sort=avg';
+  const p = new URLSearchParams(href.replace(/^#/, ''));
+  assert.equal(p.get('shape'), 'slow-burn');
+  assert.equal(p.get('gems'), 'on');
+  assert.equal(p.get('minAvg'), '8');
+});
+
+test('mood chip: Worst endings href has shape=bad-finale', () => {
+  const href = '#shape=bad-finale&minAvg=7.5&sort=avg';
+  const p = new URLSearchParams(href.replace(/^#/, ''));
+  assert.equal(p.get('shape'), 'bad-finale');
+  assert.equal(p.get('minAvg'), '7.5');
+});
+
+// ---------------------------------------------------------------------------
+// Feature 9: Decade mappings — no off-by-one
+// ---------------------------------------------------------------------------
+
+test('DECADE_RANGES: 90s maps to minYear=1990, maxYear=1999', () => {
+  const ranges = helpers.DECADE_RANGES;
+  assert.ok(ranges, 'DECADE_RANGES should be exposed');
+  assert.equal(ranges['90s'][0], 1990);
+  assert.equal(ranges['90s'][1], 1999);
+});
+
+test('DECADE_RANGES: 00s maps to minYear=2000, maxYear=2009', () => {
+  assert.equal(helpers.DECADE_RANGES['00s'][0], 2000);
+  assert.equal(helpers.DECADE_RANGES['00s'][1], 2009);
+});
+
+test('DECADE_RANGES: 80s maps to minYear=1980, maxYear=1989', () => {
+  assert.equal(helpers.DECADE_RANGES['80s'][0], 1980);
+  assert.equal(helpers.DECADE_RANGES['80s'][1], 1989);
+});
+
+test('DECADE_RANGES: 20s maps to minYear=2020, maxYear=2029', () => {
+  assert.equal(helpers.DECADE_RANGES['20s'][0], 2020);
+  assert.equal(helpers.DECADE_RANGES['20s'][1], 2029);
+});
+
+test('activeDecadeKey: returns "90s" when state has 1990/1999', () => {
+  if (!helpers.state || !helpers.activeDecadeKey) return;
+  helpers.state.minYear = 1990;
+  helpers.state.maxYear = 1999;
+  assert.equal(helpers.activeDecadeKey(), '90s');
+});
+
+test('activeDecadeKey: returns "all" when no year filters', () => {
+  if (!helpers.state || !helpers.activeDecadeKey) return;
+  helpers.state.minYear = null;
+  helpers.state.maxYear = null;
+  assert.equal(helpers.activeDecadeKey(), 'all');
+});
+
+test('activeDecadeKey: returns null for custom year range', () => {
+  if (!helpers.state || !helpers.activeDecadeKey) return;
+  helpers.state.minYear = 1995;
+  helpers.state.maxYear = 2005;
+  assert.equal(helpers.activeDecadeKey(), null);
+});

--- a/apps/rising-seasons/tests/render-show-page.test.js
+++ b/apps/rising-seasons/tests/render-show-page.test.js
@@ -3,7 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { renderShowPage, buildDescription } = require('../scripts/render-show-page.js');
+const { renderShowPage, buildDescription, buildTvSeasonSchema, renderSeasonNav } = require('../scripts/render-show-page.js');
 const { groupBySeries } = require('../scripts/build-show-pages.js');
 
 const BREAKING_BAD = {
@@ -197,6 +197,144 @@ test('renderShowPage omits the cast section when there is no cast', () => {
   const html = renderShowPage({ ...BREAKING_BAD, cast: null, dominantShape: 'rising', dominantShapeSlug: 'rising', relatedShows: [] });
   assert.ok(!html.includes('id="cast-heading"'));
   assert.ok(!html.includes('"actor"'));
+});
+
+// --- Feature 4: TVSeason JSON-LD per-season aggregateRating ---
+
+test('buildTvSeasonSchema emits correct ratingValue and ratingCount', () => {
+  const season = {
+    season: 4,
+    seasonYear: 2011,
+    avgRating: 8.44,
+    episodes: [
+      { episode: 1, rating: 8.4, votes: 60000 },
+      { episode: 2, rating: 8.5, votes: 40000 },
+    ],
+    shapes: ['rising'],
+  };
+  const canonical = 'https://shevato.com/apps/rising-seasons/shows/breaking-bad-tt0903747/';
+  const block = buildTvSeasonSchema(season, 'Breaking Bad', canonical);
+  assert.ok(block.includes('"@type": "TVSeason"'));
+  assert.ok(block.includes('"ratingValue": "8.4"'));
+  assert.ok(block.includes('"ratingCount": 100000'));
+  assert.ok(block.includes(`"url": "${canonical}#season-4"`));
+  assert.ok(block.includes('"partOfSeries"'));
+});
+
+test('renderShowPage emits TVSeason JSON-LD blocks for each season', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('"@type": "TVSeason"'));
+  assert.ok(html.includes('"seasonNumber": 1'));
+  assert.ok(html.includes('#season-1'));
+});
+
+// --- Feature 8: Season jump nav ---
+
+test('renderSeasonNav returns a string with correct href for 4-season fixture', () => {
+  const seasons = [
+    { season: 1, episodes: [] },
+    { season: 2, episodes: [] },
+    { season: 3, episodes: [] },
+    { season: 4, episodes: [] },
+  ];
+  const nav = renderSeasonNav(seasons);
+  assert.ok(nav.includes('href="#season-3"'));
+  assert.ok(nav.includes('href="#season-4"'));
+  assert.ok(nav.includes('class="season-jump-nav"'));
+});
+
+test('renderSeasonNav returns empty string for a 3-season fixture', () => {
+  const seasons = [
+    { season: 1, episodes: [] },
+    { season: 2, episodes: [] },
+    { season: 3, episodes: [] },
+  ];
+  const nav = renderSeasonNav(seasons);
+  assert.ok(!nav);
+});
+
+test('renderShowPage includes season-jump-nav for a 4+ season show', () => {
+  const show = {
+    ...BREAKING_BAD,
+    seasons: [
+      { season: 1, seasonYear: 2008, episodes: [{ episode: 1, rating: 8.0, votes: 1000, name: 'Ep1' }], firstRating: 8.0, lastRating: 8.0, avgRating: 8.0, shapes: ['rising'] },
+      { season: 2, seasonYear: 2009, episodes: [{ episode: 1, rating: 8.1, votes: 900, name: 'Ep1' }], firstRating: 8.1, lastRating: 8.1, avgRating: 8.1, shapes: ['rising'] },
+      { season: 3, seasonYear: 2010, episodes: [{ episode: 1, rating: 8.2, votes: 800, name: 'Ep1' }], firstRating: 8.2, lastRating: 8.2, avgRating: 8.2, shapes: ['rising'] },
+      { season: 4, seasonYear: 2011, episodes: [{ episode: 1, rating: 8.5, votes: 700, name: 'Ep1' }], firstRating: 8.5, lastRating: 8.5, avgRating: 8.5, shapes: ['rising'] },
+    ],
+  };
+  const html = renderShowPage(show);
+  assert.ok(html.includes('class="season-jump-nav"'));
+  assert.ok(html.includes('href="#season-3"'));
+});
+
+test('renderShowPage omits season-jump-nav for a 1-season show', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(!html.includes('class="season-jump-nav"'));
+});
+
+// --- Feature 10: Richer OG/Twitter meta ---
+
+test('renderShowPage emits og:image:width, og:image:height, and richer og:image:alt when poster exists', () => {
+  const html = renderShowPage({ ...BREAKING_BAD, dominantShape: 'rebound', dominantShapeSlug: 'rebound', relatedShows: [] });
+  assert.ok(html.includes('og:image:width" content="500"'));
+  assert.ok(html.includes('og:image:height" content="750"'));
+  assert.ok(html.includes('og:image:alt" content="'));
+  // alt must contain parentheses (not em dashes) and the shape label
+  const altMatch = html.match(/og:image:alt" content="([^"]+)"/);
+  assert.ok(altMatch, 'og:image:alt meta tag missing');
+  assert.ok(altMatch[1].includes('('), 'alt text must use parentheses, not em dashes');
+  assert.ok(!altMatch[1].includes('—'), 'alt text must not contain em dashes');
+});
+
+test('renderShowPage does not emit og:image:width when no poster', () => {
+  const html = renderShowPage({ ...BREAKING_BAD, poster: null });
+  assert.ok(!html.includes('og:image:width'));
+});
+
+test('renderShowPage emits twitter:label1=Shape and twitter:data1 with shape label when dominantShape is set', () => {
+  const html = renderShowPage({ ...BREAKING_BAD, dominantShape: 'rebound', dominantShapeSlug: 'rebound', relatedShows: [] });
+  assert.ok(html.includes('name="twitter:label1" content="Shape"'));
+  assert.ok(html.includes('name="twitter:data1" content="Rebound"'));
+  assert.ok(html.includes('name="twitter:label2" content="Avg episode rating"'));
+  assert.ok(html.includes('name="twitter:data2"'));
+});
+
+test('renderShowPage omits twitter label/data cards when no dominantShape', () => {
+  const html = renderShowPage({ ...BREAKING_BAD, dominantShape: null, dominantShapeSlug: null });
+  assert.ok(!html.includes('twitter:label1'));
+  assert.ok(!html.includes('twitter:data1'));
+});
+
+// --- Scroll-to-top button ---
+
+test('renderShowPage includes scroll-to-top button with aria-label', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('class="page-scroll-top"'));
+  assert.ok(html.includes('aria-label="Scroll back to top"'));
+  assert.ok(html.includes('id="pageScrollTop"'));
+});
+
+test('renderShowPage includes inline scroll script for the scroll-to-top button', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('pageScrollTop'));
+  assert.ok(html.includes('page-scroll-top--visible'));
+  assert.ok(html.includes("window.scrollTo"));
+});
+
+test('renderShowPage includes scroll-to-top button regardless of season count', () => {
+  const singleSeason = renderShowPage(BREAKING_BAD);
+  const multiSeason = renderShowPage({
+    ...BREAKING_BAD,
+    seasons: [
+      { season: 1, seasonYear: 2008, episodes: [{ episode: 1, rating: 8.0, votes: 1000, name: 'Ep1' }], firstRating: 8.0, lastRating: 8.0, avgRating: 8.0, shapes: ['rising'] },
+      { season: 2, seasonYear: 2009, episodes: [{ episode: 1, rating: 8.1, votes: 900, name: 'Ep1' }], firstRating: 8.1, lastRating: 8.1, avgRating: 8.1, shapes: ['rising'] },
+      { season: 3, seasonYear: 2010, episodes: [{ episode: 1, rating: 8.2, votes: 800, name: 'Ep1' }], firstRating: 8.2, lastRating: 8.2, avgRating: 8.2, shapes: ['rising'] },
+      { season: 4, seasonYear: 2011, episodes: [{ episode: 1, rating: 8.5, votes: 700, name: 'Ep1' }], firstRating: 8.5, lastRating: 8.5, avgRating: 8.5, shapes: ['rising'] },
+    ],
+  });
+  assert.ok(singleSeason.includes('class="page-scroll-top"'));
+  assert.ok(multiSeason.includes('class="page-scroll-top"'));
 });
 
 test('groupBySeries backfills series-level fields from any season', () => {


### PR DESCRIPTION
## Summary

Sixteen changes to the Rising Seasons app across discovery, navigation, visual polish, and SEO.

### Features & UX

- **Mood presets**: "Explore by mood" chips applying curated filter combinations (including shape-anchored picks like Best rebounders and Unmissable finales), with a "More moods" overflow toggle (first 6 shown, active mood never hidden) and a mobile collapse behind a pill
- **Decade quick filters**: 80s/90s/00s/10s/20s chips synced with the advanced-drawer year inputs
- **Genre filtering consolidated**: top 8 genre chips (tri-state include/exclude/clear) in the quick-filters panel; the duplicate Genre section is removed from the More filters drawer
- **New sort**: "Most volatile" (episode-to-episode standard deviation)
- **More seasons like this**: season modal lists up to 10 related seasons (shared shape AND genre, same language, similar popularity and rating), ranked by likeness; 4 shown + "N more" toggle
- **More shows like this**: show modal lists shows with a shared genre, same language, similar popularity, and the closest IMDb-vs-average-episode rating gap; same 4 + "N more" pattern
- **Modal navigation**: drill-down history with a back button (chevron glass circle beside the close button); every modal open/switch lands scrolled to the top
- **Scroll-to-top**: gradient-glass pill in both modals (sticky, bottom-right past 400px of scroll) and on every static show page (fixed, lifts above the sticky CTA banner while it is visible)
- **Season overlay legend toggles**: legend entries are chips filled with their line color; clicking hides/restores that season's line
- **Copy link**: button in the active-filter bar copies the current filtered-view URL
- **Episode rows**: outbound arrow on episodes that deep-link to IMDb

### Visual

- **Filter-bar contrast and chip styling**: brighter labels and placeholders; inactive chips get faint surfaces, hairline borders, and white text; fixes for sitewide-theme `!important` collisions that rendered chip/button text gray (and red on hover/press)

### SEO (static show pages)

- Per-season `TVSeason` JSON-LD with `aggregateRating` and `partOfSeries`
- Season jump nav (S1 S2 ...) on shows with 4+ seasons
- Richer Open Graph / Twitter card meta (image dimensions/alt, Shape and Avg episode rating labels)

Also adds `tests/app-features.test.js` covering the new helpers (likeness scoring, related-show selection, std dev, decade ranges), updates the README feature table, and gitignores transient `.screenshots/` test evidence.

## Testing

- `npm test`: 755/755 passing (3 new static-page tests, expanded app-helper suite)
- Full acceptance plan executed (16 sections, both viewports, computed-style checks): 1 layout bug found and fixed during testing (scroll-to-top pill overlapping the sticky CTA banner)
- Visual states screenshot-verified on desktop 1280px and mobile 390px
