### PR TITLE
feat(mario-kart): visual audit round, modal/chart/table fixes, and owner feature round

### DIFF
--- a/apps/mario-kart/README.md
+++ b/apps/mario-kart/README.md
@@ -19,19 +19,21 @@ Mario Kart Race Tracker is a feature-rich web application that allows you to:
 - **Player Management**: Customizable player names and emoji/icons
 - **Date Filtering**: View stats for specific time periods
 - **Undo/Redo**: Full history support for all actions
-- **Data Persistence**: Automatic saving to browser localStorage
+- **Data Persistence**: Automatic saving to browser localStorage, with account sync across devices when signed in
 - **Export/Import**: JSON file support for data backup and transfer
+- **Restore**: One-click recovery from the rolling auto-backup snapshot (taken every 10 minutes)
+- **Safe Deletes**: Deleting a race asks for confirmation first; undo/redo still covers every action
 
 ### Statistics & Analytics
 - **Comprehensive Stats**: Win rates, average positions, streaks, and more
-- **Achievement System**: 5 achievement categories with progress tracking
-- **Head-to-Head Analysis**: Detailed matchup statistics between players
+- **Achievement System**: 5 achievement categories with progress tracking; records show the live active streak count alongside the best, e.g. "10 (3)"
+- **Head-to-Head Analysis**: Detailed matchup statistics between players, including when each longest win streak ended (or that it is still active)
 - **Performance Trends**: Visual charts showing improvement over time
 - **Activity Heatmaps**: Calendar view of racing activity and performance
 - **Position Analysis**: Heat maps and sweet spot visualizations
 
 ### User Interface
-- **Theme**: Toggleable themes (theme recommended)
+- **Theme**: Single cohesive dark theme
 - **Responsive Design**: Works on desktop, tablet, and mobile devices
 - **Modern UI**: Card-based layouts with smooth animations
 - **Multiple Views**: 8 different tabs for various statistics and analyses
@@ -47,9 +49,9 @@ The tracker works best on modern browsers:
 ## ⚠️ Important Notes
 
 ### Mobile Support
-- The application is functional on mobile devices but not fully optimized
-- The Trends chart may not display correctly on smaller screens
-- Touch interactions are supported but may have minor issues
+- Fully responsive: desktop table views switch to card layouts on smaller screens
+- Charts (Trends, Activity) render at all screen sizes
+- Touch targets meet the 40px guideline throughout
 
 ### Player System
 - Players are tracked by their slot position (Player 1, 2, 3, 4)
@@ -60,13 +62,13 @@ The tracker works best on modern browsers:
 ### Data Storage
 - All data is stored locally in your browser's localStorage
 - Data persists between sessions on the same device/browser
-- Clearing browser data will delete all race history
-- No cloud sync or cross-device support
-- Regular backups via Export are recommended
+- Clearing browser data will delete all local race history
+- Sign in to sync your data to your account across devices
+- A rolling auto-backup snapshot is taken every 10 minutes (recoverable via Restore)
+- Regular backups via Export are still recommended
 
 ### Optimal Configuration
-- **Players**: Designed for 3 players (1, 2, or 4 players may have visual issues)
-- **Theme**: Dark mode is the primary theme with better visual consistency
+- **Players**: Supports 1-4 players; layouts verified at all player counts
 - **Browser**: Chrome or Firefox on desktop for best experience
 
 ## 🛠️ Technical Details
@@ -75,13 +77,13 @@ The tracker works best on modern browsers:
 - **Frontend**: Vanilla JavaScript, HTML5, CSS3
 - **Charts**: Chart.js for data visualization
 - **Icons**: Font Awesome for UI icons
-- **Storage**: Browser localStorage for data persistence
-- **Backup**: Google Drive API integration (optional)
+- **Storage**: Browser localStorage, synced to the account when signed in (Firebase sync system)
+- **Backup**: Rolling auto-backup snapshot in localStorage every 10 minutes, plus JSON export/import
 
 ### File Structure
 ```
 mario-kart/
-├── tracker.html          # Main application file
+├── index.html            # Main application file
 ├── css/                  # All styling files
 │   ├── base.css         # Base styles and resets
 │   ├── theme.css        # Theme variables and dark/alternative theme
@@ -97,8 +99,8 @@ mario-kart/
 
 ## 🚀 Getting Started
 
-1. **Access the Tracker**: Navigate to `https://www.shevato.com/apps/mario-kart/tracker.html`
-2. **Set Up Players**: Click the 👤 button to configure player names and icons
+1. **Access the Tracker**: Navigate to `https://www.shevato.com/apps/mario-kart/`
+2. **Set Up Players**: Open the sidebar and use "Manage Players" to configure player names and icons
 3. **Record a Race**: Enter finishing positions and click "Add Race"
 4. **View Statistics**: Explore different tabs to see various analyses
 5. **Backup Your Data**: Use the Export button regularly to save your data
@@ -115,9 +117,7 @@ mario-kart/
 ## 🔮 Future Improvements
 
 Planned enhancements include:
-- Full mobile optimization
 - Player profiles independent of slot positions
-- Cloud sync support
 - More achievement categories
 - Additional chart types
 - Custom race configurations

--- a/apps/mario-kart/css/charts.css
+++ b/apps/mario-kart/css/charts.css
@@ -232,17 +232,19 @@ body.theme #trends-chart-container {
     padding: 24px;
     backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0.6);
-    display: flex;
-    align-items: center;
-    justify-content: center;
     position: relative;
     width: 400px;
     height: 400px;
+    box-sizing: border-box;
 }
 
+/* Model the doughnut sizing on the Trends line chart: the canvas fills a
+   block-level relatively-positioned box. Flex-centering the canvas made it
+   collapse to 0 width on first layout in the column (mobile) layout. */
 .activity-chart-wrapper canvas {
-    max-width: 100% !important;
-    max-height: 100% !important;
+    width: 100% !important;
+    height: 100% !important;
+    display: block;
 }
 
 /* Modern Table Styling */
@@ -559,22 +561,33 @@ body.theme .weekly-breakdown-table tbody tr:hover {
         padding: 8px;
         margin: 0 -4px;
     }
-    
+
+    /* Fit the full table in the viewport instead of clipping P2/P3 behind a
+       silent horizontal scroll. table-layout:fixed lets columns share width. */
     .weekly-breakdown-table {
         font-size: 0.65rem;
-        min-width: 450px;
+        min-width: 0;
+        width: 100%;
+        table-layout: fixed;
+        white-space: normal;
     }
-    
+
     .weekly-breakdown-table th,
     .weekly-breakdown-table td {
         padding: 4px 2px !important;
-        min-width: 35px;
+        min-width: 0;
+        white-space: normal;
+        overflow-wrap: break-word;
+        word-break: normal;
+        hyphens: none;
     }
