### PR TITLE
Standardize user-visible date formats across all six apps

### DIFF
--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -664,14 +664,14 @@
         <section class="stage stage-end" id="stage-end" hidden>
           <header class="end-head">
             <p id="end-summary"></p>
-            <!-- Share result card — generates a canvas image of the
-                 final standings and triggers a download / Web Share. -->
+            <!-- Copy result — builds a plain-text standings summary and
+                 writes it to the clipboard. -->
             <button type="button" class="btn btn-ghost btn-sm end-share-btn" id="end-share-btn" hidden>
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/>
                 <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
               </svg>
-              Share result
+              Copy result
             </button>
           </header>
 

--- a/apps/arena/js/app.js
+++ b/apps/arena/js/app.js
@@ -4672,140 +4672,77 @@ async function writeEndOfGameStats(me, didWin) {
 }
 
 /**
- * Generate and download (or Web Share) a canvas result card for the
- * current finished game. Card includes: game type, top score, and the
- * final standings for all players.
+ * Build a plain-text share blurb for a finished Arena game.
+ * Pure function — no DOM access, safe to call from tests.
+ *
+ * @param {string} gameTypeLabel - Human-readable game type, e.g. 'Globe Drop'.
+ * @param {Array<{displayName:string,score:number}>} rankedPlayers - Already ranked, highest first.
+ * @param {string} dateStr - Formatted date string, e.g. 'Jun 5, 2026'.
+ * @returns {string}
+ */
+function buildResultShareText(gameTypeLabel, rankedPlayers, dateStr) {
+    const medals = ['🥇', '🥈', '🥉'];
+    const header = `🏆 Arena: ${gameTypeLabel}\n${dateStr}`;
+    const rows = rankedPlayers.map((p, i) => {
+        const prefix = medals[i] || `${i + 1}.`;
+        const name = p.displayName || 'Player';
+        return `${prefix} ${name}: ${p.score}`;
+    }).join('\n');
+    return `${header}\n\n${rows}\n\nshevato.com/apps/arena`;
+}
+
+/**
+ * Copy a plain-text game-result summary to the clipboard.
+ * On success, briefly swaps the button label to confirm the copy.
  */
 async function shareResultCard() {
     if (!state.roomData || !state.roomPlayers) return;
+
+    const gameTypeLabel = state.roomData.gameType === 'globe-drop' ? 'Globe Drop' : 'Trivia';
+    const dateStr = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    const ranked = Scoring.rankPlayers(state.roomPlayers.map((p) => ({
+        displayName: p.displayName,
+        score: p.score || 0,
+        streak: p.streak || 0,
+        uid: p.uid
+    })));
+    const text = buildResultShareText(gameTypeLabel, ranked, dateStr);
+
     const btn = $('#end-share-btn');
-    if (btn) btn.disabled = true;
+    const originalLabel = btn ? btn.innerHTML : null;
+
+    const confirmCopy = () => {
+        if (!btn) return;
+        btn.innerHTML = '✓ Copied';
+        setTimeout(() => { btn.innerHTML = originalLabel; }, 1200);
+    };
+
+    // Prefer the async Clipboard API; fall back to execCommand for non-secure contexts.
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        try {
+            await navigator.clipboard.writeText(text);
+            confirmCopy();
+            return;
+        } catch (_) { /* fall through to execCommand */ }
+    }
 
     try {
-        const W = 600, H = 340;
-        const canvas = document.createElement('canvas');
-        canvas.width = W;
-        canvas.height = H;
-        const ctx = canvas.getContext('2d');
-
-        // Background gradient
-        const bg = ctx.createLinearGradient(0, 0, W, H);
-        bg.addColorStop(0, '#06070d');
-        bg.addColorStop(1, '#0e1220');
-        ctx.fillStyle = bg;
-        ctx.fillRect(0, 0, W, H);
-
-        // Accent border top
-        const topBar = ctx.createLinearGradient(0, 0, W, 0);
-        topBar.addColorStop(0, '#22d3ee');
-        topBar.addColorStop(1, '#a855f7');
-        ctx.fillStyle = topBar;
-        ctx.fillRect(0, 0, W, 3);
-
-        // Title
-        ctx.font = 'bold 22px "Space Grotesk", sans-serif';
-        ctx.fillStyle = '#eef2ff';
-        const gameType = state.roomData.gameType === 'globe-drop' ? 'Globe Drop' : 'Trivia';
-        ctx.fillText(`Arena — ${gameType}`, 28, 40);
-
-        // Date
-        ctx.font = '13px "Outfit", sans-serif';
-        ctx.fillStyle = '#8b95b3';
-        const dateStr = new Date().toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
-        ctx.fillText(dateStr, 28, 62);
-
-        // Ranked players
-        const ranked = Scoring.rankPlayers(state.roomPlayers.map((p) => ({
-            displayName: p.displayName,
-            score: p.score || 0,
-            streak: p.streak || 0,
-            uid: p.uid
-        })));
-        const medals = ['🥇', '🥈', '🥉'];
-        const rowH = 44;
-        const startY = 90;
-        ranked.slice(0, 5).forEach((p, i) => {
-            const y = startY + i * rowH;
-            const isWinner = i === 0;
-
-            // Row background for winner
-            if (isWinner) {
-                ctx.fillStyle = 'rgba(251,191,36,0.08)';
-                ctx.beginPath();
-                ctx.roundRect(20, y - 8, W - 40, rowH - 4, 8);
-                ctx.fill();
-            }
-
-            // Medal or rank number
-            if (medals[i]) {
-                ctx.font = '20px serif';
-                ctx.fillText(medals[i], 28, y + 18);
-            } else {
-                ctx.font = 'bold 14px "JetBrains Mono", monospace';
-                ctx.fillStyle = '#22d3ee';
-                ctx.fillText(String(i + 1), 32, y + 18);
-            }
-
-            // Name
-            ctx.font = isWinner ? 'bold 16px "Outfit", sans-serif' : '15px "Outfit", sans-serif';
-            ctx.fillStyle = isWinner ? '#fbbf24' : '#eef2ff';
-            const maxNameW = 340;
-            let name = p.displayName || 'Player';
-            while (ctx.measureText(name).width > maxNameW && name.length > 1) name = name.slice(0, -1);
-            if (name !== p.displayName) name += '…';
-            ctx.fillText(name, 68, y + 18);
-
-            // Score pill
-            ctx.font = 'bold 14px "JetBrains Mono", monospace';
-            ctx.fillStyle = isWinner ? '#fbbf24' : '#22d3ee';
-            const scoreStr = String(p.score);
-            const scoreW = ctx.measureText(scoreStr).width;
-            ctx.fillText(scoreStr, W - 48 - scoreW / 2, y + 18);
-        });
-
-        // Footer
-        ctx.font = '12px "Outfit", sans-serif';
-        ctx.fillStyle = '#5b6585';
-        ctx.fillText('shevato.com/apps/arena', 28, H - 16);
-
-        // Gradient cyan line bottom-right
-        const footerBar = ctx.createLinearGradient(W - 200, 0, W, 0);
-        footerBar.addColorStop(0, 'transparent');
-        footerBar.addColorStop(1, '#22d3ee');
-        ctx.fillStyle = footerBar;
-        ctx.fillRect(W - 200, H - 3, 200, 3);
-
-        const filename = `arena-result-${Date.now()}.png`;
-        const dataUrl = canvas.toDataURL('image/png');
-
-        if (navigator.share && navigator.canShare) {
-            // Attempt Web Share API (mobile)
-            try {
-                const res = await fetch(dataUrl);
-                const blob = await res.blob();
-                const file = new File([blob], filename, { type: 'image/png' });
-                if (navigator.canShare({ files: [file] })) {
-                    await navigator.share({
-                        files: [file],
-                        title: `Arena ${gameType} results`,
-                        text: ranked[0] ? `${ranked[0].displayName} won with ${ranked[0].score} points!` : 'Check out the results!'
-                    });
-                    return;
-                }
-            } catch (_) { /* fall through to download */ }
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        const ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        if (ok) {
+            confirmCopy();
+        } else {
+            console.warn('shareResultCard: execCommand copy returned false');
         }
-
-        // Fallback: download
-        const a = document.createElement('a');
-        a.href = dataUrl;
-        a.download = filename;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
     } catch (err) {
         console.warn('shareResultCard failed:', err);
-    } finally {
-        if (btn) btn.disabled = false;
     }
 }
 
