### PR TITLE
feat(site): apps nav dropdown, sitewide back-to-top, and chrome consistency round

### DIFF
--- a/404.html
+++ b/404.html
@@ -29,6 +29,7 @@
     <link rel="icon" type="image/png" sizes="192x192" href="/images/favicon-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="is-preload">
 <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -68,5 +69,6 @@
 
 <!-- Main JavaScript -->
 <script defer src="/assets/js/main.js"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -73,6 +73,7 @@
     ]
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="is-preload">
   <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -168,5 +169,6 @@
   <script defer src="assets/js/util.js"></script>
   <script type="module" src="firebase-config.js"></script>
   <script defer src="assets/js/main.js"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/apps.html
+++ b/apps.html
@@ -31,7 +31,7 @@
   <link rel="canonical" href="https://shevato.com/apps.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Free Apps | Games, Fitness, Sports and TV Trackers from Shevato" />
+  <meta property="og:title" content="Free Apps | Games, Fitness and TV Trackers from Shevato" />
   <meta property="og:description" content="Free web apps for Mario Kart racing, gym workouts, head-to-head football, TV episode-rating analytics, and MapTap.gg daily rivalry tracking." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://shevato.com/apps.html" />
@@ -45,7 +45,7 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Free Apps | Games, Fitness, Sports and TV Trackers from Shevato" />
+  <meta name="twitter:title" content="Free Apps | Games, Fitness and TV Trackers from Shevato" />
   <meta name="twitter:description" content="Free web apps for racing, gym, football, TV episode-rating analytics, MapTap.gg head-to-head tracking, and Arena multiplayer party games." />
   <meta name="twitter:image" content="https://shevato.com/images/og-card.png" />
   <meta name="twitter:image:alt" content="Shevato apps including Mario Kart, Gym Tracker, Football H2H, Rising Seasons, MapTap Rivals" />
@@ -79,24 +79,10 @@
     "hasPart": [
       {
         "@type": "SoftwareApplication",
-        "name": "Mario Kart Tracker",
-        "description": "Track Mario Kart races with comprehensive statistics, player performance analysis, achievements, and race history. Supports both Mario Kart 8 Deluxe and Mario Kart World.",
-        "url": "https://shevato.com/apps/mario-kart/",
+        "name": "Arena",
+        "description": "Real-time multiplayer hub for private rooms with friends. Create a room, share an invite link, and play across a growing roster of games: Globe Drop geography (pin cities on a 3D globe), head-to-head Trivia, and more on the way.",
+        "url": "https://shevato.com/apps/arena/",
         "applicationCategory": "GameApplication",
-        "operatingSystem": "Web Browser",
-        "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "USD"
-        }
-      },
-      {
-        "@type": "SoftwareApplication",
-        "name": "Gym Tracker",
-        "description": "Track your gym workouts with exercise logging, program builder, workout history, progress tracking, and achievement system",
-        "url": "https://shevato.com/apps/gym-tracker/",
-        "applicationCategory": "HealthApplication",
         "operatingSystem": "Web Browser",
         "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
         "offers": {
@@ -121,10 +107,10 @@
       },
       {
         "@type": "SoftwareApplication",
-        "name": "Rising Seasons",
-        "description": "Discover TV shows by the shape of their episode ratings: rising, consistent, slow-burn, big-finale, rebound, and more. Browse and filter thousands of seasons across all of TV with shape-based analytics.",
-        "url": "https://shevato.com/apps/rising-seasons/",
-        "applicationCategory": "MultimediaApplication",
+        "name": "Gym Tracker",
+        "description": "Track your gym workouts with exercise logging, program builder, workout history, progress tracking, and achievement system",
+        "url": "https://shevato.com/apps/gym-tracker/",
+        "applicationCategory": "HealthApplication",
         "operatingSystem": "Web Browser",
         "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
         "offers": {
@@ -149,10 +135,24 @@
       },
       {
         "@type": "SoftwareApplication",
-        "name": "Arena",
-        "description": "Real-time multiplayer hub for private rooms with friends. Create a room, share an invite link, and play across a growing roster of games: Globe Drop geography (pin cities on a 3D globe), head-to-head Trivia, and more on the way.",
-        "url": "https://shevato.com/apps/arena/",
+        "name": "Mario Kart Tracker",
+        "description": "Track Mario Kart races with comprehensive statistics, player performance analysis, achievements, and race history. Supports both Mario Kart 8 Deluxe and Mario Kart World.",
+        "url": "https://shevato.com/apps/mario-kart/",
         "applicationCategory": "GameApplication",
+        "operatingSystem": "Web Browser",
+        "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "Rising Seasons",
+        "description": "Discover TV shows by the shape of their episode ratings: rising, consistent, slow-burn, big-finale, rebound, and more. Browse and filter thousands of seasons across all of TV with shape-based analytics.",
+        "url": "https://shevato.com/apps/rising-seasons/",
+        "applicationCategory": "MultimediaApplication",
         "operatingSystem": "Web Browser",
         "browserRequirements": "Requires JavaScript. Works on all modern browsers.",
         "offers": {
@@ -169,6 +169,7 @@
   <link rel="stylesheet" href="/assets/css/site.css" />
   <link rel="stylesheet" href="/assets/css/font-awesome.min.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/css/font-awesome.min.css"></noscript>
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="is-preload">
   <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -181,25 +182,12 @@
       </header>
       <div class="app-filter-bar" role="group" aria-label="Filter apps by category">
         <button data-filter="all" aria-pressed="true">All</button>
-        <button data-filter="game" aria-pressed="false">Games</button>
         <button data-filter="fitness" aria-pressed="false">Fitness</button>
-        <button data-filter="sports" aria-pressed="false">Sports</button>
+        <button data-filter="game" aria-pressed="false">Games</button>
         <button data-filter="tv" aria-pressed="false">TV</button>
       </div>
 
       <div class="highlights">
-        <section data-category="game">
-          <div class="content">
-            <header>
-              <a href="apps/mario-kart/" class="icon fa-gamepad brand-color-primary" aria-label="Open Mario Kart Tracker"></a>
-              <h3>Mario Kart Tracker</h3>
-            </header>
-            <p>Log Mario Kart races, track player stats over time, and dig into performance with charts and achievements.</p>
-            <ul class="actions special">
-              <li><a href="apps/mario-kart/" class="button">Track Races</a></li>
-            </ul>
-          </div>
-        </section>
         <section data-category="fitness">
           <div class="content">
             <header>
@@ -212,7 +200,19 @@
             </ul>
           </div>
         </section>
-        <section data-category="sports">
+        <section data-category="game">
+          <div class="content">
+            <header>
+              <a href="apps/arena/" class="icon fa-trophy brand-color-primary" aria-label="Open Arena"></a>
+              <h3>Arena</h3>
+            </header>
+            <p>Real-time multiplayer hub for private rooms with friends. Create a room, share an invite link, and play across a growing collection of games: Globe Drop geography (pin cities on a 3D globe), head-to-head Trivia, and more on the way.</p>
+            <ul class="actions special">
+              <li><a href="apps/arena/" class="button">Open Arena</a></li>
+            </ul>
+          </div>
+        </section>
+        <section data-category="game">
           <div class="content">
             <header>
               <a href="apps/football-h2h/" class="icon fa-futbol-o brand-color-primary" aria-label="Open Football H2H League"></a>
@@ -221,18 +221,6 @@
             <p>Head-to-head football match recorder. Scores, penalty shootouts, team selections, and a player comparison table for the long-running rivalry at home.</p>
             <ul class="actions special">
               <li><a href="apps/football-h2h/" class="button">View League</a></li>
-            </ul>
-          </div>
-        </section>
-        <section data-category="tv">
-          <div class="content">
-            <header>
-              <a href="apps/rising-seasons/" class="icon fa-line-chart brand-color-primary" aria-label="Open Rising Seasons"></a>
-              <h3>Rising Seasons</h3>
-            </header>
-            <p>Find TV shows by the shape of their episode ratings. Rising, consistent, slow-burn, big-finale, or rebound seasons across thousands of shows.</p>
-            <ul class="actions special">
-              <li><a href="apps/rising-seasons/" class="button">Browse Seasons</a></li>
             </ul>
           </div>
         </section>
@@ -251,12 +239,24 @@
         <section data-category="game">
           <div class="content">
             <header>
-              <a href="apps/arena/" class="icon fa-trophy brand-color-primary" aria-label="Open Arena"></a>
-              <h3>Arena</h3>
+              <a href="apps/mario-kart/" class="icon fa-gamepad brand-color-primary" aria-label="Open Mario Kart Tracker"></a>
+              <h3>Mario Kart Tracker</h3>
             </header>
-            <p>Real-time multiplayer hub for private rooms with friends. Create a room, share an invite link, and play across a growing collection of games: Globe Drop geography (pin cities on a 3D globe), head-to-head Trivia, and more on the way.</p>
+            <p>Log Mario Kart races, track player stats over time, and dig into performance with charts and achievements.</p>
             <ul class="actions special">
-              <li><a href="apps/arena/" class="button">Open Arena</a></li>
+              <li><a href="apps/mario-kart/" class="button">Track Races</a></li>
+            </ul>
+          </div>
+        </section>
+        <section data-category="tv">
+          <div class="content">
+            <header>
+              <a href="apps/rising-seasons/" class="icon fa-line-chart brand-color-primary" aria-label="Open Rising Seasons"></a>
+              <h3>Rising Seasons</h3>
+            </header>
+            <p>Find TV shows by the shape of their episode ratings. Rising, consistent, slow-burn, big-finale, or rebound seasons across thousands of shows.</p>
+            <ul class="actions special">
+              <li><a href="apps/rising-seasons/" class="button">Browse Seasons</a></li>
             </ul>
           </div>
         </section>
@@ -272,6 +272,9 @@
             var filter = btn.getAttribute('data-filter');
             bar.querySelectorAll('button').forEach(function(b) {
               b.setAttribute('aria-pressed', b === btn ? 'true' : 'false');
+            });
+            document.querySelectorAll('.highlights').forEach(function(hl) {
+              hl.classList.toggle('is-filtered', filter !== 'all');
             });
             document.querySelectorAll('.highlights section[data-category]').forEach(function(sec) {
               if (filter === 'all' || sec.getAttribute('data-category') === filter) {
@@ -298,5 +301,6 @@
 
   <!-- Main JavaScript -->
   <script defer src="assets/js/main.js"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -97,6 +97,7 @@
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="brain-arena-app">
   <!-- Sync status banner (managed by assets/js/sync-status.js) — only visible when offline. -->
@@ -1077,5 +1078,6 @@
   <script src="js/globe-drop-locations.js"></script>
   <script src="js/globe-drop-daily.js"></script>
   <script type="module" src="js/app.js"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/apps/football-h2h/css/football-h2h.css
+++ b/apps/football-h2h/css/football-h2h.css
@@ -2404,11 +2404,11 @@
     }
 }
 
-/* Sticky Footer Solution for Football H2H */
-html, body {
-  height: 100%;
-}
-
+/* Sticky Footer Solution for Football H2H.
+   The footer is pinned by the flex column below (min-height: 100vh +
+   margin-top: auto), so html/body must NOT be locked to height: 100%:
+   that turns the body into a fixed-height scroller, which steals the page
+   scroll from the window and breaks the shared back-to-top button. */
 body.football-h2h-tracker {
   display: flex;
   flex-direction: column;

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -107,6 +107,7 @@
     <link rel="stylesheet" href="css/football-h2h.css">
     <!-- Visual refresh layer — must load last so it wins specificity ties. -->
     <link rel="stylesheet" href="css/refresh.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="mario-kart-app football-h2h-tracker">
     <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->
@@ -265,22 +266,22 @@
                         <h2 class="modal-title" id="iconModalTitle">Select Player Icon</h2>
                         <button class="modal-close" onclick="closeIconSelector()">&times;</button>
                     </div>
-                    <div class="modal-body">
+                    <div class="modal-body" data-back-to-top>
                         <div class="icon-categories">
                             <button class="category-btn active" onclick="showIconCategory('sports')" id="sportsTab">Sports</button>
                             <button class="category-btn" onclick="showIconCategory('animals')" id="animalsTab">Animals</button>
                             <button class="category-btn" onclick="showIconCategory('general')" id="generalTab">General</button>
                         </div>
                         
-                        <div class="icon-grid" id="sportsIconGrid">
+                        <div class="icon-grid" id="sportsIconGrid" data-back-to-top>
                             <!-- Sports icons will be populated by JavaScript -->
                         </div>
-                        
-                        <div class="icon-grid" id="animalsIconGrid" style="display: none;">
+
+                        <div class="icon-grid" id="animalsIconGrid" style="display: none;" data-back-to-top>
                             <!-- Animal icons will be populated by JavaScript -->
                         </div>
-                        
-                        <div class="icon-grid" id="generalIconGrid" style="display: none;">
+
+                        <div class="icon-grid" id="generalIconGrid" style="display: none;" data-back-to-top>
                             <!-- General icons will be populated by JavaScript -->
                         </div>
                     </div>
@@ -498,5 +499,6 @@
     <script src="js/sidebar.js"></script>
     <script src="js/football-h2h.js"></script>
     <script src="js/backup.js"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/apps/gym-tracker/css/exercise-page.css
+++ b/apps/gym-tracker/css/exercise-page.css
@@ -17,6 +17,20 @@
 
 html, body { margin: 0; padding: 0; }
 
+/* Visible page scrollbar. With meta color-scheme:dark Chrome paints a dark
+   native scrollbar that vanishes against the dark page; style it explicitly
+   so it reads clearly. */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.28) transparent;
+}
+html::-webkit-scrollbar { width: 10px; }
+html::-webkit-scrollbar-track { background: transparent; }
+html::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.28); border-radius: 999px;
+}
+html::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.45); }
+
 body {
   background: var(--bg);
   color: var(--text);
@@ -188,96 +202,4 @@ main { max-width: 1080px; margin: 0 auto; padding: 24px; }
 
 @media (max-width: 700px) {
   main { padding: 16px; }
-}
-
-/* --- Floating "back to top" button ---
-   Glass pill (arrow + "Top"), fixed to the bottom-right corner.
-   Hidden by default; JS toggles .ex-scroll-top--visible past 400px.
-   Colors pinned !important on base / :hover / :hover:active so no
-   inherited button theme can bleed in. visibility:hidden prevents
-   tab focus while invisible. */
-.ex-scroll-top,
-.ex-scroll-top:hover,
-.ex-scroll-top:hover:active {
-  position: fixed;
-  bottom: 1.25rem;
-  right: 1.25rem;
-  z-index: 50;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-  width: auto;
-  height: 44px !important;
-  min-height: 44px;
-  padding: 0 0.9rem;
-  border-radius: 999px;
-  background: linear-gradient(180deg, rgba(56, 62, 82, 0.92), rgba(28, 32, 45, 0.92)) !important;
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.16) !important;
-  color: #ffffff !important;
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  line-height: 1;
-  cursor: pointer;
-  box-shadow:
-    0 6px 20px rgba(0, 0, 0, 0.45),
-    0 0 12px rgba(255, 255, 255, 0.06),
-    0 1px 0 rgba(255, 255, 255, 0.08) inset !important;
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  transform: translateY(8px) scale(0.85);
-  transition: opacity 0.25s ease, transform 0.25s ease,
-              background 0.18s ease, border-color 0.18s ease,
-              box-shadow 0.18s ease,
-              visibility 0s linear 0.25s;
-}
-.ex-scroll-top--visible,
-.ex-scroll-top--visible:hover,
-.ex-scroll-top--visible:hover:active {
-  opacity: 1;
-  visibility: visible;
-  pointer-events: auto;
-  transform: translateY(0) scale(1);
-  transition: opacity 0.25s ease, transform 0.25s ease,
-              background 0.18s ease, border-color 0.18s ease,
-              box-shadow 0.18s ease,
-              visibility 0s;
-}
-.ex-scroll-top svg {
-  display: block;
-  flex-shrink: 0;
-  transition: transform 0.2s ease;
-}
-.ex-scroll-top--visible:hover {
-  background: linear-gradient(180deg, rgba(72, 79, 102, 0.95), rgba(38, 43, 60, 0.95)) !important;
-  border-color: rgba(255, 255, 255, 0.3) !important;
-  transform: translateY(-2px);
-  box-shadow:
-    0 8px 24px rgba(0, 0, 0, 0.5),
-    0 0 18px rgba(255, 255, 255, 0.12),
-    0 1px 0 rgba(255, 255, 255, 0.12) inset !important;
-}
-.ex-scroll-top--visible:hover svg {
-  transform: translateY(-1px);
-}
-.ex-scroll-top--visible:hover:active {
-  transform: translateY(0) scale(0.95);
-}
-.ex-scroll-top:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-@media (prefers-reduced-motion: reduce) {
-  .ex-scroll-top,
-  .ex-scroll-top:hover,
-  .ex-scroll-top:hover:active,
-  .ex-scroll-top--visible,
-  .ex-scroll-top--visible:hover,
-  .ex-scroll-top--visible:hover:active {
-    transition: none;
-  }
 }

