### PR TITLE
feat(maptap-rivals): location reveal, insight-driven rival view, matrix/history/seasons overhaul

### DIFF
--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -419,10 +419,14 @@ body.maptap-rivals-app button {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1rem 1.1rem;
+  /* Kept in place above the dashboard (the hint references the profile
+     card "above") but rendered deliberately compact when collapsed —
+     owner request: this is a secondary, optional entry path. */
+  padding: 0.6rem 0.9rem;
   margin-bottom: 1.25rem;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
 }
+.paste-collapse[open] { padding: 0.4rem 0.2rem 0; }
 
 .paste-collapse > summary {
   list-style: none;
@@ -452,15 +456,16 @@ body.maptap-rivals-app button {
   border-radius: var(--radius-sm);
 }
 .paste-collapse-title {
-  font-size: 1.05rem;
-  font-weight: 700;
+  font-size: 0.88rem;
+  font-weight: 600;
   letter-spacing: -0.01em;
-  color: var(--text);
+  color: var(--muted);
 }
 .paste-collapse-hint {
-  color: var(--muted);
-  font-size: 0.82rem;
+  color: var(--muted-2);
+  font-size: 0.72rem;
 }
+.paste-collapse > summary:hover .paste-collapse-title { color: var(--text); }
 .paste-collapse-body { margin-top: 0.9rem; }
 
 .paste-head {
@@ -1043,20 +1048,29 @@ body.maptap-rivals-app button {
    sit on surface-2, today wears a subtle accent ring, and the selected
    pill uses accent-soft + accent border to match the rest of the
    "selected state" treatment elsewhere in the app — no harsh fills. */
+/* ---------- Predictions day selector ----------
+   The 7-day strip is the centrepiece of the predictions view, so the
+   tabs read as premium pills: resting tabs are quiet, the selected day
+   blooms into a larger accent-gradient pill with a soft glow + raised
+   number, and "Today" carries a distinct dot marker. Horizontal scroll
+   is preserved for narrow viewports. Click/aria semantics are untouched. */
 .pred-day-tabs {
   display: flex;
-  gap: 0.4rem;
+  gap: 0.5rem;
   overflow-x: auto;
-  padding: 0.05rem 0.15rem 0.75rem;
-  margin: -0.2rem -0.15rem 0.6rem;
+  padding: 0.35rem 0.2rem 0.85rem;
+  margin: -0.2rem -0.2rem 0.7rem;
   scrollbar-width: thin;
+  scroll-snap-type: x proximity;
+  -webkit-overflow-scrolling: touch;
 }
 .pred-day-tab {
+  position: relative;
   flex: 0 0 auto;
-  min-width: 62px;
-  padding: 0.42rem 0.6rem;
+  min-width: 66px;
+  padding: 0.5rem 0.7rem 0.55rem;
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius);
   background: var(--surface-2);
   color: var(--muted);
   font: inherit;
@@ -1064,57 +1078,85 @@ body.maptap-rivals-app button {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.08rem;
-  line-height: 1.1;
-  transition: border-color 0.16s ease, background 0.16s ease, color 0.16s ease, transform 0.12s ease;
+  gap: 0.12rem;
+  line-height: 1.05;
+  scroll-snap-align: center;
+  transition: border-color 0.18s ease, background 0.18s ease,
+              color 0.18s ease, transform 0.16s ease, box-shadow 0.18s ease;
 }
 .pred-day-tab:hover {
   border-color: var(--border-strong);
   background: var(--surface-3);
   color: var(--text);
+  transform: translateY(-1px);
 }
+.pred-day-tab:active { transform: translateY(0); }
+
+/* Today (when not the selected day): subtle accent text so the current
+   day is locatable at a glance. (The little dot marker was removed —
+   owner request; the accent-colored text and "Today" label suffice.) */
 .pred-day-tab.is-today { color: var(--text); }
 .pred-day-tab.is-today .pred-day-tab-num { color: var(--accent-2); }
+
+/* Selected day: the centrepiece. Larger pill via scale, accent gradient
+   fill, layered glow, and a brighter raised number. */
 .pred-day-tab.is-active {
-  background: linear-gradient(180deg,
-              rgba(99, 102, 241, 0.22) 0%,
-              rgba(99, 102, 241, 0.12) 100%);
+  background:
+    radial-gradient(120% 140% at 50% 0%,
+      rgba(129, 140, 248, 0.30) 0%, rgba(99, 102, 241, 0.10) 60%,
+      rgba(99, 102, 241, 0.06) 100%),
+    linear-gradient(180deg, var(--surface-3), var(--surface-2));
   border-color: var(--accent);
   color: var(--accent-2);
-  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.04),
-              0 0 0 1px rgba(99, 102, 241, 0.18);
+  transform: translateY(-2px) scale(1.06);
+  box-shadow:
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.08),
+    0 0 0 1px rgba(99, 102, 241, 0.35),
+    0 8px 22px -8px rgba(99, 102, 241, 0.55);
 }
+.pred-day-tab.is-active:hover { transform: translateY(-2px) scale(1.06); }
 .pred-day-tab.is-active::after {
   content: '';
   position: absolute;
   left: 50%;
-  top: -1px;
+  bottom: -0.5rem;
   transform: translateX(-50%);
-  width: 24px;
-  height: 2px;
-  border-radius: 0 0 4px 4px;
-  background: var(--accent);
+  width: 26px;
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  box-shadow: 0 0 8px rgba(99, 102, 241, 0.6);
 }
-.pred-day-tab { position: relative; }
-.pred-day-tab.is-active .pred-day-tab-num { color: var(--accent-2); }
-.pred-day-tab.is-loading { opacity: 0.65; }
-.pred-day-tab.is-error   { border-color: rgba(251, 146, 60, 0.45); color: var(--warn); }
-.pred-day-tab:focus-visible { outline: 2px solid var(--accent-2); outline-offset: 2px; }
+.pred-day-tab.is-active .pred-day-tab-num { color: var(--accent-ink); }
+
+.pred-day-tab.is-loading { opacity: 0.6; cursor: progress; }
+.pred-day-tab.is-loading .pred-day-tab-num { color: var(--muted-2); }
+.pred-day-tab.is-error {
+  border-color: rgba(251, 146, 60, 0.45);
+  color: var(--warn);
+}
+.pred-day-tab.is-error .pred-day-tab-name,
+.pred-day-tab.is-error .pred-day-tab-num { color: var(--warn); }
+.pred-day-tab:focus-visible { outline: 2px solid var(--accent-2); outline-offset: 3px; }
+
 .pred-day-tab-name {
-  font-size: 0.62rem;
+  font-size: 0.6rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   font-weight: 700;
   color: var(--muted);
+  transition: color 0.18s ease;
 }
 .pred-day-tab.is-active .pred-day-tab-name { color: var(--accent-2); }
 .pred-day-tab.is-today  .pred-day-tab-name { color: var(--accent-2); }
 .pred-day-tab-num {
-  font-size: 1.02rem;
-  font-weight: 700;
+  font-size: 1.12rem;
+  font-weight: 800;
   font-variant-numeric: tabular-nums;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
+  transition: color 0.18s ease;
 }
+.pred-day-tab.is-active .pred-day-tab-num { font-size: 1.22rem; }
 
 /* Per-round chips — premium compact stat modules. A thin top accent
    line keys the chip to its Δ direction; the background carries a
@@ -1252,6 +1294,112 @@ body.maptap-rivals-app button {
   .prc-nums { font-size: 0.86rem; gap: 0.22rem; }
   .prc-head { font-size: 0.55rem; }
   .prc-weight { font-size: 0.5rem; top: 0.25rem; right: 0.28rem; }
+}
+
+/* ---------- Location reveal strip ----------
+   Day-level "Locations" row shown only after the user has logged their own
+   game for the selected day. One toggle per round; revealing fills in the
+   city name in place. Buttons must pin their own colour/box-shadow on hover
+   and focus because site-wide main.css paints `button:hover` red !important. */
+.pred-loc {
+  margin-top: 0.35rem;
+  padding-top: 0.65rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.pred-loc-head {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+}
+.pred-loc-strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+.pred-loc-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.18rem;
+  min-width: 0;
+  overflow: hidden;
+  /* Override main.css button defaults that break this component:
+     main.css sets height:3.25rem and white-space:nowrap on all buttons;
+     neither works for a multi-line location chip. */
+  height: auto;
+  line-height: inherit;
+  white-space: normal;
+  padding: 0.42rem 0.35rem;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--muted) !important;
+  font: inherit;
+  cursor: pointer;
+  text-align: center;
+  box-shadow: none !important;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.pred-loc-btn:hover {
+  border-color: var(--border-strong) !important;
+  background: var(--surface-3);
+  color: var(--text) !important;
+  box-shadow: none !important;
+}
+.pred-loc-btn:focus-visible {
+  outline: 2px solid var(--accent-2);
+  outline-offset: 2px;
+  color: var(--text) !important;
+  box-shadow: none !important;
+}
+.pred-loc-slot {
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+}
+.pred-loc-name {
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  hyphens: auto;
+  width: 100%;
+}
+.pred-loc-btn.is-revealed {
+  background: var(--accent-soft);
+  border-color: var(--accent-strong) !important;
+  color: var(--accent-2) !important;
+}
+.pred-loc-btn.is-revealed .pred-loc-slot { color: var(--accent-2); }
+.pred-loc-btn.is-revealed .pred-loc-name { color: var(--text); }
+.pred-loc-btn.is-revealed:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent) !important;
+  color: var(--accent-2) !important;
+}
+.pred-loc-btn.is-loading .pred-loc-name { color: var(--muted-2); }
+.pred-loc-btn.is-error {
+  border-color: rgba(251, 146, 60, 0.45) !important;
+}
+.pred-loc-btn.is-error .pred-loc-name { color: var(--warn); }
+
+@media (max-width: 520px) {
+  /* 3+2 grid: five ~65px columns force mid-word breaks in long names
+     ("Normand y, France"); three ~108px columns let names wrap at
+     spaces instead. */
+  .pred-loc-strip { gap: 0.32rem; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .pred-loc-btn { padding: 0.36rem 0.22rem; }
+  .pred-loc-name { font-size: 0.66rem; }
+  .pred-loc-slot { font-size: 0.5rem; }
 }
 
 /* ---------- Dashboard rival grid ---------- */
@@ -1406,6 +1554,28 @@ body.maptap-rivals-app button {
   flex-wrap: wrap;
   font-size: 0.8rem;
   color: var(--muted);
+}
+
+.rival-card-note {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  margin-top: 0.55rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.74rem;
+  color: var(--muted);
+}
+.rival-card-note-emoji {
+  flex: none;
+  font-size: 0.8rem;
+  line-height: 1;
+}
+.rival-card-note-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .form-pills {
@@ -1580,9 +1750,36 @@ body.maptap-rivals-app button {
   color: var(--muted);
   margin-top: 0.15rem;
 }
+/* Multi-line subs (e.g. the No-multiplier H2H card showing the actual
+   record above its flips note) stack each .sub-line on its own row. */
+.stat-card .sub .sub-line { display: block; }
 .stat-card.is-good .value { color: var(--good); }
 .stat-card.is-bad .value { color: var(--bad); }
 .stat-card.is-accent .value { color: var(--accent-2); }
+
+/* Grouped stat cards (rival view): Performance / Momentum / Key Insights.
+   When #rival-stat-cards holds groups it stacks them vertically; each group
+   keeps its own .stat-cards grid inside, so the card mechanics are unchanged.
+   The takeaway-led cards run longer than the old metric cards, so the value
+   shrinks a touch to read as a sentence rather than a single big number. */
+#rival-stat-cards {
+  display: block;
+}
+.stat-card-group { margin-bottom: 1rem; }
+.stat-card-group:last-child { margin-bottom: 0; }
+.stat-card-group > .stat-cards { margin-bottom: 0; }
+.stat-card-group-title {
+  font-size: 0.74rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted-2);
+  margin: 0 0 0.5rem;
+}
+.stat-card-group .stat-card .value {
+  font-size: 1.04rem;
+  line-height: 1.25;
+}
 
 .charts-grid {
   display: grid;
@@ -1645,6 +1842,72 @@ body.maptap-rivals-app button {
   gap: 0.5rem;
   margin-bottom: 0.85rem;
 }
+.loc-callouts[hidden] { display: none; }
+
+/* Insight groups: top-of-section, scannable. Each group leads with one big
+   plain-language headline; supporting numbers sit smaller below it. A left
+   accent rail color-codes the category (good / bad / warn / neutral). */
+.loc-insight-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.7rem;
+  margin-bottom: 1.25rem;
+}
+.loc-insight-groups[hidden] { display: none; }
+.loc-insight-group {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 0.9rem 0.8rem;
+}
+.loc-insight-group.good { border-left-color: var(--good); }
+.loc-insight-group.bad { border-left-color: var(--bad); }
+.loc-insight-group.warn { border-left-color: var(--warn); }
+.lig-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted-2);
+}
+.lig-headline {
+  font-size: 1.02rem;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.3;
+  margin-top: 0.25rem;
+}
+.lig-headline strong { color: var(--accent-2); font-weight: 700; }
+.loc-insight-group.good .lig-headline strong { color: var(--good); }
+.loc-insight-group.bad .lig-headline strong { color: var(--bad); }
+.loc-insight-group.warn .lig-headline strong { color: var(--warn); }
+.lig-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.55rem;
+}
+.lig-stat {
+  font-size: 0.72rem;
+  color: var(--muted);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.12rem 0.5rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Sub-headings that demote the dense data (charts, per-round cards) below the
+   insight groups. */
+.loc-subhead {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin: 0.25rem 0 0.7rem;
+}
 
 .loc-card-grid {
   display: grid;
@@ -1653,7 +1916,11 @@ body.maptap-rivals-app button {
   margin-top: 1rem;
 }
 .loc-card {
-  background: var(--surface);
+  /* --loc-tint (set inline per card) layers a subtle win-rate tint over the
+     surface: greenest = best round, reddest = worst. Unset → plain surface. */
+  background:
+    linear-gradient(var(--loc-tint, transparent), var(--loc-tint, transparent)),
+    var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   padding: 0.7rem 0.65rem;
@@ -1799,8 +2066,10 @@ body.maptap-rivals-app button {
   font-weight: 700;
   line-height: 1.15;
 }
-.continent-scores .col.me .v { color: var(--good); }
-.continent-scores .col.them .v { color: var(--accent-2); }
+/* Winner green / loser red, set per continent by renderContinentSection;
+   ties carry neither class and stay neutral. */
+.continent-scores .col .v.is-win { color: var(--good); }
+.continent-scores .col .v.is-lose { color: var(--bad); }
 
 .continent-record {
   font-size: 0.72rem;
@@ -1927,6 +2196,20 @@ body.maptap-rivals-app button {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+/* Date links out to maptap.gg — same quiet dotted-underline treatment as
+   the history table's date column (and pinned against main.css link reds). */
+.heatmap-rowlabel .maptap-day-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted currentColor;
+  padding-bottom: 1px;
+}
+.heatmap-rowlabel .maptap-day-link:hover,
+.heatmap-rowlabel .maptap-day-link:focus-visible {
+  color: var(--accent-2);
+  border-bottom-style: solid;
+  outline: none;
 }
 /* Round-by-round cells live inside .heatmap-row's 1fr grid columns.
    Scoped to .heatmap-row so the calendar-heatmap dots (.heatmap-cell at
@@ -2102,6 +2385,83 @@ body.maptap-rivals-app button {
   outline: none;
 }
 
+/* History thead — a distinct, intentional legend row. Layered surface +
+   bottom border lift it off the data; small-caps letterspacing matches the
+   section labels elsewhere. Sticky within the table's own scroll so the
+   columns stay legible on long days. Scoped to #history-table so the
+   leaderboard header is untouched. */
+#history-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.11em;
+  background:
+    linear-gradient(180deg, var(--surface-2), var(--surface));
+  border-bottom: 1px solid var(--border-strong);
+  box-shadow: inset 0 -1px 0 var(--border);
+}
+#history-table thead th:first-child {
+  border-top-left-radius: 12px;
+}
+#history-table thead th:last-child {
+  border-top-right-radius: 12px;
+}
+
+/* ---------- History day grouping ----------
+   The Full Game History is grouped by day so it reads date-by-date
+   instead of as a continuous rival-by-rival mix. Each day opens with a
+   full-width header row carrying the maptap.gg day link; member rows drop
+   their repeated date (first cell left empty as a quiet gutter). Stronger
+   top spacing/divider separates one day from the next. */
+#history-table tbody tr.history-day-header td {
+  padding: 1.05rem 0.95rem 0.5rem;
+  border-bottom: 1px solid var(--border-strong);
+  background: linear-gradient(180deg,
+    rgba(99, 102, 241, 0.07), rgba(99, 102, 241, 0));
+}
+/* No big top gap before the very first day group on a page. */
+#history-table tbody tr.history-day-header:first-child td {
+  padding-top: 0.55rem;
+}
+.history-day-head-inner {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+#history-table .history-day-link,
+#history-table .history-day-label {
+  color: var(--text);
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  font-variant-numeric: tabular-nums;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--border-strong);
+  padding-bottom: 1px;
+}
+#history-table .history-day-label { border-bottom: 0; }
+#history-table .history-day-link:hover,
+#history-table .history-day-link:focus-visible {
+  color: var(--accent-2);
+  border-bottom-color: var(--accent-2);
+  border-bottom-style: solid;
+  outline: none;
+}
+/* Member rows: the empty leading cell becomes a thin accent gutter so the
+   eye still tracks the day group down the left edge. */
+#history-table tbody tr.history-day-row td.history-row-date {
+  width: 0;
+  padding: 0;
+  border-left: 2px solid var(--accent-soft);
+}
+/* Tighten the divider between rows inside a day; the day header carries
+   the strong divider so member rows stay airy and grouped. */
+#history-table tbody tr.history-day-row td {
+  border-bottom-color: rgba(255, 255, 255, 0.025);
+}
+
 .rounds-cell { width: 0; }
 .rounds-cell .round-dots { display: inline-flex; }
 
