### PR TITLE
Fix homepage de-indexing: remove noindex from /, clean edge redirect, apex canonical strategy

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Shevato - Software Engineering Services</title>
   <meta name="description" content="Shevato LLC delivers Spring Boot microservices, REST APIs, and full stack web applications for client teams, plus a handful of free web apps." />
-  <meta name="robots" content="noindex, follow" />
+  <!-- NO robots meta here. This stub serves at "/", which Google treats as
+       the site homepage: a noindex on it de-indexes the whole domain root
+       (it did, 2026-06: GSC "excluded by noindex"). In production the edge
+       301 in netlify.toml supersedes this file; the meta-refresh below is
+       the local-dev / no-JS fallback only. -->
   <meta name="google-site-verification" content="IbbJIj83Wn2D-MXH6-ZVYbknM_R1Nst4Z1IAqdEJH_o" />
   <link rel="icon" href="/favicon.ico" sizes="48x48 32x32 16x16">
   <link rel="icon" type="image/png" sizes="192x192" href="/images/favicon-192.png">

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,17 @@
 [functions]
   node_bundler = "esbuild"
 
+# The site homepage lives at /home.html; "/" must be a clean edge 301 so
+# Google indexes the real homepage. force = true makes this win over the
+# committed index.html stub (which previously served at "/" carrying a
+# noindex meta that de-indexed the domain root - GSC, 2026-06). The stub
+# remains only as a local-dev / no-JS fallback.
+[[redirects]]
+  from = "/"
+  to = "/home.html"
+  status = 301
+  force = true
+
 # product.html was retired as part of the marketing/portfolio refresh.
 # Its services content now lives at the top of /work.html. Permanent
 # redirect so anyone with a bookmark or inbound link lands cleanly.


### PR DESCRIPTION
## Summary

Google Search Console reported both `https://shevato.com/` and `https://www.shevato.com/` **excluded from the index: "'noindex' detected in 'robots' meta tag"**.

### Root cause

1. `index.html` - the stub served at `/` - carried `<meta name="robots" content="noindex, follow">`. It was meant to keep the "redirecting..." stub out of the index, but `/` IS the homepage in Google's eyes, so it de-indexed the domain root on both hosts (confirmed live on apex and www).
2. Canonical conflict: Netlify's primary domain is currently **www** (the edge 301s apex -> www) while every canonical tag, og:url, sitemap, and JSON-LD block says **apex** - which is why GSC shows "Google-selected canonical: www.shevato.com/home.html" against the user-declared apex canonical.
3. No `X-Robots-Tag` headers and no other noindex sources anywhere (`404.html`'s noindex is intentional and retained).

### Fix

- Removed the noindex from `index.html`, with a comment explaining why none must ever return.
- Added an edge redirect in `netlify.toml`: `/ -> /home.html` (301, `force = true`), so production serves a clean redirect instead of the stub. The stub remains as a local-dev / no-JS fallback.
- Canonical host strategy: **apex (`shevato.com`)** - matches all existing markup and sitemaps.

### After merge + deploy (owner actions)

1. **Netlify dashboard**: Domain management -> set `shevato.com` as the **primary domain** (Netlify then auto-301s www -> apex, resolving the canonical conflict). This setting cannot live in the repo.
2. Verify: `curl -sI https://shevato.com/` -> 301 to `/home.html`; `curl -sL https://shevato.com/ | grep robots` -> only `index, follow`.
3. GSC (both properties): Request Indexing for `/` and `/home.html`.

## Testing

- `npm test`: 734/734
- Repo-wide verification: noindex only in `404.html`; all root-page canonicals apex-consistent; sitemaps + robots.txt apex-only; redirect block structurally matches the four existing working blocks