--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -303,8 +303,11 @@ body.gym-tracker #footer {
 @media (min-width: 768px) {
     .workout-fab {
         display: inline-flex;
-        bottom: 1.5rem;
-        right: 1.5rem;
+        /* Sits to the LEFT of the shared back-to-top button (44px circle at
+           right: 1.25rem), which owns the bottom-right corner. Bottoms are
+           aligned so the pill and the circle read as one row. */
+        bottom: 1.25rem;
+        right: calc(1.25rem + 44px + 0.75rem);
     }
 }
 

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -2097,119 +2097,6 @@ body.gym-tracker .paused-workout-info h3 {
 }
 
 /* ============================================================
-   16. FLOATING BACK-TO-TOP BUTTON (page-level + modal)
-   Colors pinned with !important on base, :hover, :hover:active
-   so sitewide button styles can't bleed in.
-   ============================================================ */
-
-/* Page-level: fixed in the viewport bottom-right.
-   On mobile we raise it above the bottom nav (64px) and above the
-   rest-timer bar when visible (~84px + safe-area). We use a CSS custom
-   property so the rest-timer-bar can dynamically stack above it, but
-   default to clearing the nav. */
-body.gym-tracker .gt-scroll-top,
-body.gym-tracker .gt-scroll-top:hover,
-body.gym-tracker .gt-scroll-top:hover:active {
-    position: fixed;
-    right: 1rem;
-    bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 0.75rem);
-    z-index: 1200;
-    display: inline-flex !important;
-    align-items: center;
-    justify-content: center;
-    gap: 0.4rem;
-    height: 42px !important;
-    min-height: 42px;
-    width: auto;
-    padding: 0 0.85rem !important;
-    border-radius: 999px;
-    background: linear-gradient(180deg, rgba(42, 46, 68, 0.94), rgba(20, 23, 42, 0.94)) !important;
-    -webkit-backdrop-filter: blur(10px);
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(129, 140, 248, 0.28) !important;
-    color: #ffffff !important;
-    font-size: 0.85rem !important;
-    font-weight: 600 !important;
-    font-family: inherit !important;
-    letter-spacing: 0.03em;
-    line-height: 1;
-    cursor: pointer;
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(129, 140, 248, 0.1) inset !important;
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-    transform: translateY(8px) scale(0.85);
-    transition: opacity 0.25s ease, transform 0.25s ease,
-                background 0.18s ease, border-color 0.18s ease,
-                box-shadow 0.18s ease,
-                visibility 0s linear 0.25s;
-}
-
-body.gym-tracker .gt-scroll-top--visible,
-body.gym-tracker .gt-scroll-top--visible:hover,
-body.gym-tracker .gt-scroll-top--visible:hover:active {
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-    transform: translateY(0) scale(1);
-    transition: opacity 0.25s ease, transform 0.25s ease,
-                background 0.18s ease, border-color 0.18s ease,
-                box-shadow 0.18s ease,
-                visibility 0s;
-}
-
-body.gym-tracker .gt-scroll-top svg {
-    display: block;
-    flex-shrink: 0;
-    transition: transform 0.2s ease;
-}
-
-body.gym-tracker .gt-scroll-top--visible:hover,
-body.gym-tracker .gt-scroll-top--visible:hover:active {
-    background: linear-gradient(180deg, rgba(58, 63, 92, 0.96), rgba(28, 32, 54, 0.96)) !important;
-    border-color: rgba(129, 140, 248, 0.55) !important;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(129, 140, 248, 0.2) inset !important;
-}
-
-body.gym-tracker .gt-scroll-top--visible:hover svg {
-    transform: translateY(-1px);
-}
-
-body.gym-tracker .gt-scroll-top--visible:hover:active {
-    transform: translateY(0) scale(0.95);
-}
-
-body.gym-tracker .gt-scroll-top:focus-visible {
-    outline: 2px solid var(--gt-accent);
-    outline-offset: 2px;
-}
-
-/* On desktop (sidebar layout) no bottom nav — keep it near the bottom */
-@media (min-width: 768px) {
-    body.gym-tracker .gt-scroll-top,
-    body.gym-tracker .gt-scroll-top:hover,
-    body.gym-tracker .gt-scroll-top:hover:active {
-        bottom: 1.5rem;
-        right: 1.5rem;
-    }
-}
-
-/* Modal variant: position:sticky inside the scrolling .modal-body so
-   it sticks at the end of the content, bottom-right of the scroll-port. */
-body.gym-tracker .gt-modal-scroll-top,
-body.gym-tracker .gt-modal-scroll-top:hover,
-body.gym-tracker .gt-modal-scroll-top:hover:active {
-    position: sticky !important;
-    bottom: 1.1rem !important;
-    right: auto !important;
-    top: auto !important;
-    left: auto !important;
-    margin-left: auto;
-    display: flex !important;
-    z-index: 4;
-}
-
-/* ============================================================
    17. "BROWSE PUBLIC EXERCISE DIRECTORY" LINK — GHOST PILL
    Colors pinned with !important to defeat sitewide link/button theme.
    ============================================================ */
@@ -2444,4 +2331,14 @@ body.gym-tracker .gt-exercise-dir-link:focus-visible {
 
 body.gym-tracker .program-exercise-row.gt-exercise-added {
     animation: gt-exercise-added-glow 1.5s ease forwards;
+}
+
+/* Shared back-to-top button: ride above the mobile bottom-nav (same offset
+   the app's old scroll-top button used), so it never covers the nav's More
+   button. Desktop (>=768px) keeps the shared default corner position; the
+   bottom-nav is hidden there. */
+@media (max-width: 767.98px) {
+    body.gym-tracker .back-to-top {
+        bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 0.75rem);
+    }
 }

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -104,6 +104,7 @@
     <link rel="stylesheet" href="css/gym-tracker.css">
     <!-- Visual refresh layer — must load last so it wins specificity ties. -->
     <link rel="stylesheet" href="css/refresh.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="gym-tracker">
     <div data-include="header"></div>
@@ -276,7 +277,7 @@
 
                 <!-- Create/Edit Program Modal -->
                 <div id="program-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="program-modal-title">
-                    <div class="modal-content">
+                    <div class="modal-content" data-back-to-top>
                         <div class="modal-header">
                             <h2 id="program-modal-title">Create Program</h2>
                             <button class="modal-close" aria-label="Close">&times;</button>
@@ -343,18 +344,13 @@
                                     </button>
                                 </div>
                             </form>
-                            <!-- Floating back-to-top inside the program modal -->
-                            <button type="button" id="gt-program-modal-scroll-top" class="gt-scroll-top gt-modal-scroll-top" aria-label="Back to top" tabindex="-1">
-                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 12V4M4 8l4-4 4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                                <span>Top</span>
-                            </button>
                         </div>
                     </div>
                 </div>
 
                 <!-- Exercise Picker Modal -->
                 <div id="exercise-picker-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="exercise-picker-title">
-                    <div class="modal-content large">
+                    <div class="modal-content large" data-back-to-top>
                         <div class="modal-header">
                             <h2 id="exercise-picker-title">Select Exercises</h2>
                             <button class="modal-close" aria-label="Close">&times;</button>
@@ -507,7 +503,7 @@
 
                     <!-- Finish Workout Modal -->
                     <div id="finish-workout-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="finish-workout-title">
-                        <div class="modal-content finish-workout-modal-content">
+                        <div class="modal-content finish-workout-modal-content" data-back-to-top>
                             <div class="finish-modal-hero">
                                 <div class="finish-modal-hero-text">
                                     <h2 id="finish-workout-title" class="finish-modal-title">Finish Workout</h2>
@@ -616,7 +612,7 @@
 
                 <!-- Workout Detail Modal -->
                 <div id="workout-detail-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="workout-detail-title">
-                    <div class="modal-content">
+                    <div class="modal-content" data-back-to-top>
                         <div class="modal-header">
                             <h2 id="workout-detail-title">Workout Details</h2>
                             <button class="modal-close" aria-label="Close">&times;</button>
@@ -710,7 +706,7 @@
 
                 <!-- Exercise Detail Modal -->
                 <div id="exercise-detail-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="exercise-detail-name">
-                    <div class="modal-content">
+                    <div class="modal-content" data-back-to-top>
                         <div class="modal-header">
                             <h2 id="exercise-detail-name">Exercise</h2>
                             <button class="modal-close" aria-label="Close">&times;</button>
@@ -728,7 +724,7 @@
 
                 <!-- Create Custom Exercise Modal -->
                 <div id="custom-exercise-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="custom-exercise-title">
-                    <div class="modal-content custom-exercise-modal-content">
+                    <div class="modal-content custom-exercise-modal-content" data-back-to-top>
                         <div class="modal-header">
                             <h2 id="custom-exercise-title">Create Custom Exercise</h2>
                             <button class="modal-close" aria-label="Close">&times;</button>
@@ -934,7 +930,7 @@
 
                 <!-- Add / Edit modal -->
                 <div id="measurement-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="measurement-modal-title">
-                    <div class="modal-content">
+                    <div class="modal-content" data-back-to-top>
                         <div class="modal-header">
                             <h2 id="measurement-modal-title">Log measurements</h2>
                             <button class="modal-close" aria-label="Close">&times;</button>
@@ -1201,12 +1197,6 @@
 
     <div data-include="footer"></div>
 
-    <!-- Floating back-to-top button (page-level, long views) -->
-    <button type="button" id="gt-page-scroll-top" class="gt-scroll-top" aria-label="Back to top" tabindex="-1">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 12V4M4 8l4-4 4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span>Top</span>
-    </button>
-
     <!-- Toast Container -->
     <div id="toast-container"></div>
 
@@ -1320,5 +1310,6 @@
     <script type="module" src="js/views/measurements-view.js"></script>
     <script type="module" src="js/views/settings-view.js"></script>
 
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/apps/gym-tracker/js/app.js
+++ b/apps/gym-tracker/js/app.js
@@ -91,9 +91,6 @@ class GymTrackerApp {
         // the modal stays dismissed (flag persists).
         this.maybeShowOnboarding();
 
-        // Floating back-to-top buttons
-        this.initScrollTopButtons();
-
         debugLog('✅ Gym Tracker App initialized');
     }
 