-    
+
     .weekly-breakdown-table th:first-child,
     .weekly-breakdown-table td:first-child {
-        min-width: 70px;
+        min-width: 0;
+        width: 22%;
         font-size: 0.6rem;
+        position: static;
     }
     
     .activity-chart-wrapper {

--- a/apps/mario-kart/css/mario-kart-overrides.css
+++ b/apps/mario-kart/css/mario-kart-overrides.css
@@ -69,6 +69,22 @@ body.theme .pagination-btn:hover:not(:disabled) {
     background: #4b5563 !important;
 }
 
+/* Active page. Without this, `body.theme .pagination-btn` (higher specificity
+   than `.pagination-btn.active`) flattens the active page to the inactive
+   grey. Pin the accent fill + a ring so the current page is unmistakable. */
+body.theme .pagination-btn.active {
+    color: white !important;
+    background: #8b5cf6 !important;
+    border-color: #8b5cf6 !important;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.35) !important;
+}
+
+body.theme .pagination-btn.active:hover:not(:disabled) {
+    color: white !important;
+    background: #7c4dff !important;
+    border-color: #7c4dff !important;
+}
+
 /* Export / Import / Backup base classes — fully restyled in
    css/refresh.css (`body.mario-kart-app .export-btn` etc.) to live on a
    neutral surface with the new dark palette. The legacy green/teal/blue
@@ -89,7 +105,11 @@ body.theme .pagination-btn:hover:not(:disabled) {
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 1000;
+    /* Above the sidebar (z 1001) so the clear-data confirm — opened from a
+       button inside the open sidebar — is never occluded by it at 390/768.
+       Stays below the icon picker (10000), tooltips (10002), back-to-top
+       (9000) and the sync banner (10100), which are unrelated flows. */
+    z-index: 1100;
     backdrop-filter: blur(5px);
 }
 
@@ -102,6 +122,29 @@ body.theme .pagination-btn:hover:not(:disabled) {
     width: 90%;
     text-align: center;
     animation: modalSlideIn 0.3s ease;
+}
+
+@keyframes modalSlideIn {
+    from { opacity: 0; transform: scale(0.9) translateY(-20px); }
+    to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* Default (desktop) modal button row: side by side, centered. The mobile
+   @media block below collapses this to a stacked column. Without this base
+   rule .modal-buttons computes display:block and the buttons stack
+   left-aligned at uneven widths on desktop. */
+.modal-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+.modal-buttons .modal-btn-primary,
+.modal-buttons .modal-btn-secondary,
+.modal-buttons .modal-btn-danger {
+    flex: 1 1 0;
+    max-width: 220px;
 }
 
 
@@ -150,27 +193,99 @@ body.theme .pagination-btn:hover:not(:disabled) {
     line-height: 1;
 }
 
-
-/* Specific styling for Edit Race modal buttons */
-#save-edit {
-    background: #10b981 !important;
+/* Destructive confirm button ("Delete Everything"). Without this rule the
+   site-wide theme trap (main.css `button { color:#555 !important }`) renders
+   the label gray on the purple primary gradient — a destructive action that
+   looks like a primary one. Red fill + white text pinned !important across
+   base / hover / active so the trap can never reclaim the colour. */
+.modal-btn-danger {
+    background: #ef4444;
     color: white !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    min-height: 44px !important;
-    line-height: 1 !important;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif !important;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.5rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    line-height: 1;
 }
 
-#cancel-edit {
+.modal-btn-danger:hover {
+    background: #dc2626;
     color: white !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    min-height: 44px !important;
-    line-height: 1 !important;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif !important;
+}
+
+.modal-btn-danger:hover:active {
+    background: #b91c1c;
+    color: white !important;
+}
+
+
+/* ===========================================
+   Edit Race modal (class-driven, mirrors clear-data modal)
+   =========================================== */
+/* Wider than the confirm dialog: holds date/time + per-player rows. */
+.edit-race-dialog {
+    max-width: 500px;
+    max-height: 80vh;
+    overflow-y: auto;
+    text-align: left;
+}
+
+.edit-race-dialog .modal-icon,
+.edit-race-dialog .modal-title {
+    text-align: center;
+}
+
+.edit-race-meta {
+    text-align: center;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+    color: var(--modal-text-color, #a0aec0);
+}
+
+.edit-race-datetime {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.edit-race-field {
+    margin-bottom: 1rem;
+}
+
+.edit-race-label {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--modal-title-color, #e2e8f0);
+    font-weight: 600;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+/* Scoped under body.mario-kart-app so it outranks the global
+   `body.mario-kart-app input[type=...]` rule in refresh.css that otherwise
+   forces every edit input to the near-black surface token. type="time" is
+   absent from that rule, so without this all three inputs would render with
+   mismatched backgrounds. One uniform surface for date/time/number here. */
+body.mario-kart-app .edit-race-input,
+body.mario-kart-app input[type="number"].edit-race-input,
+body.mario-kart-app input[type="date"].edit-race-input,
+body.mario-kart-app input[type="time"].edit-race-input {
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid #4a5568 !important;
+    border-radius: 0.5rem !important;
+    background: #4a5568 !important;
+    color: #e2e8f0 !important;
+    color-scheme: dark;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    box-sizing: border-box;
 }
 
 /* ===========================================
@@ -483,6 +598,33 @@ body.theme .h2h-player-pill {
    Responsive Design
    =========================================== */
 
+/* ===========================================
+   Race-history table/card swap breakpoint (loads AFTER responsive.css)
+   =========================================== */
+/* responsive.css swaps table<->cards at 768px. At 768-900 the desktop table
+   is cramped (dates wrap, the two action buttons stack) — a dead-zone. Raise
+   the swap to 900 so tablet-portrait gets the roomy card layout. This block
+   wins because mario-kart-overrides.css loads after responsive.css at equal
+   specificity. KEEP IN SYNC with the pagination-container hide below. */
+@media (max-width: 900px) {
+    .table-container {
+        display: none;
+    }
+
+    .mobile-cards {
+        display: flex;
+    }
+
+    /* Cards render every race and ignore pagination; the desktop-only
+       pagination control would read "Showing 1-10 of N" while the cards run
+       past it. Hide the misleading control whenever cards are the active
+       presentation. The real fix (slicing the cards) is behavioral and
+       deferred to /audit-app. */
+    .pagination-container {
+        display: none !important;
+    }
+}
+
 /* Mobile sidebar toggle improvements */
 @media (max-width: 768px) {
     .sidebar-toggle {
@@ -507,7 +649,19 @@ body.theme .h2h-player-pill {
         flex-direction: column;
         gap: 0.75rem;
     }
-    
+
+    .modal-buttons .modal-btn-primary,
+    .modal-buttons .modal-btn-secondary,
+    .modal-buttons .modal-btn-danger {
+        max-width: none;
+    }
+
+    /* Collapse the date/time pair to one column so the time input + its
+       clock icon never overflow the dialog edge at 390/360. */
+    .edit-race-datetime {
+        grid-template-columns: 1fr;
+    }
+
     .form-grid {
         grid-template-columns: 1fr;
     }

--- a/apps/mario-kart/css/race-history.css
+++ b/apps/mario-kart/css/race-history.css
@@ -134,8 +134,52 @@
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
-#history-table th:hover {
-    background: rgba(255, 255, 255, 0.1);
+/* Player-name headers (everything except Race # / Date / Action) can be
+   20-30 chars with the long-names data; cap their width and ellipsize so a
+   single long name can't starve the Date and Action columns into wrapping.
+   nowrap (above) keeps the ellipsis working. */
+#history-table th:not(:first-child):not(:nth-child(2)):not(:last-child) {
+    max-width: 140px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Keep Date and Action columns from being squeezed below a usable width. */
+#history-table th:nth-child(2),
+#history-table td:nth-child(2) {
+    min-width: 110px;
+    white-space: nowrap;
+}
+
+#history-table th:last-child,
+#history-table td:last-child {
+    min-width: 120px;
+    white-space: nowrap;
+}
+
+#history-table th:hover,
+#history-table th.sortable-header:focus-visible {
+    background: rgba(255, 255, 255, 0.12);
+    outline: none;
+}
+
+/* Sort indicator glyph. Dim when neutral (↕), full-opacity + accent tint
+   when the column is the active sort (↑/↓). */
+#history-table th .sort-indicator {
+    display: inline-block;
+    margin-left: 4px;
+    opacity: 0.55;
+    font-size: 0.8em;
+}
+
+#history-table th.sorted-active {
+    background: rgba(255, 255, 255, 0.16);
+}
+
+#history-table th.sorted-active .sort-indicator {
+    opacity: 1;
+    color: #ffffff;
+    font-weight: 700;
 }
 
 /* Add subtle dividers between headers */
