### PR TITLE
fix(mario-kart): paginate mobile race cards, proper hidden-class toggling, per-version player count

### DIFF
--- a/apps/mario-kart/css/mario-kart-overrides.css
+++ b/apps/mario-kart/css/mario-kart-overrides.css
@@ -605,7 +605,7 @@ body.theme .h2h-player-pill {
    is cramped (dates wrap, the two action buttons stack) — a dead-zone. Raise
    the swap to 900 so tablet-portrait gets the roomy card layout. This block
    wins because mario-kart-overrides.css loads after responsive.css at equal
-   specificity. KEEP IN SYNC with the pagination-container hide below. */
+   specificity. */
 @media (max-width: 900px) {
     .table-container {
         display: none;
@@ -613,15 +613,6 @@ body.theme .h2h-player-pill {
 
     .mobile-cards {
         display: flex;
-    }
-
-    /* Cards render every race and ignore pagination; the desktop-only
-       pagination control would read "Showing 1-10 of N" while the cards run
-       past it. Hide the misleading control whenever cards are the active
-       presentation. The real fix (slicing the cards) is behavioral and
-       deferred to /audit-app. */
-    .pagination-container {
-        display: none !important;
     }
 }
 

--- a/apps/mario-kart/js/dateFilter.js
+++ b/apps/mario-kart/js/dateFilter.js
@@ -24,10 +24,13 @@ function setDateFilter(filter) {
         }
     });
 
-    // Show/hide custom date range
+    // Show/hide custom date range by toggling the .hidden utility class so the
+    // panel's flex layout comes from CSS (.custom-date-range) rather than an
+    // inline style. This keeps working even if .hidden is later hardened with
+    // !important.
     const customRange = document.getElementById('custom-date-range');
     if (customRange) {
-        customRange.style.display = filter === 'custom' ? 'flex' : 'none';
+        customRange.classList.toggle('hidden', filter !== 'custom');
         // Clear any error message when hiding custom range
         if (filter !== 'custom') {
             clearCustomDateError();

--- a/apps/mario-kart/js/main.js
+++ b/apps/mario-kart/js/main.js
@@ -1147,8 +1147,9 @@ function updateRaceHistoryTable(filteredRaces) {
         tableContainer.insertAdjacentHTML('afterend', paginationHtml);
     }
 
-    // Also update mobile cards (showing all races for mobile)
-    updateMobileRaceCards(filteredRaces);
+    // Mobile cards render the SAME paginated slice and the SAME index maps as
+    // the table, so the two presentations can never desync.
+    updateMobileRaceCards(filteredRaces, racesToDisplay, filteredIndexMap, racesIndexMap);
 
     // Update player icons in race history after rendering
     if (window.updateAllPlayerIcons) {
@@ -1158,7 +1159,7 @@ function updateRaceHistoryTable(filteredRaces) {
     }
 }
 
-function updateMobileRaceCards(filteredRaces) {
+function updateMobileRaceCards(filteredRaces, racesToDisplay, filteredIndexMap, racesIndexMap) {
     // Get the race history section element
     const raceHistorySection = document.querySelector('.race-history');
 
@@ -1175,9 +1176,14 @@ function updateMobileRaceCards(filteredRaces) {
         raceHistorySection.style.display = 'block';
     }
 
-    const mobileHtml = filteredRaces.slice().reverse().map((race, index) => {
+    // Render the same paginated slice the table renders (latest-first, current
+    // page only) so cards and table stay in lockstep.
+    const mobileHtml = racesToDisplay.map((race) => {
         const positions = players.map(player => race[player]).filter(pos => pos !== null);
-        const raceNumber = filteredRaces.length - index;
+        // Race number is the position within the filtered set (1-based), matching
+        // the table's numbering across pages.
+        const raceNumber = (filteredIndexMap.get(race) ?? -1) + 1;
+        const globalIndex = racesIndexMap.get(race) ?? -1;
 
         const playerPositions = players.map(player => {
             const position = race[player];
@@ -1202,8 +1208,8 @@ function updateMobileRaceCards(filteredRaces) {
                 ${playerPositions}
             </div>
             <div class="race-card-actions">
-                <button class="edit-btn" onclick="editRace(${races.indexOf(race)})" title="Edit race">✏️</button>
-                <button class="delete-btn" onclick="deleteRace(${races.indexOf(race)})" title="Delete race">🗑️</button>
+                <button class="edit-btn" onclick="editRace(${globalIndex})" title="Edit race">✏️</button>
+                <button class="delete-btn" onclick="deleteRace(${globalIndex})" title="Delete race">🗑️</button>
             </div>
         </div>
     `;

--- a/apps/mario-kart/js/sidebarPlayerSettings.js
+++ b/apps/mario-kart/js/sidebarPlayerSettings.js
@@ -46,7 +46,8 @@
         const container = document.getElementById('sidebar-player-settings');
         if (!container) return;
 
-        const playerCount = localStorage.getItem('marioKartPlayerCount') || '3';
+        const countKey = window.getStorageKey ? window.getStorageKey('PlayerCount') : 'marioKartPlayerCount';
+        const playerCount = localStorage.getItem(countKey) || '3';
         const playerNames = window.PlayerNameManager ? window.PlayerNameManager.getAll() : 
             { player1: 'Player 1', player2: 'Player 2', player3: 'Player 3', player4: 'Player 4' };
         


### PR DESCRIPTION
Functional/behavioral audit of the mario-kart app: a ~52-row behavioral inventory was built from a full source read, the living plan gained complete functional sections (A1-A8) which were then executed end to end, and the three real behavioral defects found (two previously deferred, one discovered live during execution) were fixed. `npm test` 896 pass / 0 fail at every step; rebased onto current master (post #160) before pushing.

## apps/mario-kart/js/main.js (+13/−7)

- `updateRaceHistoryTable` now passes its already-computed page slice (`racesToDisplay`) and the two index maps into the cards renderer instead of letting the cards re-derive their own list.
- `updateMobileRaceCards` signature changed to `(filteredRaces, racesToDisplay, filteredIndexMap, racesIndexMap)`: it maps the table's exact slice (previously `filteredRaces.slice().reverse()` — every race, ignoring pagination). Race numbering uses `filteredIndexMap` (identical to the table's numbers) and edit/delete use the `racesIndexMap` global index (previously `races.indexOf(race)`).
- Net effect: on phones the cards show only the current page, and table/cards consume the same array object, so the two presentations cannot desync — there is no second slice anywhere.

## apps/mario-kart/css/mario-kart-overrides.css (+1/−10)

- Removed the `.pagination-container { display:none !important }` stopgap from the `@media (max-width:900px)` block (added in #159 as a visual-honesty measure while the cards ignored pagination). The pagination bar is now visible and accurate in card mode: page buttons, prev/next, rows-per-page, and the "Showing X-Y of Z" summary all work at ≤900px. The rest of the media block (table/card swap) is unchanged; a stale "KEEP IN SYNC" comment tied to the removed rule was also dropped.

## apps/mario-kart/js/dateFilter.js (+5/−2)

- The custom date range panel was shown via inline `style.display = 'flex'` while its `.hidden` class stayed ON — it worked only because the inline style outranked the class, and any future `.hidden { !important }` hardening would have silently broken it. Now `classList.toggle('hidden', filter !== 'custom')`; no inline display writes. The visible state's `display:flex` comes from the existing `.custom-date-range` rule (layout.css). This was the only code path that set display on the panel, so all show/hide paths are covered.

## apps/mario-kart/js/sidebarPlayerSettings.js (+2/−1)

- Bug found and confirmed live during plan execution: the Manage Players count selector read `localStorage.getItem('marioKartPlayerCount')` directly — the MK8 Deluxe key — regardless of game version, so in MK World mode it showed the MK8D count (probe: MK World count set to 2, selector showed 3). Now resolves the key via the canonical `getStorageKey('PlayerCount')` pattern used everywhere else (dataManager). Re-probed post-fix: selector shows the per-version count with conflicting keys seeded.

## Bugfixes found along the way

- The MK World player-count read above is the audit's one newly-discovered defect; the other two fixes close out the items deferred from the #159 visual audit.

## Explicitly untouched

- `assets/js/pagination.js` (shared): all pagination behavior changes are app-side; the shared component is unmodified.
- Candidate bugs investigated and proven NOT bugs (no code change): undo-after-ADD removes the correct race even with an intervening delete (probed through the full add/delete/undo/undo sequence); clear-all is intentionally not undoable and the undo button state reflects the stack correctly; player names containing HTML render literally in the table header, mobile cards, and tooltip attributes (escape-html/setAttribute paths verified); old-format race data migrates on load; MK8D/MK World data isolation held in every probe.
- Dead-code handler references (`#player-count`, `#clear-btn`, non-sidebar `#undo-btn`/`#redo-btn`, `#date-button`/`#calendar-dropdown` — referenced in JS, absent from the DOM, silent no-ops): documented in the plan as cleanup candidates, deliberately not removed to keep this diff behavioral-only.
- README: unchanged — it was brought current in #159 and none of these fixes alter documented behavior claims.

## Judgment calls

- Mobile pagination bar placement: it renders directly under the "Race History" heading, above the cards (natural insertion point once the table container is hidden). Left as-is after screenshot review; trivially movable if below-the-cards is preferred.
- Card slice mechanism: chose passing the table's computed slice + shared Maps over having the cards call the pagination API themselves — one source of truth beats two synchronized consumers.
- The plan's B1-B28 visual sections were not re-executed (verified exhaustively the same day in #159 on this same code); only B11 was rewritten and re-run because the pagination fix changed its contract from "control hidden on mobile" to "control visible and accurate on mobile".

## Testing

- `npm test`: 896 pass / 0 fail (baseline, after each fix, post-rebase).
- Living plan pair (`.features/mario-kart-claude.md` + `-human.md`): A1-A8 functional sections authored this round and executed across two runner passes — latest run reports record 62 passed/observed, 0 failed, 46 unverified-headless (each annotated inline with the limitation and mirrored as an owner walkthrough item), plus the consolidation entry covering the three fixes.
- Fix verification: mobile cards probed at 390px (10 cards page 1, page-2 swap to "Showing 11-20 of 36", rows-per-page re-slice + scroll-to-top); custom-range probed for class state and zero inline-display residue across show/apply/hide; player-count fix re-probed with conflicting per-version keys seeded.
- Audit report archived: `.features/archive/mario-kart-functional-audit-2026-06-06.md`.