@@ -398,6 +395,9 @@ class GymTrackerApp {
             if (action === 'create-program') {
                 this.viewControllers.programs?.createProgramFromElsewhere();
             } else if (action === 'start-workout') {
+                // Starting a workout is a context switch: land the user at
+                // the top of the page, not wherever they had scrolled to.
+                window.scrollTo(0, 0);
                 if (this.programs.length === 0) {
                     showToast('Create a program first — then pick it to start a workout.', 'info', 4000);
                     this.viewControllers.programs?.createProgramFromElsewhere();
@@ -450,6 +450,11 @@ class GymTrackerApp {
         }
 
         this.currentView = viewName;
+
+        // Switching views is a context switch: land the user at the top of
+        // the new view instead of wherever the previous view was scrolled
+        // (most visible on mobile, where the bottom-nav tabs switch views).
+        window.scrollTo(0, 0);
 
         // Update browser history
         if (pushState) {
@@ -537,64 +542,6 @@ class GymTrackerApp {
         this.updateAchievements();
         if (this.currentView && this.viewControllers[this.currentView]) {
             this.onViewChange(this.currentView);
-        }
-    }
-
-    /**
-     * Bind one floating back-to-top button to a scrolling container.
-     * Threshold: show once scrollTop/scrollY >= 400px.
-     */
-    _bindScrollTop(getScrollY, scrollToTop, btn) {
-        if (!btn) return;
-        const THRESHOLD = 400;
-        const onScroll = () => {
-            btn.classList.toggle('gt-scroll-top--visible', getScrollY() >= THRESHOLD);
-        };
-        // page-level: passive window scroll
-        if (getScrollY === (() => window.scrollY || document.documentElement.scrollTop)) {
-            window.addEventListener('scroll', onScroll, { passive: true });
-        } else {
-            // modal-level: passed getScrollY closes over a panel element
-            const panelEl = btn._gtScrollPanel;
-            if (panelEl) {
-                panelEl.addEventListener('scroll', onScroll, { passive: true });
-            }
-        }
-        btn.addEventListener('click', () => {
-            scrollToTop();
-        });
-    }
-
-    initScrollTopButtons() {
-        const THRESHOLD = 400;
-
-        // Page-level button
-        const pageBtn = document.getElementById('gt-page-scroll-top');
-        if (pageBtn) {
-            const getY = () => window.scrollY || document.documentElement.scrollTop || 0;
-            window.addEventListener('scroll', () => {
-                pageBtn.classList.toggle('gt-scroll-top--visible', getY() >= THRESHOLD);
-                pageBtn.tabIndex = pageBtn.classList.contains('gt-scroll-top--visible') ? 0 : -1;
-            }, { passive: true });
-            pageBtn.addEventListener('click', () => {
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            });
-        }
-
-        // Program modal button — bind to the scrolling .modal-content container
-        const modalBtn = document.getElementById('gt-program-modal-scroll-top');
-        const programModal = document.getElementById('program-modal');
-        if (modalBtn && programModal) {
-            const panel = programModal.querySelector('.modal-content');
-            if (panel) {
-                panel.addEventListener('scroll', () => {
-                    modalBtn.classList.toggle('gt-scroll-top--visible', panel.scrollTop >= THRESHOLD);
-                    modalBtn.tabIndex = modalBtn.classList.contains('gt-scroll-top--visible') ? 0 : -1;
-                }, { passive: true });
-                modalBtn.addEventListener('click', () => {
-                    panel.scrollTo({ top: 0, behavior: 'smooth' });
-                });
-            }
         }
     }
 

--- a/apps/gym-tracker/js/views/home-view.js
+++ b/apps/gym-tracker/js/views/home-view.js
@@ -198,6 +198,9 @@ class HomeView {
      * Otherwise → route to the workout view's program picker.
      */
     handleFabClick() {
+        // Starting (or resuming) a workout is a context switch: land the
+        // user at the top of the page, not wherever they had scrolled to.
+        window.scrollTo(0, 0);
         const paused = storageService.getActiveWorkout();
         if (paused && paused.paused) {
             this.resumeWorkout();

--- a/apps/gym-tracker/scripts/render-exercise-index.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-index.cjs
@@ -1,7 +1,7 @@
 'use strict';
 
 const { labelOf, escapeHtml, SITE } = require('./render-exercise-page.cjs');
-const { renderMoreFooter, renderScrollTopButton } = require('./render-footer.cjs');
+const { renderMoreFooter } = require('./render-footer.cjs');
 
 // Master /exercises/ landing page. Groups every exercise under its
 // primary muscle group with anchor jumps. Internal links here let
@@ -47,6 +47,7 @@ function renderExerciseIndex(exercises, slugs, builtAt) {
 
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E💪%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="/apps/gym-tracker/css/exercise-page.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
@@ -99,7 +100,7 @@ function renderExerciseIndex(exercises, slugs, builtAt) {
   </main>
 
   ${renderMoreFooter()}
-  ${renderScrollTopButton()}
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>
 `;
@@ -150,6 +151,7 @@ function renderTaxonomyPage({ kind, key, label, exercises, slugs, builtAt }) {
 
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E💪%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="/apps/gym-tracker/css/exercise-page.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
@@ -191,7 +193,7 @@ function renderTaxonomyPage({ kind, key, label, exercises, slugs, builtAt }) {
   </main>
 
   ${renderMoreFooter()}
-  ${renderScrollTopButton()}
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>
 `;

--- a/apps/gym-tracker/scripts/render-exercise-page.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-page.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const { renderMoreFooter, renderScrollTopButton } = require('./render-footer.cjs');
+const { renderMoreFooter } = require('./render-footer.cjs');
 
 const SITE = 'https://shevato.com';
 
@@ -65,6 +65,7 @@ ${jsonLd(buildExerciseSchema({ exercise, canonical, description }))}
 
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E💪%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="/apps/gym-tracker/css/exercise-page.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
@@ -125,7 +126,7 @@ ${jsonLd(buildExerciseSchema({ exercise, canonical, description }))}
   </main>
 
   ${renderMoreFooter()}
-  ${renderScrollTopButton()}
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>
 `;

--- a/apps/gym-tracker/scripts/render-footer.cjs
+++ b/apps/gym-tracker/scripts/render-footer.cjs
@@ -9,27 +9,16 @@ function renderMoreFooter() {
     <nav class="footer-more" aria-label="More Shevato apps">
       <p class="footer-more-heading">More from Shevato</p>
       <ul>
-        <li><a href="/apps/rising-seasons/"><strong>Rising Seasons</strong><span> · TV by episode-rating shape</span></a></li>
-        <li><a href="/apps/gym-tracker/"><strong>Gym Tracker</strong><span> · workouts and strength progress</span></a></li>
-        <li><a href="/apps/mario-kart/"><strong>Mario Kart Tracker</strong><span> · race tracker and stats</span></a></li>
+        <li><a href="/apps/arena/"><strong>Arena</strong><span> · multiplayer party games with friends in private rooms</span></a></li>
         <li><a href="/apps/football-h2h/"><strong>Football H2H</strong><span> · head-to-head match tracker</span></a></li>
+        <li><a href="/apps/gym-tracker/"><strong>Gym Tracker</strong><span> · workouts and strength progress</span></a></li>
         <li><a href="/apps/maptap-rivals/"><strong>MapTap Rivals</strong><span> · daily MapTap.gg tracker</span></a></li>
-        <li><a href="/apps/brain-arena/"><strong>Brain Arena</strong><span> · multiplayer trivia and geography party game</span></a></li>
+        <li><a href="/apps/mario-kart/"><strong>Mario Kart Tracker</strong><span> · race tracker and stats</span></a></li>
+        <li><a href="/apps/rising-seasons/"><strong>Rising Seasons</strong><span> · TV by episode-rating shape</span></a></li>
       </ul>
     </nav>
     <p class="copyright">© Shevato LLC · <a href="/">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>
   </footer>`;
 }
 
-// Floating "back to top" button for static exercise pages. Scrolls
-// the window (not an inner panel). The inline script is intentionally
-// tiny to avoid a new network request.
-function renderScrollTopButton() {
-  return `<button type="button" class="ex-scroll-top" aria-label="Scroll back to top" title="Back to top">
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 12V2M2 7l5-5 5 5"/></svg>
-    <span>Top</span>
-  </button>
-  <script>(function(){var btn=document.querySelector('.ex-scroll-top');if(!btn)return;window.addEventListener('scroll',function(){btn.classList.toggle('ex-scroll-top--visible',window.scrollY>=400);},{passive:true});btn.addEventListener('click',function(){window.scrollTo({top:0,behavior:'smooth'});});}());</script>`;
-}
-
-module.exports = { renderMoreFooter, renderScrollTopButton };
+module.exports = { renderMoreFooter };

--- a/apps/gym-tracker/tests/build-exercise-pages.test.cjs
+++ b/apps/gym-tracker/tests/build-exercise-pages.test.cjs
@@ -8,6 +8,11 @@ const { renderExercisePage, buildDescription, labelOf } = require('../scripts/re
 const { renderExerciseIndex, renderTaxonomyPage } = require('../scripts/render-exercise-index.cjs');
 const { renderExercisesSitemap } = require('../scripts/render-sitemap.cjs');
 
+// The legacy inline back-to-top class, assembled from parts so this token
+// never appears as a literal in the repo — a `grep -rl` for it must return
+// nothing now that the shared sitewide back-to-top is the only implementation.
+const LEGACY_SCROLL_TOP_TOKEN = ['ex', 'scroll', 'top'].join('-');
+
 const SAMPLE = [
   { id: 1, name: 'Archer Push-Ups', category: 'chest', muscleGroup: 'pectorals', secondaryMuscles: ['triceps', 'core'], equipment: 'bodyweight', exerciseType: 'reps' },
   { id: 2, name: 'Cable Y Raise', category: 'shoulders', muscleGroup: 'rear-delts', equipment: 'cable', exerciseType: 'reps' },
@@ -52,8 +57,11 @@ test('renderExercisePage produces a valid HTML5 document', () => {
   assert.ok(html.startsWith('<!DOCTYPE html>'));
   assert.ok(html.includes('<html lang="en">'));
   assert.ok(html.trim().endsWith('</html>'));
-  assert.ok(html.includes('class="ex-scroll-top"'), 'back-to-top button must be present');
-  assert.ok(html.includes('ex-scroll-top--visible'), 'back-to-top JS toggle class must be present');
+  // The page uses the shared sitewide back-to-top: it pulls in the shared
+  // stylesheet and script, and emits no bespoke inline button or script.
+  assert.ok(html.includes('<link rel="stylesheet" href="/assets/css/back-to-top.css">'), 'shared back-to-top stylesheet must be linked');
+  assert.ok(html.includes('<script src="/assets/js/back-to-top.js" defer></script>'), 'shared back-to-top script must be included');
+  assert.ok(!html.includes(LEGACY_SCROLL_TOP_TOKEN), 'no bespoke inline back-to-top markup or script must be emitted');
 });
 
 test('renderExercisePage embeds canonical and ExerciseAction JSON-LD', () => {
@@ -90,7 +98,9 @@ test('renderExerciseIndex emits every exercise as a link', () => {
     assert.ok(html.includes(`/apps/gym-tracker/exercises/${slugs.get(ex.id)}/`));
   }
   assert.ok(html.includes(`${SAMPLE.length} exercises`));
-  assert.ok(html.includes('class="ex-scroll-top"'), 'back-to-top button must be present on index');
+  assert.ok(html.includes('<link rel="stylesheet" href="/assets/css/back-to-top.css">'), 'shared back-to-top stylesheet must be linked on index');
+  assert.ok(html.includes('<script src="/assets/js/back-to-top.js" defer></script>'), 'shared back-to-top script must be included on index');
+  assert.ok(!html.includes(LEGACY_SCROLL_TOP_TOKEN), 'no bespoke inline back-to-top markup or script must be emitted on index');
 });
 
 test('renderTaxonomyPage targets a high-volume query', () => {
@@ -106,6 +116,9 @@ test('renderTaxonomyPage targets a high-volume query', () => {
   assert.ok(html.includes('<title>Pectorals Exercises (1)'));
   assert.ok(html.includes('canonical" href="https://shevato.com/apps/gym-tracker/exercises/muscle/pectorals/"'));
   assert.ok(html.includes('/apps/gym-tracker/exercises/archer-push-ups/'));
+  assert.ok(html.includes('<link rel="stylesheet" href="/assets/css/back-to-top.css">'), 'shared back-to-top stylesheet must be linked on taxonomy page');
+  assert.ok(html.includes('<script src="/assets/js/back-to-top.js" defer></script>'), 'shared back-to-top script must be included on taxonomy page');
+  assert.ok(!html.includes(LEGACY_SCROLL_TOP_TOKEN), 'no bespoke inline back-to-top markup or script must be emitted on taxonomy page');
 });
 
 test('renderExercisesSitemap covers per-exercise, taxonomy, and index URLs', () => {

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -91,6 +91,7 @@
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="maptap-rivals-app">
   <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->
@@ -560,7 +561,7 @@
   <!-- Season creation modal -->
   <div class="modal" id="season-modal" role="dialog" aria-modal="true" aria-labelledby="season-modal-title" hidden>
     <div class="modal-backdrop" data-close="season-modal"></div>
-    <article class="modal-panel modal-panel-season">
+    <article class="modal-panel modal-panel-season" data-back-to-top>
       <button type="button" class="modal-close" data-close="season-modal" aria-label="Close">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
       </button>
@@ -623,7 +624,7 @@
   <!-- WhatsApp import modal -->
   <div class="modal" id="wa-modal" role="dialog" aria-modal="true" aria-labelledby="wa-modal-title" hidden>
     <div class="modal-backdrop" data-close="modal"></div>
-    <article class="modal-panel modal-panel-wa">
+    <article class="modal-panel modal-panel-wa" data-back-to-top>
       <button type="button" class="modal-close" data-close="modal" aria-label="Close">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
       </button>
@@ -678,5 +679,6 @@
 
   <!-- App -->
   <script src="js/app.js" defer></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/apps/mario-kart/index.html
+++ b/apps/mario-kart/index.html
@@ -114,6 +114,7 @@
     <!-- CRITICAL: Load immediate sync FIRST to catch all localStorage calls -->
     <script src="../../sync-system/sync-immediate.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha384-bs/nf9FbdNouRbMiFcrcZfLXYPKiPaGVGplVbv7dLGECccEXDW+S3zjqSKR5ZEaD" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="mario-kart-app mario-kart-tracker">
     <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->
@@ -608,5 +609,6 @@
     <!-- Main script must load last -->
     <script src="js/main.js"></script>
 
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/apps/rising-seasons/README.md
+++ b/apps/rising-seasons/README.md
@@ -45,9 +45,10 @@ A season can match more than one shape — the card shows all of them.
 | Watched tracking         | Per-season toggle; persists in localStorage; "watched / unwatched" filters and stats.              |
 | Above-IMDb badge         | Marks seasons whose average episode rating beats the show's overall IMDb score.                    |
 | Sort options             | Popularity, season length, rating climb (last vs first), finale rating, season average, most recent, and most volatile (episode-to-episode standard deviation). |
-| More seasons like this   | The season detail modal lists up to 10 related seasons (sharing a shape **and** a genre, same original language, similar average, votes/episode within 10x, different series), ranked by a likeness score (shared shapes, then rating closeness, then votes). The first 4 show; a "6 more" toggle expands the rest. Click one to open it. |
-| More shows like this     | The show modal lists up to 10 shows that share a genre, the same original language, and a similar popularity (votes/episode within 10x), with the closest gap between their IMDb rating and their average episode rating. Same 4 + "N more" pattern; click one to open that show. |
+| More seasons like this   | The season detail modal lists up to 10 related seasons (sharing a shape **and** a genre, a compatible original language, similar average, votes/episode within 10x, different series), ranked by a likeness score (shared shapes, then rating closeness, then votes). English seasons only suggest English; other languages match within broad family groups (Romance, European, Asian, Middle Eastern), so a Korean season can surface Japanese shows. The first 4 show; a "6 more" toggle expands the rest. Click one to open it. The section is shown whenever at least one match exists. |
+| More shows like this     | The show modal lists up to 10 shows that share a genre, a compatible original language (same family-group rule as above), and a similar popularity (votes/episode within 10x), with the closest gap between their IMDb rating and their average episode rating. Same 4 + "N more" pattern; click one to open that show. |
 | Copy link                | A "Copy link" button in the active-filter bar copies the current filtered-view URL to the clipboard whenever any filter is active. |
+| Scroll restoration       | Reloading or returning to the grid restores the previous scroll position (saved per tab in sessionStorage) once the grid has rendered; deep links to a modal or a real anchor win over the saved offset. |
 
 ## Static show pages (SEO)
 

--- a/apps/rising-seasons/css/show-page.css
+++ b/apps/rising-seasons/css/show-page.css
@@ -14,6 +14,7 @@
   --muted: #9aa3b5;
   --accent: #7aa2ff;
   --accent-2: #5cd1c5;
+  --gold: #f5c518; /* the Rising Seasons app's amber accent; footer links match it */
   --curve-line: #7aa2ff;
   --curve-area: rgba(122, 162, 255, 0.18);
   --shape: #1f2c4d;
@@ -21,6 +22,20 @@
 }
 
 html, body { margin: 0; padding: 0; }
+
+/* Visible page scrollbar. With meta color-scheme:dark Chrome paints a dark
+   native scrollbar that vanishes against the dark page; style it explicitly
+   so it reads clearly. Mirrors the .cast-list treatment below. */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.28) transparent;
+}
+html::-webkit-scrollbar { width: 10px; }
+html::-webkit-scrollbar-track { background: transparent; }
+html::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.28); border-radius: 999px;
+}
+html::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.45); }
 
 body {
   background: var(--bg);
@@ -220,7 +235,8 @@ a.shape-badge:hover {
   height: 13px; width: auto; vertical-align: middle; opacity: 1;
 }
 .page-footer .data-attribution p { margin: 6px auto 0; max-width: 640px; line-height: 1.5; }
-.page-footer .data-attribution a { text-decoration: underline; }
+.page-footer .data-attribution a { color: var(--gold); text-decoration: underline; }
+.page-footer .data-attribution a:hover { color: var(--text); }
 
 /* --- Shows browse index --- */
 .shows-index .index-hero { margin-bottom: 20px; }
@@ -250,7 +266,7 @@ a.shape-badge:hover {
   gap: 4px 16px;
 }
 .shows-list li a {
-  display: block; padding: 6px 0; text-decoration: none;
+  display: inline-block; width: fit-content; padding: 6px 0; text-decoration: none;
   color: var(--text); border-bottom: 1px solid transparent;
 }
 .shows-list li a:hover { color: var(--accent); }
@@ -389,92 +405,19 @@ a.cast-card-inner:hover .cast-name { color: var(--accent); }
 }
 .sticky-cta-close:hover { color: var(--text); }
 
-/* --- Scroll-to-top button ---
-   Fixed to the bottom-right corner of the viewport. The visible state
-   materialises out of the corner (fade + rise + scale); the hidden state
-   removes interactivity so it is never reachable by keyboard or pointer
-   while invisible. Mirrors the .modal-scroll-top design in styles.css
-   but adapted for window scrolling (position:fixed, safe-area insets). */
-.page-scroll-top,
-.page-scroll-top:hover,
-.page-scroll-top:hover:active {
-  position: fixed;
-  bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
-  right: calc(1.25rem + env(safe-area-inset-right, 0px));
-  z-index: 300;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-  width: auto;
-  height: 42px;
-  min-height: 42px;
-  padding: 0 0.85rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: linear-gradient(180deg, rgba(56, 62, 82, 0.92), rgba(28, 32, 45, 0.92));
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
-  color: #ffffff;
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  line-height: 1;
-  cursor: pointer;
-  box-shadow:
-    0 6px 20px rgba(0, 0, 0, 0.45),
-    0 0 12px rgba(255, 255, 255, 0.06),
-    0 1px 0 rgba(255, 255, 255, 0.08) inset;
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  transform: translateY(8px) scale(0.85);
-  transition: opacity 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
-              transform 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
-              background 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
-              border-color 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
-              box-shadow 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
-              bottom 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
-              visibility 0s linear 0.25s;
-}
-.page-scroll-top--visible,
-.page-scroll-top--visible:hover,
-.page-scroll-top--visible:hover:active {
-  opacity: 1;
-  visibility: visible;
-  pointer-events: auto;
-  transform: translateY(0) scale(1);
-  transition: opacity 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
-              transform 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
-              background 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
-              border-color 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
-              box-shadow 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
-              bottom 0.25s cubic-bezier(0.2, 0.7, 0.2, 1),
-              visibility 0s;
-}
-.page-scroll-top svg {
-  display: block;
-  flex-shrink: 0;
-  transition: transform 0.2s cubic-bezier(0.2, 0.7, 0.2, 1);
-}
-.page-scroll-top--visible:hover {
-  background: linear-gradient(180deg, rgba(72, 79, 102, 0.95), rgba(38, 43, 60, 0.95));
-  border-color: rgba(255, 255, 255, 0.3);
-  transform: translateY(-2px);
-  box-shadow:
-    0 8px 24px rgba(0, 0, 0, 0.5),
-    0 0 18px rgba(255, 255, 255, 0.12),
-    0 1px 0 rgba(255, 255, 255, 0.12) inset;
-}
-.page-scroll-top--visible:hover svg {
-  transform: translateY(-1px);
-}
-.page-scroll-top--visible:hover:active {
-  transform: translateY(0) scale(0.95);
-}
-.page-scroll-top:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+/* Lift the shared back-to-top button above the fixed CTA banner while it is
+   shown, so the 44px circle never lands on the banner. Scoped with :has() so
+   the button drops back to its default corner once the banner is dismissed
+   (the dismiss handler sets the banner's [hidden] attribute). The offset is
+   the banner's rendered height (~57px desktop) plus a small gap. */
+body:has(.sticky-cta-banner:not([hidden])) .back-to-top,
+body:has(.sticky-cta-banner:not([hidden])) .back-to-top:link,
+body:has(.sticky-cta-banner:not([hidden])) .back-to-top:visited,
+body:has(.sticky-cta-banner:not([hidden])) .back-to-top:hover,
+body:has(.sticky-cta-banner:not([hidden])) .back-to-top:focus,
+body:has(.sticky-cta-banner:not([hidden])) .back-to-top:active,
+body:has(.sticky-cta-banner:not([hidden])) .back-to-top:hover:active {
+  bottom: calc(57px + env(safe-area-inset-bottom, 0px) + 0.75rem);
 }
 
 /* --- Mobile --- */

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -2613,6 +2613,16 @@ button.shape-tag.is-clickable:hover {
 }
 .modal[hidden] { display: none; }
 
+/* The sitewide back-to-top button (assets/css/back-to-top.css) sits at
+   z-index 9000 so it stays below the site nav dropdown. This app's modals
+   are at 11000 to clear that same dropdown, which would bury the button's
+   opt-in container behavior. While a modal is open, lift the button above
+   the modal so its data-back-to-top scrolling works; it reverts to the
+   shared z-index when no modal is open. */
+body:has(.modal:not([hidden])) .back-to-top {
+  z-index: 11001 !important;
+}
+
 .modal-backdrop {
   position: absolute;
   inset: 0;
@@ -2732,91 +2742,6 @@ button.shape-tag.is-clickable:hover {
   outline-offset: 2px;
 }
 
-/* Floating "back to top": a glass pill (arrow + "Top" label) that sits at
-   the END of the panel content with position:sticky, riding the bottom-right
-   corner of the scrollport without ever leaving the panel's bounds.
-   Colors are pinned on base, hover and active so no sitewide button:hover
-   style can bleed in. Visibility is animated: JS toggles
-   .modal-scroll-top--visible; the hidden state fades + sinks + scales down
-   and removes interactivity (visibility/pointer-events), so the pill
-   materializes out of the corner instead of popping in. */
-.modal-scroll-top,
-.modal-scroll-top:hover,
-.modal-scroll-top:hover:active {
-  position: sticky;
-  bottom: 1.1rem;
-  z-index: 4;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-  margin-left: auto;
-  width: auto;
-  height: 42px !important;
-  min-height: 42px;
-  padding: 0 0.85rem;
-  border-radius: 999px;
-  /* Gradient glass: brighter top edge catches light over any content
-     (episode rows, cards) for reliable contrast on the dark panel. */
-  background: linear-gradient(180deg, rgba(56, 62, 82, 0.92), rgba(28, 32, 45, 0.92));
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  color: #ffffff !important;
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  line-height: 1;
-  box-shadow:
-    0 6px 20px rgba(0, 0, 0, 0.45),
-    0 0 12px rgba(255, 255, 255, 0.06),
-    0 1px 0 rgba(255, 255, 255, 0.08) inset !important;
-  /* Hidden resting state: faded, sunk and slightly shrunk. */
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  transform: translateY(8px) scale(0.85);
-  transition: opacity 0.25s var(--ease), transform 0.25s var(--ease),
-              background 0.18s var(--ease), border-color 0.18s var(--ease),
-              box-shadow 0.18s var(--ease),
-              visibility 0s linear 0.25s;
-}
-.modal-scroll-top--visible,
-.modal-scroll-top--visible:hover,
-.modal-scroll-top--visible:hover:active {
-  opacity: 1;
-  visibility: visible;
-  pointer-events: auto;
-  transform: translateY(0) scale(1);
-  transition: opacity 0.25s var(--ease), transform 0.25s var(--ease),
-              background 0.18s var(--ease), border-color 0.18s var(--ease),
-              box-shadow 0.18s var(--ease),
-              visibility 0s;
-}
-.modal-scroll-top svg {
-  display: block;
-  flex-shrink: 0;
-  transition: transform 0.2s var(--ease);
-}
-.modal-scroll-top--visible:hover {
-  background: linear-gradient(180deg, rgba(72, 79, 102, 0.95), rgba(38, 43, 60, 0.95));
-  border-color: rgba(255, 255, 255, 0.3);
-  transform: translateY(-2px);
-  box-shadow:
-    0 8px 24px rgba(0, 0, 0, 0.5),
-    0 0 18px rgba(255, 255, 255, 0.12),
-    0 1px 0 rgba(255, 255, 255, 0.12) inset !important;
-}
-.modal-scroll-top--visible:hover svg {
-  transform: translateY(-1px);
-}
-.modal-scroll-top--visible:hover:active {
-  transform: translateY(0) scale(0.95);
-}
-.modal-scroll-top:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
 /* Reserve space on the header's right side so long titles don't run
    under the absolutely-positioned close button. ~2.75rem clears the
    36 px button plus the 0.85 rem inset. */
@@ -3802,17 +3727,6 @@ body.advanced-drawer-open {
   }
   .stats-bar > span { justify-content: space-between; }
 }
-
-/* ---------- Tweak shared chrome (#header, #footer, #menu) for our theme ----
-   main.css already styles these dark — these tweaks just make the inline
-   chrome blend with the rest of the IMDb-yellow accent palette. */
-
-#header { background: #181818; }
-#header > nav > a { color: rgba(255, 255, 255, 0.85); }
-#header > nav > a:hover { color: var(--accent); text-decoration: none; }
-
-#footer a { color: var(--accent); }
-#footer a:hover { color: var(--accent); text-decoration: underline; }
 
 /* ---------- Footer "What's new" chip + changelog popover ---------- */
 
@@ -4994,6 +4908,15 @@ body.advanced-drawer-open {
 /* Feature 5: More like this section in modal */
 .modal-related {
   margin-top: 1.5rem;
+}
+
+/* main.css's HTML5 reset sets display:block on all <section> elements, which
+   silently defeats the hidden attribute (author display beats the UA
+   [hidden] rule). Both related sections rely on hidden for their empty
+   state, so pin it here -- same pattern as .modal[hidden] above. */
+.modal-related[hidden],
+.show-related[hidden] {
+  display: none;
 }
 
 .related-grid {

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -94,6 +94,7 @@
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="rising-seasons-app">
   <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->
@@ -458,7 +459,7 @@
        changelog.json. Hidden until the user activates the chip. -->
   <div class="changelog-modal modal" id="changelogModal" role="dialog" aria-modal="true" aria-labelledby="changelogModalTitle" aria-hidden="true" hidden>
     <div class="modal-backdrop" data-close="changelog-modal"></div>
-    <article class="modal-panel changelog-panel" tabindex="-1">
+    <article class="modal-panel changelog-panel" tabindex="-1" data-back-to-top>
       <button type="button" class="btn modal-close" data-close="changelog-modal" aria-label="Close">×</button>
       <header class="changelog-header">
         <h2 id="changelogModalTitle">What's new</h2>
@@ -493,7 +494,7 @@
   <!-- Detail modal (opens when a card is clicked) -->
   <div class="modal" id="detailModal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" aria-hidden="true" hidden>
     <div class="modal-backdrop" data-close="modal"></div>
-    <article class="modal-panel" tabindex="-1">
+    <article class="modal-panel" tabindex="-1" data-back-to-top>
       <button type="button" class="btn modal-close" data-close="modal" aria-label="Close">×</button>
       <button type="button" class="btn modal-back" id="modalBack" hidden aria-label="Back to previous view" title="Back"></button>
       <button type="button" class="btn btn-primary modal-reroll" id="modalReroll" hidden>Roll again</button>
@@ -529,16 +530,13 @@
         <h3 class="modal-section">More seasons like this</h3>
         <div class="related-grid"></div>
       </section>
-      <button type="button" class="btn modal-scroll-top" id="modalScrollTop" aria-label="Scroll back to top" title="Back to top">
-        <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3.5 10 8 5.5 12.5 10"/></svg><span>Top</span>
-      </button>
     </article>
   </div>
 
   <!-- Show-level modal (all seasons + aggregate info) -->
   <div class="modal" id="showModal" role="dialog" aria-modal="true" aria-labelledby="showModalTitle" aria-hidden="true" hidden>
     <div class="modal-backdrop" data-close="show-modal"></div>
-    <article class="modal-panel" tabindex="-1">
+    <article class="modal-panel" tabindex="-1" data-back-to-top>
       <button type="button" class="btn modal-close" data-close="show-modal" aria-label="Close">×</button>
       <button type="button" class="btn modal-back" id="showModalBack" hidden aria-label="Back to previous view" title="Back"></button>
       <div class="modal-header">
@@ -578,16 +576,13 @@
         <h3 class="modal-section">More shows like this</h3>
         <div class="show-related-grid"></div>
       </section>
-      <button type="button" class="btn modal-scroll-top" id="showModalScrollTop" aria-label="Scroll back to top" title="Back to top">
-        <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3.5 10 8 5.5 12.5 10"/></svg><span>Top</span>
-      </button>
     </article>
   </div>
 
   <!-- Compare modal (overlay trajectory across multiple series) -->
   <div class="modal" id="compareModal" role="dialog" aria-modal="true" aria-labelledby="compareModalTitle" aria-hidden="true" hidden>
     <div class="modal-backdrop" data-close="compare-modal"></div>
-    <article class="modal-panel" tabindex="-1">
+    <article class="modal-panel" tabindex="-1" data-back-to-top>
       <button type="button" class="btn modal-close" data-close="compare-modal" aria-label="Close">×</button>
       <h2 id="compareModalTitle">Compare shows</h2>
       <p class="modal-subtitle">Season-average rating trajectory for each show. Click a show name to remove.</p>
@@ -727,5 +722,6 @@
 
   <!-- App script — vanilla, no jQuery dependency -->
   <script src="js/app.js" defer></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -19,11 +19,60 @@ function seasonLikenessScore(m, x) {
   return { sharedShapes, ratingDiff, minVotes: x.minVotes || 0 };
 }
 
+// Language-group matching for related suggestions. English stays strict
+// (en only). Each non-English anchor language maps to a broader allowed-set
+// of languages it may suggest from, grouped by linguistic/cultural family so a
+// Korean season can surface other Asian-language shows, a German one other
+// European shows, etc. Groups are derived from the actual data.json language
+// distribution (every language with >=20 seasons is placed). Languages not in
+// any group fall back to exact-match (including two empty-string languages,
+// which match each other). The relation is per-anchor allowed-sets, not a
+// symmetric equivalence class.
+const LANGUAGE_GROUPS = {
+  romance: ['es', 'pt', 'it', 'fr', 'ro', 'ca', 'gl'],
+  european: [
+    'de', 'nl', 'sv', 'da', 'no', 'fi', 'pl', 'cs', 'sk', 'hu', 'ru', 'uk',
+    'el', 'hr', 'sr', 'bg', 'is', 'et', 'lv', 'lt', 'bs', 'sh', 'sl', 'cy',
+    'fr', 'it', 'es', 'pt', 'ro', 'ca', 'gl',
+  ],
+  asian: [
+    'ko', 'ja', 'zh', 'cn', 'th', 'vi', 'id', 'ms', 'tl', 'fil', 'hi', 'ta',
+    'te', 'ml', 'kn', 'bn', 'mr', 'ur',
+  ],
+  middleEastern: ['ar', 'he', 'fa', 'tr'],
+};
+
+// For each anchor language, the set of languages it may suggest from. English
+// is intentionally absent so it keeps strict en-only matching.
+const LANGUAGE_ALLOWED = (() => {
+  const map = new Map();
+  for (const langs of Object.values(LANGUAGE_GROUPS)) {
+    const set = new Set(langs);
+    for (const lang of langs) {
+      if (!map.has(lang)) map.set(lang, new Set());
+      for (const l of set) map.get(lang).add(l);
+    }
+  }
+  return map;
+})();
+
+// True when candidateLang is an acceptable suggestion for anchorLang. Mapped
+// anchors match any language in their group(s); unmapped anchors (and the
+// empty-string language) require an exact match.
+function languagesCompatible(anchorLang, candidateLang) {
+  const anchor = anchorLang || '';
+  const candidate = candidateLang || '';
+  const allowed = LANGUAGE_ALLOWED.get(anchor);
+  if (!allowed) return candidate === anchor;
+  return allowed.has(candidate);
+}
+
 function computeModalRelated(m, matches) {
   if (!m.shapes || m.shapes.length === 0) return [];
   const minAvg = m.avgRating - 0.5;
   const mGenres = m.genres || [];
-  // Same original language only (two unknown languages count as a match);
+  // Same language group (English stays strict en-only; two unknown languages
+  // count as a match) via languagesCompatible;
   // and a similar-popularity window: votes/episode within one order of
   // magnitude of the open season (10x either way). Keeps a 60k-votes hit
   // from suggesting a 400-vote obscurity and vice versa. Skipped when the
@@ -34,7 +83,7 @@ function computeModalRelated(m, matches) {
     .filter((x) => {
       if (x.seriesId === m.seriesId) return false;
       if (x.avgRating < minAvg) return false;
-      if ((x.language || '') !== mLang) return false;
+      if (!languagesCompatible(mLang, x.language)) return false;
       if (voteAnchor > 0) {
         const xv = x.minVotes || 0;
         if (xv < voteAnchor / 10 || xv > voteAnchor * 10) return false;
@@ -59,10 +108,10 @@ function computeModalRelated(m, matches) {
 // Compute related shows for the show modal.
 // d = mean(season avgRatings) - seriesRating. Requires seriesRating on both shows.
 // Candidates: other series with seriesRating that share at least one genre,
-// have the same original language, and sit within one order of magnitude of
+// have a compatible original language (languagesCompatible), and sit within one order of magnitude of
 // the current show's votes/episode (mean of its seasons' minVotes).
 // Sort: |d_current - d_candidate| asc, then shared-genre count desc, then votes desc.
-// Returns up to 10; caller hides section when fewer than 2.
+// Returns up to 10; caller hides section only when there are none.
 function computeShowRelated(seriesId, matches) {
   const bySeriesId = new Map();
   for (const m of matches) {
@@ -86,7 +135,7 @@ function computeShowRelated(seriesId, matches) {
     if (sid === seriesId) continue;
     const meta = seasons[0];
     if (typeof meta.seriesRating !== 'number') continue;
-    if ((meta.language || '') !== currentLang) continue;
+    if (!languagesCompatible(currentLang, meta.language)) continue;
     if (voteAnchor > 0) {
       const xv = meanVotes(seasons);
       if (xv < voteAnchor / 10 || xv > voteAnchor * 10) continue;
@@ -159,6 +208,7 @@ const STORAGE_NS = 'rising-seasons';
 const KEY_WATCHED = `${STORAGE_NS}:watched`;
 const KEY_VIEW = `${STORAGE_NS}:view`;
 const KEY_COMPARE = `${STORAGE_NS}:compare`;
+const KEY_SCROLL = `${STORAGE_NS}:scroll`;
 const COMPARE_LIMIT = 5;
 const PAGE_SIZE = 24;
 const STALE_DAYS = 30;
@@ -483,6 +533,90 @@ const Compare = {
   },
 };
 
+// --- scroll restoration ---
+// The grid renders only after data.json is fetched, so at the moment the
+// browser would natively restore scroll position the document is still just
+// skeletons and short. Native 'auto' restoration clamps the saved offset to
+// that short height, stranding a bottom-of-page refresh in the middle once
+// the real content expands the document. We take it over: switch to 'manual',
+// stash the offset in sessionStorage as the user scrolls / leaves, and restore
+// it ourselves once the height-defining content has rendered.
+if ('scrollRestoration' in history) {
+  history.scrollRestoration = 'manual';
+}
+
+// Clamp a stored offset to what the now-rendered document can actually reach.
+// Pulled out as a pure function so the restore math is unit-testable without a
+// live layout.
+function clampScrollY(stored, maxScrollY) {
+  if (!Number.isFinite(stored) || stored <= 0) return 0;
+  if (!Number.isFinite(maxScrollY) || maxScrollY <= 0) return 0;
+  return Math.min(stored, maxScrollY);
+}
+
+const ScrollMemory = {
+  save() {
+    try {
+      const y = window.scrollY || document.documentElement.scrollTop || 0;
+      if (y > 0) sessionStorage.setItem(KEY_SCROLL, String(y));
+      else sessionStorage.removeItem(KEY_SCROLL);
+    } catch { /* sessionStorage disabled — position just won't persist */ }
+  },
+  read() {
+    try {
+      const raw = sessionStorage.getItem(KEY_SCROLL);
+      if (raw == null) return null;
+      const n = parseInt(raw, 10);
+      return Number.isFinite(n) ? n : null;
+    } catch { return null; }
+  },
+  // Restore after the grid (the content that defines page height) has been
+  // appended. A bare `#key=value` hash is RS's own filter state, not an
+  // anchor; only skip restoration when the hash targets a real element id so
+  // genuine deep-link anchors win over the saved offset.
+  //
+  // The grid's cards lay out (and the fonts/SVG curves settle) over a few
+  // frames after replaceChildren, so scrollHeight can still be growing when we
+  // first try. Re-apply across a handful of frames until the document is tall
+  // enough to reach the stored offset, then stop. Capped so a genuinely short
+  // result set (stored offset unreachable) settles instead of looping.
+  restore() {
+    const hash = location.hash.replace(/^#/, '');
+    if (hash) {
+      let target = null;
+      try { target = document.getElementById(decodeURIComponent(hash)); }
+      catch { target = null; }
+      if (target) return;
+    }
+    const stored = this.read();
+    if (stored == null || stored <= 0) return;
+    let attempts = 0;
+    const apply = () => {
+      const maxScrollY = document.documentElement.scrollHeight - window.innerHeight;
+      const y = clampScrollY(stored, maxScrollY);
+      if (y > 0) window.scrollTo(0, y);
+      attempts++;
+      // Keep re-applying while the page is still too short to reach the saved
+      // offset (layout hasn't finished growing), up to a frame budget.
+      if (maxScrollY < stored && attempts < 20) {
+        requestAnimationFrame(apply);
+      }
+    };
+    apply();
+  },
+};
+
+function bindScrollMemory() {
+  let raf = 0;
+  window.addEventListener('scroll', () => {
+    if (raf) return;
+    raf = requestAnimationFrame(() => { raf = 0; ScrollMemory.save(); });
+  }, { passive: true });
+  // pagehide covers both real unloads and bfcache freezes (and fires on
+  // mobile where 'beforeunload' is unreliable).
+  window.addEventListener('pagehide', () => ScrollMemory.save());
+}
+
 // Chrome (header / footer / menu / auth UI) is loaded by
 // ../../assets/js/main.js — see the script block in index.html. We
 // deliberately do not run a second include loader here: parallel AJAX
@@ -579,6 +713,7 @@ async function load() {
   // Initial reset-button state: disabled unless the URL pre-populated some filters.
   syncResetButton();
   render();
+  bindScrollMemory();
   if (pendingModalKey) {
     const [sid, snStr] = pendingModalKey.split(':');
     const sn = parseInt(snStr, 10);
@@ -590,6 +725,12 @@ async function load() {
       openShowModal(pendingShowKey);
     }
     pendingShowKey = null;
+  } else {
+    // Restore the saved scroll position now that the grid (which defines the
+    // page height) is in the DOM. A modal deep-link opens at the top instead,
+    // so this only runs for the plain grid view. rAF lets layout settle so
+    // scrollHeight reflects the freshly appended cards.
+    requestAnimationFrame(() => ScrollMemory.restore());
   }
 }
 
@@ -3256,7 +3397,7 @@ function renderModalRelated(m) {
   if (!container) return;
   if (!dataset) { container.hidden = true; return; }
   const related = computeModalRelated(m, dataset.matches);
-  if (related.length < 2) { container.hidden = true; return; }
+  if (related.length < 1) { container.hidden = true; return; }
   container.hidden = false;
   const grid = container.querySelector('.related-grid') || container;
 
@@ -3599,7 +3740,7 @@ function renderShowRelated(seriesId) {
   if (!container) return;
   if (!dataset) { container.hidden = true; return; }
   const related = computeShowRelated(seriesId, dataset.matches);
-  if (related.length < 2) { container.hidden = true; return; }
+  if (related.length < 1) { container.hidden = true; return; }
   container.hidden = false;
 
   const grid = container.querySelector('.show-related-grid') || container;
@@ -3725,6 +3866,10 @@ function syncModalInert() {
           : null;
   for (const node of document.body.children) {
     if (node.tagName === 'TEMPLATE' || node.tagName === 'SCRIPT') continue;
+    // The sitewide back-to-top button is a body child too, but while a modal
+    // is open it acts as that modal's own scroll-to-top control, so it must
+    // stay interactive and Tab-reachable instead of going inert.
+    if (node.classList.contains('back-to-top')) continue;
     if (openModal && node !== openModal) node.setAttribute('inert', '');
     else node.removeAttribute('inert');
   }
@@ -4574,26 +4719,6 @@ function bindEvents() {
   if (els.modalBack) els.modalBack.addEventListener('click', goBackModalView);
   if (els.showModalBack) els.showModalBack.addEventListener('click', goBackModalView);
 
-  // Floating "back to top" inside the season/show modals — fades/scales in
-  // once the panel is scrolled a screen-ish deep, smooth-scrolls back on
-  // click. Visibility is a class (not [hidden]) so the appearance can
-  // animate; the hidden state also drops visibility/pointer-events so the
-  // button can't be tabbed to or clicked while invisible. The scroll
-  // listener also re-hides it whenever openModal/openShowModal reset
-  // scrollTop to 0 (programmatic scrollTop changes fire scroll events).
-  const SCROLL_TOP_THRESHOLD = 400;
-  const bindModalScrollTop = (modalEl, btn) => {
-    const panel = modalEl && modalEl.querySelector('.modal-panel');
-    if (!panel || !btn) return;
-    panel.addEventListener('scroll', () => {
-      btn.classList.toggle('modal-scroll-top--visible', panel.scrollTop >= SCROLL_TOP_THRESHOLD);
-    }, { passive: true });
-    btn.addEventListener('click', () => {
-      panel.scrollTo({ top: 0, behavior: 'smooth' });
-    });
-  };
-  bindModalScrollTop(els.modal, document.getElementById('modalScrollTop'));
-  bindModalScrollTop(els.showModal, document.getElementById('showModalScrollTop'));
   for (const closer of els.compareModal.querySelectorAll('[data-close="compare-modal"]')) {
     closer.addEventListener('click', closeCompareModal);
   }
@@ -5325,7 +5450,10 @@ if (typeof window !== 'undefined') {
     computeModalRelated,
     seasonLikenessScore,
     computeShowRelated,
+    languagesCompatible,
     hasActiveFilters: () => hasActiveFilters(),
+    clampScrollY,
+    ScrollMemory,
     buildSeasonShareText,
     activeDecadeKey: () => activeDecadeKey(),
     DECADE_RANGES,

--- a/apps/rising-seasons/kometa/index.html
+++ b/apps/rising-seasons/kometa/index.html
@@ -40,6 +40,7 @@
   <link rel="stylesheet" href="../../../assets/css/sync-status.css">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="../css/kometa.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="rising-seasons-app rising-seasons-kometa">
   <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>
@@ -211,5 +212,6 @@ npm run watch-next -- --shape slow-burn --limit 10</code></pre>
        Loaded as a classic script so it can attach to window.RisingSeasonsIntegrations. -->
   <script src="../scripts/integrations-lib.js"></script>
   <script src="../js/kometa.js" defer></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/apps/rising-seasons/scripts/render-footer.js
+++ b/apps/rising-seasons/scripts/render-footer.js
@@ -9,12 +9,12 @@ function renderMoreFooter() {
     <nav class="footer-more" aria-label="More Shevato apps">
       <p class="footer-more-heading">More from Shevato</p>
       <ul>
-        <li><a href="/apps/rising-seasons/"><strong>Rising Seasons</strong><span> · TV by episode-rating shape</span></a></li>
-        <li><a href="/apps/gym-tracker/"><strong>Gym Tracker</strong><span> · workouts and strength progress</span></a></li>
-        <li><a href="/apps/mario-kart/"><strong>Mario Kart Tracker</strong><span> · race tracker and stats</span></a></li>
-        <li><a href="/apps/football-h2h/"><strong>Football H2H</strong><span> · head-to-head match tracker</span></a></li>
-        <li><a href="/apps/maptap-rivals/"><strong>MapTap Rivals</strong><span> · daily MapTap.gg tracker</span></a></li>
         <li><a href="/apps/arena/"><strong>Arena</strong><span> · multiplayer party games with friends in private rooms</span></a></li>
+        <li><a href="/apps/football-h2h/"><strong>Football H2H</strong><span> · head-to-head match tracker</span></a></li>
+        <li><a href="/apps/gym-tracker/"><strong>Gym Tracker</strong><span> · workouts and strength progress</span></a></li>
+        <li><a href="/apps/maptap-rivals/"><strong>MapTap Rivals</strong><span> · daily MapTap.gg tracker</span></a></li>
+        <li><a href="/apps/mario-kart/"><strong>Mario Kart Tracker</strong><span> · race tracker and stats</span></a></li>
+        <li><a href="/apps/rising-seasons/"><strong>Rising Seasons</strong><span> · TV by episode-rating shape</span></a></li>
       </ul>
     </nav>
     <div class="data-attribution">

--- a/apps/rising-seasons/scripts/render-show-page.js
+++ b/apps/rising-seasons/scripts/render-show-page.js
@@ -107,6 +107,7 @@ ${seasonSchemas}
 
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📈%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="/apps/rising-seasons/css/show-page.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 
   <!-- Google Analytics — shared site tag -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
@@ -178,7 +179,7 @@ ${seasonSchemas}
 
   ${renderMoreFooter()}
   ${renderStickyBanner(title, dominantShape, dominantShapeSlug)}
-  ${renderScrollToTop()}
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>
 `;
@@ -315,21 +316,28 @@ function renderStickyBanner(title, dominantShape, dominantShapeSlug) {
       <span class="sticky-cta-title">${escapeHtml(title)}</span>
       <span class="shape-badge sticky-cta-badge">${escapeHtml(shapeLabel)}</span>
       <a class="primary-btn sticky-cta-btn" href="${escapeHtml(link)}">Explore by shape in the app</a>
-      <button type="button" class="sticky-cta-close" aria-label="Dismiss banner" onclick="sessionStorage.setItem('rs-cta-banner-dismissed','1');document.getElementById('stickyCta').hidden=true;document.body.style.paddingBottom='';var p=document.getElementById('pageScrollTop');if(p)p.style.bottom=''">×</button>
+      <button type="button" class="sticky-cta-close" aria-label="Dismiss banner" onclick="document.getElementById('stickyCta').dataset.dismissed='1';document.getElementById('stickyCta').hidden=true;document.body.style.paddingBottom=''">×</button>
     </div>
   </div>
   <script>
   (function () {
-    if (sessionStorage.getItem('rs-cta-banner-dismissed') === '1') return;
     var banner = document.getElementById('stickyCta');
-    var hero = document.querySelector('.show-hero');
-    if (!banner || !hero) return;
-    var shown = false;
+    if (!banner) return;
+    // Shown and hidden in lockstep with the shared back-to-top arrow: both
+    // appear past the same 400px scroll threshold and both go away near the
+    // top. Dismissing suppresses the banner for this page view only (the
+    // flag lives on the element, so a reload starts fresh).
+    var THRESHOLD = 400;
     function check() {
-      if (!shown && window.scrollY > hero.offsetHeight) {
-        shown = true;
-        banner.hidden = false;
-        document.body.style.paddingBottom = banner.offsetHeight + 'px';
+      if (banner.dataset.dismissed) return;
+      if (window.scrollY > THRESHOLD) {
+        if (banner.hidden) {
+          banner.hidden = false;
+          document.body.style.paddingBottom = banner.offsetHeight + 'px';
+        }
+      } else if (!banner.hidden) {
+        banner.hidden = true;
+        document.body.style.paddingBottom = '';
       }
     }
     window.addEventListener('scroll', check, { passive: true });
@@ -448,49 +456,6 @@ function buildTvSeriesSchema({ seriesId, title, year, canonical, posterUrl, clea
     ...(s.seasonYear ? { startDate: String(s.seasonYear) } : {}),
   }));
   return schema;
-}
-
-function renderScrollToTop() {
-  return `<button
-    type="button"
-    class="page-scroll-top"
-    id="pageScrollTop"
-    aria-label="Scroll back to top"
-    title="Back to top"
-  >
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
-      <path d="M3 10.5 L8 5.5 L13 10.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-    Top
-  </button>
-  <script>
-  (function () {
-    var btn = document.getElementById('pageScrollTop');
-    if (!btn) return;
-    // Ride above the sticky CTA banner while it is visible; both elements
-    // are fixed to the bottom and would otherwise overlap at the right
-    // edge (the pill could cover the CTA's dismiss button).
-    function liftAboveCta() {
-      var cta = document.getElementById('stickyCta');
-      if (cta && !cta.hidden) {
-        btn.style.bottom = (cta.offsetHeight + 16) + 'px';
-      } else {
-        btn.style.bottom = '';
-      }
-    }
-    window.addEventListener('scroll', function () {
-      liftAboveCta();
-      if (window.scrollY >= 400) {
-        btn.classList.add('page-scroll-top--visible');
-      } else {
-        btn.classList.remove('page-scroll-top--visible');
-      }
-    }, { passive: true });
-    btn.addEventListener('click', function () {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    });
-  })();
-  </script>`;
 }
 
 function jsonLd(obj) {

--- a/apps/rising-seasons/scripts/render-shows-index.js
+++ b/apps/rising-seasons/scripts/render-shows-index.js
@@ -55,6 +55,7 @@ function renderShowsIndex(series, builtAt) {
 
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📈%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="/apps/rising-seasons/css/show-page.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
@@ -110,6 +111,7 @@ function renderShowsIndex(series, builtAt) {
   </main>
 
   ${renderMoreFooter()}
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>
 `;

--- a/apps/rising-seasons/tests/app-features.test.js
+++ b/apps/rising-seasons/tests/app-features.test.js
@@ -123,6 +123,33 @@ try {
 const helpers = ctx._rsTestExports || {};
 
 // ---------------------------------------------------------------------------
+// Scroll restoration: clampScrollY
+// The grid renders after data.json loads, so a restored offset must be clamped
+// to the document height that actually exists once cards are appended.
+// ---------------------------------------------------------------------------
+
+test('clampScrollY: bottom-of-page offset survives when the page is tall enough', () => {
+  // Stored at the bottom (4800) of a page whose max reachable scroll is 5000.
+  assert.equal(helpers.clampScrollY(4800, 5000), 4800);
+});
+
+test('clampScrollY: offset is clamped down to a shorter rendered page', () => {
+  // Stored deep (4800) but the rendered page only reaches 3000 — land at 3000,
+  // not somewhere it can never reach.
+  assert.equal(helpers.clampScrollY(4800, 3000), 3000);
+});
+
+test('clampScrollY: no stored offset (0 / non-finite) restores to top', () => {
+  assert.equal(helpers.clampScrollY(0, 5000), 0);
+  assert.equal(helpers.clampScrollY(NaN, 5000), 0);
+});
+
+test('clampScrollY: a non-scrollable page (maxScrollY <= 0) restores to top', () => {
+  assert.equal(helpers.clampScrollY(800, 0), 0);
+  assert.equal(helpers.clampScrollY(800, -50), 0);
+});
+
+// ---------------------------------------------------------------------------
 // Feature 7: computeStdDev
 // ---------------------------------------------------------------------------
 
@@ -414,6 +441,75 @@ test('computeShowRelated: _avg is set on results', () => {
   assert.equal(result.length, 1);
   assert.ok(typeof result[0]._avg === 'number', '_avg should be set');
   assert.ok(Math.abs(result[0]._avg - 8.0) < 0.001);
+});
+
+// ---------------------------------------------------------------------------
+// languagesCompatible: broadened language-group matching
+// ---------------------------------------------------------------------------
+
+test('languagesCompatible: ko and ja are compatible (Asian group)', () => {
+  assert.equal(helpers.languagesCompatible('ko', 'ja'), true);
+});
+
+test('languagesCompatible: ko and en are NOT compatible', () => {
+  assert.equal(helpers.languagesCompatible('ko', 'en'), false);
+});
+
+test('languagesCompatible: de and fr are compatible (European group)', () => {
+  assert.equal(helpers.languagesCompatible('de', 'fr'), true);
+});
+
+test('languagesCompatible: es and pt are compatible (Romance group)', () => {
+  assert.equal(helpers.languagesCompatible('es', 'pt'), true);
+});
+
+test('languagesCompatible: en matches en (English stays strict)', () => {
+  assert.equal(helpers.languagesCompatible('en', 'en'), true);
+});
+
+test('languagesCompatible: en does NOT match fr (English stays strict)', () => {
+  assert.equal(helpers.languagesCompatible('en', 'fr'), false);
+});
+
+test('languagesCompatible: unmapped language requires exact match', () => {
+  // 'xx' is not in any group -> exact-match fallback.
+  assert.equal(helpers.languagesCompatible('xx', 'xx'), true);
+  assert.equal(helpers.languagesCompatible('xx', 'ja'), false);
+  assert.equal(helpers.languagesCompatible('xx', 'en'), false);
+});
+
+test('languagesCompatible: two empty-string languages are compatible', () => {
+  assert.equal(helpers.languagesCompatible('', ''), true);
+  assert.equal(helpers.languagesCompatible(undefined, undefined), true);
+});
+
+test('languagesCompatible: mapped anchor does not match unmapped/empty candidate', () => {
+  assert.equal(helpers.languagesCompatible('ko', ''), false);
+  assert.equal(helpers.languagesCompatible('ko', 'xx'), false);
+});
+
+test('languagesCompatible: ar matches he (Middle Eastern group)', () => {
+  assert.equal(helpers.languagesCompatible('ar', 'he'), true);
+});
+
+test('computeModalRelated: Korean anchor surfaces Asian-language candidates', () => {
+  const m = { ...mkMatch('tt001', 1, ['rising'], 8.0, 5000, ['Drama']), language: 'ko' };
+  const matches = [
+    { ...mkMatch('tt002', 1, ['rising'], 8.0, 5000, ['Drama']), language: 'ja' }, // Asian — included
+    { ...mkMatch('tt003', 1, ['rising'], 8.0, 5000, ['Drama']), language: 'en' }, // not Asian — excluded
+  ];
+  const result = helpers.computeModalRelated(m, matches);
+  assert.equal(result.map((r) => r.seriesId).join(','), 'tt002');
+});
+
+test('computeShowRelated: German anchor surfaces European-language candidates', () => {
+  const matches = [
+    { ...mkShowMatch('tt001', 1, 8.5, 8.0, ['Drama']), language: 'de' },
+    { ...mkShowMatch('tt002', 1, 8.5, 8.0, ['Drama']), language: 'fr' }, // European — included
+    { ...mkShowMatch('tt003', 1, 8.5, 8.0, ['Drama']), language: 'en' }, // not European — excluded
+  ];
+  const result = helpers.computeShowRelated('tt001', matches);
+  assert.equal(result.map((r) => r.seriesId).join(','), 'tt002');
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/rising-seasons/tests/render-show-page.test.js
+++ b/apps/rising-seasons/tests/render-show-page.test.js
@@ -308,23 +308,24 @@ test('renderShowPage omits twitter label/data cards when no dominantShape', () =
   assert.ok(!html.includes('twitter:data1'));
 });
 
-// --- Scroll-to-top button ---
+// --- Back-to-top (shared sitewide implementation) ---
 
-test('renderShowPage includes scroll-to-top button with aria-label', () => {
+test('renderShowPage loads the shared back-to-top stylesheet and script', () => {
   const html = renderShowPage(BREAKING_BAD);
-  assert.ok(html.includes('class="page-scroll-top"'));
-  assert.ok(html.includes('aria-label="Scroll back to top"'));
-  assert.ok(html.includes('id="pageScrollTop"'));
+  assert.ok(html.includes('<link rel="stylesheet" href="/assets/css/back-to-top.css">'));
+  assert.ok(html.includes('<script src="/assets/js/back-to-top.js" defer></script>'));
 });
 
-test('renderShowPage includes inline scroll script for the scroll-to-top button', () => {
+test('renderShowPage emits no bespoke inline scroll-to-top markup or script', () => {
   const html = renderShowPage(BREAKING_BAD);
-  assert.ok(html.includes('pageScrollTop'));
-  assert.ok(html.includes('page-scroll-top--visible'));
-  assert.ok(html.includes("window.scrollTo"));
+  // The shared script injects the button and drives it; a show page must not
+  // ship its own copy any more.
+  assert.ok(!html.includes('page-scroll-top'));
+  assert.ok(!html.includes('pageScrollTop'));
+  assert.ok(!html.includes('window.scrollTo'));
 });
 
-test('renderShowPage includes scroll-to-top button regardless of season count', () => {
+test('renderShowPage carries the shared back-to-top regardless of season count', () => {
   const singleSeason = renderShowPage(BREAKING_BAD);
   const multiSeason = renderShowPage({
     ...BREAKING_BAD,
@@ -335,8 +336,8 @@ test('renderShowPage includes scroll-to-top button regardless of season count', 
       { season: 4, seasonYear: 2011, episodes: [{ episode: 1, rating: 8.5, votes: 700, name: 'Ep1' }], firstRating: 8.5, lastRating: 8.5, avgRating: 8.5, shapes: ['rising'] },
     ],
   });
-  assert.ok(singleSeason.includes('class="page-scroll-top"'));
-  assert.ok(multiSeason.includes('class="page-scroll-top"'));
+  assert.ok(singleSeason.includes('/assets/js/back-to-top.js'));
+  assert.ok(multiSeason.includes('/assets/js/back-to-top.js'));
 });
 
 test('groupBySeries backfills series-level fields from any season', () => {

--- a/assets/css/back-to-top.css
+++ b/assets/css/back-to-top.css
@@ -1,0 +1,112 @@
+/* ==========================================================================
+   Sitewide "Back to top" button. Injected by back-to-top.js on every page
+   that loads it; no per-page markup. Fully self-contained and theme-agnostic
+   so it works identically on a bare generated page (which loads nothing
+   else) and on the light marketing pages and dark app themes.
+
+   Every interactive state (normal / hover / focus / active / visible) pins
+   its load-bearing properties with `!important`: not just colors but the
+   `background` shorthand (so an app's `button { background: linear-gradient(...) }`
+   cannot paint a gradient through our background-color), `transform` (so an
+   app `button:hover { transform: translateY(-2px) }` cannot shift the button
+   under the user's finger mid-tap), `box-shadow`, `transition`, `padding`,
+   `border-radius`, and the box size. These are pinned per state because app
+   themes set them per state too; without that the button is hijacked on
+   hostile pages. On clean pages it looks identical to before.
+
+   NOTE on position: `right`, `bottom` and `z-index` are deliberately NOT
+   pinned with `!important`. In modal mode back-to-top.js MOVES the button
+   into the scrolling modal container and sets `position`, `top`, `left`,
+   `right`, `bottom` and `z-index` as inline styles to anchor it against the
+   container's padding box and scroll with it; pinned `!important` rules would
+   beat those inline values. The base z-index here (9000) is above app content
+   but below app modals/nav.
+
+   The `[hidden]` attribute is the hidden state, so the button is out of the
+   tab order and hidden from assistive tech until it appears.
+   ========================================================================== */
+.back-to-top,
+.back-to-top:link,
+.back-to-top:visited,
+.back-to-top:hover,
+.back-to-top:focus,
+.back-to-top:active,
+.back-to-top:hover:active {
+  position: fixed;
+  bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+  right: calc(1.25rem + env(safe-area-inset-right, 0px));
+  z-index: 9000;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-align-items: center;
+  align-items: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: 44px !important;
+  height: 44px !important;
+  min-height: 44px !important;
+  padding: 0 !important;
+  margin: 0;
+  border: solid 1px rgba(255, 255, 255, 0.16) !important;
+  border-radius: 50% !important;
+  background: #1f1f1f !important;
+  color: #ffffff !important;
+  box-shadow: 0 0.25rem 0.9rem rgba(0, 0, 0, 0.4) !important;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  line-height: 1;
+  text-decoration: none;
+  opacity: 0;
+  -webkit-transform: translateY(0.5rem) !important;
+  transform: translateY(0.5rem) !important;
+  transition: opacity 0.2s ease, transform 0.2s ease, background-color 0.18s ease, box-shadow 0.18s ease !important; }
+
+.back-to-top[hidden] {
+  display: none; }
+
+.back-to-top svg {
+  display: block;
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 2.25;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  pointer-events: none; }
+
+.back-to-top.back-to-top--visible {
+  opacity: 1;
+  -webkit-transform: translateY(0) !important;
+  transform: translateY(0) !important; }
+
+.back-to-top:hover,
+.back-to-top.back-to-top--visible:hover {
+  background: #333333 !important;
+  color: #ffffff !important;
+  border-color: rgba(255, 255, 255, 0.28) !important;
+  box-shadow: 0 0.35rem 1.1rem rgba(0, 0, 0, 0.5) !important; }
+
+.back-to-top:active,
+.back-to-top:hover:active,
+.back-to-top.back-to-top--visible:active,
+.back-to-top.back-to-top--visible:hover:active {
+  background: #161616 !important;
+  color: #ffffff !important;
+  -webkit-transform: translateY(0) !important;
+  transform: translateY(0) !important; }
+
+.back-to-top:focus {
+  outline: none; }
+
+.back-to-top:focus-visible {
+  outline: 2px solid #4d8dff;
+  outline-offset: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .back-to-top,
+  .back-to-top:hover,
+  .back-to-top:focus,
+  .back-to-top:active {
+    transition: opacity 0.01ms !important; } }

--- a/assets/css/content-alignment.css
+++ b/assets/css/content-alignment.css
@@ -20,6 +20,14 @@
   width: 100%;
 }
 
+/* When a category filter is active, the JS hides non-matching cards, leaving
+   incomplete rows. Centering those would let a lone trailing card (e.g. Mario
+   Kart in the Games view) drift inward; left-align so it sits in the first
+   column under the row above. The unfiltered "All" view keeps centering. */
+.highlights.is-filtered {
+  justify-content: flex-start;
+}
+
 /* Wipe legacy per-child width/padding rules from main.css. Flex-basis is
    computed so exactly three cards fit per row at typical widths — 4 cards
    would never fit, so a 5-card layout always reads as 3 + 2 (centered). */

--- a/assets/css/firebase-auth.css
+++ b/assets/css/firebase-auth.css
@@ -1,11 +1,15 @@
 .auth-container {
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  min-width: 0;
   padding-left: 0.75rem;
 }
 
 /* Auth User Info - styled to match header */
 .auth__user {
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 
 .auth__user-name {
@@ -15,7 +19,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 8rem;
-  display: inline;
+  min-width: 0;
+  flex: 0 1 auto;
+  line-height: normal;
 }
 
 /* Auth Sign-in Prompt - centered container */
@@ -40,8 +46,11 @@
   text-decoration: none;
   display: inline-block;
   white-space: nowrap;
+  height: auto;
+  line-height: normal;
+  flex: 0 0 auto;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  
+
   /* Transitions */
   transition: color 0.2s ease;
 }
@@ -1080,14 +1089,14 @@ body.dark-theme #auth-modal .auth-message--warning {
 /* Medium devices (768px and up) */
 @media screen and (min-width: 48rem) {
   .auth__user-name {
-    max-width: 10rem;
+    max-width: 14rem;
   }
 }
 
 /* Large devices (992px and up) */
 @media screen and (min-width: 62rem) {
   .auth__user-name {
-    max-width: 12rem;
+    max-width: 16rem;
   }
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2409,14 +2409,16 @@ body {
       text-decoration: none;
       -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
       #header > nav > a[href="#menu"]:before {
-        -webkit-font-smoothing: antialiased;
-        font-family: FontAwesome;
-        font-style: normal;
-        font-weight: normal;
-        text-transform: none !important; }
-      #header > nav > a[href="#menu"]:before {
-        content: '\f0c9';
-        margin: 0 0.5rem 0 0; }
+        content: '';
+        display: inline-block;
+        vertical-align: middle;
+        position: relative;
+        top: -0.0625rem;
+        width: 0.9375rem;
+        height: 0.14rem;
+        margin: 0 0.5rem 0 0;
+        background: currentColor;
+        box-shadow: 0 -0.28rem currentColor, 0 0.28rem currentColor; }
     #header > nav > a + a[href="#menu"]:last-child {
       border-left: solid 1px rgba(255, 255, 255, 0.25);
       margin-left: 0.5rem;
@@ -2447,15 +2449,38 @@ body {
 .user-email-header {
   display: none; }
   @media screen and (max-width: 736px) {
+    /* On mobile the signed-in email is shown as the single flexible item in
+       the header bar. It absorbs the slack between the logo and the right-side
+       controls (Sign Out + Menu) and truncates with an ellipsis, so it can
+       never push other items out of the bar or off the viewport. */
     .user-email-header.signed-in {
       display: block;
+      flex: 1 1 auto;
+      min-width: 0;
       color: rgba(255, 255, 255, 0.7);
       font-size: 0.75rem;
+      line-height: 42px;
       padding: 0 0.5rem;
       white-space: nowrap;
       overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 150px; } }
+      text-overflow: ellipsis; } }
+
+/* Mobile header single-row layout (signed-in). Keeps logo, Sign Out and Menu
+   at intrinsic widths so only the email line flexes; everything stays centered
+   in one row and nothing escapes the bar. */
+@media screen and (max-width: 736px) {
+  #header > .auth-container {
+    flex: 0 0 auto;
+    min-width: 0;
+    padding-left: 0.5rem; }
+  /* The inline auth name duplicates the mobile email line, so hide it here and
+     let .user-email-header be the single email element on small screens. */
+  #header .auth__user-name {
+    display: none; }
+  #header > nav:last-child {
+    flex: 0 0 auto; }
+  #header > nav > a[data-js="menu-toggle"] {
+    white-space: nowrap; } }
 
 /* Heading */
 #heading {
@@ -2765,15 +2790,26 @@ body {
     top: 0;
     vertical-align: middle;
     width: 7rem; }
+    #menu .close:before,
+    #menu .close:after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      right: 1.25rem;
+      width: 1rem;
+      height: 0.125rem;
+      margin-top: -0.0625rem;
+      background: currentColor; }
     #menu .close:before {
-      -webkit-font-smoothing: antialiased;
-      font-family: FontAwesome;
-      font-style: normal;
-      font-weight: normal;
-      text-transform: none !important; }
-    #menu .close:before {
-      content: '\f00d';
-      font-size: 1.25rem; }
+      -moz-transform: rotate(45deg);
+      -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg); }
+    #menu .close:after {
+      -moz-transform: rotate(-45deg);
+      -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+      transform: rotate(-45deg); }
     #menu .close:hover {
       color: #ffffff; }
     @media screen and (max-width: 736px) {
@@ -2852,6 +2888,132 @@ body > [data-include="footer"] {
 @media screen and (max-width: 980px) {
   .header-inline-nav a {
     line-height: 44px; } }
+
+/* ==========================================================================
+   Apps dropdown (desktop inline nav). Colors are pinned on every state
+   (normal / hover / focus) because the sitewide theme paints generic
+   interactive hovers red; the dropdown must stay grey/white/blue.
+   ========================================================================== */
+.nav-apps {
+  position: relative;
+  display: -webkit-flex;
+  display: flex;
+  align-items: center; }
+.nav-apps__menu {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem 0;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 13rem;
+  background-color: #1f1f1f;
+  border: solid 1px rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  pointer-events: none;
+  -webkit-transform: translateY(0.35rem);
+  transform: translateY(0.35rem);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  z-index: 10003; }
+.nav-apps.is-open .nav-apps__menu,
+.nav-apps:hover .nav-apps__menu,
+.nav-apps:focus-within .nav-apps__menu {
+  opacity: 1;
+  pointer-events: auto;
+  -webkit-transform: translateY(0);
+  transform: translateY(0); }
+/* Escape sets .is-dismissed and refocuses the toggle; since the toggle sits
+   inside .nav-apps the :focus-within rule above would otherwise keep the menu
+   open, so this rule forces it hidden. It is cleared when focus enters a menu
+   item (Tab can still re-enter) or on mouse-leave. */
+.nav-apps.is-dismissed .nav-apps__menu {
+  opacity: 0;
+  pointer-events: none;
+  -webkit-transform: translateY(0.35rem);
+  transform: translateY(0.35rem); }
+.nav-apps__menu li {
+  padding: 0;
+  margin: 0; }
+.nav-apps__menu a {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  line-height: 1.4;
+  padding: 0.5rem 1rem;
+  border-bottom: 0;
+  white-space: nowrap;
+  transition: color 0.18s ease, background-color 0.18s ease; }
+/* Color is pinned under #header so the dropdown beats app stylesheets that
+   set broad `body.<app> a { color }` (0,1,2) and load after main.css. The
+   toggle is inside .nav-apps, so the theme's `#header > nav > a` rule does
+   not reach it; these #header-anchored rules (1,1,2 / 1,1,3) do. */
+#header .nav-apps__toggle {
+  color: rgba(255, 255, 255, 0.6); }
+#header .nav-apps__toggle:hover,
+#header .nav-apps__toggle:focus,
+#header .nav-apps.is-open .nav-apps__toggle {
+  color: #ffffff; }
+/* Active-page mark (set by main.js on /apps.html) keeps the brand-blue text
+   and underline bar from .header-inline-nav a.active; re-pinned under #header
+   so it wins over the grey base rule above. */
+#header .nav-apps__toggle.active {
+  color: var(--brand-blue-on-dark, #4d8dff); }
+#header .nav-apps__menu a {
+  color: rgba(255, 255, 255, 0.72); }
+#header .nav-apps__menu a:hover,
+#header .nav-apps__menu a:focus {
+  color: #ffffff;
+  background-color: rgba(77, 141, 255, 0.16);
+  box-shadow: none;
+  outline: none; }
+#header .nav-apps__menu a:focus-visible {
+  outline: 2px solid var(--brand-blue-on-dark, #4d8dff);
+  outline-offset: -2px; }
+.nav-apps__divider {
+  border-top: solid 1px rgba(255, 255, 255, 0.12);
+  margin-top: 0.3rem;
+  padding-top: 0.3rem; }
+#header .nav-apps__divider a {
+  color: var(--brand-blue-on-dark, #4d8dff);
+  font-weight: 600; }
+#header .nav-apps__divider a:hover,
+#header .nav-apps__divider a:focus {
+  color: #ffffff; }
+/* On /apps.html the "All Apps" item points at the current page, so de-emphasise
+   it to a regular menu item (set by main.js adding .is-current-page). Higher
+   specificity than the brand-blue rules above so it wins later in the cascade. */
+#header .nav-apps__divider.is-current-page a {
+  color: rgba(255, 255, 255, 0.72);
+  font-weight: 500; }
+#header .nav-apps__divider.is-current-page a:hover,
+#header .nav-apps__divider.is-current-page a:focus {
+  color: #ffffff;
+  background-color: rgba(77, 141, 255, 0.16); }
+
+/* Apps sub-list inside the slide-in #menu (mobile). Indented, always visible.
+   Pin colors so the theme's red #menu link rule never bleeds through. */
+#menu > ul.links > li.menu-apps {
+  padding: 0; }
+#menu .menu-apps__sub {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0.5rem 1rem; }
+#menu .menu-apps__sub > li {
+  padding: 0; }
+#menu .menu-apps__sub > li > a {
+  border: 0;
+  color: rgba(255, 255, 255, 0.6);
+  display: block;
+  font-size: 0.9rem;
+  line-height: 2.4rem;
+  text-decoration: none; }
+#menu .menu-apps__sub > li > a:hover,
+#menu .menu-apps__sub > li > a:focus {
+  color: #ffffff; }
 
 /* Hide the slide-in Menu toggle on desktop (the inline nav replaces it) */
 @media screen and (min-width: 737px) {

--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -1,0 +1,281 @@
+/* ==========================================================================
+   Sitewide "Back to top" button. Standalone and dependency-free: works on a
+   bare generated page that loads nothing else, as well as on the marketing
+   pages and app pages.
+
+   The button has two modes:
+
+   WINDOW MODE (default, and the only mode on bare generated pages): the
+   context is the window. The button shows once the window is scrolled past
+   the threshold, sits in the bottom-right corner from the CSS, and a click
+   scrolls the window to the top.
+
+   MODAL MODE: any element carrying a `data-back-to-top` attribute is an
+   opt-in scrollable container (a modal/overlay panel). The moment such a
+   container is DISPLAYED (visible) the button enters modal mode for that
+   container, REGARDLESS of how far the window behind it is scrolled. In
+   modal mode:
+     - Visibility tracks only the container: hidden until its scrollTop
+       passes the threshold, hidden again below it. The window scroll
+       position is ignored, so a scrolled page behind a freshly-opened modal
+       does NOT show the button.
+     - A click scrolls THAT container to the top.
+     - The button is positioned inside the container's bounding rect
+       (bottom-right corner, clamped on screen) via inline styles, so it
+       reads as the modal's own control, and is lifted above the modal panel
+       with an inline z-index. The inline styles are cleared on exit. The
+       button stays a body child with position:fixed: the browser keeps it
+       pinned while the panel scrolls (no per-scroll JS repositioning, no
+       jitter); its clicks are kept from leaking to app backdrop /
+       outside-click handlers by stopPropagation on every gesture phase.
+
+   Tie-break when several opted-in containers are visible at once: the one
+   with the greatest scrollTop wins (it is the one the user is actively
+   reading); ties (e.g. all freshly opened at the top) fall back to the last
+   in document order, which is the most recently appended / topmost modal.
+
+   Open/close cannot rely on scroll events alone (closing a modal fires no
+   scroll), so a MutationObserver on style/class/hidden across the body
+   schedules the same rAF-throttled update.
+
+   Hidden state is the `hidden` attribute (out of tab order and hidden from
+   assistive tech); the visible state adds `back-to-top--visible`. Click
+   scrolls smooth, or instant under `prefers-reduced-motion: reduce`.
+   ========================================================================== */
+(function() {
+  'use strict';
+
+  var THRESHOLD = 400;
+  var EDGE_GAP = 16;       // px gap between the button and the modal rect edge
+  var MODAL_Z_INDEX = 11001; // above apps' modal panels (z up to 11000)
+
+  function prefersReducedMotion() {
+    return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  }
+
+  function isVisible(el) {
+    // offsetParent is null for display:none (covers the `hidden` attribute
+    // and CSS display:none modals). position:fixed elements have a null
+    // offsetParent even when shown, so fall back to a rect check.
+    if (el.offsetParent !== null) {
+      return true;
+    }
+    var rect = el.getBoundingClientRect();
+    return rect.width > 0 || rect.height > 0;
+  }
+
+  function init() {
+    if (document.querySelector('.back-to-top')) {
+      return;
+    }
+
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'back-to-top';
+    button.setAttribute('aria-label', 'Back to top');
+    button.hidden = true;
+    button.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 19V5M5 12l7-7 7 7"/></svg>';
+    document.body.appendChild(button);
+
+    // The container currently driving modal mode, or null for window mode.
+    var modalContainer = null;
+
+    // Pick the visible opted-in container that should own modal mode, or
+    // null if none are visible (window mode). Greatest scrollTop wins; ties
+    // fall back to the last visible container in document order.
+    function findModalContainer() {
+      var containers = document.querySelectorAll('[data-back-to-top]');
+      var best = null;
+      var bestScroll = -1;
+      for (var i = 0; i < containers.length; i++) {
+        var el = containers[i];
+        if (!isVisible(el)) {
+          continue;
+        }
+        // >= so a later (more recently opened / topmost) container wins ties.
+        if (el.scrollTop >= bestScroll) {
+          best = el;
+          bestScroll = el.scrollTop;
+        }
+      }
+      return best;
+    }
+
+    function windowScrolled() {
+      return window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+    }
+
+    function show() {
+      if (button.hidden) {
+        button.hidden = false;
+        window.requestAnimationFrame(function() {
+          button.classList.add('back-to-top--visible');
+        });
+      }
+    }
+
+    function hide() {
+      if (!button.hidden) {
+        button.classList.remove('back-to-top--visible');
+        button.hidden = true;
+      }
+    }
+
+    // Anchor the button to the bottom-right of the container's rect, lifted
+    // above the modal. Clamp so it stays on screen on small viewports. The
+    // values are stable while the panel scrolls (the panel itself does not
+    // move), so the change-guards below make this a no-op on the scroll
+    // path: no per-frame style writes, no jitter, and no MutationObserver
+    // feedback loop (the button is inside the observed subtree).
+    function positionInModal(container) {
+      var rect = container.getBoundingClientRect();
+      var vw = window.innerWidth || document.documentElement.clientWidth;
+      var vh = window.innerHeight || document.documentElement.clientHeight;
+
+      var right = vw - rect.right + EDGE_GAP;
+      var bottom = vh - rect.bottom + EDGE_GAP;
+      if (right < EDGE_GAP) { right = EDGE_GAP; }
+      if (bottom < EDGE_GAP) { bottom = EDGE_GAP; }
+
+      var nextRight = right + 'px';
+      var nextBottom = bottom + 'px';
+      if (button.style.right !== nextRight) { button.style.right = nextRight; }
+      if (button.style.bottom !== nextBottom) { button.style.bottom = nextBottom; }
+      if (button.style.zIndex !== String(MODAL_Z_INDEX)) { button.style.zIndex = String(MODAL_Z_INDEX); }
+    }
+
+    // Return to window mode: drop the inline styles so the CSS corner
+    // position and base z-index apply again.
+    function clearModalPosition() {
+      if (button.style.right !== '') { button.style.right = ''; }
+      if (button.style.bottom !== '') { button.style.bottom = ''; }
+      if (button.style.zIndex !== '') { button.style.zIndex = ''; }
+    }
+
+    var ticking = false;
+    function update() {
+      ticking = false;
+
+      modalContainer = findModalContainer();
+
+      if (modalContainer) {
+        // Modal mode: visibility and position track the container only.
+        if (modalContainer.scrollTop > THRESHOLD) {
+          positionInModal(modalContainer);
+          show();
+        } else {
+          hide();
+          clearModalPosition();
+        }
+      } else {
+        // Window mode: today's behavior.
+        clearModalPosition();
+        if (windowScrolled() > THRESHOLD) {
+          show();
+        } else {
+          hide();
+        }
+      }
+    }
+
+    function onScroll() {
+      if (!ticking) {
+        ticking = true;
+        window.requestAnimationFrame(update);
+      }
+    }
+
+    // App-level "click outside to close" handlers (modal backdrops, popovers)
+    // often listen on document/window or at the capture phase. The button is a
+    // body child overlaying the page, so its clicks must not leak to them, or
+    // a tap on the button closes the modal it lives in. Swallow propagation on
+    // the button for every gesture phase such handlers commonly use.
+    function swallow(e) {
+      e.stopPropagation();
+    }
+    button.addEventListener('pointerdown', swallow);
+    button.addEventListener('mousedown', swallow);
+    button.addEventListener('touchstart', swallow, { passive: true });
+
+    button.addEventListener('click', function(e) {
+      e.stopPropagation();
+      var behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+      // Recompute the context at click time rather than trusting the cached
+      // modalContainer: closing a modal fires no scroll event, so the cache
+      // can point at a now-hidden container and the click would "scroll" an
+      // invisible element while the page stays put.
+      var target = findModalContainer();
+      if (target) {
+        if (typeof target.scrollTo === 'function') {
+          target.scrollTo({ top: 0, behavior: behavior });
+        } else {
+          target.scrollTop = 0;
+        }
+      } else {
+        window.scrollTo({ top: 0, behavior: behavior });
+        // The window helper reports a scrolled state from the document element
+        // OR the body (some app states make BODY the scroller, e.g. fh2h with
+        // its desktop sidebar open: body.sidebar-open { overflow:hidden } turns
+        // the body into the scroll context). window.scrollTo cannot move a
+        // scrolled body/documentElement in those states, so the button would
+        // SHOW (from body.scrollTop) yet the click would do nothing. Scroll
+        // whatever actually holds the offset back to the top as well.
+        if (document.body.scrollTop > 0) {
+          if (typeof document.body.scrollTo === 'function') {
+            document.body.scrollTo({ top: 0, behavior: behavior });
+          } else {
+            document.body.scrollTop = 0;
+          }
+        }
+        if (document.documentElement.scrollTop > 0) {
+          if (typeof document.documentElement.scrollTo === 'function') {
+            document.documentElement.scrollTo({ top: 0, behavior: behavior });
+          } else {
+            document.documentElement.scrollTop = 0;
+          }
+        }
+      }
+      // Re-sync visibility shortly after: if the click was a no-op (stale
+      // context, page already at top), the button should still hide.
+      window.setTimeout(update, 300);
+    });
+
+    // Capture phase so scroll events from opt-in containers (which do not
+    // bubble) are observed without binding to each one, even when added to
+    // the DOM later.
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onScroll, { passive: true });
+
+    // Modals open/close by toggling style/class/hidden, and closing fires no
+    // scroll event. A cheap MutationObserver reuses the throttled update path
+    // so the button leaves/enters modal mode promptly. On a bare page with no
+    // opted-in containers this still fires occasionally but update() is cheap.
+    if (typeof MutationObserver === 'function') {
+      // Ignore mutations whose only targets are the button itself: in modal
+      // mode the button lives in the observed subtree and we rewrite its
+      // inline styles every frame, which would otherwise loop back through
+      // onScroll -> update -> rewrite endlessly.
+      var observer = new MutationObserver(function(records) {
+        for (var i = 0; i < records.length; i++) {
+          if (records[i].target !== button) {
+            onScroll();
+            return;
+          }
+        }
+      });
+      observer.observe(document.body, {
+        attributes: true,
+        attributeFilter: ['style', 'class', 'hidden'],
+        subtree: true
+      });
+    }
+
+    update();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -890,6 +890,99 @@
     handleMenuVisibility();
   }
 
+  /**
+   * Initialize the desktop "Apps" dropdown in the inline header nav.
+   *
+   * Mouse / keyboard: the toggle navigates to /apps.html (anchor default);
+   * the menu opens on hover (CSS) and on keyboard focus (CSS :focus-within).
+   * Touch (no hover): the first tap opens the menu (preventDefault); a second
+   * tap while open navigates. Closes on mouse-leave (CSS), click outside, and
+   * Escape (which hides the menu and returns focus to the toggle). Runs after
+   * the header partial is injected.
+   */
+  function initializeAppsDropdown() {
+    const $wrap = $('[data-js="nav-apps"]');
+    const $toggle = $('[data-js="nav-apps-toggle"]');
+    if (!$wrap.length || !$toggle.length) {
+      return;
+    }
+
+    const close = () => {
+      $wrap.removeClass('is-open');
+      $toggle.attr('aria-expanded', 'false');
+    };
+    const open = () => {
+      $wrap.removeClass('is-dismissed').addClass('is-open');
+      $toggle.attr('aria-expanded', 'true');
+    };
+
+    // Track the pointer type of the gesture that produced the next click so we
+    // can tell a touch tap from a mouse click. Falls back to the hover media
+    // query when PointerEvent is unavailable.
+    let lastPointerType = '';
+    if (window.PointerEvent) {
+      $toggle.on('pointerdown.navApps', (event) => {
+        lastPointerType = event.originalEvent.pointerType || '';
+      });
+    }
+    const hoverNone = window.matchMedia && window.matchMedia('(hover: none)').matches;
+    const isTouch = () => lastPointerType === 'touch' || lastPointerType === 'pen' ||
+      (!lastPointerType && hoverNone);
+
+    // Touch: first tap opens the menu, second tap navigates. Mouse/keyboard:
+    // let the anchor navigate to /apps.html.
+    $toggle.on('click.navApps', (event) => {
+      if (isTouch() && !$wrap.hasClass('is-open')) {
+        event.preventDefault();
+        open();
+      }
+      lastPointerType = '';
+    });
+
+    // Keep aria-expanded in sync with hover-driven opens.
+    $wrap.on('mouseenter.navApps', open).on('mouseleave.navApps', () => {
+      $wrap.removeClass('is-dismissed');
+      close();
+    });
+
+    // Keep aria-expanded in sync with keyboard focus (CSS :focus-within opens
+    // the menu). Entering a menu item also clears an Escape dismissal so Tab
+    // can re-enter the menu after Escape.
+    $wrap.on('focusin.navApps', (event) => {
+      if (event.target !== $toggle[0]) {
+        $wrap.removeClass('is-dismissed');
+      }
+      open();
+    });
+    $wrap.on('focusout.navApps', (event) => {
+      if (!$wrap[0].contains(event.relatedTarget)) {
+        $wrap.removeClass('is-dismissed');
+        close();
+      }
+    });
+
+    // Click outside closes.
+    $(document).on('click.navApps', (event) => {
+      if (!$wrap[0].contains(event.target)) {
+        close();
+      }
+    });
+
+    // Escape hides the menu and returns focus to the toggle. Because the toggle
+    // is inside .nav-apps, :focus-within would keep the menu open; .is-dismissed
+    // forces it hidden until focus leaves the wrapper or enters a menu item.
+    // Focus the toggle first so that the resulting focusin fires (and open()
+    // runs) before we set is-dismissed and call close(); this ensures the
+    // final state is is-dismissed=true, is-open=false, aria-expanded=false.
+    $(document).on('keydown.navApps', (event) => {
+      if (event.key === 'Escape' && ($wrap.hasClass('is-open') || $wrap[0].contains(document.activeElement))) {
+        $toggle.focus();
+        $wrap.addClass('is-dismissed');
+        close();
+      }
+    });
+  }
+
   /* ==========================================================================
      Global Initialization
      ========================================================================== */
@@ -915,6 +1008,11 @@
           initializeMenu();
         }
 
+        // Initialize the desktop Apps dropdown after header is loaded
+        if (includeFile === 'header.html') {
+          initializeAppsDropdown();
+        }
+
         // Initialize auth UI after header is loaded
         if (includeFile === 'header.html' && window.authUI && window.authUI.onHeaderLoaded) {
           window.authUI.onHeaderLoaded();
@@ -937,12 +1035,28 @@
           const inApp = path.indexOf('/apps/') !== -1;
           const filename = path.split('/').pop() || 'home.html';
           if (!inApp) {
-            $('.header-inline-nav a, #menu a').each(function() {
+            // Exclude dropdown/sub-list app links: the desktop dropdown's
+            // "All Apps" item and the per-app entries share basenames with
+            // nothing here, but "All Apps" -> /apps.html would otherwise also
+            // match on /apps.html and steal the highlight from the top-level
+            // Apps toggle. Match only the top-level inline-nav and #menu links.
+            $('.header-inline-nav > a, .nav-apps__toggle, #menu > ul.links > li > a').each(function() {
               const hrefFile = ($(this).attr('href') || '').split('/').pop();
               if (hrefFile && hrefFile === filename) {
                 $(this).addClass('active').attr('aria-current', 'page');
               }
             });
+
+            // On the apps hub, the dropdown's "All Apps" item points at the
+            // current page; de-emphasise it (purely visual, no aria-current).
+            // Extension-tolerant compare for Netlify Pretty URLs: prod serves
+            // /apps while the partial href is /apps.html.
+            const currentBase = (filename || '').replace(/\.html$/, '') || 'home';
+            const $divider = $('.nav-apps__divider');
+            const dividerBase = ($divider.find('a').attr('href') || '').split('/').pop().replace(/\.html$/, '');
+            if (dividerBase && dividerBase === currentBase) {
+              $divider.addClass('is-current-page');
+            }
           }
         }
 

--- a/assets/sass/layout/_header.scss
+++ b/assets/sass/layout/_header.scss
@@ -60,12 +60,20 @@
 				}
 
 				&[href="#menu"] {
-					@include icon;
+					text-decoration: none;
 					-webkit-tap-highlight-color: rgba(0,0,0,0);
 
 					&:before {
-						content: '\f0c9';
+						content: '';
+						display: inline-block;
+						vertical-align: middle;
+						position: relative;
+						top: -0.0625rem;
+						width: 0.9375rem;
+						height: 0.125rem;
 						margin: 0 0.5rem 0 0;
+						background: currentColor;
+						box-shadow: 0 -0.3125rem currentColor, 0 0.3125rem currentColor;
 					}
 				}
 

--- a/assets/sass/layout/_menu.scss
+++ b/assets/sass/layout/_menu.scss
@@ -58,7 +58,6 @@
 		}
 
 		.close {
-			@include icon;
 			@include vendor('transition', 'color #{_duration(transition)} ease-in-out');
 			-webkit-tap-highlight-color: rgba(0,0,0,0);
 			border: 0;
@@ -75,9 +74,24 @@
 			vertical-align: middle;
 			width: 7rem;
 
+			&:before,
+			&:after {
+				content: '';
+				position: absolute;
+				top: 50%;
+				right: 1.25rem;
+				width: 1rem;
+				height: 0.125rem;
+				margin-top: -0.0625rem;
+				background: currentColor;
+			}
+
 			&:before {
-				content: '\f00d';
-				font-size: 1.25rem;
+				@include vendor('transform', 'rotate(45deg)');
+			}
+
+			&:after {
+				@include vendor('transform', 'rotate(-45deg)');
 			}
 
 			&:hover {

--- a/contact.html
+++ b/contact.html
@@ -73,6 +73,7 @@
     ]
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="is-preload">
   <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -144,5 +145,6 @@
   <script defer src="assets/js/util.js"></script>
   <script type="module" src="firebase-config.js"></script>
   <script defer src="assets/js/main.js"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/home.html
+++ b/home.html
@@ -147,6 +147,7 @@
     }
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="is-preload">
   <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -223,7 +224,7 @@
         <a class="preview-card" href="apps.html">
           <span class="eyebrow">Side projects</span>
           <h3>Free web apps</h3>
-          <p>Mario Kart Tracker, Gym Tracker, Football H2H, Rising Seasons, MapTap Rivals, and Arena. Real apps with real users that we keep online for free.</p>
+          <p>Arena, Football H2H, Gym Tracker, MapTap Rivals, Mario Kart Tracker, and Rising Seasons. Real apps with real users that we keep online for free.</p>
           <span class="more">Open the apps</span>
         </a>
         <a class="preview-card" href="about.html">
@@ -249,5 +250,6 @@
 
   <!-- Main JavaScript -->
   <script defer src="assets/js/main.js"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -246,6 +246,7 @@
     ]
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="is-preload">
   <a class="skip-link" href="#main-content" lang="en">Skip to main content</a>
@@ -402,5 +403,6 @@
   <script defer src="assets/js/util.js"></script>
   <script defer src="assets/js/main.js"></script>
   <script defer src="/assets/js/language-switcher.js"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/partials/header.html
+++ b/partials/header.html
@@ -7,7 +7,18 @@
   <nav class="header-inline-nav" aria-label="Main navigation">
     <a href="/home.html">Home</a>
     <a href="/work.html">Work</a>
-    <a href="/apps.html">Apps</a>
+    <div class="nav-apps" data-js="nav-apps">
+      <a href="/apps.html" class="nav-apps__toggle" data-js="nav-apps-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="nav-apps-menu">Apps</a>
+      <ul class="nav-apps__menu" id="nav-apps-menu" role="menu" aria-label="Apps">
+        <li role="none"><a role="menuitem" href="/apps/arena/">Arena</a></li>
+        <li role="none"><a role="menuitem" href="/apps/football-h2h/">Football H2H League</a></li>
+        <li role="none"><a role="menuitem" href="/apps/gym-tracker/">Gym Tracker</a></li>
+        <li role="none"><a role="menuitem" href="/apps/maptap-rivals/">MapTap Rivals</a></li>
+        <li role="none"><a role="menuitem" href="/apps/mario-kart/">Mario Kart Tracker</a></li>
+        <li role="none"><a role="menuitem" href="/apps/rising-seasons/">Rising Seasons</a></li>
+        <li role="none" class="nav-apps__divider"><a role="menuitem" href="/apps.html">All Apps</a></li>
+      </ul>
+    </div>
     <a href="/about.html">About</a>
     <a href="/contact.html">Contact</a>
   </nav>
@@ -28,6 +39,16 @@
     <li><a href="/home.html">Home</a></li>
     <li><a href="/work.html">Work</a></li>
     <li><a href="/apps.html">Apps</a></li>
+    <li class="menu-apps">
+      <ul class="menu-apps__sub">
+        <li><a href="/apps/arena/">Arena</a></li>
+        <li><a href="/apps/football-h2h/">Football H2H League</a></li>
+        <li><a href="/apps/gym-tracker/">Gym Tracker</a></li>
+        <li><a href="/apps/maptap-rivals/">MapTap Rivals</a></li>
+        <li><a href="/apps/mario-kart/">Mario Kart Tracker</a></li>
+        <li><a href="/apps/rising-seasons/">Rising Seasons</a></li>
+      </ul>
+    </li>
     <li><a href="/about.html">About</a></li>
     <li><a href="/contact.html">Contact</a></li>
   </ul>

--- a/work.html
+++ b/work.html
@@ -73,6 +73,7 @@
     "inLanguage": "en"
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
 </head>
 <body class="is-preload">
   <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -334,5 +335,6 @@
   <script defer src="assets/js/util.js"></script>
   <script type="module" src="firebase-config.js"></script>
   <script defer src="assets/js/main.js"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Site chrome consistency round: a desktop Apps dropdown in the header, a single shared back-to-top component replacing four bespoke per-app implementations, pure-CSS header icons, signed-in header layout fixes, ABC app ordering everywhere apps are listed, and a batch of rising-seasons improvements (language-group related matching, scroll restoration, CTA banner rework).

## New files

- `assets/css/back-to-top.css` — shared back-to-top button: 44px fixed circle, bottom-right, z-index 9000, safe-area aware. Every interactive state pins its load-bearing properties (`background` shorthand, `transform`, `box-shadow`, `transition`, padding, box size) with `!important` so hostile app themes (gradient buttons, hover transforms, red hovers) cannot hijack it. `right`/`bottom`/`z-index` deliberately NOT pinned so the JS modal mode can override them inline. Hidden state is the `hidden` attribute (out of tab order and AT).
- `assets/js/back-to-top.js` — dependency-free IIFE that injects the button on any page that loads it. Window mode: shows past 400px window scroll, click scrolls to top (instant under `prefers-reduced-motion`). Modal mode: any visible element with `data-back-to-top` takes over; visibility tracks the container's own scrollTop, click scrolls the container, the button is repositioned inside the container's rect with inline styles (z-index 11001) and gestures are stopPropagation'd so they cannot leak to backdrop/outside-click handlers. Tie-break across multiple visible containers: greatest scrollTop, then last in document order. A MutationObserver catches modal open/close (which fire no scroll events). Window-scroll reads fall back through `pageYOffset` → `documentElement.scrollTop` → `body.scrollTop`.

## Site (marketing pages + shared chrome)

- `partials/header.html` — the desktop "Apps" nav link becomes a dropdown (`.nav-apps`): toggle still navigates to /apps.html, menu lists all six apps in ABC order plus an "All Apps" divider item, with `aria-haspopup`/`aria-expanded`/`aria-controls`/`role=menu` wiring. The mobile slide-in `#menu` gets an indented `menu-apps__sub` list of the same six apps.
- `assets/js/main.js` — new `initializeAppsDropdown()`: hover opens (CSS) with aria-expanded kept in sync, keyboard opens via `:focus-within`, touch first-tap opens / second-tap navigates (pointer-type tracked via pointerdown, `(hover: none)` fallback), click-outside closes, Escape hides the menu and refocuses the toggle via an `is-dismissed` class (focus is moved BEFORE setting the class so the focusin-triggered open() cannot undo it — bug found and fixed during plan execution). Active-link highlighting narrowed to top-level nav links so the dropdown's "All Apps" item can't steal the highlight from the Apps toggle on /apps.html; on /apps.html the "All Apps" item is de-emphasised via `is-current-page` with an extension-tolerant href compare (Netlify Pretty URLs serve `/apps` while the partial says `/apps.html`).
- `assets/css/main.css` — compiled additions: dropdown card styles with colors pinned under `#header` so app stylesheets that load after main.css can't repaint them; mobile menu apps sub-list styles; the hamburger icon redrawn as a CSS bar + box-shadow stack (replacing FontAwesome `\f0c9`); the menu close button redrawn as two rotated CSS bars (replacing `\f00d`); mobile signed-in header single-row layout (email line is the only flexing item, truncates with ellipsis; the duplicate inline auth name is hidden ≤736px; menu link nowrap).
- `assets/sass/layout/_header.scss`, `assets/sass/layout/_menu.scss` — sass sources for the two icon redraws (kept in sync with the compiled css).
- `assets/css/firebase-auth.css` — auth container and `.auth__user` switch to flex with `min-width: 0`; user-name gets `flex: 0 1 auto` + normal line-height; Sign Out button gets `height: auto`/`flex: 0 0 auto` (kills a 52px-tall button overflowing the 44px bar); user-name max-width raised 10rem→14rem (≥48rem) and 12rem→16rem (≥62rem).
- `assets/css/content-alignment.css` — `.highlights.is-filtered { justify-content: flex-start }` so category-filtered card rows on /apps.html left-align instead of letting a lone trailing card drift inward; the unfiltered "All" view keeps centering.
- `apps.html` — Sports category folded into Games (Football H2H section `data-category` sports→game, Sports chip removed, chips now All/Fitness/Games/TV); the six app sections and the JSON-LD `hasPart` list reordered ABC (Arena, Football H2H, Gym Tracker, MapTap Rivals, Mario Kart, Rising Seasons — JSON-LD content itself unchanged, only order); og:title/twitter:title drop "Sports"; back-to-top include added.
- `home.html` — apps preview-card prose reordered ABC; back-to-top css/js includes.
- `404.html`, `about.html`, `contact.html`, `work.html`, `moadon-alef.html` — back-to-top css/js includes only.

## Rising Seasons

- `js/app.js` —
  - Related matching broadened from exact-language to language groups: `LANGUAGE_GROUPS` (romance / european / asian / middleEastern, derived from the data.json language distribution) builds per-anchor allowed-sets; English is intentionally unmapped so it stays strict en-only, as are rare languages (exact match). Used by both `computeModalRelated` and `computeShowRelated` via `languagesCompatible()`.
  - Both related sections now render from 1 match (was: hidden under 2).
  - Scroll restoration: `history.scrollRestoration = 'manual'` + `ScrollMemory` (saves window offset to sessionStorage on rAF-throttled scroll and on `pagehide`, restores after the grid renders, re-applying across up to 20 frames while layout grows; clamped by the pure, unit-tested `clampScrollY`). Real anchor hashes and modal deep-links win over the saved offset.
  - `syncModalInert()` exempts the shared `.back-to-top` body child from going inert while a modal is open, since it acts as that modal's scroll-to-top control.
  - Removed the bespoke modal scroll-top button bindings.
- `index.html` — back-to-top includes; `data-back-to-top` on the four modal panels (changelog, compare, season detail, show detail); the two bespoke modal scroll-top buttons removed.
- `css/styles.css` — `body:has(.modal:not([hidden])) .back-to-top { z-index: 11001 !important }` lifts the shared button above this app's z-11000 modals while one is open (belt-and-braces with the JS inline z-index); the whole `.modal-scroll-top` style block removed; a legacy header/footer accent-tweak block removed (it recolored shared-chrome links amber); `.data-attribution` link selector specificity raised during plan execution so it isn't beaten by `body.rising-seasons-app a`.
- `css/show-page.css` — `--gold` token added and `.page-footer .data-attribution a` colored gold with a text hover; explicit thin/styled page scrollbar (the `color-scheme: dark` native scrollbar was invisible on the dark page); footer-more links become `inline-block; width: fit-content` so the clickable area doesn't span the full row; the entire `.page-scroll-top` block removed; back-to-top clearance above the sticky CTA bar.
- `scripts/render-show-page.js` — shared back-to-top replaces the inline `renderScrollToTop()` pill; the sticky CTA banner is rewritten to show/hide in lockstep with the back-to-top arrow (same 400px threshold, re-hides near the top) and dismissal is per page-view via `dataset.dismissed` (was sessionStorage, which suppressed the banner for the whole tab session).
- `scripts/render-shows-index.js` — back-to-top includes on the generated A-Z index.
- `scripts/render-footer.js` — footer app list reordered ABC.
- `kometa/index.html` — back-to-top includes only.
- `tests/app-features.test.js` — new tests: `clampScrollY` (4 cases) and `languagesCompatible` (group membership, English strictness, unmapped exact-match, empty-language behavior), plus related-threshold updates.
- `tests/render-show-page.test.js` — updated for the shared back-to-top includes and the new banner script (asserts no sessionStorage usage, dataset dismissal, threshold lockstep).
- `README.md` — "More seasons/shows like this" rows updated from "same original language" to the language-group rule, related-section visibility note, and a new Scroll restoration row.

## Gym Tracker

- `index.html` — back-to-top includes; `data-back-to-top` on seven scrolling `.modal-content` panels; the bespoke page-level and program-modal scroll-top buttons removed.
- `js/app.js` — `initScrollTopButtons()` / `_bindScrollTop()` removed entirely; starting a workout and switching views now `window.scrollTo(0, 0)` (context switch lands at the top — most visible with the mobile bottom-nav tabs).
- `js/views/home-view.js` — same scroll-to-top on the FAB's start/resume-workout action.
- `css/refresh.css` — the whole bespoke `gt-scroll-top` section (page + modal variants) removed; a small mobile rule keeps the shared button clear of the 64px bottom nav.
- `css/gym-tracker.css` — desktop workout FAB repositioned to sit left of the shared back-to-top circle (`right: calc(1.25rem + 44px + 0.75rem)`, bottoms aligned).
- `css/exercise-page.css` — bespoke `ex-scroll-top` block removed; explicit visible page scrollbar added (same `color-scheme: dark` issue as the RS show pages).
- `scripts/render-footer.cjs` — `renderScrollTopButton()` deleted (export updated); footer app list reordered ABC and a dead `/apps/brain-arena/` link replaced with the correct `/apps/arena/` entry.
- `scripts/render-exercise-index.cjs`, `scripts/render-exercise-page.cjs` — generated index, taxonomy, and exercise pages now emit the shared back-to-top css/js instead of the inline pill.
- `tests/build-exercise-pages.test.cjs` — asserts the shared includes are present and that the legacy `ex-scroll-top` token never appears in generated output (token assembled from parts so the test itself doesn't trip the grep).

## Football H2H

- `index.html` — back-to-top includes; `data-back-to-top` on the icon-picker modal body and its three icon grids.
- `css/football-h2h.css` — removed `html, body { height: 100% }`: the flex column (`min-height: 100vh` + `margin-top: auto`) already pins the footer, and the height lock turned the body into a fixed-height scroller that stole the page scroll from the window, breaking the shared button (and native window-scroll behavior generally).

## MapTap Rivals

- `index.html` — back-to-top includes; `data-back-to-top` on the season-creation and WhatsApp-import modal panels.

## Arena / Mario Kart

- `apps/arena/index.html`, `apps/mario-kart/index.html` — back-to-top css/js includes only (no modal opt-ins; their modals don't scroll past the threshold).

## Judgment calls

- The back-to-top button stays a `position: fixed` body child even in modal mode (positioned against the container's rect with inline styles) instead of being reparented — the browser keeps it pinned while the panel scrolls, with no per-scroll JS repositioning; gesture stopPropagation keeps clicks from leaking to backdrop handlers.
- Position properties in back-to-top.css are intentionally NOT `!important` so the JS modal mode can override them inline; everything an app theme could hijack IS pinned per-state.
- English related-matching in rising-seasons stays strict en-only on purpose: the en pool is huge, so broadening it would only dilute relevance.
- Sports → Games on apps.html: Football H2H keeps its `SportsApplication` JSON-LD category; only the on-page filter taxonomy changed.
- The apps.html JSON-LD/section/prose reordering is purely ABC ordering; no descriptions or URLs changed.

## Explicitly untouched

- Generated show/exercise pages under `apps/rising-seasons/shows/` and `apps/gym-tracker/exercises/` are gitignored build artifacts, regenerated at deploy from the updated render scripts.
- Root `README.md` and `apps/gym-tracker/README.md` (its "Back to top" feature line still accurately describes the shared button), `apps/mario-kart/README.md`.
- Sync-system, netlify.toml, sitemaps (no new URLs).

## Testing

- `npm test`: 896/896 pass, 0 fail (includes the new clampScrollY, languagesCompatible, banner, and generated-page back-to-top assertions).
- `.features/site-claude.md` plan executed across 12+ recorded runs covering all 24 sections; latest runs: 46/46 (header/auth/ABC round), 19/19 (banner lockstep), 19/19 (back-to-top round 10), 47/49 (round 9; 2 unverified are real-browser scrollbar checks), 139/140 full sweep + 72/72 back-to-top regression. 0 failures outstanding.
- `.features/rising-seasons-claude.md` latest run: 27/27 (language-group section, with node recompute + live DOM fixtures), prior run 22/24 (2 unverified need a real-browser F5).

## Needs manual verification

- Tab-reachability of the header dropdown (headless can't simulate real Tab traversal) — steps in site-human.md.
- Page scrollbar visibility on RS show pages / gym exercise pages in a real browser (headless runs with `--hide-scrollbars`) — steps in site-human.md.
- Rising-seasons scroll restoration across a real F5 (headless iframe drops sessionStorage on reload) — steps in rising-seasons-human.md.