@@ -250,18 +294,23 @@
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s ease;
-    min-width: 45px;
+    min-width: 40px;
     width: 45px;
-    height: 38px;
+    min-height: 40px;
+    height: 40px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
-.edit-btn {
+/* White glyph pinned against the site-wide `button { color:#555 !important }`
+   trap in main.css, across base / hover / active so it can never reclaim it. */
+.edit-btn,
+.edit-btn:hover,
+.edit-btn:hover:active {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
+    color: #ffffff !important;
     box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
 }
 
@@ -270,9 +319,11 @@
     box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
 }
 
-.delete-btn {
+.delete-btn,
+.delete-btn:hover,
+.delete-btn:hover:active {
     background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
-    color: white;
+    color: #ffffff !important;
     box-shadow: 0 2px 8px rgba(239, 68, 68, 0.3);
 }
 
@@ -291,26 +342,20 @@
     background: var(--history-bg-white);
 }
 
-/* Mobile Card Layout */
+/* Mobile Card Layout. NOTE: the table/card SWAP itself lives in
+   responsive.css (`@media (min-width:768px)` shows table / hides cards) and
+   is overridden up to 900px in mario-kart-overrides.css, which loads after
+   responsive.css. Do not re-declare the swap here — it would lose the
+   cascade to responsive.css (which loads after this file). */
 @media (max-width: 768px) {
     .race-history {
         padding: 20px;
         border-radius: 16px;
     }
-    
+
     #history-heading {
         font-size: 1.2em;
         margin-bottom: 20px;
-    }
-    
-    /* Hide table on mobile */
-    .table-container {
-        display: none;
-    }
-    
-    /* Show mobile cards */
-    .mobile-cards {
-        display: block;
     }
 }
 
@@ -319,12 +364,6 @@
     display: none;
     gap: 16px;
     flex-direction: column;