@@ -2217,55 +2577,77 @@ body.maptap-rivals-app button {
   font-variant-numeric: tabular-nums;
 }
 
-/* Row action — compact icon button that sits muted until the row is
-   hovered/focused, like Linear / Notion table actions. */
-.icon-btn,
-.icon-btn:hover {
+/* Row action — compact icon button. Reads as clearly interactive at rest
+   (defined surface + border + legible stroke) and brightens on row
+   hover/focus. Used in Full Game History and rival Recent games. */
+.icon-btn {
   width: 24px;
   height: 24px;
   min-width: 36px;
   min-height: 36px;
   padding: 0;
-  border: 0;
-  background: transparent;
-  color: var(--muted-2);
+  border: 1px solid var(--border-strong);
+  background: var(--surface-2);
+  color: var(--muted);
   cursor: pointer;
-  border-radius: 5px;
+  border-radius: 6px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  opacity: 0.5;
-  transition: opacity 0.12s ease, background 0.12s ease, color 0.12s ease;
+  opacity: 1;
+  transition: background 0.12s ease, color 0.12s ease,
+    border-color 0.12s ease, box-shadow 0.12s ease;
 }
 .icon-btn svg { width: 13px; height: 13px; display: block; }
 .icon-btn:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface-3);
+  border-color: var(--border-strong);
   color: var(--text);
-  opacity: 1;
 }
 .icon-btn:focus-visible {
   outline: none;
-  opacity: 1;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface-3);
+  color: var(--text);
   box-shadow: 0 0 0 2px var(--accent-soft);
 }
+/* Row hover lifts the action affordance a touch further. */
 tr:hover .icon-btn,
 tr:focus-within .icon-btn {
-  opacity: 1;
+  border-color: var(--border-strong);
+  color: var(--text);
 }
-.icon-btn-danger:hover {
-  background: rgba(248, 113, 113, 0.12);
+/* Danger keeps a persistent red tint so destructive intent reads at rest. */
+.icon-btn-danger {
+  color: var(--bad);
+  border-color: rgba(248, 113, 113, 0.28);
+  background: rgba(248, 113, 113, 0.07);
+}
+.icon-btn-danger:hover,
+tr:hover .icon-btn-danger,
+tr:focus-within .icon-btn-danger {
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(248, 113, 113, 0.45);
   color: var(--bad);
 }
 .icon-btn-danger:focus-visible {
-  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.22);
+  background: rgba(248, 113, 113, 0.16);
+  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.3);
 }