@@ -6092,7 +6029,7 @@ function formatRelativeDate(d) {
     if (diff < day) return 'today';
     if (diff < 2 * day) return 'yesterday';
     if (diff < 7 * day) return Math.floor(diff / day) + 'd ago';
-    return d.toLocaleDateString();
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 /* =====================================================================

--- a/apps/football-h2h/js/backup.js
+++ b/apps/football-h2h/js/backup.js
@@ -68,7 +68,7 @@ function restoreFromBackup() {
             return;
         }
 
-        const backupDate = new Date(backupData.backupDate).toLocaleString(undefined, { hour12: false });
+        const backupDate = new Date(backupData.backupDate).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false });
         const gameCount = backupData.games.length;
 
         createConfirmationModal({
@@ -190,7 +190,7 @@ function restoreFromFile() {
                     return;
                 }
                 
-                const backupDate = backupData.backupDate ? new Date(backupData.backupDate).toLocaleString(undefined, { hour12: false }) : 'Unknown';
+                const backupDate = backupData.backupDate ? new Date(backupData.backupDate).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false }) : 'Unknown';
                 const gameCount = backupData.games.length;
                 
                 createConfirmationModal({

--- a/apps/football-h2h/js/football-h2h.js
+++ b/apps/football-h2h/js/football-h2h.js
@@ -350,18 +350,7 @@ function formatDateTime(dateString) {
         minute: '2-digit',
         hour12: false
     };
-    return date.toLocaleString(undefined, options);
-}
-
-// Format date for display (short version)
-function formatDate(dateString) {
-    const date = new Date(dateString);
-    const options = {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit'
-    };
-    return date.toLocaleDateString('en-US', options);
+    return date.toLocaleString('en-US', options);
 }
 
 // Sort games by column
@@ -1594,7 +1583,7 @@ function renderGamesTableWithData(gamesData) {
         if (winner) row.classList.add(`${winner}-win`);
         
         const date = new Date(game.dateTime);
-        const formattedDate = date.toLocaleDateString();
+        const formattedDate = date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
         const formattedTime = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
         
         // Score styling and penalty display
@@ -2238,7 +2227,7 @@ function buildSessionSummaryText(gamesData) {
         } else {
             p2Wins++;
         }
-        const dateStr = g.dateTime ? new Date(g.dateTime).toLocaleDateString() : '';
+        const dateStr = g.dateTime ? new Date(g.dateTime).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : '';
         const noteStr = g.note ? ` — ${g.note}` : '';
         lines.push(`${scoreStr}${suffix} (${dateStr})${noteStr}`);
     }

--- a/apps/football-h2h/js/playerStats.js
+++ b/apps/football-h2h/js/playerStats.js
@@ -379,7 +379,7 @@
         const d = new Date(iso);
         if (isNaN(d.getTime())) return null;
         return d.toLocaleDateString('en-US', {
-            month: 'numeric',
+            month: 'short',
             day: 'numeric',
             year: 'numeric'
         });

--- a/apps/football-h2h/js/sidebar.js
+++ b/apps/football-h2h/js/sidebar.js
@@ -246,8 +246,8 @@ function updateSidebarDate() {
                 todayBtn.classList.add('hidden');
             }
         } else {
-            // Display the actual date in YYYY-MM-DD format when it's not today
-            if (dateText) dateText.textContent = dateInput.value;
+            // Display the actual date as "Jun 4, 2026" when it's not today
+            if (dateText) dateText.textContent = formatDateForDisplay(dateInput.value);
             // Show the "Set to Today" button when it's not today
             if (todayBtn) {
                 todayBtn.classList.remove('hidden');
@@ -258,17 +258,12 @@ function updateSidebarDate() {
 
 function formatDateForDisplay(dateStr) {
     if (!dateStr) return 'No date';
-    
+
     try {
         const [year, month, day] = dateStr.split('-');
         const date = new Date(parseInt(year), parseInt(month) - 1, parseInt(day));
-        
-        // Format as M/D/YYYY (e.g., 8/20/2025)
-        const displayMonth = parseInt(month);
-        const displayDay = parseInt(day);
-        const displayYear = parseInt(year);
-        
-        return `${displayMonth}/${displayDay}/${displayYear}`;
+
+        return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
     } catch (e) {
         return dateStr;
     }

--- a/apps/football-h2h/tests/playerStats.test.js
+++ b/apps/football-h2h/tests/playerStats.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Pin timezone so M/D/YYYY assertions on ISO dates are deterministic across
+// Pin timezone so date assertions on ISO dates are deterministic across
 // CI/dev machines. Must be set before any Date objects are constructed.
 process.env.TZ = 'UTC';
 
@@ -639,11 +639,11 @@ test('longestRun: games missing dateTime → length counted, dates can be null',
     assert.equal(run.endDate, null);
 });
 
-test('formatDateShort: renders M/D/YYYY with no leading zeros, no month name', () => {
-    assert.equal(formatDateShort('2026-04-24T12:00:00Z'), '4/24/2026');
-    assert.equal(formatDateShort('2025-01-03T12:00:00Z'), '1/3/2025');
-    assert.equal(formatDateShort('2026-10-07T12:00:00Z'), '10/7/2026');
-    assert.equal(formatDateShort('2026-12-31T12:00:00Z'), '12/31/2026');
+test('formatDateShort: renders abbreviated-month date (e.g. Apr 24, 2026)', () => {
+    assert.equal(formatDateShort('2026-04-24T12:00:00Z'), 'Apr 24, 2026');
+    assert.equal(formatDateShort('2025-01-03T12:00:00Z'), 'Jan 3, 2025');
+    assert.equal(formatDateShort('2026-10-07T12:00:00Z'), 'Oct 7, 2026');
+    assert.equal(formatDateShort('2026-12-31T12:00:00Z'), 'Dec 31, 2026');
 });
 
 test('formatDateShort: bad input → null (no NaN/Invalid Date leaks)', () => {
@@ -653,22 +653,22 @@ test('formatDateShort: bad input → null (no NaN/Invalid Date leaks)', () => {
     assert.equal(formatDateShort('not-a-date'), null);
 });
 
-test('formatRangeText: multi-game run → "(M/D/YYYY – M/D/YYYY)"', () => {
+test('formatRangeText: multi-game run → "(Mon D, YYYY – Mon D, YYYY)"', () => {
     const text = formatRangeText({
         length: 14,
         startDate: '2026-04-10T12:00:00Z',
         endDate: '2026-04-24T12:00:00Z'
     });
-    assert.equal(text, '(4/10/2026 – 4/24/2026)');
+    assert.equal(text, '(Apr 10, 2026 – Apr 24, 2026)');
 });
 
-test('formatRangeText: single-game run collapses to "(M/D/YYYY)"', () => {
+test('formatRangeText: single-game run collapses to "(Mon D, YYYY)"', () => {
     const text = formatRangeText({
         length: 1,
         startDate: '2026-04-24T12:00:00Z',
         endDate: '2026-04-24T12:00:00Z'
     });
-    assert.equal(text, '(4/24/2026)');
+    assert.equal(text, '(Apr 24, 2026)');
 });
 
 test('formatRangeText: length 0 or missing dates → null', () => {
@@ -690,7 +690,7 @@ test('formatRangeText: reversed range is swapped, never displayed backwards', ()
         startDate: '2026-04-24T12:00:00Z', // later
         endDate: '2026-04-10T12:00:00Z'    // earlier
     });
-    assert.equal(text, '(4/10/2026 – 4/24/2026)');
+    assert.equal(text, '(Apr 10, 2026 – Apr 24, 2026)');
 });
 
 // -- Highest-score game (with opponent score and date) --
@@ -778,16 +778,16 @@ test('highestScoreGame: null opponent score is preserved on the result', () => {
     });
 });
 
-test('formatMatchText: full detail → "(M/D/YYYY, me–opp)"', () => {
+test('formatMatchText: full detail → "(Mon D, YYYY, me–opp)"', () => {
     assert.equal(formatMatchText({
         score: 5, opponentScore: 3, date: '2025-01-12T12:00:00Z'
-    }), '(1/12/2025, 5–3)');
+    }), '(Jan 12, 2025, 5–3)');
 });
 
 test('formatMatchText: score of 0 is still valid (shutout loss)', () => {
     assert.equal(formatMatchText({
         score: 0, opponentScore: 2, date: '2025-01-12T12:00:00Z'
-    }), '(1/12/2025, 0–2)');
+    }), '(Jan 12, 2025, 0–2)');
 });
 
 test('formatMatchText: missing date → null (UI falls back to bare value)', () => {
@@ -817,7 +817,7 @@ test('highestScoreGame + formatMatchText: end-to-end produces the displayed stri
         { id: 3, dateTime: '2025-01-14T12:00:00Z', player1Goals: 1, player2Goals: 0 }
     ];
     const best = highestScoreGame(games, 'player1Goals', 'player2Goals');
-    assert.equal(formatMatchText(best), '(1/12/2025, 5–3)');
+    assert.equal(formatMatchText(best), '(Jan 12, 2025, 5–3)');
 });
 
 test('longestRun + formatRangeText: end-to-end produces the displayed string', () => {
@@ -830,7 +830,7 @@ test('longestRun + formatRangeText: end-to-end produces the displayed string', (
     ];
     const run = longestRun(games, 'player1Goals', (s) => s > 0);
     assert.equal(run.length, 3);
-    assert.equal(formatRangeText(run), '(4/10/2026 – 4/20/2026)');
+    assert.equal(formatRangeText(run), '(Apr 10, 2026 – Apr 20, 2026)');
 });
 
 test('longestRun: works for scoreless predicate too', () => {

--- a/apps/gym-tracker/js/utils/dark-calendar.js
+++ b/apps/gym-tracker/js/utils/dark-calendar.js
@@ -95,7 +95,7 @@ export class DarkCalendar {
         return `${y}-${m}-${d}`;
     }
     formatDisplay(date) {
-        return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+        return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
     }
     isSameDay(a, b) {
         return !!(a && b

--- a/apps/gym-tracker/js/utils/helpers.js
+++ b/apps/gym-tracker/js/utils/helpers.js
@@ -110,7 +110,7 @@ export function formatDate(dateString, format = 'short') {
         return date.toLocaleDateString('en-US', {
             weekday: 'long',
             year: 'numeric',
-            month: 'long',
+            month: 'short',
             day: 'numeric'
         });
     }
@@ -181,7 +181,7 @@ export function formatSessionDateTime(session) {
     const timeSrc = session.endTime || session.startTime || session.timestamp;
     if (!timeSrc) return datePart;
     const time = formatTimeOfDay(timeSrc);
-    return time ? `${datePart} • ${time}` : datePart;
+    return time ? `${datePart}, ${time}` : datePart;
 }
 
 /**

--- a/apps/gym-tracker/js/views/calendar-view.js
+++ b/apps/gym-tracker/js/views/calendar-view.js
@@ -257,8 +257,8 @@ class CalendarView {
             .filter(s => s.date === this.selectedDate)
             .sort((a, b) => new Date(b.sortTimestamp) - new Date(a.sortTimestamp));
         const dateObj = new Date(this.selectedDate);
-        const headerLabel = dateObj.toLocaleDateString(undefined, {
-            weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
+        const headerLabel = dateObj.toLocaleDateString('en-US', {
+            weekday: 'long', month: 'short', day: 'numeric', year: 'numeric',
         });
 
         if (daySessions.length === 0) {

--- a/apps/gym-tracker/js/views/exercises-view.js
+++ b/apps/gym-tracker/js/views/exercises-view.js
@@ -540,7 +540,7 @@ class ExercisesView {
             : history.reduce((best, current) => current.volume > best.volume ? current : best);
 
         // Friendly date helpers — "Mar 25, 2026" instead of "3/25/2026"
-        const fmtDate = (dateStr) => parseLocalDate(dateStr).toLocaleDateString(undefined, {
+        const fmtDate = (dateStr) => parseLocalDate(dateStr).toLocaleDateString('en-US', {
             year: 'numeric', month: 'short', day: 'numeric',
         });
 

--- a/apps/gym-tracker/js/views/insights-view.js
+++ b/apps/gym-tracker/js/views/insights-view.js
@@ -79,7 +79,7 @@ class InsightsView {
         const unit = this.app.settings?.weightUnit || 'kg';
 
         if (caption) {
-            const fmt = (d) => d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+            const fmt = (d) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
             caption.textContent = `${fmt(start)} – ${fmt(now)}`;
         }
 
@@ -179,7 +179,7 @@ class InsightsView {
         `;
 
         if (caption) {
-            const fmt = (d) => d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+            const fmt = (d) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
             caption.textContent = `${fmt(start)} – ${fmt(today)}`;
         }
     }

--- a/apps/gym-tracker/js/views/workout-view.js
+++ b/apps/gym-tracker/js/views/workout-view.js
@@ -2064,7 +2064,7 @@ class WorkoutView {
     _absoluteDate(isoOrDate) {
         if (!isoOrDate) return '';
         const d = new Date(isoOrDate);
-        return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+        return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
     }
 
     async endWorkout() {

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -327,7 +327,7 @@
   function fmtDateShort(iso) {
     if (!iso) return '—';
     const d = new Date(iso + 'T00:00:00');
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   }
   // Shared `<MonthName><Day>` token used by both the maptap.gg history
   // deep link and the daily-puzzle data URL. English month names are
@@ -425,7 +425,7 @@
   function fmtDateLong(iso) {
     if (!iso) return '—';
     const d = new Date(iso + 'T00:00:00');
-    return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+    return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
   }
 
   // ---------- analytics ----------
@@ -1007,7 +1007,7 @@
     if (!g) return;
     const myLabel = iPlayed(g) ? String(getMyTotal(g)) : '—';
     const theirLabel = theyPlayed(g) ? String(getTheirTotal(g)) : '—';
-    if (!confirm(`Delete this game (${fmtDateShort(g.date)}, ${myLabel} vs ${theirLabel})?`)) return;
+    if (!confirm(`Delete this game (${shortDate(g.date)}, ${myLabel} vs ${theirLabel})?`)) return;
     state.games = state.games.filter(x => x.id !== id);
     persistGames();
     if (state.view === 'dashboard') renderDashboard();
@@ -2689,10 +2689,10 @@
       s.streak.curMine > 0 ? `${s.streak.curMine} W` : s.streak.curTheirs > 0 ? `${s.streak.curTheirs} L` : '—',
       `Longest: ${s.streak.longestMine} W / ${s.streak.longestTheirs} L`,
       s.streak.curMine > 0 ? 'is-good' : s.streak.curTheirs > 0 ? 'is-bad' : ''));
-    const bestMineDate  = s.bestMineGame  ? fmtDateShort(s.bestMineGame.date)  : null;
-    const worstMineDate = s.worstMineGame ? fmtDateShort(s.worstMineGame.date) : null;
-    const bestTheirsDate  = s.bestTheirsGame  ? fmtDateShort(s.bestTheirsGame.date)  : null;
-    const worstTheirsDate = s.worstTheirsGame ? fmtDateShort(s.worstTheirsGame.date) : null;
+    const bestMineDate  = s.bestMineGame  ? shortDate(s.bestMineGame.date)  : null;
+    const worstMineDate = s.worstMineGame ? shortDate(s.worstMineGame.date) : null;
+    const bestTheirsDate  = s.bestTheirsGame  ? shortDate(s.bestTheirsGame.date)  : null;
+    const worstTheirsDate = s.worstTheirsGame ? shortDate(s.worstTheirsGame.date) : null;
     cardsHost.appendChild(makeStatCard('Best score (you)', s.bestMine,
       bestMineDate
         ? `${bestMineDate} · Worst ${s.worstMine}${worstMineDate ? ` (${worstMineDate})` : ''}`
@@ -2704,10 +2704,10 @@
         : `Worst: ${s.worstTheirs}`));
     cardsHost.appendChild(makeStatCard('Consistency (you)', s.consistencyMine.toFixed(1), 'σ — lower = steadier'));
     cardsHost.appendChild(makeStatCard('Biggest win', s.biggestWinGame ? `+${s.biggestWinMargin}` : '—',
-      s.biggestWinGame ? `${s.biggestWinGame.myScore}–${s.biggestWinGame.theirScore} on ${fmtDateShort(s.biggestWinGame.date)}` : '—',
+      s.biggestWinGame ? `${s.biggestWinGame.myScore}–${s.biggestWinGame.theirScore} on ${shortDate(s.biggestWinGame.date)}` : '—',
       s.biggestWinGame ? 'is-good' : ''));
     cardsHost.appendChild(makeStatCard('Biggest loss', s.biggestLossGame ? `−${s.biggestLossMargin}` : '—',
-      s.biggestLossGame ? `${s.biggestLossGame.myScore}–${s.biggestLossGame.theirScore} on ${fmtDateShort(s.biggestLossGame.date)}` : '—',
+      s.biggestLossGame ? `${s.biggestLossGame.myScore}–${s.biggestLossGame.theirScore} on ${shortDate(s.biggestLossGame.date)}` : '—',
       s.biggestLossGame ? 'is-bad' : ''));
 
     // callouts
@@ -2716,7 +2716,7 @@
     if (s.onColdStreak) calloutsHost.appendChild(callout('bad', '❄️', `${rivalNameSafe} has won the last <strong>${s.streak.curTheirs} games</strong>. Time to bounce back.`));
     if (s.total >= 3) {
       const pb = s.games.find(g => getMyTotal(g) === s.bestMine);
-      if (pb) calloutsHost.appendChild(callout('good', '⭐', `Personal best <strong>${s.bestMine}</strong> set vs ${rivalNameSafe} on ${fmtDateShort(pb.date)}.`));
+      if (pb) calloutsHost.appendChild(callout('good', '⭐', `Personal best <strong>${s.bestMine}</strong> set vs ${rivalNameSafe} on ${shortDate(pb.date)}.`));
     }
     } // end if (s.total)
     // games table (most recent first), paginated. Use the unfiltered list
@@ -2744,7 +2744,7 @@
       const theirT = themHere ? getTheirTotal(g) : null;
       const diff = (meHere && themHere) ? (myT - theirT) : null;
       tableBody.appendChild(el('tr', { class: r ? '' : 'row-one-sided' }, [
-        el('td', {}, fmtDateShort(g.date)),
+        el('td', {}, shortDate(g.date)),
         el('td', {
           style: 'font-weight:600',
           title: hasLocs(g) ? `Rounds: ${g.myScores.join(' / ')}` : (meHere ? '' : 'You didn\'t play this day'),
@@ -2869,7 +2869,7 @@
       const firstDay = new Date(weeks[wi][0] + 'T00:00:00');
       if (firstDay.getMonth() !== lastMonth) {
         lastMonth = firstDay.getMonth();
-        const mo = firstDay.toLocaleDateString(undefined, { month: 'short' });
+        const mo = firstDay.toLocaleDateString('en-US', { month: 'short' });
         monthLabelItems.push({ colIdx: wi, label: mo });
       }
     }
@@ -3643,7 +3643,7 @@
           : 'tie';
         dots.appendChild(el('span', {
           class: `matrix-form-dot is-${cls}`,
-          title: `${fmtDateShort(m.date)} · ${m.rowScore} vs ${m.colScore}`,
+          title: `${shortDate(m.date)} · ${m.rowScore} vs ${m.colScore}`,
         }));
       });
       // Current streak: walk backward from the latest meeting.
@@ -3891,8 +3891,8 @@
             rel: 'noopener noreferrer',
             class: 'maptap-day-link',
             title: 'Open this day on maptap.gg',
-          }, fmtDateShort(g.date))])
-        : el('td', {}, fmtDateShort(g.date));
+          }, shortDate(g.date))])
+        : el('td', {}, shortDate(g.date));
       tbody.appendChild(el('tr', { class: r ? '' : 'row-one-sided' }, [
         dateCell,
         el('td', {}, rival ? `${rival.icon} ${rival.name}` : '—'),
@@ -4215,9 +4215,9 @@
   }
   function shortDate(iso) {
     if (!iso) return '';
-    const d = new Date(iso);
+    const d = new Date(iso + 'T00:00:00');
     if (isNaN(d)) return '';
-    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
   }
 
   // Convert profile.gameHistory into { "YYYY-MM-DD": { scores: number[5], cities: {lat,lng,name}[5] } }.
@@ -4982,7 +4982,7 @@
         const diff = g.myScore - g.theirScore;
         const r = diff > 0 ? 'gw' : diff < 0 ? 'gl' : 'gt';
         list.appendChild(el('div', {}, [
-          `${fmtDateShort(g.date)} — `,
+          `${shortDate(g.date)}: `,
           el('span', { class: r }, `${g.myScore} vs ${g.theirScore}`),
           ` (Δ${diff > 0 ? '+' : ''}${diff})`,
         ]));

--- a/apps/mario-kart/js/achievements.js
+++ b/apps/mario-kart/js/achievements.js
@@ -937,7 +937,7 @@ function generateAchievementDetail(achievementKey, achievement, player) {
             day: 'numeric', 
             year: 'numeric' 
         });
-        return timeStr ? `${dateFormatted} ${timeStr}` : dateFormatted;
+        return timeStr ? `${dateFormatted}, ${timeStr}` : dateFormatted;
     };
 
     // Helper function to check if streak is active and get breaking position

--- a/apps/mario-kart/js/backup.js
+++ b/apps/mario-kart/js/backup.js
@@ -53,7 +53,7 @@ function restoreFromBackup() {
             return;
         }
 
-        const backupDate = new Date(backupData.backupDate).toLocaleString();
+        const backupDate = new Date(backupData.backupDate).toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false });
         const raceCount = backupData.races.length;
 
         // Create a beautiful confirmation modal

--- a/apps/mario-kart/js/dataManager.js
+++ b/apps/mario-kart/js/dataManager.js
@@ -174,7 +174,7 @@ function editRace(index) {
         <div style="text-align: center; margin-bottom: 1.5rem;">
             <div style="font-size: 2.5rem; margin-bottom: 0.5rem;">✏️</div>
             <h3 style="color: #e2e8f0; margin-bottom: 0.5rem; font-size: 1.5rem; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">Edit Race</h3>
-            <p style="color: #a0aec0; font-size: 0.9rem; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">${race.date}${race.timestamp ? ' ' + race.timestamp : ''}</p>
+            <p style="color: #a0aec0; font-size: 0.9rem; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">${formatDateForDisplay(race.date)}${race.timestamp ? ', ' + race.timestamp : ''}</p>
         </div>
         
         <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem;">

--- a/apps/mario-kart/js/main.js
+++ b/apps/mario-kart/js/main.js
@@ -212,12 +212,7 @@ function formatDateForDisplay(dateStr) {
         const [year, month, day] = dateStr.split('-');
         const date = new Date(parseInt(year), parseInt(month) - 1, parseInt(day));
         
-        // Format as M/D/YYYY (e.g., 8/20/2025)
-        const displayMonth = parseInt(month);
-        const displayDay = parseInt(day);
-        const displayYear = parseInt(year);
-        
-        return `${displayMonth}/${displayDay}/${displayYear}`;
+        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
     } catch (e) {
         return dateStr;
     }
@@ -1113,7 +1108,7 @@ function updateRaceHistoryTable(filteredRaces) {
         return `
         <tr>
             <td>${raceNumber}</td>
-            <td>${race.date}${race.timestamp ? '<br><small>' + race.timestamp + '</small>' : ''}</td>
+            <td>${formatDateForDisplay(race.date)}${race.timestamp ? '<br><small>' + race.timestamp + '</small>' : ''}</td>
             ${playerCells}
             <td>
                 <button class="edit-btn" onclick="editRace(${globalIndex})" title="Edit race">✏️</button>
@@ -1189,7 +1184,7 @@ function updateMobileRaceCards(filteredRaces) {
         <div class="race-card">
             <div class="race-card-header">
                 <span class="race-number">Race #${raceNumber}</span>
-                <span class="race-date">${race.date}${race.timestamp ? ' ' + race.timestamp : ''}</span>
+                <span class="race-date">${formatDateForDisplay(race.date)}${race.timestamp ? ', ' + race.timestamp : ''}</span>
             </div>
             <div class="race-positions">
                 ${playerPositions}

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -1392,7 +1392,7 @@ function hasMeaningfulChange(entry) {
 function formatBuiltAt(iso) {
   if (!iso) return 'unknown';
   const d = new Date(iso);
-  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
 function buildItem(m) {

--- a/apps/rising-seasons/scripts/render-show-page.js
+++ b/apps/rising-seasons/scripts/render-show-page.js
@@ -273,7 +273,7 @@ function renderPrimaryCtaBtn(dominantShape, dominantShapeSlug) {
 }
 
 function renderFreshnessLine(builtAt, seasonCount) {
-  const dateStr = builtAt ? new Date(builtAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) : null;
+  const dateStr = builtAt ? new Date(builtAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : null;
   const text = dateStr
     ? `Ratings refreshed ${escapeHtml(dateStr)} · ${seasonCount} season${seasonCount === 1 ? '' : 's'} indexed`
     : `Data refreshed weekly · ${seasonCount} season${seasonCount === 1 ? '' : 's'} indexed`;


### PR DESCRIPTION
## What

Standardizes every user-visible standalone date to **"Jun 4, 2026"** (abbreviated month, no leading-zero day, full year) and datetimes to **"Jun 4, 2026, 14:30"** across all six apps. Locale is pinned to en-US everywhere so output no longer varies by browser language.

**Explicitly untouched (by design):** ISO strings in localStorage, `<input type="date">` values, relative times ("2 hours ago", "yesterday", "Nd ago"), pure time-of-day displays (arena chat "14:30", gym time-of-day), and partial dates that omit the year for space (chart axes, "Week of Jun 4", "Jun 4 – Jun 15" ranges, maptap heatmap/prediction-tab labels). maptap-rivals keeps its weekday prefix ("Wed, Jun 4, 2026").

## Complete change list

### gym-tracker (6 files)
- `js/utils/helpers.js`: `formatDate('long')` month long → short ("Sunday, Jun 4, 2026"); `formatSessionDateTime` separator " • " → ", " — time portion still respects the 12/24h user setting ("Jun 4, 2026, 6:42 PM" / "Jun 4, 2026, 14:30")
- `js/utils/dark-calendar.js`: `formatDisplay()` locale pinned
- `js/views/calendar-view.js`: day-detail header → "Monday, Jun 4, 2026" (weekday kept, month abbreviated, pinned)
- `js/views/exercises-view.js`: exercise-detail best-set date lambda pinned
- `js/views/insights-view.js`: both range captions pinned (heatmap caption is a full date; volume caption stays partial by design)
- `js/views/workout-view.js`: `_absoluteDate()` pinned (feeds the program-card "Last done" hover tooltip)

### mario-kart (4 files)
- `js/main.js`: `formatDateForDisplay()` manual "8/20/2025" assembly → "Aug 20, 2025" (sidebar date + "Race date set to..." toast); race-history table cell and mobile race card were rendering **raw ISO** (`${race.date}` → "2026-06-04") — now formatted, timestamp kept as-is ("14:30:05 CDT" in `<small>` / after a comma)
- `js/dataManager.js`: Edit Race modal subtitle — same raw-ISO fix ("Jun 4, 2026, 14:30:05 CDT"); date/time inputs untouched
- `js/achievements.js`: `formatDateTime` gains comma before the time ("Ended: Jun 4, 2026, 14:30")
- `js/backup.js`: restore modal bare `toLocaleString()` → "Jun 4, 2026, 14:30" (en-US, 24h, no seconds)

### football-h2h (5 files)
- `js/football-h2h.js`: `formatDateTime` locale pinned; game-row fallback date formatted (adjacent time stays "HH:MM:SS" — it is a separate `<small>` element, deliberate); session-summary dates formatted; unused `formatDate` helper **deleted** (zero call sites)
- `js/sidebar.js`: `formatDateForDisplay()` rewritten to "Jun 4, 2026" — and the live path `updateSidebarDate()` now actually calls it (it was writing the raw input value "2026-06-04"; the helper was dead code)
- `js/playerStats.js`: `formatDateShort` "4/24/2026" → "Apr 24, 2026" (player detail, streak range labels; the stats-export object inherits the new format)
- `js/backup.js`: both restore-confirmation modals → "Jun 4, 2026, 14:30"
- `tests/playerStats.test.js`: 8 assertions updated to the new format

### maptap-rivals (1 file)
- `js/app.js`: `fmtDateShort`/`fmtDateLong`/`shortDate` locale pinned; standalone displays upgraded from "Jun 4" to full "Jun 4, 2026" via `shortDate()` (delete-game confirm, personal-stat callouts, biggest win/loss, history + rivalry table cells, matrix tooltip, modal preview); compact contexts deliberately stay "Jun 4" (trend/difference chart axes, heatmap month + row labels, prediction day tabs, season range); **bugfix**: `shortDate` parsed date-only ISO as UTC midnight, rendering a day early in negative-UTC offsets — now `new Date(iso + 'T00:00:00')`; em dash in modal preview text replaced with a colon

### arena (2 files)
- `js/app.js`: `formatRelativeDate()` >7-day fallback pinned to "Jun 4, 2026" (today/yesterday/Nd-ago branches untouched); **feature (owner-requested)**: `shareResultCard()` no longer draws a 600x340 canvas PNG with download/Web Share — it copies a plain-text standings blurb (trophy header + game type, date line, medal rows for top 3, "N." ranks after, shevato.com/apps/arena footer) via `navigator.clipboard` with a textarea fallback and a 1.2s "✓ Copied" flash; text built by pure, node-testable `buildResultShareText()`
- `index.html`: button relabeled "Share result" → "Copy result"; stale canvas comment updated

### rising-seasons (2 files)
- `js/app.js`: `formatBuiltAt` "June 4, 2026" → "Jun 4, 2026" (footer "Last updated", changelog subtitle + detail)
- `scripts/render-show-page.js`: freshness line month long → short; committed static show pages intentionally NOT regenerated — they pick up the format on the next data refresh

## Judgment calls (reviewed with owner during the round)

- gym-tracker datetimes keep the 12/24h user preference rather than forcing 24h
- Partial dates (chart axes, week/range captions, prediction tabs) keep omitting the year
- maptap table date columns widened to full dates — verified to fit at 390px
- Times with stored seconds/timezone ("14:30:00", "14:30:05 CDT") kept verbatim in standalone time elements
- gym-tracker "Last done" chip stays relative ("3 weeks ago") with the absolute date in its hover tooltip — confirmed as-is

## Testing

- `npm test`: 880/880 at HEAD
- Combined acceptance plan executed across all six apps (two full runs + targeted re-runs after each fix), 90+ assertions on desktop 1280 and mobile 390: format checks against seeded populated lists, negative assertions (no "6/4/2026", "06/04/2026", raw "2026-06-04", or "June 4, 2026" user-visible), and unchanged-by-design checks (ISO storage, inputs, relative times, partial dates)
- Two hollow first-run passes were caught and re-verified against populated/non-default states (mario-kart empty race list; football sidebar default "Today")

## Remaining manual checks (need live interaction)

1. mario-kart sidebar custom date + toast (date picker)
2. mario-kart backup-restore modal (file picker)
3. football-h2h backup-restore modal (file picker)
4. arena leaderboard "last played" >7-day date (live Firebase data)
5. arena "Copy result" clipboard paste (live finished room)