-}
-
-@media (max-width: 768px) {
-    .mobile-cards {
-        display: flex;
-    }
 }
 
 .race-card {
@@ -486,4 +525,37 @@ body.theme .race-card:hover {
 
 .race-card {
     animation: fadeInUp 0.3s ease-out;
+}
+
+/* Dark-theme the rows-per-page select (scoped to the mario-kart app so the
+   shared pagination component keeps its defaults elsewhere). color-scheme:dark
+   makes the native dropdown popup render dark in Chromium. Colors pinned
+   against the main.css theme trap. */
+body.mario-kart-app .pagination-container .pagination-size select {
+    color-scheme: dark;
+    background-color: var(--mk-surface-2, #181c26) !important;
+    color: var(--mk-text, #f1f3f8) !important;
+    border: 1px solid var(--mk-border-strong, #343a4f) !important;
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-weight: 600;
+    cursor: pointer;
+    appearance: auto;
+}
+
+body.mario-kart-app .pagination-container .pagination-size select:hover,
+body.mario-kart-app .pagination-container .pagination-size select:focus {
+    background-color: var(--mk-surface-3, #232836) !important;
+    color: var(--mk-text, #f1f3f8) !important;
+    border-color: var(--mk-accent, #818cf8) !important;
+    outline: none;
+}
+
+body.mario-kart-app .pagination-container .pagination-size select option {
+    background-color: var(--mk-surface-2, #181c26);
+    color: var(--mk-text, #f1f3f8);
+}
+
+body.mario-kart-app .pagination-container .pagination-size label {
+    color: var(--mk-muted, #a4adbd) !important;
 }

--- a/apps/mario-kart/css/refresh.css
+++ b/apps/mario-kart/css/refresh.css
@@ -107,11 +107,16 @@ body.mario-kart-app .game-version-toggle {
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
 }
 
-body.mario-kart-app .game-version-toggle button.version-btn,
-body.mario-kart-app .game-version-toggle button.version-btn:not(.active) {
-    background: transparent !important;
+/* Shared layout/typography for both states. Deliberately NO background or
+   color here: those are state-specific and live on the `:not(.active)` and
+   `.active` rules below. Setting them on the bare `.version-btn` selector
+   leaked the inactive (transparent/muted) look onto the active button,
+   because that bare selector also matches the active element — the active
+   rule should win on specificity, but the tie produced a render-order
+   inversion (active highlight landed on the wrong button). Scoping the
+   inactive colours strictly to `:not(.active)` removes the ambiguity. */
+body.mario-kart-app .game-version-toggle button.version-btn {
     border: none !important;
-    color: var(--mk-muted) !important;
     border-radius: 999px !important;
     padding: 0.5rem 1.1rem !important;
     font-size: 0.88rem !important;
@@ -126,6 +131,11 @@ body.mario-kart-app .game-version-toggle button.version-btn:not(.active) {
     gap: 0.4rem !important;
     text-align: center !important;
     min-height: 32px;
+}
+
+body.mario-kart-app .game-version-toggle button.version-btn:not(.active) {
+    background: transparent !important;
+    color: var(--mk-muted) !important;
 }
 
 /* Keep the racing-car / globe icons (and any other glyphs) vertically
@@ -144,7 +154,7 @@ body.mario-kart-app .game-version-toggle button.version-btn .version-text {
     line-height: 1;
 }
 
-body.mario-kart-app .game-version-toggle button.version-btn:hover {
+body.mario-kart-app .game-version-toggle button.version-btn:not(.active):hover {
     background: rgba(255, 255, 255, 0.04) !important;
     color: var(--mk-text) !important;
     transform: none !important;
@@ -556,6 +566,43 @@ body.mario-kart-app .sidebar-action-btn .action-text {
     line-height: 1;
 }
 
+/* Date filter buttons — location-independent base. sidebar.js physically
+   moves the date-filter section into the sidebar shortly after load; until
+   that move completes the buttons fall outside `.sidebar`, so the
+   `.sidebar`-scoped rules below didn't apply and the site-wide theme trap
+   (#555) painted the labels gray for ~1-3s (FOUC). `body.mario-kart-app`
+   is on the <body> from first paint, so pinning here makes the colours
+   correct from the very first frame. Values mirror the moved-in state
+   below, so there is no jump when the section is relocated. */
+body.mario-kart-app .filter-btn,
+body.mario-kart-app .date-filter-btn {
+    color: var(--mk-text) !important;
+    background: var(--mk-surface-2) !important;
+}
+body.mario-kart-app .filter-btn.active,
+body.mario-kart-app .date-filter-btn.active {
+    color: var(--mk-text) !important;
+    background: var(--mk-accent-soft) !important;
+}
+
+/* Disabled filter (e.g. Today force-disabled on the Activity view). The
+   JS sets an inline grey background (#6b7280) but the `.sidebar .filter-btn`
+   !important background defeats it, and the theme trap leaves the label at
+   #555 on a dark fill — illegible. Pin a muted-but-legible token text on a
+   visibly dimmed surface. Specificity (with :disabled + the dual-selector)
+   beats both the base and the `.sidebar .filter-btn` rule for the disabled
+   case. */
+body.mario-kart-app .filter-btn:disabled,
+body.mario-kart-app .filter-btn[disabled],
+body.mario-kart-app .sidebar .filter-btn:disabled,
+body.mario-kart-app .sidebar .filter-btn[disabled] {
+    color: var(--mk-muted) !important;
+    background: var(--mk-surface) !important;
+    border-color: var(--mk-border) !important;
+    opacity: 0.6 !important;
+    cursor: not-allowed !important;
+}
+
 /* Date filter buttons in the sidebar */
 body.mario-kart-app .sidebar .date-filter-controls { gap: 0.4rem !important; }
 body.mario-kart-app .sidebar .filter-btn,
@@ -672,6 +719,16 @@ body.mario-kart-app textarea:focus {
     border-color: var(--mk-accent) !important;
     box-shadow: 0 0 0 3px var(--mk-accent-soft) !important;
     background: var(--mk-surface) !important;
+}
+
+/* Out-of-range / invalid number entry (e.g. position > max). Previously the
+   only feedback was on submit; give an immediate visual cue using the danger
+   token. Scoped to filled inputs so empty/required-only fields aren't flagged
+   before the user types. */
+body.mario-kart-app input[type="number"]:out-of-range,
+body.mario-kart-app input[type="number"]:invalid:not(:placeholder-shown) {
+    border-color: var(--mk-danger) !important;
+    box-shadow: 0 0 0 3px var(--mk-danger-soft) !important;
 }
 
 /* ---------- Export/Import/Backup/Clear buttons used in main area ---------- */

--- a/apps/mario-kart/css/sidebar.css
+++ b/apps/mario-kart/css/sidebar.css
@@ -671,13 +671,18 @@ body.theme .sidebar-overlay {
     flex: 1;
 }
 
-/* Date icon wrapper - simplified for ACTIONS button style */
+/* Date icon wrapper - simplified for ACTIONS button style.
+   Absolutely centered against the container (position:relative on
+   .sidebar-date-btn-container): immune to the flex-stack quirks that
+   pinned the icon above the vertical midline. */
 .sidebar-date-icon-wrapper {
-    position: relative;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 16px;
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 100%;
 }
 
 /* Hidden date input - spans entire button */
@@ -708,6 +713,10 @@ body.theme .sidebar-overlay {
     background: transparent;
     border: none;
     padding: 0;
+    /* base.css gives bare labels margin-bottom:5px; flex centers the margin
+       box, so any label margin pushes the icon off the vertical midline */
+    margin: 0;
+    line-height: 1;
     cursor: pointer;
     transition: all 0.2s ease;
     display: flex;
@@ -715,7 +724,6 @@ body.theme .sidebar-overlay {
     justify-content: center;
     position: relative;
     z-index: 1;
-    height: 100%;
     width: auto;
 }
 
@@ -1755,6 +1763,10 @@ body.theme .sidebar-player-name-input:focus {
     width: 2rem;
     height: 2rem;
     background: transparent;
+    /* Pin a legible text colour: the site-wide theme trap
+       (main.css `button { color:#555 !important }`) otherwise wins here and
+       would render any non-emoji glyph invisible-dark. */
+    color: var(--mk-text, #f1f3f8) !important;
     border: 1px solid transparent;
     border-radius: 0.25rem;
     font-size: 1.25rem;

--- a/apps/mario-kart/css/stats.css
+++ b/apps/mario-kart/css/stats.css
@@ -518,6 +518,16 @@
     line-height: 1.0;
 }
 
+/* Muted date/active suffix on the longest-win-streak line. Cell text is forced
+   white by the colored-background rules below, so we dim via opacity to keep it
+   legible on both the green winner and red loser cards. */
+.h2h-streak-meta {
+    font-size: 0.55rem;
+    font-weight: 500;
+    opacity: 0.85;
+    white-space: nowrap;
+}
+
 /* Biggest win display styles */
 .h2h-biggest-win {
     font-size: 0.6rem;
@@ -689,16 +699,39 @@ body.theme .h2h-table-container {
     .h2h-table-container {
         padding: 1rem;
         overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        scroll-padding-right: 1rem;
     }
-    
+
     .h2h-table,
     .h2h-daily-table {
-        min-width: 500px;
+        min-width: 460px;
     }
-    
+
     .h2h-daily-breakdown {
         padding: 1rem;
         margin-top: 1rem;
+        position: relative;
+    }
+
+    /* Scroll affordance: the H2H matrix is wider than the phone viewport, so
+       it scrolls horizontally. A right-edge fade signals "more to the right"
+       and makes the clip at the card's rounded corner look intentional. */
+    .h2h-daily-breakdown::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 32px;
+        pointer-events: none;
+        border-radius: 0 16px 16px 0;
+        background: linear-gradient(
+            to right,
+            rgba(31, 41, 55, 0) 0%,
+            var(--h2h-bg) 90%
+        );
+        z-index: 5;
     }
     
     .h2h-daily-item {

--- a/apps/mario-kart/css/visualizations-modern.css
+++ b/apps/mario-kart/css/visualizations-modern.css
@@ -137,6 +137,18 @@
     transition: all 0.3s ease;
 }
 
+/* Live "(N)" active-streak count shown next to the all-time record. Green to
+   echo the active-streak glow on the bar; pinned so the parent's inline color
+   (set in achievements.js) doesn't tint it. */
+.achievement-number .achievement-active-count {
+    font-size: 9px;
+    font-weight: 700;
+    color: #34d399 !important;
+    margin-left: 2px;
+    vertical-align: super;
+    line-height: 1;
+}
+
 /* Modern Toggle Buttons */
 .achievement-buttons-container {
     display: flex;

--- a/apps/mario-kart/index.html
+++ b/apps/mario-kart/index.html
@@ -257,7 +257,7 @@
             <div class="help-content">
                 <div class="help-section">
                     <h4>🏆 What is this?</h4>
-                    <p>A comprehensive Mario Kart race tracking application that records race results, calculates detailed statistics, tracks achievements, and provides in-depth performance analysis for up to 4 players. All data is stored locally in your browser.</p>
+                    <p>A comprehensive Mario Kart race tracking application that records race results, calculates detailed statistics, tracks achievements, and provides in-depth performance analysis for up to 4 players. All data is stored locally in your browser, and syncs to your account when you sign in.</p>
                 </div>
                 
                 <div class="help-grid">
@@ -406,12 +406,11 @@
                 <div class="help-section help-disclaimers">
                     <h4>⚠️ Disclaimers</h4>
                     <ul class="help-features disclaimer-list">
-                        <li><strong>Player Count:</strong> The app is optimized for 3 players. Using 1, 2, or 4 players may result in some visual spacing issues.</li>
                         <li><strong>Data Storage:</strong> All data is saved locally in your browser's local storage. This means:
                             <ul>
                                 <li>Data persists between sessions on the same device/browser</li>
-                                <li>Clearing browser data will delete all race history</li>
-                                <li>Data doesn't sync across devices (yet)</li>
+                                <li>Clearing browser data will delete all local race history</li>
+                                <li>Sign in to sync your data across devices; without signing in, data stays on this device only</li>
                             </ul>
                         </li>
                         <li><strong>Player Tracking:</strong> Players are saved based on their position slot (e.g., Player 1, Player 2) and not by name. This means that <strong>Player 1's results will always appear in the leftmost position</strong>, even if the name changes later. Player statistics and positions are tied to their assigned number, not their current name label. I intend to improve this in the future, but for now this works for my usage.</li>

--- a/apps/mario-kart/js/achievements.js
+++ b/apps/mario-kart/js/achievements.js
@@ -1384,12 +1384,20 @@ function updateAchievements(raceData = null) {
                 return;
             }
 
-            // Show the actual current value
-            numberElement.textContent = achievement.current;
-            
+            // Show the all-time record value, plus the live "(N)" active count
+            // when a streak for this achievement is currently ongoing.
+            const activeCount = getActiveStreakCount(achievementKey, achievement, player, raceData);
+            if (activeCount > 0) {
+                numberElement.innerHTML =
+                    `${achievement.current}<span class="achievement-active-count" title="Active streak: ${activeCount}">(${activeCount})</span>`;
+            } else {
+                numberElement.textContent = achievement.current;
+            }
+
             // Update aria-label and title
             if (achievementBar) {
-                achievementBar.setAttribute('aria-label', `${achievementDef.name}: ${achievementDef.description}`);
+                const activeNote = activeCount > 0 ? `, active streak: ${activeCount}` : '';
+                achievementBar.setAttribute('aria-label', `${achievementDef.name}: ${achievementDef.description}${activeNote}`);
                 achievementBar.setAttribute('title', achievementDef.description);
             }
             
@@ -1548,6 +1556,59 @@ function checkForActiveStreak(achievementKey, achievement, player, raceData) {
             
         default:
             return false;
+    }
+}
+
+// Returns the CURRENT ongoing count for an achievement when its streak is still
+// active (extends to the latest race / today), otherwise 0. Mirrors the active
+// detection in checkForActiveStreak but yields the live count so it can be shown
+// as a small "(N)" next to the all-time record.
+function getActiveStreakCount(achievementKey, achievement, player, raceData) {
+    if (!achievement || !achievement.details || !achievement.current) return 0;
+
+    const playerRaces = raceData.filter(race => race[player] !== null);
+    if (playerRaces.length === 0) return 0;
+
+    const chronologicalRaces = [...playerRaces].sort((a, b) => {
+        const dateA = new Date(a.date + (a.timestamp ? ' ' + a.timestamp : ''));
+        const dateB = new Date(b.date + (b.timestamp ? ' ' + b.timestamp : ''));
+        return dateA - dateB;
+    });
+
+    switch (achievementKey) {
+        case 'winStreak': {
+            // Count trailing consecutive 1st-place finishes.
+            let count = 0;
+            for (let i = chronologicalRaces.length - 1; i >= 0; i--) {
+                if (chronologicalRaces[i][player] === 1) count++;
+                else break;
+            }
+            return count;
+        }
+        case 'hotStreak': {
+            // Count trailing consecutive podium (top 3) finishes.
+            let count = 0;
+            for (let i = chronologicalRaces.length - 1; i >= 0; i--) {
+                if (chronologicalRaces[i][player] <= 3) count++;
+                else break;
+            }
+            return count;
+        }
+        case 'clutchMaster':
+        case 'momentumBuilder':
+            return (achievement.details.currentActiveStreak && achievement.details.currentActiveStreak.count) || 0;
+        case 'perfectDay': {
+            // Active when every race today is a good (top-half) finish.
+            const today = new Date().toLocaleDateString('en-CA');
+            const todayRaces = playerRaces.filter(race => race.date === today);
+            const threshold = getGoodFinishThreshold();
+            if (todayRaces.length > 0 && todayRaces.every(race => race[player] <= threshold)) {
+                return todayRaces.length;
+            }
+            return 0;
+        }
+        default:
+            return 0;
     }
 }
 

--- a/apps/mario-kart/js/dataManager.js
+++ b/apps/mario-kart/js/dataManager.js
@@ -126,75 +126,42 @@ function editRace(index) {
     const race = races[index];
     if (!race) return;
 
-    // Create a beautiful edit modal
+    // Create the edit modal (class-driven, matches the clear-data modal)
     const modal = document.createElement('div');
-    modal.style.cssText = `
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0, 0, 0, 0.5);
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        z-index: 1000;
-        backdrop-filter: blur(5px);
-    `;
+    modal.className = 'modal-overlay';
 
     const dialog = document.createElement('div');
-    dialog.style.cssText = `
-        background: #2d3748;
-        border-radius: 1rem;
-        padding: 2rem;
-        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-        max-width: 500px;
-        width: 90%;
-        max-height: 80vh;
-        overflow-y: auto;
-        animation: modalSlideIn 0.3s ease;
-    `;
+    dialog.className = 'modal-dialog edit-race-dialog';
 
     const playerInputs = players.map(player => {
         const currentValue = race[player] || '';
         return `
-            <div style="margin-bottom: 1rem;">
-                <label style="display: block; margin-bottom: 0.5rem; color: #e2e8f0; font-weight: 600; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">
+            <div class="edit-race-field">
+                <label class="edit-race-label" for="edit-${player}">
                     ${window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player)}'s Position:
                 </label>
-                <input type="number" id="edit-${player}" min="${MIN_POSITIONS}" max="${MAX_POSITIONS}" value="${currentValue}" 
-                    style="width: 100%; padding: 0.75rem; border: 1px solid #4a5568; 
-                    border-radius: 0.5rem; background: #4a5568; 
-                    color: #e2e8f0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;" placeholder="${MIN_POSITIONS}-${MAX_POSITIONS} or leave empty">
+                <input type="number" id="edit-${player}" class="edit-race-input" min="${MIN_POSITIONS}" max="${MAX_POSITIONS}" value="${currentValue}" placeholder="${MIN_POSITIONS}-${MAX_POSITIONS} or leave empty">
             </div>
         `;
     }).join('');
 
     dialog.innerHTML = `
-        <div style="text-align: center; margin-bottom: 1.5rem;">
-            <div style="font-size: 2.5rem; margin-bottom: 0.5rem;">✏️</div>
-            <h3 style="color: #e2e8f0; margin-bottom: 0.5rem; font-size: 1.5rem; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">Edit Race</h3>
-            <p style="color: #a0aec0; font-size: 0.9rem; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">${formatDateForDisplay(race.date)}${race.timestamp ? ', ' + race.timestamp : ''}</p>
-        </div>
-        
-        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem;">
-            <div>
-                <label style="display: block; margin-bottom: 0.5rem; color: #e2e8f0; font-weight: 600; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">
+        <div class="modal-icon">✏️</div>
+        <h3 class="modal-title">Edit Race</h3>
+        <p class="modal-text edit-race-meta">${formatDateForDisplay(race.date)}${race.timestamp ? ', ' + race.timestamp : ''}</p>
+
+        <div class="edit-race-datetime">
+            <div class="edit-race-field">
+                <label class="edit-race-label" for="edit-date">
                     Race Date:
                 </label>
-                <input type="date" id="edit-date" value="${race.date}" 
-                    style="width: 100%; padding: 0.75rem; border: 1px solid #4a5568; 
-                    border-radius: 0.5rem; background: #4a5568; 
-                    color: #e2e8f0; color-scheme: dark; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">
+                <input type="date" id="edit-date" class="edit-race-input" value="${race.date}">
             </div>
-            <div>
-                <label style="display: block; margin-bottom: 0.5rem; color: #e2e8f0; font-weight: 600; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">
+            <div class="edit-race-field">
+                <label class="edit-race-label" for="edit-time">
                     Race Time:
                 </label>
-                <input type="time" id="edit-time" value="${race.timestamp ? (race.timestamp.includes(':') ? race.timestamp.split(' ')[0] : '') : ''}" step="1"
-                    style="width: 100%; padding: 0.75rem; border: 1px solid #4a5568; 
-                    border-radius: 0.5rem; background: #4a5568; 
-                    color: #e2e8f0; color-scheme: dark; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;" placeholder="Optional">
+                <input type="time" id="edit-time" class="edit-race-input" value="${race.timestamp ? (race.timestamp.includes(':') ? race.timestamp.split(' ')[0] : '') : ''}" step="1" placeholder="Optional">
             </div>
         </div>
 
@@ -205,19 +172,6 @@ function editRace(index) {
             <button id="cancel-edit" class="modal-btn-secondary ">Cancel</button>
         </div>
     `;
-
-    // Add CSS animation if not already added
-    if (!document.querySelector('#modal-animation-style')) {
-        const style = document.createElement('style');
-        style.id = 'modal-animation-style';
-        style.textContent = `
-            @keyframes modalSlideIn {
-                from { opacity: 0; transform: scale(0.9) translateY(-20px); }
-                to { opacity: 1; transform: scale(1) translateY(0); }
-            }
-        `;
-        document.head.appendChild(style);
-    }
 
     modal.appendChild(dialog);
     document.body.appendChild(modal);
@@ -365,10 +319,54 @@ function editRace(index) {
 }
 
 function deleteRace(index) {
+    const race = races[index];
+    if (!race) return;
+
+    // Confirmation modal (matches the clear-data modal family)
+    const modal = document.createElement('div');
+    modal.className = 'modal-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = `modal-dialog `;
+
+    const raceNumber = index + 1;
+    const raceMeta = `Race #${raceNumber}, ${formatDateForDisplay(race.date)}`;
+
+    dialog.innerHTML = `
+        <div class="modal-icon">🗑️</div>
+        <h3 class="modal-title ">Delete this race?</h3>
+        <p class="modal-text ">${raceMeta}</p>
+        <div class="modal-buttons">
+            <button id="confirm-delete-race" class="modal-btn-danger">Delete Race</button>
+            <button id="cancel-delete-race" class="modal-btn-secondary ">Cancel</button>
+        </div>
+    `;
+
+    modal.appendChild(dialog);
+    document.body.appendChild(modal);
+
+    const closeModal = () => {
+        if (modal.parentNode) modal.parentNode.removeChild(modal);
+        document.removeEventListener('keydown', escapeHandler);
+    };
+    const escapeHandler = (e) => { if (e.key === 'Escape') closeModal(); };
+    document.addEventListener('keydown', escapeHandler);
+
+    document.getElementById('cancel-delete-race').onclick = closeModal;
+
+    document.getElementById('confirm-delete-race').onclick = () => {
+        closeModal();
+        performDeleteRace(index);
+    };
+
+    modal.onclick = (e) => { if (e.target === modal) closeModal(); };
+}
+
+function performDeleteRace(index) {
     // Save action for undo/redo before deleting
     const raceToDelete = races[index];
     saveAction('DELETE_RACE', { race: raceToDelete, index });
-    
+
     races.splice(index, 1);
     try {
         const storageKey = window.getStorageKey ? window.getStorageKey('Races') : 'marioKartRaces';

--- a/apps/mario-kart/js/main.js
+++ b/apps/mario-kart/js/main.js
@@ -1044,15 +1044,27 @@ function updateHistoryTableHeaders() {
     const headerRow = document.querySelector('#history-table thead tr');
     if (!headerRow) return;
 
+    // Indicator reflects the live sort state (sortColumn/sortDirection):
+    // active column shows ↑/↓, the rest show the neutral ↕.
+    const sortIndicator = (column) => {
+        if (sortColumn !== column) return '↕';
+        return sortDirection === 'asc' ? '↑' : '↓';
+    };
+    const ariaSort = (column) => {
+        if (sortColumn !== column) return '';
+        return ` aria-sort="${sortDirection === 'asc' ? 'ascending' : 'descending'}"`;
+    };
+    const sortedClass = (column) => (sortColumn === column ? ' sorted-active' : '');
+
     // Generate dynamic headers
     const playerHeaders = players.map(player => {
         const name = escapeHtml(window.PlayerNameManager ? window.PlayerNameManager.get(player) : getPlayerName(player));
-        return `<th style="cursor: pointer;" onclick="sortTable('${player}')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('${player}')" aria-label="Sort by ${name}'s position">${name} ↕</th>`;
+        return `<th class="sortable-header${sortedClass(player)}"${ariaSort(player)} onclick="sortTable('${player}')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('${player}')" aria-label="Sort by ${name}'s position">${name} <span class="sort-indicator">${sortIndicator(player)}</span></th>`;
     }).join('');
 
     headerRow.innerHTML = `
         <th>Race #</th>
-        <th style="cursor: pointer;" onclick="sortTable('date')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('date')" aria-label="Sort by date">Date ↕</th>
+        <th class="sortable-header${sortedClass('date')}"${ariaSort('date')} onclick="sortTable('date')" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' ')sortTable('date')" aria-label="Sort by date">Date <span class="sort-indicator">${sortIndicator('date')}</span></th>
         ${playerHeaders}
         <th>Action</th>
     `;
@@ -1522,7 +1534,22 @@ document.addEventListener('DOMContentLoaded', function() {
             updateCallback: updateDisplay
         });
     }
-    
+
+    // When the user changes rows-per-page, jump back to the top of the race
+    // history (the shared component already resets to page 1, but the user
+    // may be scrolled far down). App-level hook so shared pagination.js stays
+    // generic for the other apps.
+    document.addEventListener('change', (event) => {
+        const select = event.target.closest(
+            '.pagination-container[data-pagination-instance="mario-kart-races"] select[data-action="size"]'
+        );
+        if (!select) return;
+        const heading = document.getElementById('history-heading');
+        if (heading) {
+            heading.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    });
+
     // Set date to user's local timezone
     const localDate = new Date().toLocaleDateString('en-CA');
     const dateInput = document.getElementById('date');
@@ -1583,8 +1610,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
     
-    // Open sidebar by default
-    openSidebar();
+    // Sidebar stays closed on page load; users open it via the toggle
 
     // Ensure player names are loaded from localStorage
     if (typeof loadPlayerNames === 'function') {

--- a/apps/mario-kart/js/statistics.js
+++ b/apps/mario-kart/js/statistics.js
@@ -316,23 +316,25 @@ function generateH2HTable(stats) {
                 const displayStreak = longestStreak;
                 
                 if (displayStreak > 0) {
-                    let formattedDate = '';
-                    if (streakDate && !isActiveStreak) {
-                        // Parse date string directly to avoid timezone issues
-                        const [year, month, day] = streakDate.split('-');
-                        const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 
-                                          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-                        formattedDate = `${monthNames[parseInt(month) - 1]} ${parseInt(day)}`;
+                    // Append the date the streak peaked (its final win). For an
+                    // active streak the record is still ongoing, so we mark it
+                    // active rather than dating it.
+                    let streakSuffix = '';
+                    if (isActiveStreak) {
+                        streakSuffix = ' <span class="h2h-streak-meta">(active)</span>';
+                    } else if (streakDate) {
+                        const formattedDate = (typeof formatDateForDisplay === 'function')
+                            ? formatDateForDisplay(streakDate)
+                            : streakDate;
+                        streakSuffix = ` <span class="h2h-streak-meta">(ended ${formattedDate})</span>`;
                     }
-                    
-                    const activeIndicator = isActiveStreak ? ' (active)' : '';
-                    
+
                     // Format streak details (only show for historical streaks, not current active ones)
                     const detailsText = (streakDetails.length > 0 && !isActiveStreak) ? `: ${streakDetails.join(', ')}` : '';
-                    
+
                     streakDisplay = `
                         <div class="h2h-streak">
-                            <div class="h2h-streak-main">Longest Win Streak - ${displayStreak}${activeIndicator}</div>
+                            <div class="h2h-streak-main">Longest Win Streak - ${displayStreak}${streakSuffix}</div>
                             ${detailsText ? `<div class="h2h-streak-details">${detailsText.substring(2)}</div>` : ''}
                         </div>
                     `;

--- a/apps/mario-kart/js/tooltip.js
+++ b/apps/mario-kart/js/tooltip.js
@@ -69,7 +69,8 @@ class TooltipManager {
         this.tooltipElement.setAttribute('role', 'tooltip');
         this.tooltipElement.setAttribute('aria-hidden', 'true');
         this.tooltipElement.style.position = 'absolute';
-        this.tooltipElement.style.zIndex = '9999';
+        // Above the shared site header (z-index 10001), below the sync banner (10100)
+        this.tooltipElement.style.zIndex = '10005';
         this.tooltipElement.style.pointerEvents = 'none';
         document.body.appendChild(this.tooltipElement);
     }
@@ -263,9 +264,11 @@ class TooltipManager {
         // Default position: above the element
         let top = rect.top - tooltipRect.height - 8;
         let left = rect.left + (rect.width - tooltipRect.width) / 2;
-        
-        // Adjust if tooltip would go off-screen
-        if (top < 5) {
+
+        // Adjust if tooltip would go off-screen or under the fixed site header
+        const siteHeader = document.getElementById('header');
+        const headerBottom = siteHeader ? siteHeader.getBoundingClientRect().bottom : 0;
+        if (top < Math.max(5, headerBottom + 4)) {
             // Position below instead
             top = rect.bottom + 8;
         }

--- a/assets/js/sync-status.js
+++ b/assets/js/sync-status.js
@@ -68,7 +68,7 @@
             bannerEl.hidden = false;
             bannerEl.dataset.state = 'offline';
             bannerEl.dataset.fading = 'false';
-            bannerEl.textContent = 'You’re offline — changes saved on this device';
+            bannerEl.textContent = 'You’re offline, changes saved on this device';
             return;
         }
 


### PR DESCRIPTION
Exhaustive visual audit of the mario-kart app (every view × state at 1280/768/390, plus 360/1024 where fragile), the resulting fixes, and a same-day owner feedback + feature round. All verification was done against rendered pixels in fresh-profile headless Chromium; `npm test` 896 pass / 0 fail.

## mario-kart — CSS

- **css/mario-kart-overrides.css** (+~190): new `.modal-btn-danger` (red, white text pinned `!important` across base/:hover/:hover:active; the clear-data "Delete Everything" button previously rendered gray #555 via the sitewide button trap because this class had no rule); `.modal-overlay` z-index 1000 → 1100 (was occluded by the open sidebar, z 1001, at 390/768); edit-race modal classes (`.modal-dialog.edit-race-dialog`, `.edit-race-input`, `.edit-race-datetime` grid that collapses to one column ≤768, `.modal-buttons` flex row, `@keyframes modalSlideIn` which was referenced but never defined anywhere); removed the old green `#save-edit !important` rule; table↔cards swap breakpoint raised 768 → 900 (the real swap lives in responsive.css which loads after race-history.css, so the override lives here, which loads last); pagination container hidden ≤900px (see judgment calls).
- **css/race-history.css** (+~124): long player-name headers capped (max-width 140px + ellipsis) with Date/Action column minimums (20+ char names previously collapsed the table layout); `.edit-btn`/`.delete-btn` text pinned white `!important` (computed #555 via the trap, invisible only because the labels are emoji) and bumped to ≥40px touch size; `body.theme .pagination-btn.active` purple highlight (active page was indistinguishable); sort-indicator styles (`.sort-indicator`, `.sorted-active`, focus-visible); rows-per-page select styled dark with `color-scheme: dark` so the native popup list renders dark too, tokens pinned against the trap.
- **css/charts.css** (+~35): Activity doughnut wrapper no longer flex-centers the canvas (Chart.js + centered flex collapsed the canvas to 0 at ≤1200px, leaving the chart blank on tablet/mobile; fix modeled on the working Trends wrapper); weekly-breakdown table at ≤480px drops its `min-width:450px`+nowrap for fixed-layout word-wrap so all five columns fit at 390/360.
- **css/stats.css** (+~39): H2H matrix mobile overflow made intentional: right-edge gradient fade (`.h2h-daily-breakdown::after`, token-based) + table min-width 500→460; `.h2h-streak-meta` muted suffix style for streak dates.
- **css/refresh.css** (+~67): version-toggle active/inactive rules disambiguated (inactive styles moved onto `:not(.active)`, hover scoped) — hardening for a reported inversion that turned out to be a false positive (see judgment calls); location-independent filter-button color pins (buttons flashed gray #555 for 1-3s before sidebar.js moves the date-filter section under `.sidebar`); token-based `.filter-btn:disabled` (disabled "Today" on Activity was #555-on-gray and its intended inline grey-out was defeated by an `!important` background); `:out-of-range`/`:invalid` red border+ring cue for position inputs (out-of-range values previously showed no feedback).
- **css/sidebar.css** (+~20): `.sidebar-icon-option` color pinned (latent #555); Race Date calendar icon vertically centered — root cause was base.css's bare-`label` `margin-bottom:5px` (flex centers the margin box) plus unresolvable percentage heights; the icon wrapper is now absolutely positioned top:0/bottom:0 and flex-centered, the label gets margin:0/line-height:1.
- **css/visualizations-modern.css** (+12): `.achievement-active-count` style (small green superscript).

## mario-kart — JS

- **js/dataManager.js** (±~126): edit-race modal rebuilt class-driven (was ~70 lines of hardcoded inline styles: `#2d3748`/`#4a5568`, green Save, `display:block` button stack, time field clipping at 390) — all ids, input types/values, handlers, and aria preserved; `deleteRace` now opens an on-family confirmation modal ("Delete this race?", red Delete Race / Cancel) with the actual deletion moved to `performDeleteRace`, undo path unchanged.
- **js/main.js** (+~36): removed the `openSidebar()` call at init (sidebar auto-opened on every load, overlapping the H1, contradicting the stay-closed comment in sidebar.js); history header rebuild restores `class="sortable-header"` and renders ↑/↓ + `aria-sort` on the actively sorted column (markup string only, no sort-logic change); app-level `change` listener scoped to `data-pagination-instance="mario-kart-races"` scrolls smoothly to `#history-heading` when rows-per-page changes.
- **js/achievements.js** (+~69): new `getActiveStreakCount()` computes the live ongoing count per achievement (trailing wins/podiums, `currentActiveStreak`, today's perfect-day count); records render a small green "(n)" suffix with `title="Active streak: n"` when active.
- **js/statistics.js** (±26): H2H "Longest Win Streak - X" now renders the already-computed-but-never-displayed streak dates: "(ended <date>)" via the existing `formatDateForDisplay` (no raw date interpolation) or "(active)" for ongoing streaks.
- **js/tooltip.js** (+11): tooltip z-index 9999 → 10005 (site header is 10001, so tooltips near the top rendered underneath it); `positionTooltip` flip threshold is now header-aware (flips below the target when the above-position would land under the fixed `#header`). Three generations of dead CSS for this same bug exist (tooltip.css:171-180, mario-kart-overrides.css:387-421 — scoped to ancestors the body-appended tooltip never has); left in place, now superseded, flagged for future cleanup.

## mario-kart — content/docs

- **index.html** (±7): Disclaimers updated — removed "optimized for 3 players" (this audit verified 2- and 4-player layouts clean at every viewport), replaced "Data doesn't sync across devices (yet)" with the sign-in sync reality; intro line now mentions account sync.
- **README.md**: brought in line with the app as it now is — single dark theme (was "toggleable themes"), responsive/mobile claims updated (Trends/Activity now render at all sizes), data-storage section covers sign-in sync + the 10-minute auto-backup/Restore, removed the nonexistent "Google Drive API integration", `tracker.html` → `index.html` (file does not exist), Getting Started steps match the current sidebar UI, new features documented (delete confirmation, achievement active counts, H2H streak dates), Future Improvements pruned of shipped items.

## shared (sitewide effect)

- **assets/js/sync-status.js** (1 line): offline banner copy "You're offline — changes saved on this device" → comma instead of the em dash (standing no-em-dash rule for user-visible copy). This component is loaded by every app, so the new copy ships sitewide.

## Bugfixes found along the way

- Clear-data modal was nearly unusable at 390 (fully hidden behind the sidebar) and clipped at 768 — z-index fix above.
- Mobile pagination control claimed "Showing 1-10 of 36" while the cards rendered all 36 races (cards ignore pagination). Visual-honesty stopgap: the control is hidden ≤900px. The genuine fix (slicing `filteredRaces` in `updateMobileRaceCards`) is behavioral and deferred to /audit-app.
- `h2hLongestStreakDates` was computed but never rendered — now surfaced by the H2H date feature.
- `@keyframes modalSlideIn` was referenced but never defined, so the clear-data modal silently had no entrance animation; defining it (needed for the edit modal) animates both modals now.

## Explicitly untouched

- `assets/js/pagination.js` (shared): the rows-per-page scroll behavior is an app-level listener in mario-kart's main.js, not a shared-behavior change.
- Restore button: investigated for removal at the owner's request and deliberately KEPT — Restore recovers the rolling auto-backup snapshot in localStorage (written every 10 minutes), Import loads an exported JSON file from disk; different recovery paths.
- `sync-system/sync-loading-modal.js` (white modal over the dark app) and the shared footer (dim text): both flagged in the audit as cross-app/site-level decisions, not changed here.
- Three generations of dead tooltip-positioning CSS (superseded by the tooltip.js fix): left in place to keep this diff reviewable; cleanup candidate.

## Judgment calls

- Table↔cards swap moved 768→900: tablet portrait previously got a cramped 6-column table (wrapped dates, stacked buttons); cards are the cleaner experience there. Alternative (shrinking table typography at 768) rejected.
- Edit-race modal is a deliberate restyle to the app's modal family: green Save became the system purple. If the green was preferred it can come back as a token.
- Achievement "(n)" styling: small green superscript tied to the existing active-streak glow color, so it reads as a live annotation without competing with the record number.
- H2H date placement: inline "(ended <date>)" / "(active)" suffix after the count, opacity-dimmed so it works on both the green and red matchup cards.
- Weekly-table headers may wrap mid-word at 360 ("PLAYER 1" can break); full column visibility was chosen over one-line headers.
- A reported "mkworld version-toggle highlight inverted" defect was disproven (headless `getComputedStyle` returns stale/inverted values after a JS class swap; rendered pixels were always correct) — the CSS was hardened anyway so no cascade tie can ever produce the inversion in a real browser.

## Testing

- `npm test`: 896 pass / 0 fail (run after every fix wave and again at ship).
- Living plan pair `.features/mario-kart-claude.md` + `mario-kart-human.md` seeded this round: B1-B28 visual assertions all verified (see plan summary table + the 2026-06-06 run report); A1-A7 functional stubs await /audit-app.
- Visual verification: ~75 view×state screenshot matrix + per-fix before/after re-shots, all read and judged; key fixes additionally probed (z-stacks via DOM probes, geometry midlines, scroll spies, confirm/cancel state counts).
- Audit report + findings archived to `.features/archive/mario-kart-visual-*-2026-06-06.md`.

## Needs manual verification

- The real offline banner (go offline on a device): headless cannot reliably trigger the offline event; copy + colors were force-rendered for verification.
- Edit-race modal entrance animation in a real browser (headless snaps a fixed frame).
- Rows-per-page native dropdown list on your machine after a hard refresh (Ctrl+Shift+R) — the closed select and `color-scheme` are verified; the open popup is native browser UI.
- Deferred to /audit-app: mobile cards render all races unsliced (control hidden as stopgap); custom-date-range keeps its `.hidden` class while shown via inline style (`dateFilter.js:30`).