-
-.icon-btn-share:hover {
-  background: rgba(99, 102, 241, 0.12);
+/* Share leans into the indigo accent. */
+.icon-btn-share {
+  color: var(--accent-2);
+  border-color: rgba(99, 102, 241, 0.28);
+  background: rgba(99, 102, 241, 0.07);
+}
+.icon-btn-share:hover,
+tr:hover .icon-btn-share,
+tr:focus-within .icon-btn-share {
+  background: rgba(99, 102, 241, 0.16);
+  border-color: rgba(99, 102, 241, 0.45);
   color: var(--accent-2);
 }
 .icon-btn-share:focus-visible {
+  background: rgba(99, 102, 241, 0.16);
   box-shadow: 0 0 0 2px var(--accent-soft);
 }
 
@@ -2348,8 +2730,8 @@ tr:focus-within .icon-btn {
 .pagination-controls {
   display: flex;
   align-items: center;
-  gap: 0;
-  flex-wrap: nowrap;
+  gap: 0.5rem;
+  flex-wrap: wrap;
   line-height: 0;
   font-size: 0;
 }
@@ -2368,8 +2750,7 @@ tr:focus-within .icon-btn {
   padding: 0 0.25rem 0 0.55rem;
   background: var(--surface-2);
   border: 1px solid var(--border);
-  border-radius: 5px 0 0 5px;
-  border-right-width: 0;
+  border-radius: 5px;
   gap: 0.4rem;
   font-size: 0.755rem;
   color: var(--muted);
@@ -2511,6 +2892,77 @@ tr:focus-within .icon-btn {
   line-height: 1;
 }
 
+/* Numbered pager (ported from rising-seasons): Prev, page numbers with
+   ellipsis gaps, Next. Adapted to maptap's dark tokens. The accent-tinted
+   current page replaces rising-seasons' amber. Hover is pinned on .page-btn
+   to defeat the sitewide red button:hover. The parent .pagination-controls
+   zeroes font-size/line-height for its segmented pill, so reset both here. */
+.pager {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  font-size: 0.82rem;
+  line-height: 1;
+}
+.pager[hidden] { display: none; }
+.pager .page-btn,
+.pager .page-btn:hover {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 30px;
+  height: 28px;
+  padding: 0 0.5rem;
+  background: transparent;
+  color: var(--muted) !important;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  box-shadow: none !important;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.pager .page-btn:hover {
+  background: var(--surface-2) !important;
+  border-color: var(--border-strong);
+  color: var(--text) !important;
+}
+.pager .page-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft) !important;
+}
+.pager .page-btn[aria-current="page"],
+.pager .page-btn[aria-current="page"]:hover {
+  background: var(--accent-soft) !important;
+  color: var(--accent-2) !important;
+  border-color: var(--accent-strong);
+  font-weight: 700;
+}
+.pager .page-btn:disabled,
+.pager .page-btn[aria-disabled="true"] {
+  opacity: 0.3;
+  cursor: not-allowed;
+  color: var(--muted) !important;
+  background: transparent !important;
+  border-color: transparent;
+}
+.pager .page-ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 28px;
+  color: var(--muted-2);
+  user-select: none;
+  font-size: 0.8rem;
+}
+
 @media (max-width: 540px) {
   .pagination {
     justify-content: center;
@@ -2522,16 +2974,42 @@ tr:focus-within .icon-btn {
     order: -1;
   }
   .pagination-controls { gap: 0.3rem; }
+  .pager .page-ellipsis { display: none; }
 }
-.history-filters { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+.history-filters { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+/* Premium filter pills — custom chevron, layered surface, lit accent ring on
+   focus. The trailing-chevron SVG is inlined so the control needs no markup
+   change and no extra request. */
 .history-filters select {
+  -webkit-appearance: none;
+  appearance: none;
   height: var(--ctrl-h);
-  padding: 0 0.65rem;
-  border: 1px solid var(--border);
-  border-radius: var(--ctrl-radius);
-  background: var(--surface-2);
+  padding: 0 2rem 0 0.85rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background-color: var(--surface-2);
+  background-image:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0)),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23818cf8' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center, right 0.7rem center;
   color: var(--text);
-  font-size: 0.9rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: border-color 0.12s ease, background-color 0.12s ease,
+    box-shadow 0.12s ease;
+}
+.history-filters select:hover {
+  border-color: var(--accent-strong);
+  background-color: var(--surface-3);
+}
+.history-filters select:focus,
+.history-filters select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 /* Native <select> dropdown panels render with the OS theme. Color-scheme
@@ -3034,6 +3512,33 @@ body.maptap-rivals-app select option {
   box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.18) !important;
 }
 
+/* Confirmation modal — short prompt + Cancel/Delete grouped on the right.
+   The Delete button stays a solid danger button (overrides the muted-ghost
+   .modal-actions .btn-danger above) and pins its own hover/focus so the
+   sitewide button:hover red can't bleed in. */
+.modal-confirm-body {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+.modal-actions-confirm { justify-content: flex-end; }
+.modal-actions-confirm .btn-danger,
+.modal-actions-confirm .btn-danger:hover {
+  margin-right: 0;
+  background: var(--bad);
+  color: var(--bad-ink) !important;
+  border-color: transparent;
+  font-weight: 600;
+}
+.modal-actions-confirm .btn-danger:hover { filter: brightness(1.05); }
+.modal-actions-confirm .btn-danger:focus-visible {
+  border-color: transparent;
+  outline: 2px solid var(--bad);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.18) !important;
+}
+
 /* ---------- WhatsApp import modal ---------- */
 
 .wa-overview {
@@ -3334,6 +3839,14 @@ body.maptap-rivals-app select option {
   text-overflow: ellipsis;
   max-width: 9rem;
 }
+/* Player's average daily score, shown after the name since the Avg score
+   subtab was removed. Quiet, smaller, never wraps away from the name. */
+.matrix-head-avg {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
 
 .matrix-cell {
   text-align: center;
@@ -3483,6 +3996,71 @@ body.maptap-rivals-app select option {
   .matrix-head-name { max-width: 6rem; font-size: 0.82rem; }
 }
 
+/* ---- Confusion Matrix: dedicated small-screen layout (<=640px) ----
+   The desktop grid stops scaling cleanly on phones: records wrap, the avg
+   badge crowds names, and cells lose alignment. Here we collapse column
+   heads to icon-only (full name stays in the th title), keep a short
+   ellipsized row-head name with the avg dropped to its own tiny line, force
+   records onto a single tabular line, and tighten cells to a consistent
+   size. The matrix already scrolls horizontally; the row-head column is
+   pinned so labels stay visible while scrolling the records. */
+@media (max-width: 640px) {
+  .matrix-wrap { padding: 0.5rem; }
+  .matrix-table { border-spacing: 4px; }
+
+  /* Column heads: icon only. Name is preserved in the th `title` attribute. */
+  .matrix-col-head { padding: 0.4rem 0.3rem; }
+  .matrix-col-head .matrix-head-name,
+  .matrix-col-head .matrix-head-avg { display: none; }
+  .matrix-col-head .matrix-head-chip { justify-content: center; gap: 0; }
+  .matrix-head-icon { font-size: 1.05rem; }
+
+  /* Row heads: pinned to the left edge so labels survive horizontal scroll. */
+  .matrix-row-head {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    padding: 0.45rem 0.5rem;
+    min-width: 5rem;
+    max-width: 7rem;
+  }
+  .matrix-row-head .matrix-head-chip {
+    flex-wrap: wrap;
+    gap: 0 0.3rem;
+    align-items: center;
+  }
+  .matrix-row-head .matrix-head-name {
+    max-width: 4.6rem;
+    font-size: 0.78rem;
+  }
+  /* avg moves UNDER the name as its own quiet line. */
+  .matrix-row-head .matrix-head-avg {
+    flex-basis: 100%;
+    font-size: 0.62rem;
+    line-height: 1.1;
+    margin-top: 0.05rem;
+  }
+
+  /* Cells: consistent size, records forced single-line, tighter padding. */
+  .matrix-cell {
+    min-width: 4.6rem;
+    width: 4.6rem;
+    padding: 0.45rem 0.25rem;
+  }
+  .matrix-record {
+    font-size: 0.9rem;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .matrix-margin {
+    font-size: 0.66rem;
+    white-space: nowrap;
+  }
+  .matrix-meta { font-size: 0.62rem; white-space: nowrap; }
+  .matrix-cell-empty { font-size: 0.62rem; }
+  .matrix-form-dot { width: 0.55rem; height: 0.55rem; }
+}
+
 /* ---------- Seasons view ---------- */
 
 .seasons-toolbar {
@@ -3510,6 +4088,9 @@ body.maptap-rivals-app select option {
 .season-card {
   background: var(--surface);
   border: 1px solid var(--border);
+  /* Status accent rides the left edge: green = met/on-track, amber = behind,
+     red = missed, neutral = upcoming/no signal. */
+  border-left: 3px solid var(--border-strong);
   border-radius: var(--radius);
   padding: 0.9rem 1rem;
   margin-bottom: 0.65rem;
@@ -3517,8 +4098,24 @@ body.maptap-rivals-app select option {
 
 .season-card-active {
   border-color: var(--accent-strong);
+  border-left-width: 3px;
   background: linear-gradient(135deg, rgba(99,102,241,0.06), transparent 60%), var(--surface);
 }
+
+.season-card-good { border-left-color: var(--good); }
+.season-card-warn { border-left-color: var(--warn); }
+.season-card-bad  { border-left-color: var(--bad); }
+
+.season-card-headline {
+  font-size: 1.02rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0.1rem 0 0.15rem;
+}
+.season-card-good .season-card-headline { color: var(--good); }
+.season-card-warn .season-card-headline { color: var(--warn); }
+.season-card-bad  .season-card-headline { color: var(--bad); }
 
 .season-card-past {
   opacity: 0.85;
@@ -3782,20 +4379,24 @@ body.maptap-rivals-app select option {
   color: var(--bad);
 }
 
-/* Dashboard active-season banner */
+/* Dashboard active-season banner — shares the season cards' status-accent
+   language (left edge keyed to on-track/behind). */
 .season-dash-banner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   padding: 0.65rem 0.9rem;
-  background: var(--accent-soft);
+  background: linear-gradient(135deg, rgba(99,102,241,0.10), transparent 65%), var(--surface);
   border: 1px solid var(--accent-strong);
+  border-left-width: 3px;
   border-radius: var(--radius-sm);
   margin-bottom: 1rem;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s;
 }
+.season-dash-banner.is-on-track { border-left-color: var(--good); }
+.season-dash-banner.is-behind   { border-left-color: var(--warn); }
 
 .season-dash-banner:hover {
   background: rgba(99, 102, 241, 0.22);
@@ -3808,8 +4409,17 @@ body.maptap-rivals-app select option {
 }
 
 .season-dash-banner-name {
-  font-size: 0.88rem;
+  font-size: 0.78rem;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.season-dash-banner-headline {
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
   color: var(--text);
 }
 

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -194,7 +194,8 @@
       <!-- Today's predictions: predicted vs actual head-to-head card.
            Filled in by renderTodaysPredictions() once today's puzzle
            locations are fetched and per-player history is available.
-           Coordinates only — city names are never rendered. -->
+           Only coordinates are persisted; city names render only behind the
+           "user has played this day" gate and are never written to storage. -->
       <section class="todays-card" id="todays-card" hidden>
         <header class="todays-card-head">
           <div class="todays-card-title">
@@ -255,7 +256,9 @@
           <h2 class="section-title">Round-by-round breakdown</h2>
           <span class="loc-section-sub" id="loc-section-sub"></span>
         </header>
-        <div class="loc-callouts" id="loc-callouts"></div>
+        <div class="loc-insight-groups" id="loc-insight-groups"></div>
+        <div class="loc-callouts" id="loc-callouts" hidden></div>
+        <h3 class="loc-subhead">Charts &amp; history</h3>
         <div class="charts-grid">
           <div class="chart-card" id="heatmap-section">
             <div class="chart-card-head">
@@ -285,6 +288,7 @@
             <div class="loc-heatmap" id="loc-heatmap"></div>
           </div>
         </div>
+        <h3 class="loc-subhead">Per-round detail</h3>
         <div class="loc-card-grid" id="loc-card-grid"></div>
       </section>
 
@@ -294,6 +298,7 @@
           <h2 class="section-title">Continent breakdown</h2>
           <span class="loc-section-sub" id="continent-section-sub"></span>
         </header>
+        <div class="loc-insight-groups" id="continent-insight-groups"></div>
         <div class="continent-grid" id="continent-grid"></div>
       </section>
 
@@ -334,15 +339,7 @@
                 <option value="0">All</option>
               </select>
             </label>
-            <div class="pagination-pager">
-              <button type="button" class="pagination-btn" id="rival-games-prev" aria-label="Previous page">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><polyline points="15 18 9 12 15 6"/></svg>
-              </button>
-              <span class="pagination-current" id="rival-games-pagination-current"></span>
-              <button type="button" class="pagination-btn" id="rival-games-next" aria-label="Next page">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><polyline points="9 18 15 12 9 6"/></svg>
-              </button>
-            </div>
+            <div class="pager" id="rival-games-pager"></div>
           </div>
         </nav>
       </div>
@@ -356,15 +353,15 @@
           <thead>
             <tr>
               <th>#</th>
-              <th>Rival</th>
-              <th>Games</th>
-              <th>W</th>
-              <th>L</th>
-              <th>T</th>
+              <th id="lb-th-rival" class="lb-th-sortable" tabindex="0" role="button" aria-sort="none">Rival</th>
+              <th id="lb-th-games" class="lb-th-sortable" tabindex="0" role="button" aria-sort="none">Games</th>
+              <th id="lb-th-wins" class="lb-th-sortable" tabindex="0" role="button" aria-sort="none">W</th>
+              <th id="lb-th-losses" class="lb-th-sortable" tabindex="0" role="button" aria-sort="none">L</th>
+              <th id="lb-th-ties" class="lb-th-sortable" tabindex="0" role="button" aria-sort="none">T</th>
               <th id="lb-th-winpct" class="lb-th-sortable lb-th-sorted" tabindex="0" role="button" aria-sort="descending">Win %</th>
               <th id="lb-th-rivalry" class="lb-th-sortable" tabindex="0" role="button" aria-sort="none">Rivalry <span class="lb-th-hint" title="Rivalry score blends win rate, total games played, recency of results, and average margin. Higher = you are winning the rivalry.">(?)</span></th>
-              <th>Avg Δ</th>
-              <th>Streak</th>
+              <th id="lb-th-avgdiff" class="lb-th-sortable" tabindex="0" role="button" aria-sort="none">Avg Δ</th>
+              <th id="lb-th-streak" class="lb-th-sortable" tabindex="0" role="button" aria-sort="none">Streak</th>
               <th>Form</th>
             </tr>
           </thead>
@@ -408,7 +405,6 @@
         <h2 class="section-title">Rivalry Seasons</h2>
         <button type="button" class="btn btn-primary" id="new-season-btn">+ New season</button>
       </div>
-      <div id="seasons-active-banner"></div>
       <div id="seasons-body"></div>
     </section>
 
@@ -460,15 +456,7 @@
               <option value="0">All</option>
             </select>
           </label>
-          <div class="pagination-pager">
-            <button type="button" class="pagination-btn" id="history-prev" aria-label="Previous page">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><polyline points="15 18 9 12 15 6"/></svg>
-            </button>
-            <span class="pagination-current" id="history-pagination-current"></span>
-            <button type="button" class="pagination-btn" id="history-next" aria-label="Next page">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><polyline points="9 18 15 12 9 6"/></svg>
-            </button>
-          </div>
+          <div class="pager" id="history-pager"></div>
         </div>
       </nav>
       <p class="empty-state" id="history-empty" hidden>No games yet.</p>
@@ -554,6 +542,54 @@
         <button type="button" class="btn btn-ghost" data-close="modal">Cancel</button>
         <button type="button" class="btn btn-danger" id="rival-delete-btn" hidden>Delete</button>
         <button type="button" class="btn btn-primary" id="rival-save-btn">Save</button>
+      </div>
+    </article>
+  </div>
+
+  <!-- Delete game confirmation modal -->
+  <div class="modal" id="delete-game-modal" role="dialog" aria-modal="true" aria-labelledby="delete-game-title" hidden>
+    <div class="modal-backdrop" data-close="delete-game-modal"></div>
+    <article class="modal-panel modal-panel-sm">
+      <button type="button" class="modal-close" data-close="delete-game-modal" aria-label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
+      </button>
+      <h2 id="delete-game-title">Delete game?</h2>
+      <p class="modal-confirm-body" id="delete-game-body"></p>
+      <div class="modal-actions modal-actions-confirm">
+        <button type="button" class="btn btn-ghost" id="delete-game-cancel" data-close="delete-game-modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="delete-game-confirm">Delete</button>
+      </div>
+    </article>
+  </div>
+
+  <!-- Clear-all-games confirmation modal -->
+  <div class="modal" id="clear-games-modal" role="dialog" aria-modal="true" aria-labelledby="clear-games-title" hidden>
+    <div class="modal-backdrop" data-close="clear-games-modal"></div>
+    <article class="modal-panel modal-panel-sm">
+      <button type="button" class="modal-close" data-close="clear-games-modal" aria-label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
+      </button>
+      <h2 id="clear-games-title">Clear all games?</h2>
+      <p class="modal-confirm-body" id="clear-games-body"></p>
+      <div class="modal-actions modal-actions-confirm">
+        <button type="button" class="btn btn-ghost" id="clear-games-cancel" data-close="clear-games-modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="clear-games-confirm">Clear games</button>
+      </div>
+    </article>
+  </div>
+
+  <!-- Delete-season confirmation modal -->
+  <div class="modal" id="delete-season-modal" role="dialog" aria-modal="true" aria-labelledby="delete-season-title" hidden>
+    <div class="modal-backdrop" data-close="delete-season-modal"></div>
+    <article class="modal-panel modal-panel-sm">
+      <button type="button" class="modal-close" data-close="delete-season-modal" aria-label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
+      </button>
+      <h2 id="delete-season-title">Delete season?</h2>
+      <p class="modal-confirm-body" id="delete-season-body"></p>
+      <div class="modal-actions modal-actions-confirm">
+        <button type="button" class="btn btn-ghost" id="delete-season-cancel" data-close="delete-season-modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="delete-season-confirm">Delete</button>
       </div>
     </article>
   </div>

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -52,9 +52,16 @@
   // JS file at `data/this_day_in_history/<MonthDay>.js`. The file is CORS-
   // open and contains the same 5 cities every player will play that day
   // (it lists more for editorial flexibility, but MapTap only plays the
-  // first N_LOCS in file order — verified empirically across 5+ days). We
-  // fetch the text and pull only lat/lng — names and trivia are dropped
-  // before anything reaches the predictor or the UI.
+  // first N_LOCS in file order — verified empirically across 5+ days).
+  //
+  // We fetch the text and pull only lat/lng for the predictor — those are
+  // the only fields ever persisted (KEY.DAILY_CITIES_PREFIX cache holds
+  // coordinates, never names). City names ARE parsed, but only lazily: they
+  // are fetched on demand the first time an eligible user opts to reveal a
+  // round, kept in a module-level in-memory map (dailyNames), and rendered
+  // strictly behind the "user has played this day" gate. Names never reach
+  // localStorage and never render before the gate is satisfied, so the
+  // puzzle answer can't leak to a player who hasn't finished.
   const MAPTAP_DAILY_URL_BASE = 'https://maptap.gg/data/this_day_in_history/';
 
   const COLORS = [
@@ -305,6 +312,10 @@
     predictWindowAnchorISO: null,
     // ISO date of the day currently shown in the dashboard predictions card.
     predictSelectedISO: null,
+    // Per-selected-day set of round indices whose location name is revealed.
+    // Reset whenever the selected day changes. Only ever populated while the
+    // user has played the selected day (the reveal strip is gated on that).
+    predictRevealedRounds: new Set(),
   };
 
   function persistRivals() { save(KEY.RIVALS, state.rivals); }
@@ -368,9 +379,12 @@
 
   // Pull only the first N_LOCS lat/lng pairs from a daily puzzle file.
   // The MapTap client plays the first 5 cities in file order regardless
-  // of how many the file lists (verified across May 10-14 plays). We
-  // deliberately discard name/trivia/photos so the predictor and any
-  // downstream code never accidentally surface the answer.
+  // of how many the file lists (verified across May 10-14 plays). The
+  // coordinates are all that is ever persisted (see fetchDailyCities) and
+  // all the predictor needs. City names are parsed separately and only
+  // lazily, behind the played gate (see parseDailyNamesText / fetchDailyNames)
+  // — they never enter the localStorage cache and never reach the UI before
+  // the user has logged their own game for that day.
   // Regex: match `lat:` not preceded by a letter (excludes `labelLat:`),
   // then the nearest `lng:` (same letter-boundary exclusion).
   const DAILY_LATLNG_RE =
@@ -422,6 +436,55 @@
       return null;
     }
   }
+  // ---------- daily location names (in-memory only, behind played gate) ----------
+  // Names are never persisted. They live in this module-level map keyed by
+  // ISO date once an eligible user opts to reveal a round; the value is the
+  // first N_LOCS names in file order, paired to rounds the same way
+  // parseDailyCitiesText pairs lat/lng. Cleared implicitly on reload.
+  const dailyNames = new Map();        // iso -> string[N_LOCS]
+  const dailyNamesStatus = new Map();  // iso -> 'fetching' | 'ok' | 'error'
+
+  // Match `name: "City, Country"` only when `name` is not preceded by a
+  // letter (so keys merely ending in "name", e.g. `cityname:`, can't match),
+  // mirroring the letter-boundary guard used for lat/lng.
+  const DAILY_NAME_RE = /(?<![A-Za-z])name\s*:\s*"([^"]*)"/g;
+  function parseDailyNamesText(src) {
+    if (typeof src !== 'string' || !src.length) return null;
+    DAILY_NAME_RE.lastIndex = 0;
+    const out = [];
+    let m;
+    while ((m = DAILY_NAME_RE.exec(src)) !== null) {
+      const name = m[1].trim();
+      if (name) out.push(name);
+      if (out.length >= N_LOCS) break;
+    }
+    return out.length === N_LOCS ? out : null;
+  }
+
+  // Fetch + parse the day's location names into the in-memory map. Resolves
+  // to true on success, false on any failure (network, parse, wrong count).
+  // Idempotent: a second call while one is in flight or after success is a
+  // no-op that resolves immediately.
+  async function fetchDailyNames(iso) {
+    if (dailyNames.has(iso)) return true;
+    if (dailyNamesStatus.get(iso) === 'fetching') return false;
+    const url = mapTapDailyDataUrl(iso);
+    if (!url) { dailyNamesStatus.set(iso, 'error'); return false; }
+    dailyNamesStatus.set(iso, 'fetching');
+    try {
+      const res = await fetch(url, { credentials: 'omit' });
+      if (!res.ok) { dailyNamesStatus.set(iso, 'error'); return false; }
+      const names = parseDailyNamesText(await res.text());
+      if (!names) { dailyNamesStatus.set(iso, 'error'); return false; }
+      dailyNames.set(iso, names);
+      dailyNamesStatus.set(iso, 'ok');
+      return true;
+    } catch (_) {
+      dailyNamesStatus.set(iso, 'error');
+      return false;
+    }
+  }
+
   function fmtDateLong(iso) {
     if (!iso) return '—';
     const d = new Date(iso + 'T00:00:00');
@@ -1005,9 +1068,39 @@
   function deleteGame(id) {
     const g = state.games.find(x => x.id === id);
     if (!g) return;
-    const myLabel = iPlayed(g) ? String(getMyTotal(g)) : '—';
-    const theirLabel = theyPlayed(g) ? String(getTheirTotal(g)) : '—';
-    if (!confirm(`Delete this game (${shortDate(g.date)}, ${myLabel} vs ${theirLabel})?`)) return;
+    openDeleteGameModal(g);
+  }
+
+  function openDeleteGameModal(g) {
+    const modal = $('#delete-game-modal');
+    const body = $('#delete-game-body');
+    const cancelBtn = $('#delete-game-cancel');
+
+    const myLabel = iPlayed(g) ? String(getMyTotal(g)) : '-';
+    const theirLabel = theyPlayed(g) ? String(getTheirTotal(g)) : '-';
+    const rival = state.rivals.find(r => r.id === g.rivalId);
+    const rivalPart = rival ? ` vs ${rival.name}` : '';
+    body.textContent = `${shortDate(g.date)}${rivalPart}: ${myLabel} to ${theirLabel}. This cannot be undone.`;
+
+    state.deleteGameLastFocus = document.activeElement;
+    state.pendingDeleteGameId = g.id;
+    modal.hidden = false;
+    setTimeout(() => cancelBtn.focus(), 30);
+  }
+
+  function closeDeleteGameModal() {
+    $('#delete-game-modal').hidden = true;
+    state.pendingDeleteGameId = null;
+    const prev = state.deleteGameLastFocus;
+    state.deleteGameLastFocus = null;
+    if (prev && document.body.contains(prev)) setTimeout(() => prev.focus(), 0);
+  }
+
+  function confirmDeleteGame() {
+    const id = state.pendingDeleteGameId;
+    closeDeleteGameModal();
+    if (!id) return;
+    if (!state.games.some(x => x.id === id)) return;
     state.games = state.games.filter(x => x.id !== id);
     persistGames();
     if (state.view === 'dashboard') renderDashboard();
@@ -1191,7 +1284,38 @@
   }
 
   function seasonDateRange(season) {
-    return fmtDateShort(season.startDate) + ' – ' + fmtDateShort(season.endDate);
+    return fmtDateShort(season.startDate) + ' to ' + fmtDateShort(season.endDate);
+  }
+
+  // Story-first one-liner for a season card / the dashboard banner. Always
+  // dash-free; phrasing varies by bucket and goal type.
+  function seasonHeadline(season, stats, bucket) {
+    const goalV = Number(season.goalValue);
+    if (bucket === 'upcoming') {
+      const days = Math.max(1, daysBetween(todayISO(), season.startDate));
+      return `Starts in ${days} day${days === 1 ? '' : 's'}`;
+    }
+    const cur = seasonCurrentStat(season, stats);
+    if (season.goalType === 'winPct') {
+      if ((stats.wins + stats.losses) === 0) {
+        return bucket === 'past' ? 'No decided games this season' : 'No decided games yet';
+      }
+      const pct = stats.winPct.toFixed(0);
+      if (bucket === 'past') {
+        return stats.winPct >= goalV
+          ? `Won ${pct}% vs the ${goalV}% target`
+          : `Fell short at ${pct}% vs the ${goalV}% target`;
+      }
+      return `Winning ${pct}% vs the ${goalV}% target`;
+    }
+    const noun = season.goalType === 'wins' ? 'win' : 'game';
+    const nounS = `${noun}${goalV === 1 ? '' : 's'}`;
+    if (bucket === 'past') {
+      return cur >= goalV
+        ? `Goal met: ${cur} of ${goalV} ${nounS}`
+        : `Fell short: ${cur} of ${goalV} ${nounS}`;
+    }
+    return `${cur} of ${goalV} ${nounS} so far`;
   }
 
   function rivalLabel(rivalId) {
@@ -1211,12 +1335,19 @@
 
   function makeSeasonCard(season, bucket) {
     const stats = seasonStats(season);
-    const today = todayISO();
     const isActive = bucket === 'active';
     const isPast = bucket === 'past';
     const isUpcoming = bucket === 'upcoming';
 
-    const card = el('article', { class: 'season-card season-card-' + bucket });
+    // Status drives the card's accent: met/on-track green, behind amber,
+    // missed red, upcoming neutral.
+    const passed = isPast ? seasonVerdict(season, stats) : null;
+    const onTrack = isActive ? seasonOnTrack(season, stats) : null;
+    const statusCls =
+      isPast ? (passed ? ' season-card-good' : ' season-card-bad')
+      : isActive ? (onTrack === null ? '' : onTrack ? ' season-card-good' : ' season-card-warn')
+      : '';
+    const card = el('article', { class: 'season-card season-card-' + bucket + statusCls });
 
     // Header row
     const head = el('div', { class: 'season-card-head' });
@@ -1228,7 +1359,6 @@
     head.appendChild(headRight);
 
     if (isPast) {
-      const passed = seasonVerdict(season, stats);
       headRight.appendChild(el('span', {
         class: 'season-verdict-pill ' + (passed ? 'is-pass' : 'is-fail'),
       }, passed ? 'Passed' : 'Failed'));
@@ -1247,7 +1377,9 @@
 
     card.appendChild(head);
 
-    // Meta row
+    // Story-first headline, then the meta line.
+    card.appendChild(el('div', { class: 'season-card-headline' },
+      seasonHeadline(season, stats, bucket)));
     card.appendChild(el('div', { class: 'season-card-meta' }, [
       el('span', { class: 'season-card-meta-item' }, rivalLabel(season.rivalId)),
       el('span', { class: 'season-card-meta-sep' }, '·'),
@@ -1260,7 +1392,7 @@
     const wld = `${stats.wins}W · ${stats.losses}L · ${stats.ties}T`;
     const winPctStr = (stats.wins + stats.losses) > 0
       ? stats.winPct.toFixed(0) + '% win'
-      : '—';
+      : 'no decided games';
 
     card.appendChild(el('div', { class: 'season-card-stats' }, [
       el('span', { class: 'season-stat-num' }, String(stats.gamesPlayed)),
@@ -1271,18 +1403,19 @@
       el('span', { class: 'season-stat-pct' }, winPctStr),
     ]));
 
-    // Progress toward goal
+    // Progress toward goal. Guard the divisor: a persisted/imported season
+    // with goalValue 0 or non-numeric must not yield width:NaN%.
+    const goalV = Number(season.goalValue);
+    const goalSafe = Number.isFinite(goalV) && goalV > 0;
     const currentVal = seasonCurrentStat(season, stats);
     let progressFraction = 0;
-    if (season.goalType === 'winPct') {
-      progressFraction = stats.winPct / season.goalValue;
-    } else {
-      progressFraction = currentVal / season.goalValue;
+    if (goalSafe) {
+      progressFraction = (season.goalType === 'winPct' ? stats.winPct : currentVal) / goalV;
     }
 
     const progressLabel = season.goalType === 'winPct'
-      ? `${stats.winPct.toFixed(0)}% / ${season.goalValue}%`
-      : `${currentVal} / ${season.goalValue}`;
+      ? `${stats.winPct.toFixed(0)}% / ${goalSafe ? goalV : '?'}%`
+      : `${currentVal} / ${goalSafe ? goalV : '?'}`;
 
     const barCls = progressFraction >= 1 ? 'is-done' : '';
     card.appendChild(el('div', { class: 'season-progress-row' }, [
@@ -1291,13 +1424,10 @@
     ]));
 
     // On-track indicator (active only)
-    if (isActive) {
-      const onTrack = seasonOnTrack(season, stats);
-      if (onTrack !== null) {
-        card.appendChild(el('div', {
-          class: 'season-track-pill ' + (onTrack ? 'is-on-track' : 'is-behind'),
-        }, onTrack ? 'On track' : 'Behind'));
-      }
+    if (isActive && onTrack !== null) {
+      card.appendChild(el('div', {
+        class: 'season-track-pill ' + (onTrack ? 'is-on-track' : 'is-behind'),
+      }, onTrack ? 'On track' : 'Behind'));
     }
 
     return card;
@@ -1306,10 +1436,38 @@
   function deleteSeason(id) {
     const season = state.seasons.find(s => s.id === id);
     if (!season) return;
-    if (!confirm(`Delete season "${season.name}"? This cannot be undone.`)) return;
+    openDeleteSeasonModal(season);
+  }
+
+  // Delete-season confirmation modal — same pattern as the delete-game and
+  // clear-games modals: Cancel gets initial focus; backdrop/X/Escape close
+  // without deleting; focus returns to the trigger afterwards.
+  function openDeleteSeasonModal(season) {
+    const modal = $('#delete-season-modal');
+    $('#delete-season-body').textContent =
+      `${season.name} (${seasonDateRange(season)}). This cannot be undone.`;
+    state.pendingDeleteSeasonId = season.id;
+    state.deleteSeasonLastFocus = document.activeElement;
+    modal.hidden = false;
+    setTimeout(() => $('#delete-season-cancel').focus(), 30);
+  }
+
+  function closeDeleteSeasonModal() {
+    $('#delete-season-modal').hidden = true;
+    state.pendingDeleteSeasonId = null;
+    const prev = state.deleteSeasonLastFocus;
+    state.deleteSeasonLastFocus = null;
+    if (prev && document.body.contains(prev)) setTimeout(() => prev.focus(), 0);
+  }
+
+  function confirmDeleteSeason() {
+    const id = state.pendingDeleteSeasonId;
+    closeDeleteSeasonModal();
+    if (!id) return;
     state.seasons = state.seasons.filter(s => s.id !== id);
     persistSeasons();
     renderSeasons();
+    renderActiveSeasonBanner();
     if (state.view === 'dashboard') renderDashboard();
   }
 
@@ -1456,14 +1614,18 @@
 
     const season = active[0];
     const stats = seasonStats(season);
-    const daysLeft = daysBetween(today, season.endDate);
+    // Inclusive count — on the season's final day this reads "1 day left",
+    // not "0 days left" (the old off-by-one).
+    const daysLeft = Math.max(0, daysBetween(today, season.endDate) + 1);
     const onTrack = seasonOnTrack(season, stats);
     const trackText = onTrack === null ? '' : (onTrack ? ' · On track' : ' · Behind');
+    const statusCls = onTrack === null ? '' : (onTrack ? ' is-on-track' : ' is-behind');
 
     wrap.hidden = false;
-    const banner = el('div', { class: 'season-dash-banner', onclick: () => setView('seasons') }, [
+    const banner = el('div', { class: 'season-dash-banner' + statusCls, onclick: () => setView('seasons') }, [
       el('div', { class: 'season-dash-banner-left' }, [
         el('span', { class: 'season-dash-banner-name' }, season.name + ' is active'),
+        el('span', { class: 'season-dash-banner-headline' }, seasonHeadline(season, stats, 'active')),
         el('span', { class: 'season-dash-banner-meta' }, `${daysLeft} day${daysLeft === 1 ? '' : 's'} left${trackText}`),
       ]),
       el('span', { class: 'season-dash-banner-arrow' }, '→'),
@@ -1643,6 +1805,62 @@
     }, [head, strip]);
   }
 
+  // Day-level location reveal strip. Rendered only when the user has played
+  // the selected day (gate enforced by the caller). One button per round;
+  // each independently toggles its location name. Names are fetched lazily on
+  // the first reveal click and held in memory only — never persisted.
+  function makeLocationRevealStrip(iso) {
+    const status = dailyNamesStatus.get(iso);
+    const names = dailyNames.get(iso) || null;
+    const wrap = el('div', { class: 'pred-loc' }, [
+      el('div', { class: 'pred-loc-head' }, 'Locations'),
+    ]);
+    const strip = el('div', { class: 'pred-loc-strip' });
+    for (let i = 0; i < N_LOCS; i++) {
+      const revealed = state.predictRevealedRounds.has(i);
+      const name = revealed && names ? names[i] : null;
+      const failed = revealed && status === 'error';
+      const loading = revealed && status === 'fetching';
+      const label = name ? name
+                  : failed ? 'Location unavailable'
+                  : loading ? 'Loading…'
+                  : 'Reveal';
+      const btnCls = ['pred-loc-btn'];
+      if (revealed) btnCls.push('is-revealed');
+      if (failed) btnCls.push('is-error');
+      if (loading) btnCls.push('is-loading');
+      const aria = name
+        ? `Round ${i + 1} location: ${name}. Activate to hide.`
+        : `Reveal round ${i + 1} location`;
+      strip.appendChild(el('button', {
+        type: 'button',
+        class: btnCls.join(' '),
+        'aria-pressed': revealed ? 'true' : 'false',
+        'aria-label': aria,
+        onclick: () => {
+          if (state.predictRevealedRounds.has(i)) {
+            state.predictRevealedRounds.delete(i);
+            renderTodaysPredictions();
+            return;
+          }
+          state.predictRevealedRounds.add(i);
+          if (!dailyNames.has(iso) && dailyNamesStatus.get(iso) !== 'fetching') {
+            fetchDailyNames(iso).then(() => {
+              if (state.view === 'dashboard' &&
+                  state.predictSelectedISO === iso) renderTodaysPredictions();
+            });
+          }
+          renderTodaysPredictions();
+        },
+      }, [
+        el('span', { class: 'pred-loc-slot' }, `R${i + 1}`),
+        el('span', { class: 'pred-loc-name' }, label),
+      ]));
+    }
+    wrap.appendChild(strip);
+    return wrap;
+  }
+
   // Day-tab pill. Shows weekday + day-of-month. Today is labelled "Today";
   // tomorrow gets a thinner accent so the upcoming run reads at a glance.
   function makeDayTab(entry, todayIso) {
@@ -1661,6 +1879,7 @@
       onclick: () => {
         if (state.predictSelectedISO === entry.iso) return;
         state.predictSelectedISO = entry.iso;
+        state.predictRevealedRounds = new Set();
         renderTodaysPredictions();
       },
     }, [
@@ -1731,35 +1950,58 @@
     const myRounds = myProfileRounds();
     const myPred = predictRoundsForPlayer(myRounds, selected.cities, selectedISO);
     const myActuals = isPastOrToday ? actualScoresForDay(selectedISO) : { mineScores: null, mineTotal: null };
-    body.appendChild(makePredictionRow({
+
+    // Collect every player's row first, then order the leaderboard:
+    // players who already played rank first by actual score, everyone
+    // else follows by predicted score (actual is the #1 sort key,
+    // predicted the #2). Name is the final tie-break.
+    const rows = [];
+    rows.push({
       label: `${state.myIcon || '🧍'} ${state.me || 'You'}`,
+      sortName: state.me || 'You',
       predictedScores: myPred ? myPred.scores : null,
       actualScores:    myActuals.mineScores,
       predictedTotal:  myPred ? predTotalFromScores(myPred.scores) : null,
       actualTotal:     myActuals.mineTotal,
       isYou: true,
       accentColor: 'var(--accent-2)',
-    }));
+    });
 
     let predictedCount = myPred ? 1 : 0;
-    state.rivals
-      .slice()
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .forEach(r => {
-        const rounds = rivalRounds(r.id);
-        const pred = predictRoundsForPlayer(rounds, selected.cities, selectedISO);
-        if (pred) predictedCount++;
-        const act = isPastOrToday ? actualScoresForRivalDay(r.id, selectedISO) : { scores: null, total: null };
-        body.appendChild(makePredictionRow({
-          label: `${r.icon || '🎯'} ${r.name}`,
-          predictedScores: pred ? pred.scores : null,
-          actualScores:    act.scores,
-          predictedTotal:  pred ? predTotalFromScores(pred.scores) : null,
-          actualTotal:     act.total,
-          isYou: false,
-          accentColor: r.color,
-        }));
+    state.rivals.forEach(r => {
+      const rounds = rivalRounds(r.id);
+      const pred = predictRoundsForPlayer(rounds, selected.cities, selectedISO);
+      if (pred) predictedCount++;
+      const act = isPastOrToday ? actualScoresForRivalDay(r.id, selectedISO) : { scores: null, total: null };
+      rows.push({
+        label: `${r.icon || '🎯'} ${r.name}`,
+        sortName: r.name,
+        predictedScores: pred ? pred.scores : null,
+        actualScores:    act.scores,
+        predictedTotal:  pred ? predTotalFromScores(pred.scores) : null,
+        actualTotal:     act.total,
+        isYou: false,
+        accentColor: r.color,
       });
+    });
+
+    rows.sort((a, b) => {
+      const aPlayed = a.actualTotal != null, bPlayed = b.actualTotal != null;
+      if (aPlayed !== bPlayed) return aPlayed ? -1 : 1;
+      if (aPlayed) return (b.actualTotal - a.actualTotal) ||
+                          ((b.predictedTotal ?? -1) - (a.predictedTotal ?? -1)) ||
+                          a.sortName.localeCompare(b.sortName);
+      return ((b.predictedTotal ?? -1) - (a.predictedTotal ?? -1)) ||
+             a.sortName.localeCompare(b.sortName);
+    });
+    rows.forEach(r => body.appendChild(makePredictionRow(r)));
+
+    // Location reveal strip — gated strictly on the user having logged their
+    // own game for the selected day. No affordance (and no name in the DOM)
+    // exists for unplayed days; names are fetched lazily on first reveal.
+    if (myActuals.mineTotal != null) {
+      body.appendChild(makeLocationRevealStrip(selectedISO));
+    }
 
     if (predictedCount === 0) {
       status.textContent = 'Need more games';
@@ -2138,8 +2380,11 @@
     }
 
     // Refresh the dashboard tiles + summary so saved games land immediately.
+    // The active-season banner counts these games too — without this it
+    // showed stale progress until the next full dashboard render.
     renderDashSummary();
     renderRivalGrid();
+    renderActiveSeasonBanner();
   }
 
   function renderDashSummary() {
@@ -2175,7 +2420,10 @@
     const todayGames = h2hGames.filter(g => g.date === todayISO()).length;
 
     wrap.innerHTML = '';
-    wrap.appendChild(makeSummaryCard('Total games', totalGames, `${wins}W · ${losses}L · ${ties}T`));
+    // "Total games" (a raw logged-game count) was dropped as a headline —
+    // owner request. The record itself is the useful part, so it leads now.
+    wrap.appendChild(makeSummaryCard('Record', `${wins}W · ${losses}L · ${ties}T`,
+      `across ${state.rivals.length} rival${state.rivals.length === 1 ? '' : 's'}`));
     wrap.appendChild(makeSummaryCard('Overall win %', `${winPct.toFixed(0)}%`, totalGames ? `over ${totalGames} games` : '—'));
     wrap.appendChild(makeSummaryCard('Avg score', myAvg ? myAvg.toFixed(0) : '—', 'all-time'));
     wrap.appendChild(makeSummaryCard('Today', todayGames, todayGames === 1 ? 'game logged' : 'games logged'));
@@ -2558,7 +2806,279 @@
     }
     card.appendChild(foot);
 
+    const note = rivalryStatLine(s);
+    if (note) {
+      card.appendChild(el('div', { class: 'rival-card-note' }, [
+        el('span', { class: 'rival-card-note-emoji', 'aria-hidden': 'true' }, note.emoji),
+        el('span', { class: 'rival-card-note-text' }, note.text),
+      ]));
+    }
+
     return card;
+  }
+
+  // One quiet "fun stat" line at the foot of every rivalry card with at
+  // least one H2H game. We gather EVERY candidate whose condition genuinely
+  // holds for this rivalry's data, then pick one deterministically by hashing
+  // (rivalId + today's ISO date) so the stat varies day-to-day and rival-to-
+  // rival yet never flickers within a single day or re-render. Active win/loss
+  // streaks are deliberately excluded: the foot streak-tag already states the
+  // current streak, so we never repeat it here. Honesty rule: a candidate is
+  // only ever in the pool when its numbers are real, so nothing shown is faked.
+  function strHash(str) {
+    let h = 2166136261;
+    for (let i = 0; i < str.length; i++) {
+      h ^= str.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    return h >>> 0;
+  }
+
+  function rivalryStatLine(s) {
+    if (!s.total) return null;
+    const games = s.games;                 // H2H games, oldest -> newest
+    const cands = [];
+    const add = (emoji, text) => cands.push({ emoji, text });
+
+    // ----- shared derived values -----
+    const myAvg = s.myAvgAll, theirAvg = s.theirAvgAll;
+    const avgGap = Math.abs(myAvg - theirAvg);
+    const last = games[games.length - 1];
+    const lastDiff = last ? getMyTotal(last) - getTheirTotal(last) : 0;
+    const first = games[0];
+    const firstISO = first ? first.date : null;
+    const daysSinceFirst = firstISO
+      ? Math.round((Date.parse(todayISO()) - Date.parse(firstISO)) / 86400000)
+      : 0;
+
+    // Per-game margins (mine - theirs) with dates.
+    const margins = games.map(g => ({
+      diff: getMyTotal(g) - getTheirTotal(g),
+      date: g.date,
+      my: getMyTotal(g),
+      their: getTheirTotal(g),
+    }));
+    const wins = margins.filter(m => m.diff > 0);
+    const losses = margins.filter(m => m.diff < 0);
+    const ties = margins.filter(m => m.diff === 0);
+
+    // Weekend vs weekday split (Sat/Sun = weekend).
+    const isWeekend = (iso) => {
+      const d = new Date(iso + 'T00:00:00').getDay();
+      return d === 0 || d === 6;
+    };
+    const weekendGames = margins.filter(m => isWeekend(m.date));
+    const weekdayGames = margins.filter(m => !isWeekend(m.date));
+    const weekendWins = weekendGames.filter(m => m.diff > 0).length;
+    const weekdayWins = weekdayGames.filter(m => m.diff > 0).length;
+
+    // Longest gap (in days) between consecutive meetings.
+    let longestGap = 0, gapDate = null;
+    for (let i = 1; i < games.length; i++) {
+      const g = Math.round((Date.parse(games[i].date) - Date.parse(games[i - 1].date)) / 86400000);
+      if (g > longestGap) { longestGap = g; gapDate = games[i].date; }
+    }
+
+    // Comebacks: a win that immediately follows at least two straight losses.
+    let comebacks = 0;
+    let lossRun = 0;
+    for (const m of margins) {
+      if (m.diff < 0) lossRun++;
+      else { if (m.diff > 0 && lossRun >= 2) comebacks++; lossRun = 0; }
+    }
+
+    // Recent form over last 5 (newest-inclusive).
+    const recentForm = s.recentForm;       // ['W','L','T',...] oldest->newest of last5
+    const recentWins = recentForm.filter(r => r === 'W').length;
+    const recentLosses = recentForm.filter(r => r === 'L').length;
+
+    // Score-range spread of my totals.
+    const myTotals = games.map(getMyTotal);
+    const myMax = Math.max(...myTotals), myMin = Math.min(...myTotals);
+    const myRange = myMax - myMin;
+
+    // Both-high / both-low days; identical totals.
+    const bothOver900 = margins.filter(m => m.my >= 900 && m.their >= 900).length;
+    const bothUnder400 = margins.filter(m => m.my <= 400 && m.their <= 400).length;
+    const identical = margins.filter(m => m.diff === 0 && m.my === m.their).length;
+    const blowouts = margins.filter(m => Math.abs(m.diff) >= 200).length;
+
+    // Narrowest win (smallest positive margin).
+    const narrowWin = wins.length
+      ? wins.reduce((a, b) => (b.diff < a.diff ? b : a))
+      : null;
+
+    // Round-tracked extras (only when geo/round data exists).
+    const loc = s.locStats;                // null when no round data
+    const cc = s.carryChoke;
+
+    // ===================================================================
+    //  CANDIDATE POOL (~50). Each guarded so it only enters when true.
+    // ===================================================================
+
+    // -- Result / record shape --
+    if (s.wins > 0 && s.losses === 0 && s.ties === 0 && s.total >= 3)
+      add('\u{1F451}', `Flawless · ${s.wins}-0 all-time vs them`);
+    if (s.losses > 0 && s.wins === 0 && s.ties === 0 && s.total >= 3)
+      add('\u{1F9F1}', `They own you · 0-${s.losses} all-time`);
+    if (s.total >= 5 && s.winPct >= 0.7)
+      add('\u{1F4AA}', `You win ${Math.round(s.winPct * 100)}% of these`);
+    if (s.total >= 5 && s.winPct <= 0.3)
+      add('\u{1F62C}', `You only win ${Math.round(s.winPct * 100)}% of these`);
+    if (s.total >= 4 && s.wins === s.losses)
+      add('⚖️', `Dead even · ${s.wins}-${s.losses} all-time`);
+    if (s.ties >= 1)
+      add('🤝', `${s.ties} dead-heat ${s.ties === 1 ? 'day' : 'days'} between you`);
+    if (s.total >= 10)
+      add('📓', `${s.total} games deep · a real rivalry now`);
+    if (s.total >= 20)
+      add('🏟️', `Veterans · ${s.total} head-to-heads logged`);
+
+    // -- Margins / standout games --
+    if (s.biggestWinMargin >= 150 && s.biggestWinGame)
+      add('💥', `Biggest win · +${s.biggestWinMargin} on ${fmtDateShort(s.biggestWinGame.date)}`);
+    if (s.biggestLossMargin >= 150 && s.biggestLossGame)
+      add('🪓', `Worst loss · -${s.biggestLossMargin} on ${fmtDateShort(s.biggestLossGame.date)}`);
+    if (narrowWin && narrowWin.diff <= 15)
+      add('😮‍💨', `Squeaker · won by just ${narrowWin.diff} on ${fmtDateShort(narrowWin.date)}`);
+    if (blowouts >= 2)
+      add('💣', `${blowouts} blowout days (200+ margin)`);
+    if (s.bestMine >= 850 && s.bestMineGame)
+      add('🚀', `You once hit ${s.bestMine} vs them on ${fmtDateShort(s.bestMineGame.date)}`);
+    if (s.worstMine <= 200 && s.worstMineGame && s.total >= 2)
+      add('😵', `Your low was ${s.worstMine} on ${fmtDateShort(s.worstMineGame.date)}`);
+    if (s.bestTheirs >= 850 && s.bestTheirsGame)
+      add('🔥', `Their best was ${s.bestTheirs} on ${fmtDateShort(s.bestTheirsGame.date)}`);
+
+    // -- Averages / who leads --
+    if (s.total >= 4 && avgGap <= 25)
+      add('🪢', `Razor thin · avg gap only ${avgGap.toFixed(1)} pts`);
+    if (s.total >= 2 && avgGap >= 30) {
+      const ahead = myAvg >= theirAvg;
+      add('📊', ahead
+        ? `You lead by ${avgGap.toFixed(1)} pts avg`
+        : `Behind by ${avgGap.toFixed(1)} pts avg`);
+    }
+    if (s.total >= 5 && myAvg >= 800)
+      add('🎯', `You average ${Math.round(myAvg)} against them`);
+    if (s.total >= 5 && theirAvg >= 800)
+      add('👀', `They average ${Math.round(theirAvg)} · tough out`);
+
+    // -- Streaks (longest, historical, not the current one) --
+    if (s.streak.longestMine >= 3)
+      add('🌊', `Your best run · ${s.streak.longestMine} wins straight`);
+    if (s.streak.longestTheirs >= 3)
+      add('❄️', `Their best run · ${s.streak.longestTheirs} straight over you`);
+    if (comebacks >= 1)
+      add('🔄', `${comebacks} comeback win${comebacks === 1 ? '' : 's'} after losing streaks`);
+
+    // -- Recent form --
+    if (recentForm.length >= 4 && recentWins >= 3)
+      add('📈', `Hot lately · ${recentWins} of last ${recentForm.length}`);
+    if (recentForm.length >= 4 && recentLosses >= 3)
+      add('📉', `Cold lately · lost ${recentLosses} of last ${recentForm.length}`);
+
+    // -- Consistency --
+    if (s.total >= 5 && s.consistencyMine > 0 && s.consistencyMine <= 80)
+      add('📐', `Metronome · your scores swing only ±${Math.round(s.consistencyMine)}`);
+    if (s.total >= 5 && s.consistencyMine >= 180)
+      add('🎢', `Wild ride · your scores swing ±${Math.round(s.consistencyMine)}`);
+    if (s.total >= 5 && s.consistencyTheirs >= 180)
+      add('🌪️', `They're streaky · swing ±${Math.round(s.consistencyTheirs)}`);
+    if (myRange >= 400 && s.total >= 3)
+      add('📈', `Your range vs them: ${myMin} to ${myMax}`);
+
+    // -- Calendar / cadence --
+    if (firstISO)
+      add('📅', `First clash · ${fmtDateShort(firstISO)}`);
+    if (daysSinceFirst >= 30)
+      add('⏳', `${daysSinceFirst} days of rivalry and counting`);
+    if (daysSinceFirst >= 365)
+      add('🎂', `Over a year of head-to-heads`);
+    if (longestGap >= 14 && gapDate)
+      add('🕳️', `Longest break · ${longestGap} days before ${fmtDateShort(gapDate)}`);
+    if (s.total >= 4 && daysSinceFirst >= 7) {
+      const perWeek = (s.total / (daysSinceFirst / 7));
+      if (perWeek >= 1)
+        add('⚡', `Pace · about ${perWeek.toFixed(1)} games a week`);
+    }
+    if (weekendGames.length >= 3 && weekendWins / weekendGames.length >= 0.6)
+      add('🌞', `Weekend warrior · ${weekendWins}/${weekendGames.length} on weekends`);
+    if (weekdayGames.length >= 3 && weekdayWins / weekdayGames.length >= 0.6)
+      add('💼', `Weekday wins · ${weekdayWins}/${weekdayGames.length} Mon-Fri`);
+    if (weekendGames.length >= 2 && weekdayGames.length >= 2) {
+      const wWin = weekendWins / weekendGames.length;
+      const dWin = weekdayWins / weekdayGames.length;
+      if (Math.abs(wWin - dWin) >= 0.3)
+        add('🗓️', wWin > dWin
+          ? "You're better against them on weekends"
+          : "You're better against them on weekdays");
+    }
+
+    // -- Same / mirror days --
+    if (identical >= 1)
+      add('🪞', `${identical} day${identical === 1 ? '' : 's'} you tied to the point`);
+    if (bothOver900 >= 1)
+      add('🌟', `${bothOver900} day${bothOver900 === 1 ? '' : 's'} you both broke 900`);
+    if (bothUnder400 >= 1)
+      add('💤', `${bothUnder400} rough day${bothUnder400 === 1 ? '' : 's'} you both sank under 400`);
+
+    // -- Round-tracked extras (geo data present) --
+    if (loc) {
+      const myPerfRounds = loc.reduce((a, l) => a + l.myPerfects, 0);
+      const theirPerfRounds = loc.reduce((a, l) => a + l.theirPerfects, 0);
+      const mySubs = games.filter(hasLocs).reduce((a, g) =>
+        a + g.myScores.filter(x => x < 20).length, 0);
+      if (myPerfRounds >= 1)
+        add('💯', `${myPerfRounds} perfect-100 round${myPerfRounds === 1 ? '' : 's'} vs them`);
+      if (theirPerfRounds >= 1)
+        add('🎯', `They've nailed ${theirPerfRounds} perfect-100 round${theirPerfRounds === 1 ? '' : 's'}`);
+      if (mySubs >= 2)
+        add('🕳️', `${mySubs} rounds you scored under 20`);
+
+      // Per-round dominance / clutch / choke.
+      const best = loc.slice().filter(l => l.total >= 3).sort((a, b) => b.winPct - a.winPct)[0];
+      const worst = loc.slice().filter(l => l.total >= 3).sort((a, b) => a.winPct - b.winPct)[0];
+      if (best && best.winPct >= 0.7)
+        add('📍', `You dominate ${best.label} · ${Math.round(best.winPct * 100)}% won`);
+      if (worst && worst.winPct <= 0.3)
+        add('🚧', `${worst.label} is your weak spot vs them`);
+      const strongAvg = loc.slice().sort((a, b) => b.myAvg - a.myAvg)[0];
+      if (strongAvg && strongAvg.myAvg >= 70 && s.gamesWithLocsCount >= 3)
+        add('🧭', `Your best round vs them is ${strongAvg.label} (${Math.round(strongAvg.myAvg)} avg)`);
+      if (cc) {
+        const carryIdx = cc.carryInWins.indexOf(Math.max(...cc.carryInWins));
+        const chokeIdx = cc.chokeInLosses.indexOf(Math.max(...cc.chokeInLosses));
+        if (cc.carryInWins[carryIdx] >= 2)
+          add('🦸', `${LOC_LABELS[carryIdx]} carries most of your wins`);
+        if (cc.chokeInLosses[chokeIdx] >= 2)
+          add('🙅', `${LOC_LABELS[chokeIdx]} sinks most of your losses`);
+      }
+    }
+
+    // -- Always-on (sparse-data safety net): these fire from a single game so
+    //    even a brand-new rivalry shows a few honest, distinct candidates. --
+    if (lastDiff > 0)
+      add('🕑', `Last game · won by ${lastDiff} on ${fmtDateShort(last.date)}`);
+    else if (lastDiff < 0)
+      add('🕑', `Last game · lost by ${Math.abs(lastDiff)} on ${fmtDateShort(last.date)}`);
+    else if (last)
+      add('🕑', `Last game · tied ${getMyTotal(last)}-${getMyTotal(last)} on ${fmtDateShort(last.date)}`);
+    if (last)
+      add('🧾', `Latest scoreline · ${getMyTotal(last)}-${getMyTotal(last) - lastDiff} on ${fmtDateShort(last.date)}`);
+    if (s.biggestWinGame && s.biggestWinMargin > 0 && s.biggestWinMargin < 150)
+      add('💢', `Best win so far · +${s.biggestWinMargin} on ${fmtDateShort(s.biggestWinGame.date)}`);
+    if (s.biggestLossGame && s.biggestLossMargin > 0 && s.biggestLossMargin < 150)
+      add('😵‍💫', `Worst loss so far · -${s.biggestLossMargin} on ${fmtDateShort(s.biggestLossGame.date)}`);
+
+    if (!cands.length) return null;
+
+    // Deterministic rotation: index = strHash(rivalId + todayISO) % poolSize.
+    // Same rival + same calendar day -> same pick (no flicker on re-render);
+    // a new day or a different rival rotates to a different candidate.
+    const key = (s.rival && s.rival.id ? s.rival.id : '') + '|' + todayISO();
+    const idx = strHash(key) % cands.length;
+    return cands[idx];
   }
 
   // ---------- rival detail view ----------
@@ -2646,10 +3166,6 @@
       type: 'button', class: 'btn btn-ghost',
       onclick: () => openRivalModal(rival.id),
     }, '✎ Edit'));
-    actions.appendChild(el('button', {
-      type: 'button', class: 'btn btn-ghost',
-      onclick: () => setView('dashboard'),
-    }, '← Back'));
     headerHost.appendChild(actions);
 
     // Reflect any in-flight sync state on the freshly rendered button.
@@ -2674,41 +3190,151 @@
     }
     if (s.total) {
 
-    cardsHost.appendChild(makeStatCard('Win rate', `${(s.winPct * 100).toFixed(1)}%`, `${s.wins}W · ${s.losses}L · ${s.ties}T`, s.winPct >= 0.5 ? 'is-good' : 'is-bad'));
-    // Average per-game point gap rather than cumulative — comparable
-    // across rivals you've played different counts of games against.
+    // Cards are grouped into three clusters so the takeaway reads before the
+    // raw numbers: Performance (where the rivalry stands), Momentum (which way
+    // it's trending), and Key Insights (the standout swing factors). Each card
+    // leads with a plain-language value; supporting figures sit in the sub.
+    const perf = [];
+    const momentum = [];
+    const insights = [];
+
+    // --- Performance ---
+    const winPct100 = s.winPct * 100;
+    const winTakeaway =
+      s.winPct > 0.5 ? `Winning ${winPct100.toFixed(0)}% of meetings`
+      : s.winPct < 0.5 ? `Won only ${winPct100.toFixed(1)}% of meetings`
+      : 'Dead even, 50% of meetings';
+    perf.push(makeStatCard('Head-to-head', winTakeaway,
+      `${s.wins}W · ${s.losses}L · ${s.ties}T over ${s.total} game${s.total === 1 ? '' : 's'}`,
+      s.winPct >= 0.5 ? 'is-good' : 'is-bad'));
+
+    // Per-game point gap rather than cumulative, comparable across rivals
+    // you've played different counts of games against.
     const avgDiffAll = s.total ? (s.cumDiff / s.total) : 0;
-    const avgDiffSign = avgDiffAll > 0 ? '+' : '';
-    cardsHost.appendChild(makeStatCard('Avg Δ per game',
-      `${avgDiffSign}${avgDiffAll.toFixed(1)}`,
-      'your points − theirs',
+    const gapMag = Math.abs(avgDiffAll).toFixed(0);
+    const gapTakeaway =
+      avgDiffAll > 0.5 ? `Beating them by ${gapMag} pts per game`
+      : avgDiffAll < -0.5 ? `Losing by ${gapMag} pts per game`
+      : 'Scores are within a point';
+    // "Scoring edge" card removed (owner request): avg margin per game and
+    // the avg-score gap are the same number with opposite sign, so one card
+    // covers it — the sub line carries both players' averages.
+    perf.push(makeStatCard('Average margin', gapTakeaway,
+      `you ${s.myAvgAll.toFixed(0)} avg · ${rival.name} ${s.theirAvgAll.toFixed(0)} avg`,
       avgDiffAll >= 0 ? 'is-good' : 'is-bad'));
-    cardsHost.appendChild(makeStatCard('Avg score (you)', s.myAvgAll.toFixed(0), `7d ${s.myAvg7 ? s.myAvg7.toFixed(0) : '—'} · 30d ${s.myAvg30 ? s.myAvg30.toFixed(0) : '—'}`));
-    cardsHost.appendChild(makeStatCard(`Avg score (${rival.name})`, s.theirAvgAll.toFixed(0), `7d ${s.theirAvg7 ? s.theirAvg7.toFixed(0) : '—'} · 30d ${s.theirAvg30 ? s.theirAvg30.toFixed(0) : '—'}`));
-    cardsHost.appendChild(makeStatCard('Current streak',
-      s.streak.curMine > 0 ? `${s.streak.curMine} W` : s.streak.curTheirs > 0 ? `${s.streak.curTheirs} L` : '—',
-      `Longest: ${s.streak.longestMine} W / ${s.streak.longestTheirs} L`,
+
+    // --- Momentum ---
+    const streakTakeaway =
+      s.streak.curMine > 0 ? `On a ${s.streak.curMine}-game win streak`
+      : s.streak.curTheirs > 0 ? `On a ${s.streak.curTheirs}-game losing streak`
+      : 'No active streak';
+    momentum.push(makeStatCard('Current form', streakTakeaway,
+      `Longest run: ${s.streak.longestMine}W / ${s.streak.longestTheirs}L`,
       s.streak.curMine > 0 ? 'is-good' : s.streak.curTheirs > 0 ? 'is-bad' : ''));
-    const bestMineDate  = s.bestMineGame  ? shortDate(s.bestMineGame.date)  : null;
-    const worstMineDate = s.worstMineGame ? shortDate(s.worstMineGame.date) : null;
-    const bestTheirsDate  = s.bestTheirsGame  ? shortDate(s.bestTheirsGame.date)  : null;
-    const worstTheirsDate = s.worstTheirsGame ? shortDate(s.worstTheirsGame.date) : null;
-    cardsHost.appendChild(makeStatCard('Best score (you)', s.bestMine,
-      bestMineDate
-        ? `${bestMineDate} · Worst ${s.worstMine}${worstMineDate ? ` (${worstMineDate})` : ''}`
-        : `Worst: ${s.worstMine}`,
-      'is-accent'));
-    cardsHost.appendChild(makeStatCard(`Best score (${rival.name})`, s.bestTheirs,
-      bestTheirsDate
-        ? `${bestTheirsDate} · Worst ${s.worstTheirs}${worstTheirsDate ? ` (${worstTheirsDate})` : ''}`
-        : `Worst: ${s.worstTheirs}`));
-    cardsHost.appendChild(makeStatCard('Consistency (you)', s.consistencyMine.toFixed(1), 'σ — lower = steadier'));
-    cardsHost.appendChild(makeStatCard('Biggest win', s.biggestWinGame ? `+${s.biggestWinMargin}` : '—',
-      s.biggestWinGame ? `${s.biggestWinGame.myScore}–${s.biggestWinGame.theirScore} on ${shortDate(s.biggestWinGame.date)}` : '—',
-      s.biggestWinGame ? 'is-good' : ''));
-    cardsHost.appendChild(makeStatCard('Biggest loss', s.biggestLossGame ? `−${s.biggestLossMargin}` : '—',
-      s.biggestLossGame ? `${s.biggestLossGame.myScore}–${s.biggestLossGame.theirScore} on ${shortDate(s.biggestLossGame.date)}` : '—',
-      s.biggestLossGame ? 'is-bad' : ''));
+
+    // Recent vs all-time average swing tells the trend story.
+    const recentAvg = s.myAvg7 || s.myAvg30;
+    let trendTakeaway = 'Not enough recent games yet';
+    let trendMod = '';
+    if (recentAvg != null) {
+      const delta = recentAvg - s.myAvgAll;
+      trendTakeaway =
+        delta > 3 ? `Trending up, +${delta.toFixed(0)} vs your average`
+        : delta < -3 ? `Trending down, ${delta.toFixed(0)} vs your average`
+        : 'Holding steady near your average';
+      trendMod = delta > 3 ? 'is-good' : delta < -3 ? 'is-bad' : '';
+    }
+    momentum.push(makeStatCard('Recent trend', trendTakeaway,
+      `7d ${s.myAvg7 ? s.myAvg7.toFixed(0) : '—'} · 30d ${s.myAvg30 ? s.myAvg30.toFixed(0) : '—'} · all ${s.myAvgAll.toFixed(0)}`,
+      trendMod));
+
+    const consTakeaway =
+      s.consistencyMine < 10 ? 'Very steady scorer'
+      : s.consistencyMine < 20 ? 'Fairly consistent scorer'
+      : 'Streaky, high-variance scorer';
+    momentum.push(makeStatCard('Consistency', consTakeaway,
+      `σ ${s.consistencyMine.toFixed(1)} (lower is steadier)`));
+
+    // --- Key Insights ---
+    // Parity distance: how many more wins you'd need for wins ≥ losses. Only
+    // shown when behind, verbalized as flipped results to reach parity.
+    if (s.losses > s.wins) {
+      const flipsNeeded = Math.ceil((s.losses - s.wins) / 2);
+      const behindBy = s.losses - s.wins;
+      insights.push(makeStatCard('Path to parity',
+        `Need ${flipsNeeded} flipped result${flipsNeeded === 1 ? '' : 's'} to reach parity`,
+        `currently ${behindBy} game${behindBy === 1 ? '' : 's'} behind`,
+        'is-bad'));
+    }
+
+    // Main swing round: the round whose result most often decides games.
+    if (s.carryChoke) {
+      const swingIdx = argmax(s.carryChoke.decisive);
+      if (swingIdx >= 0 && s.carryChoke.decisive[swingIdx] > 0) {
+        const swingLoc = s.locStats ? s.locStats[swingIdx] : null;
+        const decided = s.carryChoke.decisive[swingIdx];
+        insights.push(makeStatCard('Main swing round',
+          `${LOC_LABELS[swingIdx]} is the main swing round`,
+          swingLoc
+            ? `decided ${decided} game${decided === 1 ? '' : 's'} · ${(swingLoc.winPct * 100).toFixed(0)}% win rate there`
+            : `decided ${decided} game${decided === 1 ? '' : 's'}`,
+          'is-accent'));
+      }
+    }
+
+    // Biggest swings combined into one insight card.
+    if (s.biggestWinGame || s.biggestLossGame) {
+      const swingSub = [];
+      if (s.biggestWinGame) {
+        swingSub.push(el('span', { class: 'sub-line' },
+          `Best win +${s.biggestWinMargin} (${s.biggestWinGame.myScore}–${s.biggestWinGame.theirScore} on ${shortDate(s.biggestWinGame.date)})`));
+      }
+      if (s.biggestLossGame) {
+        swingSub.push(el('span', { class: 'sub-line' },
+          `Worst loss −${s.biggestLossMargin} (${s.biggestLossGame.myScore}–${s.biggestLossGame.theirScore} on ${shortDate(s.biggestLossGame.date)})`));
+      }
+      const spread = (s.biggestWinGame ? s.biggestWinMargin : 0) + (s.biggestLossGame ? s.biggestLossMargin : 0);
+      insights.push(makeStatCard('Biggest swings',
+        `${spread}-point spread, best to worst`,
+        swingSub));
+    }
+
+    // "What might have been": replay the H2H with the round multipliers
+    // removed (plain sum of the 5 raw scores). Only games with both round
+    // arrays can be recomputed; totals-only games are excluded.
+    {
+      const tracked = s.games.filter(hasLocs);
+      if (tracked.length) {
+        let aw = 0, al = 0, at = 0, flips = 0;
+        for (const g of tracked) {
+          const myRaw = g.myScores.reduce((a, v) => a + (v || 0), 0);
+          const theirRaw = g.theirScores.reduce((a, v) => a + (v || 0), 0);
+          const altR = myRaw > theirRaw ? 'W' : myRaw < theirRaw ? 'L' : 'T';
+          if (altR === 'W') aw++; else if (altR === 'L') al++; else at++;
+          if (altR !== resultOf(g)) flips++;
+        }
+        // Two-line sub: the real record right under the alternate one for
+        // direct comparison, then the share of recomputable games whose
+        // outcome differs, with the new-vs-real win rates alongside.
+        const diffPct = Math.round((flips / tracked.length) * 100);
+        const altRate = Math.round((aw / tracked.length) * 100);
+        const realRate = Math.round(s.winPct * 100);
+        const sub = [
+          el('span', { class: 'sub-line' }, `(actual: ${s.wins}W · ${s.losses}L · ${s.ties}T)`),
+          el('span', { class: 'sub-line' },
+            `${diffPct}% of results would differ (win rate ${altRate}% vs ${realRate}% real)`),
+        ];
+        // Net result vs the real H2H decides the tint: more wins than the
+        // real record is good for the user, fewer is bad, equal is neutral.
+        const altDiff = (aw - al) - (s.wins - s.losses);
+        const mod = altDiff > 0 ? 'is-good' : altDiff < 0 ? 'is-bad' : '';
+        insights.push(makeStatCard('No-multiplier H2H', `${aw}W · ${al}L · ${at}T`, sub, mod));
+      }
+    }
+
+    appendStatGroup(cardsHost, 'Performance', perf);
+    appendStatGroup(cardsHost, 'Momentum', momentum);
+    appendStatGroup(cardsHost, 'Key Insights', insights);
 
     // callouts
     const rivalNameSafe = escapeHtml(rival.name);
@@ -2958,12 +3584,14 @@
   function renderContinentSection(s) {
     const section = $('#continent-section');
     const grid = $('#continent-grid');
+    const insightWrap = $('#continent-insight-groups');
     const sub = $('#continent-section-sub');
     const { rows, totalRounds } = continentBreakdown(s.games);
 
     if (!rows.length) {
       section.hidden = true;
       grid.innerHTML = '';
+      if (insightWrap) insightWrap.innerHTML = '';
       return;
     }
     section.hidden = false;
@@ -2973,6 +3601,8 @@
     sub.textContent =
       `${totalRounds} rounds across ${rows.length} continent${rows.length === 1 ? '' : 's'}` +
       (missing > 0 ? ` · ${missing} game${missing === 1 ? '' : 's'} have no geo data (re-sync to backfill)` : '');
+
+    renderContinentInsights(rows);
 
     grid.innerHTML = '';
     for (const r of rows) {
@@ -2990,13 +3620,19 @@
           el('span', { class: 'continent-rounds' }, `${r.rounds} ${r.rounds === 1 ? 'round' : 'rounds'}`),
         ]),
         el('div', { class: 'continent-scores' }, [
+          // Winner's avg renders green, loser's red; a tie leaves both
+          // neutral. Compared per continent, not overall.
           el('div', { class: 'col me' }, [
             el('div', { class: 'k' }, 'You avg'),
-            el('div', { class: 'v' }, r.myAvg.toFixed(1)),
+            el('div', {
+              class: 'v' + (r.myAvg > r.theirAvg ? ' is-win' : r.myAvg < r.theirAvg ? ' is-lose' : ''),
+            }, r.myAvg.toFixed(1)),
           ]),
           el('div', { class: 'col them' }, [
             el('div', { class: 'k' }, `${s.rival.name} avg`),
-            el('div', { class: 'v' }, r.theirAvg.toFixed(1)),
+            el('div', {
+              class: 'v' + (r.theirAvg > r.myAvg ? ' is-win' : r.theirAvg < r.myAvg ? ' is-lose' : ''),
+            }, r.theirAvg.toFixed(1)),
           ]),
         ]),
         el('div', { class: 'continent-record' }, [
@@ -3015,12 +3651,90 @@
     }
   }
 
+  // Story-first headlines above the continent cards. Surfaces the standout
+  // narratives (fortress, trouble spot, biggest gap, most-contested) so users
+  // grasp the geographic story before scanning the per-continent stats below.
+  // Reuses the insightGroup() pattern for visual consistency with the
+  // round-by-round redesign. Continents with too few rounds are excluded from
+  // the "best/worst win rate" picks so a single lucky round can't headline.
+  function renderContinentInsights(rows) {
+    const wrap = $('#continent-insight-groups');
+    if (!wrap) return;
+    wrap.innerHTML = '';
+    const groups = [];
+    const MIN_ROUNDS = 5;
+    const eligible = rows.filter(r => r.rounds >= MIN_ROUNDS);
+
+    if (eligible.length) {
+      // Fortress: best win rate among continents with enough rounds.
+      const fortress = eligible.slice().sort((a, b) => b.winPct - a.winPct)[0];
+      if (fortress.winPct > 0.5) {
+        groups.push(insightGroup('good', 'Fortress',
+          `<strong>${fortress.continent}</strong> is your fortress · <strong>${(fortress.winPct * 100).toFixed(0)}%</strong> of rounds won`,
+          [
+            `${fortress.myWins}/${fortress.rounds} rounds`,
+            `Avg ${fortress.myAvg.toFixed(0)} vs ${fortress.theirAvg.toFixed(0)}`,
+          ]));
+      }
+
+      // Trouble: worst win rate (skip if it's the same continent as fortress).
+      const trouble = eligible.slice().sort((a, b) => a.winPct - b.winPct)[0];
+      if (trouble.winPct < 0.5 && trouble.continent !== fortress.continent) {
+        groups.push(insightGroup('bad', 'Trouble spot',
+          `<strong>${trouble.continent}</strong> is where you struggle · <strong>${(trouble.winPct * 100).toFixed(0)}%</strong> of rounds won`,
+          [
+            `${trouble.myWins}/${trouble.rounds} rounds`,
+            `Avg ${trouble.myAvg.toFixed(0)} vs ${trouble.theirAvg.toFixed(0)}`,
+          ]));
+      }
+    }
+
+    // Biggest gap: largest absolute average margin per round, any round count,
+    // so even a sparse-but-lopsided continent gets a mention.
+    const byGap = rows.slice().sort((a, b) => Math.abs(b.avgDiff) - Math.abs(a.avgDiff))[0];
+    if (byGap && Math.abs(byGap.avgDiff) >= 3) {
+      const ahead = byGap.avgDiff > 0;
+      groups.push(insightGroup(ahead ? 'good' : 'bad', 'Biggest gap',
+        ahead
+          ? `You outscore them by <strong>${byGap.avgDiff.toFixed(0)}</strong> per round in <strong>${byGap.continent}</strong>`
+          : `They outscore you by <strong>${(-byGap.avgDiff).toFixed(0)}</strong> per round in <strong>${byGap.continent}</strong>`,
+        [`${byGap.rounds} rounds`, `Avg ${byGap.myAvg.toFixed(0)} vs ${byGap.theirAvg.toFixed(0)}`]));
+    }
+
+    // Most-contested: most rounds played, framed as the battleground.
+    const contested = rows.slice().sort((a, b) => b.rounds - a.rounds)[0];
+    if (contested && rows.length > 1) {
+      groups.push(insightGroup('warn', 'Most contested',
+        `<strong>${contested.continent}</strong> is your busiest battleground · <strong>${contested.rounds}</strong> rounds`,
+        [
+          `${contested.myWins}W · ${contested.theirWins}L · ${contested.ties}T`,
+          `${(contested.winPct * 100).toFixed(0)}% win rate`,
+        ]));
+    }
+
+    // Keep it scannable: at most three headlines, prioritized as built.
+    const built = groups.filter(Boolean).slice(0, 3);
+    built.forEach(g => wrap.appendChild(g));
+    wrap.hidden = built.length === 0;
+  }
+
   function makeStatCard(label, value, sub, mod) {
     return el('div', { class: 'stat-card ' + (mod || '') }, [
       el('div', { class: 'label' }, label),
       el('div', { class: 'value' }, String(value)),
       sub ? el('div', { class: 'sub' }, sub) : null,
     ]);
+  }
+
+  // Appends a titled cluster of stat cards (Performance / Momentum / Key
+  // Insights). The cards keep the .stat-cards grid mechanics; the group adds a
+  // small header above them. Empty groups render nothing.
+  function appendStatGroup(host, title, cards) {
+    if (!cards.length) return;
+    host.appendChild(el('div', { class: 'stat-card-group' }, [
+      el('div', { class: 'stat-card-group-title' }, title),
+      el('div', { class: 'stat-cards' }, cards),
+    ]));
   }
 
   function callout(kind, icon, html) {
@@ -3070,47 +3784,99 @@
       `${s.gamesWithLocsCount}/${s.total} games have round-by-round data` +
       (s.gamesWithLocsCount === s.total ? '' : ' (older games skipped)');
 
-    // Callouts
-    const cWrap = $('#loc-callouts');
-    cWrap.innerHTML = '';
-    if (s.strongest && s.weakest && s.strongest.locIdx !== s.weakest.locIdx) {
-      cWrap.appendChild(callout('good', '💪',
-        `Strongest at <strong>${s.strongest.label}</strong> — avg <strong>${s.strongest.myAvg.toFixed(1)}</strong> (rival: ${s.strongest.theirAvg.toFixed(1)}).`));
-      cWrap.appendChild(callout('bad', '🪤',
-        `Weakest at <strong>${s.weakest.label}</strong> — avg <strong>${s.weakest.myAvg.toFixed(1)}</strong> (rival: ${s.weakest.theirAvg.toFixed(1)}).`));
-    }
-    if (s.bestRoundWinPct && s.bestRoundWinPct.total >= 2) {
-      cWrap.appendChild(callout('good', '🎯',
-        `Best round win rate: <strong>${s.bestRoundWinPct.label}</strong> — won ${s.bestRoundWinPct.myWins}/${s.bestRoundWinPct.total} (${(s.bestRoundWinPct.winPct * 100).toFixed(0)}%).`));
-    }
-    if (s.worstRoundWinPct && s.worstRoundWinPct.total >= 2 && s.worstRoundWinPct !== s.bestRoundWinPct) {
-      cWrap.appendChild(callout('bad', '⚠️',
-        `Lowest round win rate: <strong>${s.worstRoundWinPct.label}</strong> — won ${s.worstRoundWinPct.myWins}/${s.worstRoundWinPct.total} (${(s.worstRoundWinPct.winPct * 100).toFixed(0)}%).`));
-    }
-    if (s.myTotalPerfects > 0 || s.theirTotalPerfects > 0) {
-      cWrap.appendChild(callout('', '💯',
-        `Perfect 100s — <strong>you ${s.myTotalPerfects}</strong>, ${escapeHtml(s.rival.name)} ${s.theirTotalPerfects}.`));
-    }
-    if (s.mostVolatile && s.mostVolatile.total >= 3) {
-      cWrap.appendChild(callout('', '🎲',
-        `Most volatile round: <strong>${s.mostVolatile.label}</strong> — σ ${s.mostVolatile.myConsistency.toFixed(1)}.`));
-    }
-    if (s.carryChoke) {
-      const carryIdx = argmax(s.carryChoke.carryInWins);
-      const chokeIdx = argmax(s.carryChoke.chokeInLosses);
-      if (carryIdx >= 0 && s.carryChoke.carryInWins[carryIdx] >= 2) {
-        cWrap.appendChild(callout('good', '🛡️',
-          `Carry round: <strong>${LOC_LABELS[carryIdx]}</strong> bailed you out in ${s.carryChoke.carryInWins[carryIdx]} wins.`));
-      }
-      if (chokeIdx >= 0 && s.carryChoke.chokeInLosses[chokeIdx] >= 2) {
-        cWrap.appendChild(callout('bad', '😬',
-          `Choke round: <strong>${LOC_LABELS[chokeIdx]}</strong> sank you in ${s.carryChoke.chokeInLosses[chokeIdx]} losses.`));
-      }
-    }
-
+    renderInsightGroups(s);
     renderLocationCards(s);
     renderHeatmap(s);
     requestAnimationFrame(() => renderLocationCharts(s));
+  }
+
+  // Builds one insight group: a category title, a lead headline (plain
+  // language, big), and a row of smaller supporting stat chips. Returns null
+  // when there's no headline to show so the caller can skip the whole group.
+  function insightGroup(kind, title, headline, supports) {
+    if (!headline) return null;
+    const chips = (supports || []).filter(Boolean).map(t =>
+      el('span', { class: 'lig-stat' }, [el('span', { html: t })]));
+    return el('div', { class: 'loc-insight-group ' + kind }, [
+      el('div', { class: 'lig-title' }, title),
+      el('div', { class: 'lig-headline', html: headline }),
+      chips.length ? el('div', { class: 'lig-stats' }, chips) : null,
+    ]);
+  }
+
+  function renderInsightGroups(s) {
+    const wrap = $('#loc-insight-groups');
+    wrap.innerHTML = '';
+    const groups = [];
+
+    // Strengths — best round by win rate, anchored to the avg-best round.
+    if (s.bestRoundWinPct && s.bestRoundWinPct.total >= 2) {
+      const b = s.bestRoundWinPct;
+      groups.push(insightGroup('good', 'Strengths',
+        `<strong>${b.label}</strong> is your power round · <strong>${(b.winPct * 100).toFixed(0)}%</strong> win rate`,
+        [
+          `Won ${b.myWins}/${b.total}`,
+          `Avg ${b.myAvg.toFixed(1)} vs ${b.theirAvg.toFixed(1)}`,
+          s.strongest && s.strongest.locIdx !== b.locIdx
+            ? `Highest avg: ${s.strongest.label} (${s.strongest.myAvg.toFixed(1)})` : null,
+          (s.myTotalPerfects > 0) ? `${s.myTotalPerfects} perfect 100s` : null,
+        ]));
+    }
+
+    // Weaknesses — lowest win-rate round (skip if it's the same as strongest).
+    if (s.worstRoundWinPct && s.worstRoundWinPct.total >= 2 &&
+        s.worstRoundWinPct !== s.bestRoundWinPct) {
+      const w = s.worstRoundWinPct;
+      groups.push(insightGroup('bad', 'Weaknesses',
+        `<strong>${w.label}</strong> is your weak spot · <strong>${(w.winPct * 100).toFixed(0)}%</strong> win rate`,
+        [
+          `Won ${w.myWins}/${w.total}`,
+          `Avg ${w.myAvg.toFixed(1)} vs ${w.theirAvg.toFixed(1)}`,
+          s.weakest && s.weakest.locIdx !== w.locIdx
+            ? `Lowest avg: ${s.weakest.label} (${s.weakest.myAvg.toFixed(1)})` : null,
+        ]));
+    }
+
+    // Volatility — steadiest vs swingiest round by my σ.
+    if (s.locStats && s.locStats.length) {
+      const byVol = s.locStats.filter(l => l.total >= 3)
+        .slice().sort((a, b) => b.myConsistency - a.myConsistency);
+      if (byVol.length >= 2) {
+        const swing = byVol[0];
+        const steady = byVol[byVol.length - 1];
+        groups.push(insightGroup('warn', 'Volatility',
+          `<strong>${swing.label}</strong> is your swingiest round · σ <strong>${swing.myConsistency.toFixed(1)}</strong>`,
+          [
+            `Steadiest: ${steady.label} (σ ${steady.myConsistency.toFixed(1)})`,
+            `${swing.label} range ${swing.myWorst}–${swing.myBest}`,
+          ]));
+      }
+    }
+
+    // Clutch / choke — which round carries wins vs sinks losses.
+    if (s.carryChoke) {
+      const carryIdx = argmax(s.carryChoke.carryInWins);
+      const chokeIdx = argmax(s.carryChoke.chokeInLosses);
+      const decisiveIdx = argmax(s.carryChoke.decisive);
+      const carryN = carryIdx >= 0 ? s.carryChoke.carryInWins[carryIdx] : 0;
+      const chokeN = chokeIdx >= 0 ? s.carryChoke.chokeInLosses[chokeIdx] : 0;
+      let headline = null;
+      if (carryN >= 2) {
+        headline = `<strong>${LOC_LABELS[carryIdx]}</strong> is your clutch round · carried <strong>${carryN}</strong> wins`;
+      } else if (chokeN >= 2) {
+        headline = `<strong>${LOC_LABELS[chokeIdx]}</strong> is your choke round · sank <strong>${chokeN}</strong> losses`;
+      }
+      groups.push(insightGroup('', 'Clutch / choke', headline, [
+        chokeN >= 1 && chokeIdx >= 0
+          ? `Choke: ${LOC_LABELS[chokeIdx]} sank ${chokeN} losses` : null,
+        decisiveIdx >= 0
+          ? `Most decisive: ${LOC_LABELS[decisiveIdx]} (${s.carryChoke.decisive[decisiveIdx]} games)` : null,
+      ]));
+    }
+
+    const built = groups.filter(Boolean);
+    built.forEach(g => wrap.appendChild(g));
+    wrap.hidden = built.length === 0;
   }
 
   function argmax(arr) {
@@ -3125,10 +3891,25 @@
   function renderLocationCards(s) {
     const grid = $('#loc-card-grid');
     grid.innerHTML = '';
+    // Subtle per-card background tint keyed to win rate: the round with the
+    // highest rate trends green, the lowest red, linearly interpolated
+    // between this rival's extremes (same red/green endpoints as heatColor,
+    // at low alpha). Skipped when all five rates are equal — no signal.
+    const pcts = s.locStats.map(l => l.winPct);
+    const minP = Math.min(...pcts);
+    const span = Math.max(...pcts) - minP;
     s.locStats.forEach(loc => {
+      let tint = '';
+      if (span > 0.001) {
+        const t = (loc.winPct - minP) / span;
+        const r = Math.round(248 + (74 - 248) * t);
+        const g = Math.round(113 + (222 - 113) * t);
+        const b = Math.round(113 + (128 - 113) * t);
+        tint = `--loc-tint:rgba(${r},${g},${b},0.1);`;
+      }
       const card = el('div', {
         class: 'loc-card',
-        style: `--loc-color:${LOC_COLORS[loc.locIdx]}`,
+        style: `--loc-color:${LOC_COLORS[loc.locIdx]};${tint}`,
         title: `${loc.name} · ×${loc.weight} weight`,
       }, [
         el('div', { class: 'lc-label' }, `${loc.label} · ×${loc.weight}`),
@@ -3169,7 +3950,19 @@
     // newest at top
     recent.slice().reverse().forEach(g => {
       const row = el('div', { class: 'heatmap-row' });
-      row.appendChild(el('span', { class: 'heatmap-rowlabel' }, fmtDateShort(g.date)));
+      // Date links out to that day's puzzle on maptap.gg — same pattern as
+      // the history table's date column.
+      const dayUrl = mapTapHistoryUrl(g.date);
+      row.appendChild(el('span', { class: 'heatmap-rowlabel' },
+        dayUrl
+          ? [el('a', {
+              href: dayUrl,
+              target: '_blank',
+              rel: 'noopener noreferrer',
+              class: 'maptap-day-link',
+              title: 'Open this day on maptap.gg',
+            }, fmtDateShort(g.date))]
+          : fmtDateShort(g.date)));
       for (let i = 0; i < N_LOCS; i++) {
         const m = g.myScores[i] || 0;
         const t = g.theirScores[i] || 0;
@@ -3343,24 +4136,67 @@
     // Differential bars
     destroyChart('diff');
     const diffs = last30.map(g => getMyTotal(g) - getTheirTotal(g));
+    // Trailing 5-game rolling average of the differential, overlaid as a line
+    // so the trend (improving / worsening / flat) reads at a glance instead of
+    // having to mentally average the bars. A trailing window (not cumulative)
+    // keeps the line responsive to recent reversals rather than smoothing them
+    // away. For the first few games the window is whatever's available, so the
+    // line is always computable even with < 5 games.
+    const ROLL = 5;
+    const rolling = diffs.map((_, i) => {
+      const start = Math.max(0, i - ROLL + 1);
+      const window = diffs.slice(start, i + 1);
+      return window.reduce((a, v) => a + v, 0) / window.length;
+    });
     state.charts.diff = new Chart($('#chart-diff'), {
-      type: 'bar',
       data: {
         labels: last30.map(g => fmtDateShort(g.date)),
-        datasets: [{
-          label: 'Score Δ',
-          data: diffs,
-          backgroundColor: diffs.map(d => d > 0 ? 'rgba(74,222,128,0.7)' : d < 0 ? 'rgba(248,113,113,0.7)' : 'rgba(154,163,178,0.7)'),
-          borderColor: diffs.map(d => d > 0 ? '#4ade80' : d < 0 ? '#f87171' : '#9aa3b2'),
-          borderWidth: 1,
-        }],
+        datasets: [
+          {
+            type: 'bar',
+            label: 'Score Δ',
+            data: diffs,
+            backgroundColor: diffs.map(d => d > 0 ? 'rgba(74,222,128,0.7)' : d < 0 ? 'rgba(248,113,113,0.7)' : 'rgba(154,163,178,0.7)'),
+            borderColor: diffs.map(d => d > 0 ? '#4ade80' : d < 0 ? '#f87171' : '#9aa3b2'),
+            borderWidth: 1,
+            order: 2,
+          },
+          {
+            type: 'line',
+            label: '5-game avg',
+            data: rolling,
+            borderColor: '#9aa3b2',
+            backgroundColor: 'rgba(154,163,178,0.08)',
+            borderWidth: 2,
+            tension: 0.3,
+            pointRadius: 0,
+            pointHoverRadius: 3,
+            fill: false,
+            order: 1,
+          },
+        ],
       },
       options: chartCommon({
         scales: {
           y: { ticks: { color: '#9aa3b2' }, grid: { color: '#252938' } },
           x: { ticks: { color: '#9aa3b2', maxRotation: 0, autoSkip: true }, grid: { color: '#1f232f' } },
         },
-        plugins: { legend: { display: false } },
+        plugins: {
+          legend: { labels: { color: '#e7e9ee', font: { size: 11 } } },
+          tooltip: {
+            backgroundColor: '#1f232f', borderColor: '#353a4b', borderWidth: 1,
+            titleColor: '#e7e9ee', bodyColor: '#e7e9ee',
+            callbacks: {
+              label: (ctx) => {
+                const v = ctx.parsed.y;
+                const sign = v > 0 ? '+' : '';
+                return ctx.dataset.label === '5-game avg'
+                  ? `5-game avg: ${sign}${v.toFixed(1)}`
+                  : `Score Δ: ${sign}${v}`;
+              },
+            },
+          },
+        },
       }),
     });
   }
@@ -3400,22 +4236,32 @@
     // Annotate each summary with its rivalry score so we compute it once.
     summaries.forEach(s => { s._rivalryScore = rivalryScore(s.rival.id); });
 
-    if (state.lbSort === 'rivalry') {
-      summaries.sort((a, b) => b._rivalryScore - a._rivalryScore || b.total - a.total);
-    } else {
-      summaries.sort((a, b) => b.winPct - a.winPct || b.total - a.total);
-    }
+    // Comparator per sortable column. Numeric columns sort descending;
+    // "rival" sorts A→Z. Ties fall back to games played, then name.
+    const LB_SORTS = {
+      rival:   (a, b) => a.rival.name.localeCompare(b.rival.name),
+      games:   (a, b) => b.total - a.total,
+      wins:    (a, b) => b.wins - a.wins,
+      losses:  (a, b) => b.losses - a.losses,
+      ties:    (a, b) => b.ties - a.ties,
+      winpct:  (a, b) => b.winPct - a.winPct,
+      rivalry: (a, b) => b._rivalryScore - a._rivalryScore,
+      avgdiff: (a, b) => (b.total ? b.cumDiff / b.total : 0) - (a.total ? a.cumDiff / a.total : 0),
+      // Streak: active win streaks (positive) first, then ties at 0, then
+      // active loss streaks (negative, longest = lowest).
+      streak:  (a, b) => (b.streak.curMine - b.streak.curTheirs) - (a.streak.curMine - a.streak.curTheirs),
+    };
+    const cmp = LB_SORTS[state.lbSort] || LB_SORTS.winpct;
+    summaries.sort((a, b) =>
+      cmp(a, b) || b.total - a.total || a.rival.name.localeCompare(b.rival.name));
 
     // Update sort-active state on the column headers.
-    const thWinPct  = $('#lb-th-winpct');
-    const thRivalry = $('#lb-th-rivalry');
-    if (thWinPct) {
-      thWinPct.classList.toggle('lb-th-sorted', state.lbSort === 'winpct');
-      thWinPct.setAttribute('aria-sort', state.lbSort === 'winpct' ? 'descending' : 'none');
-    }
-    if (thRivalry) {
-      thRivalry.classList.toggle('lb-th-sorted', state.lbSort === 'rivalry');
-      thRivalry.setAttribute('aria-sort', state.lbSort === 'rivalry' ? 'descending' : 'none');
+    for (const key of Object.keys(LB_SORTS)) {
+      const th = $('#lb-th-' + key);
+      if (!th) continue;
+      const active = state.lbSort === key;
+      th.classList.toggle('lb-th-sorted', active);
+      th.setAttribute('aria-sort', active ? (key === 'rival' ? 'ascending' : 'descending') : 'none');
     }
 
     summaries.forEach((s, i) => {
@@ -3490,7 +4336,6 @@
   const MATRIX_TABS = [
     { id: 'record', label: 'Record',    icon: '🏆' },
     { id: 'margin', label: 'Margin',    icon: '📐' },
-    { id: 'score',  label: 'Avg score', icon: '📊' },
     { id: 'form',   label: 'Last 5',    icon: '⚡' },
   ];
   function isValidMatrixTab(id) { return MATRIX_TABS.some(t => t.id === id); }
@@ -3606,30 +4451,16 @@
 
     if (subtab === 'margin') {
       const avg = (cell.rowTotal - cell.colTotal) / cell.games;
-      const tone = avg > 5 ? 'win' : avg < -5 ? 'loss' : 'tie';
+      // Any nonzero average margin colors the cell (the old ±5 dead zone hid
+      // real leads, e.g. +4/-4 over 20 games rendered gray on both sides).
+      const tone = avg > 0 ? 'win' : avg < 0 ? 'loss' : 'tie';
       const best = cell.bestMargin;
       return {
         tone,
-        title: `${row.label} vs ${col.label} — avg ${fmtSigned(avg)} per game, best ${fmtSigned(best)}, worst ${fmtSigned(cell.worstMargin)}`,
+        title: `${row.label} vs ${col.label} — avg ${fmtSigned(avg)} per game, best ${fmtSigned(best)}, worst ${fmtSigned(cell.worstMargin)} (${gamesLabel})`,
         content: [
           el('div', { class: 'matrix-record' }, fmtSigned(avg)),
           el('div', { class: 'matrix-margin' }, `best ${fmtSigned(best)}`),
-          el('div', { class: 'matrix-meta' }, gamesLabel),
-        ],
-      };
-    }
-
-    if (subtab === 'score') {
-      const rowAvg = cell.rowTotal / cell.games;
-      const colAvg = cell.colTotal / cell.games;
-      const tone = rowAvg > colAvg + 3 ? 'win' : rowAvg < colAvg - 3 ? 'loss' : 'tie';
-      return {
-        tone,
-        title: `${row.label} averages ${rowAvg.toFixed(0)} vs ${col.label}'s ${colAvg.toFixed(0)} across ${gamesLabel}`,
-        content: [
-          el('div', { class: 'matrix-record' }, String(Math.round(rowAvg))),
-          el('div', { class: 'matrix-margin' }, `vs ${Math.round(colAvg)}`),
-          el('div', { class: 'matrix-meta' }, gamesLabel),
         ],
       };
     }
@@ -3657,15 +4488,46 @@
         else if (kind === streakKind) streakLen++;
         else break;
       }
-      const streakLabel = streakLen > 0 ? `${streakKind}${streakLen}` : '—';
-      const tone = streakKind === 'W' ? 'win' : streakKind === 'L' ? 'loss' : 'tie';
+      // Longest win/loss streaks across the full meeting history.
+      let longW = 0, longL = 0, run = 0, runKind = null;
+      for (const m of cell.meetings) {
+        const kind = m.rowScore > m.colScore ? 'W'
+          : m.rowScore < m.colScore ? 'L'
+          : 'T';
+        if (kind === runKind) run++;
+        else { runKind = kind; run = 1; }
+        if (kind === 'W') longW = Math.max(longW, run);
+        else if (kind === 'L') longL = Math.max(longL, run);
+      }
+      // Label slot: a CURRENT streak only when it exceeds 5 games (a live run
+      // worth shouting about); otherwise the matchup's longest-ever WIN streak
+      // as a quieter "best W<n>" (floor of 2 — a single win is not a streak).
+      // Loss streaks never label a row's own cell: the mirrored cell shows
+      // them as the opponent's win streak. When a 6+ live streak takes the
+      // slot, the all-time best still shows on a smaller line beneath it —
+      // unless the live streak IS the best (no redundant repeat).
+      let streakLabel = null;
+      let bestLine = null;
+      if (streakLen > 5 && (streakKind === 'W' || streakKind === 'L')) {
+        streakLabel = `${streakKind}${streakLen}`;
+        const liveIsBestW = streakKind === 'W' && streakLen >= longW;
+        if (longW >= 2 && !liveIsBestW) bestLine = `best W${longW}`;
+      } else if (longW >= 2) {
+        streakLabel = `best W${longW}`;
+      }
+      // No background tone on Last 5 cells (owner request): the W/L tint
+      // would only re-encode the majority of the dots already on display,
+      // so the cell stays neutral and the dots carry all the signal.
+      const currentLabel = streakLen > 0 ? `${streakKind}${streakLen}` : 'none';
+      // No games-count meta line here — the dots already say how many recent
+      // meetings there are, and the count crowded the cell (owner request).
       return {
-        tone,
-        title: `Last ${last5.length} (oldest → newest), current streak ${streakLabel}`,
+        tone: 'plain',
+        title: `Last ${last5.length} (oldest → newest) · current streak ${currentLabel} · longest W${longW} / L${longL}`,
         content: [
           dots,
-          el('div', { class: 'matrix-margin' }, streakLabel),
-          el('div', { class: 'matrix-meta' }, gamesLabel),
+          streakLabel ? el('div', { class: 'matrix-margin' }, streakLabel) : null,
+          bestLine ? el('div', { class: 'matrix-meta' }, bestLine) : null,
         ],
       };
     }
@@ -3673,7 +4535,10 @@
     // 'record' (default)
     const winPct = (cell.wins + 0.5 * cell.ties) / cell.games;
     const winPctStr = (winPct * 100).toFixed(1) + '%';
-    const tone = winPct > 0.55 ? 'win' : winPct < 0.45 ? 'loss' : 'tie';
+    // Any lead colors the cell; neutral gray is reserved for a dead-even
+    // record. The old 45-55% dead zone hid real leads (e.g. 9-11 = 45.0%
+    // rendered gray instead of red).
+    const tone = winPct > 0.5 ? 'win' : winPct < 0.5 ? 'loss' : 'tie';
     return {
       tone,
       title: `${row.label} vs ${col.label} — ${gamesLabel}, ${winPctStr} win rate`,
@@ -3681,7 +4546,6 @@
         el('div', { class: 'matrix-record' },
           `${cell.wins}-${cell.losses}` + (cell.ties ? `-${cell.ties}` : '')),
         el('div', { class: 'matrix-margin' }, winPctStr),
-        el('div', { class: 'matrix-meta' }, gamesLabel),
       ],
     };
   }
@@ -3735,9 +4599,8 @@
 
   function matrixLegendText(subtab) {
     if (subtab === 'margin') return 'Avg point margin per game from the row\'s perspective; the small line shows the row\'s best single result vs that column.';
-    if (subtab === 'score')  return 'Row participant\'s average score in head-to-head meetings (small line: column\'s average in those same games).';
-    if (subtab === 'form')   return 'Dots = last 5 meetings (oldest left → newest right) from the row\'s perspective. Big label = current streak.';
-    return 'Wins-losses(-ties) and the row\'s win % — ties count as half a win.';
+    if (subtab === 'form')   return 'Dots = last 5 meetings (oldest left → newest right) from the row\'s perspective; cell color follows the dots\' majority. The label shows a live streak only when longer than 5 games, otherwise the row\'s longest win streak ("best W4").';
+    return 'Wins-losses(-ties) and the row\'s win % — ties count as half a win. (avg) next to each name = that player\'s average daily score.';
   }
 
   function renderMatrix() {
@@ -3771,18 +4634,40 @@
 
     const byRival = buildRivalDateIndex(sortedRivals.map(r => r.id));
 
+    // Per-participant average daily score (replaces the old "Avg score"
+    // subtab). Yours dedupes by date — the same daily score repeats across
+    // every rival you played that day.
+    const myByDate = new Map();
+    const rivalAvgById = new Map();
+    byRival.forEach((dates, rid) => {
+      let sum = 0, n = 0;
+      dates.forEach((v, date) => {
+        sum += v.theirs; n++;
+        if (!myByDate.has(date)) myByDate.set(date, v.mine);
+      });
+      rivalAvgById.set(rid, n ? sum / n : null);
+    });
+    let mySum = 0;
+    myByDate.forEach(v => { mySum += v; });
+    const myAvg = myByDate.size ? mySum / myByDate.size : null;
+    const avgFor = p => (p.type === 'you' ? myAvg : rivalAvgById.get(p.id));
+    // The "(avg)" annotation renders on the LEFT column (row heads) only —
+    // owner request; the top row stays just icon + name.
+    const headChip = (p, withAvg) => {
+      const avg = withAvg ? avgFor(p) : null;
+      return el('span', { class: 'matrix-head-chip', style: `--p-color:${p.color}` }, [
+        el('span', { class: 'matrix-head-icon' }, p.icon),
+        el('span', { class: 'matrix-head-name' }, p.label),
+        avg != null ? el('span', { class: 'matrix-head-avg' }, `(${Math.round(avg)})`) : null,
+      ]);
+    };
+
     const table = el('table', { class: 'matrix-table' });
     const thead = el('thead');
     const headRow = el('tr');
     headRow.appendChild(el('th', { class: 'matrix-corner', scope: 'col' }, ''));
     participants.forEach(p => {
-      const th = el('th', { class: 'matrix-col-head', scope: 'col' }, [
-        el('span', { class: 'matrix-head-chip', style: `--p-color:${p.color}` }, [
-          el('span', { class: 'matrix-head-icon' }, p.icon),
-          el('span', { class: 'matrix-head-name' }, p.label),
-        ]),
-      ]);
-      headRow.appendChild(th);
+      headRow.appendChild(el('th', { class: 'matrix-col-head', scope: 'col', title: p.label }, [headChip(p, false)]));
     });
     thead.appendChild(headRow);
     table.appendChild(thead);
@@ -3790,12 +4675,7 @@
     const tbody = el('tbody');
     participants.forEach(row => {
       const tr = el('tr');
-      tr.appendChild(el('th', { class: 'matrix-row-head', scope: 'row' }, [
-        el('span', { class: 'matrix-head-chip', style: `--p-color:${row.color}` }, [
-          el('span', { class: 'matrix-head-icon' }, row.icon),
-          el('span', { class: 'matrix-head-name' }, row.label),
-        ]),
-      ]));
+      tr.appendChild(el('th', { class: 'matrix-row-head', scope: 'row' }, [headChip(row, true)]));
       participants.forEach(col => {
         if (row === col) {
           tr.appendChild(el('td', { class: 'matrix-cell matrix-diag', 'aria-label': 'self' }, '—'));
@@ -3832,13 +4712,68 @@
       size === 0
         ? `Showing all ${total} game${total === 1 ? '' : 's'}`
         : `Showing ${startIdx + 1}–${endIdx} of ${total}`;
-    $('#rival-games-pagination-current').textContent =
-      size === 0 ? '—' : `${state.rivalGamesPage} / ${totalPages}`;
 
-    const prev = $('#rival-games-prev');
-    const next = $('#rival-games-next');
-    prev.disabled = size === 0 || state.rivalGamesPage <= 1;
-    next.disabled = size === 0 || state.rivalGamesPage >= totalPages;
+    renderPager($('#rival-games-pager'), state.rivalGamesPage, totalPages, size, (n) => {
+      state.rivalGamesPage = n;
+      renderRival();
+    });
+  }
+
+  // Numbered pager in the rising-seasons style: Prev, page numbers with
+  // ellipsis gaps, Next. The current page is marked aria-current; disabled
+  // ends are non-interactive. Hidden when there's only one page (or the
+  // page-size is "All"), matching the other apps' behavior.
+  function renderPager(host, current, totalPages, size, onGo) {
+    host.innerHTML = '';
+    if (size === 0 || totalPages <= 1) {
+      host.hidden = true;
+      return;
+    }
+    host.hidden = false;
+    host.appendChild(pageButton('Prev', current - 1, current <= 1, onGo));
+    for (const n of pageNumbers(current, totalPages)) {
+      if (n === '…') {
+        host.appendChild(el('span', { class: 'page-ellipsis', 'aria-hidden': 'true' }, '…'));
+      } else {
+        const btn = pageButton(String(n), n, false, onGo);
+        btn.setAttribute('aria-label', `Page ${n}`);
+        if (n === current) btn.setAttribute('aria-current', 'page');
+        host.appendChild(btn);
+      }
+    }
+    host.appendChild(pageButton('Next', current + 1, current >= totalPages, onGo));
+  }
+
+  function pageButton(label, target, disabled, onGo) {
+    const btn = el('button', { type: 'button', class: 'page-btn' }, label);
+    if (disabled) {
+      btn.disabled = true;
+      btn.setAttribute('aria-disabled', 'true');
+    } else {
+      btn.addEventListener('click', () => onGo(target));
+    }
+    return btn;
+  }
+
+  // Always include the first/last page and the window around the current one,
+  // collapsing the rest into ellipsis markers. Small ranges show every page.
+  function pageNumbers(current, total) {
+    const set = new Set([1, total]);
+    for (let i = current - 1; i <= current + 1; i++) {
+      if (i >= 1 && i <= total) set.add(i);
+    }
+    if (total <= 7) {
+      for (let i = 1; i <= total; i++) set.add(i);
+    }
+    const sorted = [...set].sort((a, b) => a - b);
+    const out = [];
+    let prev = 0;
+    for (const n of sorted) {
+      if (n - prev > 1) out.push('…');
+      out.push(n);
+      prev = n;
+    }
+    return out;
   }
 
   // ---------- history ----------
@@ -3875,7 +4810,34 @@
 
     renderHistoryPagination(total, totalPages, startIdx, endIdx);
 
+    // Group the current page's games by day so the history reads
+    // day-by-day instead of as a continuous rival-by-rival mix. Each
+    // group gets a full-width header row (carrying the maptap.gg day
+    // link); individual rows drop their repeated date. A day split
+    // across a page boundary just shows as two partial groups.
+    const HISTORY_COLSPAN = 10;
+    let lastDate = null;
     pageGames.forEach(g => {
+      if (g.date !== lastDate) {
+        lastDate = g.date;
+        const dayUrl = mapTapHistoryUrl(g.date);
+        const dayLabel = dayUrl
+          ? el('a', {
+              href: dayUrl,
+              target: '_blank',
+              rel: 'noopener noreferrer',
+              class: 'maptap-day-link history-day-link',
+              title: 'Open this day on maptap.gg',
+            }, shortDate(g.date))
+          : el('span', { class: 'history-day-label' }, shortDate(g.date));
+        tbody.appendChild(el('tr', { class: 'history-day-header' }, [
+          el('td', { colspan: String(HISTORY_COLSPAN) }, [
+            el('span', { class: 'history-day-head-inner' }, [
+              dayLabel,
+            ]),
+          ]),
+        ]));
+      }
       const rival = rivalById[g.rivalId];
       const r = resultOf(g);
       const meHere = iPlayed(g);
@@ -3883,17 +4845,8 @@
       const myT = meHere ? getMyTotal(g) : null;
       const theirT = themHere ? getTheirTotal(g) : null;
       const diff = (meHere && themHere) ? (myT - theirT) : null;
-      const dayUrl = mapTapHistoryUrl(g.date);
-      const dateCell = dayUrl
-        ? el('td', {}, [el('a', {
-            href: dayUrl,
-            target: '_blank',
-            rel: 'noopener noreferrer',
-            class: 'maptap-day-link',
-            title: 'Open this day on maptap.gg',
-          }, shortDate(g.date))])
-        : el('td', {}, shortDate(g.date));
-      tbody.appendChild(el('tr', { class: r ? '' : 'row-one-sided' }, [
+      const dateCell = el('td', { class: 'history-row-date' }, '');
+      tbody.appendChild(el('tr', { class: 'history-day-row' + (r ? '' : ' row-one-sided') }, [
         dateCell,
         el('td', {}, rival ? `${rival.icon} ${rival.name}` : '—'),
         el('td', {
@@ -3929,13 +4882,11 @@
       size === 0
         ? `Showing all ${total} game${total === 1 ? '' : 's'}`
         : `Showing ${startIdx + 1}–${endIdx} of ${total}`;
-    $('#history-pagination-current').textContent =
-      size === 0 ? '—' : `${state.historyPage} / ${totalPages}`;
 
-    const prev = $('#history-prev');
-    const next = $('#history-next');
-    prev.disabled = size === 0 || state.historyPage <= 1;
-    next.disabled = size === 0 || state.historyPage >= totalPages;
+    renderPager($('#history-pager'), state.historyPage, totalPages, size, (n) => {
+      state.historyPage = n;
+      renderHistory();
+    });
   }
 
   // ---------- MapTap profile sync ----------
@@ -5071,12 +6022,32 @@
       alert('No games to clear.');
       return;
     }
-    const ok = confirm(
-      `Delete all ${n} game${n === 1 ? '' : 's'}?\n\n` +
-      `Your rivals and their MapTap usernames will be kept, so you can ` +
-      `re-sync fresh. This can't be undone.`
-    );
-    if (!ok) return;
+    openClearGamesModal(n);
+  }
+
+  // Clear-all-games confirmation modal — same pattern as the delete-game
+  // modal: Cancel gets initial focus, backdrop/X/Escape close without
+  // clearing, focus returns to the trigger after close.
+  function openClearGamesModal(n) {
+    const modal = $('#clear-games-modal');
+    $('#clear-games-body').textContent =
+      `Delete all ${n} game${n === 1 ? '' : 's'}? Your rivals and their ` +
+      `MapTap usernames are kept, so you can re-sync fresh. This cannot be undone.`;
+    state.clearGamesLastFocus = document.activeElement;
+    modal.hidden = false;
+    setTimeout(() => $('#clear-games-cancel').focus(), 30);
+  }
+
+  function closeClearGamesModal() {
+    $('#clear-games-modal').hidden = true;
+    const prev = state.clearGamesLastFocus;
+    state.clearGamesLastFocus = null;
+    if (prev && document.body.contains(prev)) setTimeout(() => prev.focus(), 0);
+  }
+
+  function confirmClearGames() {
+    closeClearGamesModal();
+    if (!state.games.length) return;
     state.games = [];
     persistGames();
     if (state.view === 'dashboard') renderDashboard();
@@ -5216,9 +6187,28 @@
     $('#rival-name').addEventListener('keydown', (e) => {
       if (e.key === 'Enter') { e.preventDefault(); saveRivalFromModal(); }
     });
+    // Delete-game confirmation modal
+    $('#delete-game-modal').querySelectorAll('[data-close="delete-game-modal"]').forEach(node => {
+      node.addEventListener('click', closeDeleteGameModal);
+    });
+    $('#delete-game-confirm').addEventListener('click', confirmDeleteGame);
+    // Clear-all-games confirmation modal
+    $('#clear-games-modal').querySelectorAll('[data-close="clear-games-modal"]').forEach(node => {
+      node.addEventListener('click', closeClearGamesModal);
+    });
+    $('#clear-games-confirm').addEventListener('click', confirmClearGames);
+    // Delete-season confirmation modal
+    $('#delete-season-modal').querySelectorAll('[data-close="delete-season-modal"]').forEach(node => {
+      node.addEventListener('click', closeDeleteSeasonModal);
+    });
+    $('#delete-season-confirm').addEventListener('click', confirmDeleteSeason);
+
     document.addEventListener('keydown', (e) => {
       if (e.key !== 'Escape') return;
       if (!$('#wa-modal').hidden) closeWhatsAppModal();
+      else if (!$('#delete-game-modal').hidden) closeDeleteGameModal();
+      else if (!$('#clear-games-modal').hidden) closeClearGamesModal();
+      else if (!$('#delete-season-modal').hidden) closeDeleteSeasonModal();
       else if (!$('#rival-modal').hidden) closeRivalModal();
       else if (!$('#season-modal').hidden) closeSeasonModal();
     });
@@ -5321,33 +6311,20 @@
       renderHistory();
     });
 
-    // history pagination
+    // history pagination — page navigation is delegated to the numbered
+    // pager rendered by renderPager; only the page-size select is wired here.
     $('#history-page-size').value = String(state.historyPageSize);
     $('#history-page-size').addEventListener('change', (e) => {
       state.historyPageSize = Number(e.target.value);
       state.historyPage = 1;
       renderHistory();
     });
-    $('#history-prev').addEventListener('click', () => {
-      if (state.historyPage > 1) { state.historyPage--; renderHistory(); }
-    });
-    $('#history-next').addEventListener('click', () => {
-      state.historyPage++;
-      renderHistory();
-    });
 
-    // rival-detail games pagination
+    // rival-detail games pagination — see note above re: numbered pager.
     $('#rival-games-page-size').value = String(state.rivalGamesPageSize);
     $('#rival-games-page-size').addEventListener('change', (e) => {
       state.rivalGamesPageSize = Number(e.target.value);
       state.rivalGamesPage = 1;
-      renderRival();
-    });
-    $('#rival-games-prev').addEventListener('click', () => {
-      if (state.rivalGamesPage > 1) { state.rivalGamesPage--; renderRival(); }
-    });
-    $('#rival-games-next').addEventListener('click', () => {
-      state.rivalGamesPage++;
       renderRival();
     });
 
@@ -5361,16 +6338,13 @@
         if (state.view === 'leaderboard') renderLeaderboard();
       };
     }
-    const lbThWinPct  = $('#lb-th-winpct');
-    const lbThRivalry = $('#lb-th-rivalry');
-    if (lbThWinPct) {
-      lbThWinPct.addEventListener('click',   makeLbSortHandler('winpct'));
-      lbThWinPct.addEventListener('keydown', makeLbSortHandler('winpct'));
-    }
-    if (lbThRivalry) {
-      lbThRivalry.addEventListener('click',   makeLbSortHandler('rivalry'));
-      lbThRivalry.addEventListener('keydown', makeLbSortHandler('rivalry'));
-    }
+    ['rival', 'games', 'wins', 'losses', 'ties', 'winpct', 'rivalry', 'avgdiff', 'streak']
+      .forEach(key => {
+        const th = $('#lb-th-' + key);
+        if (!th) return;
+        th.addEventListener('click',   makeLbSortHandler(key));
+        th.addEventListener('keydown', makeLbSortHandler(key));
+      });
 
     // cross-tab / sync changes
     window.addEventListener('storage', onExternalStorage);


### PR DESCRIPTION
Full improvement round for MapTap Rivals: the location-reveal feature plus ~35 owner-directed follow-ups from a live feedback session. Complete diff = 3 files, all under `apps/maptap-rivals/`.

## apps/maptap-rivals/js/app.js (+1462/-many)

**Today's predictions card**
- Per-round location reveal strip (`makeLocationRevealStrip`, `fetchDailyNames`, `parseDailyNamesText`): 5 toggle buttons (R1-R5) rendered ONLY when the user's own game for the selected day is logged. Names fetched lazily from the MapTap daily file on first reveal, held in in-memory Maps, paired to rounds by file order. The localStorage daily-cities cache stays coordinates-only (existing privacy invariant preserved; stale comments updated).
- Player rows re-sorted: players with an actual score rank first by actual desc, then unplayed players by predicted desc, name tie-break ("You" no longer pinned).
- Day-selector behavior untouched (CSS-only polish, see styles.css).

**Dashboard**
- Rivalry cards: `rivalryStatLine` rebuilt as a ~52-candidate fun-stat pool (record shapes, margins, averages, historical streaks, recent form, consistency, calendar facts, mirror days, round-tracked extras, always-on safety net), rotated deterministically by FNV-1a hash of rivalId+today. "Top score vs them" removed (owner: leaked a similar high score across rivals).
- Summary tiles: "Total games" replaced by "Record" (W·L·T headline).
- Paste-commit flow now also refreshes the active-season banner (stale-render bugfix).

**Rival view**
- Best score (you)/(rival) stat cards removed; "Personal best" callout kept.
- Stat cards regrouped into Performance / Momentum / Key Insights (`appendStatGroup`) with narrative takeaways ("Losing by 155 pts per game", "Need N flipped results to reach parity", "R5 is the main swing round"). Duplicate "Scoring edge" card removed (same number as "Average margin", opposite sign).
- "No-multiplier H2H" tile: alternate W·L·T if multipliers never existed, with "(actual: ...)" line and "N% of results would differ (win rate A% vs B% real)".
- Score-differential chart: 5-game rolling-average trend line overlaid (mixed bar+line).
- Round-by-round breakdown: insight groups (Strengths/Weaknesses/Volatility/Clutch-choke) lead; charts and per-round cards follow under subheads; `#loc-callouts` retired to a no-op.
- Continent breakdown: story headlines above the cards (fortress/trouble/gap/busiest); winner-green/loser-red avg coloring per continent (replaces always-green/always-indigo).
- Round-by-round heatmap dates link to maptap.gg/history/<MonthDay> (history-table pattern).
- Recent games pagination ported from rising-seasons (`renderPager`/`pageButton`/`pageNumbers`).
- "← Back" header button removed (tabs/hash navigation remain).

**Matrix**
- Tone dead zones removed: Record (45-55%), Margin (±5) — any lead colors the cell, neutral only when dead even (fixes owner-reported 9-11 gray and +4/-4 gray cases).
- "Avg score" subtab removed; each player's average daily score shows as "(N)" next to their name in the LEFT column row heads only.
- "X games" meta text removed from all tiles (counts live in hover titles).
- Last 5: regression-tested label rules — live streak labels only when >5 ("W7"/"L7"); otherwise longest WIN streak as "best W<n>" (floor 2); when a 6+ live streak takes the slot the all-time best still shows beneath unless the live run IS the best. Cell backgrounds removed entirely on this tab (they only re-encoded the dots); col-head titles added for icon-only mobile heads.

**Leaderboard**
- All data columns sortable (Rival A-Z, Games, W, L, T, Win %, Rivalry, Avg Δ, Streak) via a comparator map; was only Win % + Rivalry. aria-sort + sorted-state styling generalized.

**History**
- Day-grouped table: full-width date-header rows carry the maptap.gg link; member rows drop per-row dates for an accent gutter; "N games" header count later removed on owner feedback.
- Pagination ported from rising-seasons (`#history-pager`).

**Seasons (functional audit + fixes)**
- Stale dashboard banner after paste-save fixed; banner days-left off-by-one fixed (inclusive, "1 day left" on the final day); NaN/Infinity progress-width guard for legacy `goalValue: 0`; en/em-dash copy replaced ("A to B", "no decided games"); story-first `seasonHeadline` on cards and banner with status-keyed accents.
- Season delete converted from native confirm() to `#delete-season-modal`.

**Modals (all native confirms in owner-touched flows replaced)**
- `#delete-game-modal`, `#clear-games-modal`, `#delete-season-modal`: shared pattern — Cancel initial focus, backdrop/X/Escape safe, focus restore, Escape chain ordered.

## apps/maptap-rivals/css/styles.css (+756)
Location-reveal strip styles (incl. 3+2 mobile grid, pinned hovers vs the sitewide red button:hover); premium day-selector treatment (selected-day scale/gradient/underline; the "Today" dot was added then removed on owner feedback); stat-card group headers + multi-line subs; loc-card win-rate tint layer; insight-group cards; continent insight reuse; pager styles (accent aria-current, pinned hovers); history day headers, premium filter pills, sticky small-caps thead, brighter action icons; mobile-specific matrix layout (<=640px: icon-only col heads, sticky row heads, nowrap records, avg on its own line); season card/banner status accents and headline styles; compact collapsed paste bar; confirm-modal action styles; rival-card fun-stat note line.

## apps/maptap-rivals/index.html (+92/-)
Three confirm-modal blocks (delete-game, clear-games, delete-season); leaderboard headers gain sortable ids/roles; dead `#seasons-active-banner` removed; stale "names never rendered" comment corrected.

## Bugfixes found along the way
- Matrix Record/Margin neutral dead zones hid real leads (owner-reported twice).
- Last 5 cell tone contradicted the visible dots (green after 1 win on 4 losses).
- Leaderboard: 7 of 9 headers were inert.
- Seasons: stale banner, days-left off-by-one, NaN progress width, dead DOM node.
- "Scoring edge" stat card duplicated "Average margin".

## Deliberate non-changes
- Other native confirms (rival delete, import/replace) untouched — owner only asked for delete-game, clear-games, and the Seasons dig.
- Pre-existing em dashes in dashboard drama-pill copy left as-is (predates this round; flagged to owner).
- maptap-rivals has never had a README (same as football-h2h/arena) — left to a /doc-coverage sweep rather than authored mid-ship.
- Calendar heatmap's large cells on sparse short-span data: pre-existing sizing behavior, code-verified as not a regression.
- No unit-test infrastructure added for this app (none existed; the root suite doesn't include it) — behavior is covered by the living acceptance plan.

## Judgment calls
- Reveal gate is strictly "you played" (a rival having played keeps names hidden — they'd spoil your puzzle).
- Location reveal is one day-level strip, not per-player (locations are a property of the day).
- Names never persist: in-memory session Maps only, preserving the app's existing spoiler-safety invariant.
- Fun-stat rotation is hash(rival+day) so cards vary across rivals/days but never flicker within a day.
- Last 5 shows only WIN streaks as "best" labels: the mirrored cell shows loss streaks as the opponent's win streak, so nothing is lost matrix-wide.
- Trend line uses a trailing 5-game rolling average (responsive to reversals) rather than cumulative.

## Testing
- `npm test`: 896 pass / 0 fail (run after every change in the round).
- Living acceptance plan `.features/maptap-rivals-{claude,human}.md` (local, gitignored): 31+ sections, 9 run reports; latest run report covers the full round. Three app-test-runner passes early in the round (23 -> ~50 verified items via an iframe-click harness), then per-change orchestrator browser probes with engineered fixtures (sort order, modal paths incl. Escape/backdrop, computed styles, Chart.js datasets, pager navigation, streak/tone rules, seasons states incl. legacy goalValue=0).
- Desktop 1280 + mobile 390 screenshot verification for every visual change (evidence dirs deleted on ship per convention).
