### PR TITLE
feat(football-h2h): functional audit round: modal a11y, import confirm, sidebar/date UX, dark dropdowns, backup UI removal, TZ/restore/sort fixes

### DIFF
--- a/apps/football-h2h/css/football-h2h.css
+++ b/apps/football-h2h/css/football-h2h.css
@@ -2583,3 +2583,8 @@ body.football-h2h-tracker {
         font-size: 1rem;
     }
 }
+
+/* Lock background scroll while any modal is open */
+body.modal-open {
+    overflow: hidden;
+}

--- a/apps/football-h2h/css/refresh.css
+++ b/apps/football-h2h/css/refresh.css
@@ -1018,9 +1018,29 @@ body.football-h2h-tracker .matchup-select {
     border: 1px solid var(--fh-border);
     border-radius: 10px;
     color: var(--fh-text);
+    /* The native dropdown list follows color-scheme, not the box styles */
+    color-scheme: dark;
     padding: 0.45rem 0.7rem;
     font-size: 0.85rem;
     cursor: pointer;
+}
+
+/* Dark theme for the shared pagination rows-per-page select (the shared
+   assets/css/pagination.css hardcodes a white background) */
+body.football-h2h-tracker .pagination-size select {
+    background: var(--fh-surface-2);
+    border-color: var(--fh-border);
+    color: var(--fh-text);
+    color-scheme: dark;
+}
+
+/* Dark dropdown LISTS for every select in the app. The popup follows the
+   DOCUMENT color-scheme (declared via <meta name="color-scheme" content="dark">
+   in index.html) in Chromium; explicit option styling covers browsers/versions
+   that paint options from author styles instead. */
+body.football-h2h-tracker select option {
+    background-color: #181c26;
+    color: #f1f3f8;
 }
 
 body.football-h2h-tracker .matchup-vs {

--- a/apps/football-h2h/css/sidebar.css
+++ b/apps/football-h2h/css/sidebar.css
@@ -690,9 +690,12 @@ body.theme .sidebar-overlay {
     flex: 1;
 }
 
-/* Date icon wrapper - simplified for ACTIONS button style */
+/* Date icon wrapper - simplified for ACTIONS button style.
+   NOTE: deliberately NOT position:relative — the hidden date input inside
+   is absolutely positioned and must span the whole .sidebar-date-btn-container
+   (the nearest positioned ancestor) so the entire row opens the picker,
+   not just the calendar icon. */
 .sidebar-date-icon-wrapper {
-    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -7,6 +7,7 @@
     
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="color-scheme" content="dark">
     <meta name="description" content="Free head-to-head football league manager. Track matches, record scores, manage penalty shootouts, and analyze player statistics with comprehensive team performance analytics.">
     <meta name="keywords" content="football tracker, head to head football, match tracker, football statistics, penalty shootout tracker, soccer league manager, football analytics, free sports tracker">
     <meta name="author" content="Shevato LLC">
@@ -191,14 +192,6 @@
                         <span class="action-icon">📥</span>
                         <span class="action-text">Import</span>
                     </button>
-                    <button class="sidebar-action-btn backup-btn" onclick="toggleBackupMenu(this)" aria-label="Download backup file (auto-backup runs every 10 minutes)">
-                        <span class="action-icon">💾</span>
-                        <span class="action-text">Backup</span>
-                    </button>
-                    <button class="sidebar-action-btn restore-btn" onclick="restoreFromBackup()" aria-label="Restore from auto-backup">
-                        <span class="action-icon">🔄</span>
-                        <span class="action-text">Restore</span>
-                    </button>
                 </div>
             </div>
             
@@ -226,15 +219,15 @@
             <div class="sidebar-section">
                 <h3 class="sidebar-section-title">Game Date</h3>
                 <div class="sidebar-game-date">
-                    <div class="sidebar-date-btn-container">
+                    <label for="sidebar-date-input" class="sidebar-date-btn-container" aria-label="Set default game date">
                         <span class="date-text" id="sidebar-date-text">Today</span>
-                        <div class="sidebar-date-icon-wrapper">
+                        <span class="sidebar-date-icon-wrapper">
                             <input type="date" id="sidebar-date-input" class="sidebar-date-input-hidden" onchange="updateSidebarDate()">
-                            <label for="sidebar-date-input" class="sidebar-date-icon-btn" aria-label="Set default game date">
+                            <span class="sidebar-date-icon-btn">
                                 <span class="date-icon">📅</span>
-                            </label>
-                        </div>
-                    </div>
+                            </span>
+                        </span>
+                    </label>
                     <button class="sidebar-date-today-btn" onclick="setSidebarDateToday()">Set to Today</button>
                 </div>
             </div>
@@ -380,14 +373,14 @@
                             <div class="matchup-select-group">
                                 <label class="matchup-label" id="matchupP1Label">Player 1's Team</label>
                                 <select id="matchupTeam1" class="matchup-select" onchange="updateMatchupResult()">
-                                    <option value="">— any —</option>
+                                    <option value="">Any</option>
                                 </select>
                             </div>
                             <span class="matchup-vs">vs</span>
                             <div class="matchup-select-group">
                                 <label class="matchup-label" id="matchupP2Label">Player 2's Team</label>
                                 <select id="matchupTeam2" class="matchup-select" onchange="updateMatchupResult()">
-                                    <option value="">— any —</option>
+                                    <option value="">Any</option>
                                 </select>
                             </div>
                         </div>

--- a/apps/football-h2h/js/backup.js
+++ b/apps/football-h2h/js/backup.js
@@ -1,4 +1,10 @@
-// Backup functionality for Football H2H Tracker
+// Silent auto-backup for Football H2H Tracker.
+//
+// Writes a snapshot of the app data to localStorage('footballH2HAutoBackup')
+// every 10 minutes as a safety net against accidental data loss. There is
+// deliberately no Backup/Restore UI (removed 2026-06-07 by owner decision:
+// Export/Import covers user-facing data portability); the snapshot can be
+// recovered manually from devtools if ever needed.
 let backupInterval = null;
 
 function initializeAutoBackup() {
@@ -17,8 +23,8 @@ function autoBackupToLocalStorage() {
         const backupData = {
             games: games,
             players: {
-                player1: document.getElementById('player1Name') ? document.getElementById('player1Name').value : '',
-                player2: document.getElementById('player2Name') ? document.getElementById('player2Name').value : ''
+                player1: player1Name || 'Player 1',
+                player2: player2Name || 'Player 2'
             },
             playerIcons: playerIcons,
             backupDate: new Date().toISOString(),
@@ -32,229 +38,8 @@ function autoBackupToLocalStorage() {
     }
 }
 
-function restoreFromBackup() {
-    try {
-        const backup = localStorage.getItem('footballH2HAutoBackup');
-        if (!backup) {
-            createWarningModal({
-                icon: '📦',
-                title: 'No Backup Found',
-                message: 'No automatic backup found. Backups are created every 10 minutes when you have game data.',
-                onConfirm: () => {},
-                onCancel: () => {}
-            });
-            return;
-        }
-
-        let backupData;
-        try {
-            backupData = JSON.parse(backup);
-        } catch (parseError) {
-            createErrorModal({
-                icon: '❌',
-                title: 'Backup Error',
-                message: 'Backup data is corrupted and cannot be restored.'
-            });
-            console.error('Backup parse error:', parseError);
-            return;
-        }
-
-        if (!backupData.games || !Array.isArray(backupData.games)) {
-            createErrorModal({
-                icon: '❌',
-                title: 'Invalid Backup',
-                message: 'Backup data is invalid - no games found.'
-            });
-            return;
-        }
-
-        const backupDate = new Date(backupData.backupDate).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false });
-        const gameCount = backupData.games.length;
-
-        createConfirmationModal({
-            icon: '🔄',
-            title: 'Restore from Backup?',
-            message: `Found backup with <strong>${gameCount} games</strong><br>
-                     Created on: <strong>${backupDate}</strong><br><br>
-                     <span style="color: #fc8181;">⚠️ Warning: This will replace all current data!</span>`,
-            onConfirm: () => {
-                // Perform the restore
-                games = backupData.games || [];
-                
-                // Restore player names
-                if (backupData.players) {
-                    if (backupData.players.player1 !== undefined) {
-                        const player1Input = document.getElementById('player1Name');
-                        if (player1Input) player1Input.value = backupData.players.player1;
-                    }
-                    if (backupData.players.player2 !== undefined) {
-                        const player2Input = document.getElementById('player2Name');
-                        if (player2Input) player2Input.value = backupData.players.player2;
-                    }
-                    savePlayers();
-                }
-                
-                // Restore player icons
-                if (backupData.playerIcons && typeof backupData.playerIcons === 'object') {
-                    playerIcons = backupData.playerIcons;
-                    savePlayerIcons();
-                    updatePlayerIconDisplays();
-                }
-                
-                // Save games and update UI
-                saveGames();
-                updateUI();
-                
-                // Show success toast
-                showToast(`Successfully restored ${gameCount} games from backup!`, 'success');
-            },
-            onCancel: () => {
-                // Modal closes automatically
-            }
-        });
-
-    } catch (e) {
-        createErrorModal({
-            icon: '❌',
-            title: 'Restore Failed',
-            message: 'Failed to restore backup. Please try again.'
-        });
-        console.error('Backup restore error:', e);
-    }
-}
-
-function backupToFile() {
-    try {
-        const player1Name = document.getElementById('player1Name') ? document.getElementById('player1Name').value : 'Player 1';
-        const player2Name = document.getElementById('player2Name') ? document.getElementById('player2Name').value : 'Player 2';
-        
-        const data = {
-            games: games,
-            players: {
-                player1: player1Name,
-                player2: player2Name
-            },
-            playerIcons: playerIcons,
-            backupDate: new Date().toISOString(),
-            version: '1.0'
-        };
-
-        const fileContent = JSON.stringify(data, null, 2);
-        const fileName = `football-h2h-data-${new Date().toISOString().split('T')[0]}.json`;
-
-        // Create downloadable backup
-        const blob = new Blob([fileContent], { type: 'application/json' });
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = fileName;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-
-        // Also save to auto-backup
-        autoBackupToLocalStorage();
-
-        // Show success toast
-        showToast(`Backup saved as ${fileName}`, 'success');
-    } catch (e) {
-        createErrorModal({
-            icon: '❌',
-            title: 'Backup Failed',
-            message: 'Failed to create backup. Please try again.'
-        });
-        console.error('Backup error:', e);
-    }
-}
-
-function restoreFromFile() {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = '.json';
-    
-    input.onchange = function(event) {
-        const file = event.target.files[0];
-        if (!file) return;
-        
-        const reader = new FileReader();
-        reader.onload = function(e) {
-            try {
-                const backupData = JSON.parse(e.target.result);
-                
-                // Validate backup data
-                if (!backupData.games || !Array.isArray(backupData.games)) {
-                    createErrorModal({
-                        icon: '❌',
-                        title: 'Invalid Backup File',
-                        message: 'The selected file is not a valid Football H2H backup.'
-                    });
-                    return;
-                }
-                
-                const backupDate = backupData.backupDate ? new Date(backupData.backupDate).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false }) : 'Unknown';
-                const gameCount = backupData.games.length;
-                
-                createConfirmationModal({
-                    icon: '📥',
-                    title: 'Restore from File?',
-                    message: `Found backup with <strong>${gameCount} games</strong><br>
-                             Created on: <strong>${backupDate}</strong><br><br>
-                             <span style="color: #fc8181;">⚠️ Warning: This will replace all current data!</span>`,
-                    onConfirm: () => {
-                        // Perform the restore
-                        games = backupData.games || [];
-                        
-                        // Restore player names
-                        if (backupData.players) {
-                            if (backupData.players.player1 !== undefined) {
-                                const player1Input = document.getElementById('player1Name');
-                                if (player1Input) player1Input.value = backupData.players.player1;
-                            }
-                            if (backupData.players.player2 !== undefined) {
-                                const player2Input = document.getElementById('player2Name');
-                                if (player2Input) player2Input.value = backupData.players.player2;
-                            }
-                            savePlayers();
-                        }
-                        
-                        // Restore player icons
-                        if (backupData.playerIcons && typeof backupData.playerIcons === 'object') {
-                            playerIcons = backupData.playerIcons;
-                            savePlayerIcons();
-                            updatePlayerIconDisplays();
-                        }
-                        
-                        // Save games and update UI
-                        saveGames();
-                        updateUI();
-                        
-                        // Show success toast
-                        showToast(`Successfully restored ${gameCount} games from file!`, 'success');
-                    },
-                    onCancel: () => {
-                        // Modal closes automatically
-                    }
-                });
-                
-            } catch (error) {
-                createErrorModal({
-                    icon: '❌',
-                    title: 'File Read Error',
-                    message: 'Error reading the backup file. Please make sure it\'s a valid JSON file.'
-                });
-                console.error('File read error:', error);
-            }
-        };
-        reader.readAsText(file);
-    };
-    
-    input.click();
-}
-
 // Auto-backup initialization is handled in football-h2h.js
 
 // Export functions to global scope
 window.initializeAutoBackup = initializeAutoBackup;
-window.restoreFromBackup = restoreFromBackup;
 window.autoBackupToLocalStorage = autoBackupToLocalStorage;
-window.backupToFile = backupToFile;
-window.restoreFromFile = restoreFromFile;

--- a/apps/football-h2h/js/football-h2h.js
+++ b/apps/football-h2h/js/football-h2h.js
@@ -248,13 +248,22 @@ function applyPlayerNameChanges(newPlayer1Name, newPlayer2Name) {
     
     if (player1Header) {
         const player1IconDisplay = playerIcons.player1 || '⚽';
-        player1Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player1IconDisplay)}</span> ${escapeHtml(player1Name)}`;
+        player1Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player1IconDisplay)}</span> ${escapeHtml(player1Name)} <span class="sort-indicator" id="sort-player1"></span>`;
     }
 
     if (player2Header) {
         const player2IconDisplay = playerIcons.player2 || '⚽';
-        player2Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player2IconDisplay)}</span> ${escapeHtml(player2Name)}`;
+        player2Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player2IconDisplay)}</span> ${escapeHtml(player2Name)} <span class="sort-indicator" id="sort-player2"></span>`;
     }
+
+    // Re-render sort indicators since the header rebuild above replaced the spans
+    updateSortIndicators();
+
+    // Keep the Player Stats comparison headers in sync with renamed players
+    const playerComparisonP1Header = document.getElementById('playerComparisonP1Header');
+    const playerComparisonP2Header = document.getElementById('playerComparisonP2Header');
+    if (playerComparisonP1Header) playerComparisonP1Header.textContent = (playerIcons.player1 || '') + ' ' + player1Name;
+    if (playerComparisonP2Header) playerComparisonP2Header.textContent = (playerIcons.player2 || '') + ' ' + player2Name;
 
     // Update modal labels (if they exist)
     const modalPlayer1Name = document.getElementById('modalPlayer1Name');
@@ -283,28 +292,36 @@ function applyPlayerNameChanges(newPlayer1Name, newPlayer2Name) {
     renderGamesTable();
 }
 
+// Assign dates to legacy games that predate the dateTime field. Spreads
+// undated games across past days based on their position so history still
+// renders in a sensible order. Returns true if any game was migrated.
+// No unit test: football-h2h.js is a DOM-coupled classic script with no
+// module exports, and we deliberately do not restructure exports here.
+function migrateGameDates(gamesArray) {
+    let needsUpdate = false;
+    gamesArray.forEach((game, index) => {
+        if (!game.dateTime) {
+            // Assign a fake date for old games (spread them out over past days)
+            const daysBack = gamesArray.length - index;
+            const fakeDate = new Date();
+            fakeDate.setDate(fakeDate.getDate() - daysBack);
+            game.dateTime = fakeDate.toISOString();
+            game.lastModified = new Date().toISOString();
+            needsUpdate = true;
+        }
+    });
+    return needsUpdate;
+}
+
 // Load games from localStorage
 function loadGames() {
     const savedGames = localStorage.getItem(STORAGE_KEY);
     if (savedGames) {
         games = JSON.parse(savedGames);
         window.games = games; // Update global reference
-        
+
         // Migrate old games without dateTime
-        let needsUpdate = false;
-        games.forEach((game, index) => {
-            if (!game.dateTime) {
-                // Assign a fake date for old games (spread them out over past days)
-                const daysBack = games.length - index;
-                const fakeDate = new Date();
-                fakeDate.setDate(fakeDate.getDate() - daysBack);
-                game.dateTime = fakeDate.toISOString();
-                game.lastModified = new Date().toISOString();
-                needsUpdate = true;
-            }
-        });
-        
-        if (needsUpdate) {
+        if (migrateGameDates(games)) {
             saveGames();
         }
     } else {
@@ -1127,19 +1144,46 @@ function importData() {
                 return;
             }
 
-            player1Name = parsed.players.player1;
-            player2Name = parsed.players.player2;
-            savePlayers();
-            applyPlayerNameChanges(player1Name, player2Name);
+            const incomingPlayer1 = parsed.players.player1;
+            const incomingPlayer2 = parsed.players.player2;
+            const gameCount = parsed.games.length;
 
-            games = parsed.games;
-            saveGames();
-            updateUI();
+            const currentCount = games.length;
+            const plural = (n) => n === 1 ? 'game' : 'games';
+            let message = `The selected file contains ${gameCount} ${plural(gameCount)}.`;
+            if (currentCount > 0) {
+                message += `<br>Importing will replace your current ${currentCount} ${plural(currentCount)}.`;
+            } else {
+                message += `<br>You currently have no saved games.`;
+            }
+            if (incomingPlayer1 !== player1Name || incomingPlayer2 !== player2Name) {
+                message += `<br><br>Player names will change from "${escapeHtml(player1Name)}" and "${escapeHtml(player2Name)}" to "${escapeHtml(incomingPlayer1)}" and "${escapeHtml(incomingPlayer2)}".`;
+            }
 
-            createSuccessModal({
+            createConfirmationModal({
                 icon: '📥',
-                title: 'Import Successful',
-                message: `Successfully imported ${games.length} games!`
+                title: 'Import Data?',
+                message,
+                isDestructive: true,
+                confirmText: 'Import',
+                onConfirm: () => {
+                    player1Name = incomingPlayer1;
+                    player2Name = incomingPlayer2;
+                    savePlayers();
+                    applyPlayerNameChanges(player1Name, player2Name);
+
+                    games = parsed.games;
+                    migrateGameDates(games);
+                    saveGames();
+                    updateUI();
+
+                    createSuccessModal({
+                        icon: '📥',
+                        title: 'Import Successful',
+                        message: `Successfully imported ${games.length} games!`
+                    });
+                },
+                onCancel: () => {}
             });
         };
         reader.readAsText(file);
@@ -1232,13 +1276,16 @@ function updatePlayerIconDisplays() {
     
     if (player1Header) {
         const player1IconDisplay = playerIcons.player1 || '⚽';
-        player1Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player1IconDisplay)}</span> ${escapeHtml(player1Name)}`;
+        player1Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player1IconDisplay)}</span> ${escapeHtml(player1Name)} <span class="sort-indicator" id="sort-player1"></span>`;
     }
 
     if (player2Header) {
         const player2IconDisplay = playerIcons.player2 || '⚽';
-        player2Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player2IconDisplay)}</span> ${escapeHtml(player2Name)}`;
+        player2Header.innerHTML = `<span class="player-header-icon">${escapeHtml(player2IconDisplay)}</span> ${escapeHtml(player2Name)} <span class="sort-indicator" id="sort-player2"></span>`;
     }
+
+    // Re-render sort indicators since the header rebuild above replaced the spans
+    updateSortIndicators();
 
     // Update player management modal if it's open
     const playerModal = document.getElementById('playerManagementModal');
@@ -1263,13 +1310,36 @@ function openIconSelector(playerNumber) {
     const iconModal = document.getElementById('iconSelectorModal');
     if (iconModal) {
         iconModal.classList.add('active');
+        lockBodyScroll();
+        const dialog = iconModal.querySelector('.modal-content') || iconModal;
+        iconSelectorReleaseFocusTrap = trapFocus(iconModal, dialog);
+    }
+
+    document.addEventListener('keydown', iconSelectorEscHandler);
+}
+
+// Focus-trap teardown for the static icon selector modal
+let iconSelectorReleaseFocusTrap = null;
+
+// Close icon selector on Escape key
+function iconSelectorEscHandler(e) {
+    if (e.key === 'Escape') {
+        closeIconSelector();
     }
 }
 
 // Close icon selector
 function closeIconSelector() {
-    document.getElementById('iconSelectorModal').classList.remove('active');
+    const iconModal = document.getElementById('iconSelectorModal');
+    if (!iconModal.classList.contains('active')) return;
+    iconModal.classList.remove('active');
     currentPlayerForIcon = null;
+    document.removeEventListener('keydown', iconSelectorEscHandler);
+    if (iconSelectorReleaseFocusTrap) {
+        iconSelectorReleaseFocusTrap();
+        iconSelectorReleaseFocusTrap = null;
+    }
+    unlockBodyScroll();
 }
 
 // Show icon category
@@ -1351,39 +1421,6 @@ updatePlayerNames = function() {
     originalUpdatePlayerNames.call(this);
     updatePlayerIconDisplays();
 };
-
-// Toggle backup menu dropdown
-function toggleBackupMenu(button) {
-    const menu = document.getElementById('backupMenu');
-    if (!menu) {
-        // If no backup menu exists, just trigger export directly
-        exportData();
-        return;
-    }
-    
-    const isOpen = menu.style.display !== 'none';
-    
-    if (isOpen) {
-        menu.style.display = 'none';
-    } else {
-        menu.style.display = 'block';
-        
-        // Close menu when clicking outside
-        setTimeout(() => {
-            document.addEventListener('click', closeBackupMenu);
-        }, 0);
-    }
-}
-
-function closeBackupMenu(event) {
-    const menu = document.getElementById('backupMenu');
-    const button = event.target.closest('.dropdown');
-    
-    if (!button || !button.contains(event.target)) {
-        menu.style.display = 'none';
-        document.removeEventListener('click', closeBackupMenu);
-    }
-}
 
 // Close modal when clicking outside
 window.onclick = function(event) {
@@ -2134,7 +2171,7 @@ function populateMatchupDropdowns() {
 
     function rebuild(sel, teams) {
         const current = sel.value;
-        sel.innerHTML = '<option value="">— any —</option>';
+        sel.innerHTML = '<option value="">Any</option>';
         for (const t of teams) {
             const opt = document.createElement('option');
             opt.value = t;
@@ -2207,7 +2244,7 @@ function buildSessionSummaryText(gamesData) {
     const p2 = player2Name;
 
     if (gamesData.length === 0) {
-        return `${p1} vs ${p2} — No games recorded.`;
+        return `${p1} vs ${p2}: No games recorded.`;
     }
 
     const lines = [];
@@ -2228,7 +2265,7 @@ function buildSessionSummaryText(gamesData) {
             p2Wins++;
         }
         const dateStr = g.dateTime ? new Date(g.dateTime).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : '';
-        const noteStr = g.note ? ` — ${g.note}` : '';
+        const noteStr = g.note ? `, ${g.note}` : '';
         lines.push(`${scoreStr}${suffix} (${dateStr})${noteStr}`);
     }
 
@@ -2291,7 +2328,6 @@ window.getCurrentPlayerNames = function() {
 
 // Export functions to global scope
 window.switchStatsTab = switchStatsTab;
-window.toggleBackupMenu = toggleBackupMenu;
 window.updateTeamOptions = updateTeamOptions;
 window.showAddGameModal = showAddGameModal;
 window.closeGameModal = closeGameModal;
@@ -2301,6 +2337,7 @@ window.deleteGame = deleteGame;
 window.confirmClearData = confirmClearData;
 window.exportData = exportData;
 window.importData = importData;
+window.migrateGameDates = migrateGameDates;
 window.sortGames = sortGames;
 window.checkForDraw = checkForDraw;
 window.openIconSelector = openIconSelector;

--- a/apps/football-h2h/js/modalUtils.js
+++ b/apps/football-h2h/js/modalUtils.js
@@ -1,5 +1,81 @@
 // Modal utility functions for Football H2H Tracker
 
+// Count of currently-open modals across both modal shapes
+// (.modal-overlay dialogs and the static #iconSelectorModal). Body scroll
+// stays locked while this is > 0 and is restored only when the last
+// modal closes.
+let openModalCount = 0;
+
+function lockBodyScroll() {
+    openModalCount += 1;
+    document.body.classList.add('modal-open');
+}
+
+function unlockBodyScroll() {
+    openModalCount = Math.max(0, openModalCount - 1);
+    if (openModalCount === 0) {
+        document.body.classList.remove('modal-open');
+    }
+}
+
+const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusable(container) {
+    return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR))
+        .filter(el => el.offsetParent !== null || el === document.activeElement);
+}
+
+// Move focus into the modal and trap Tab/Shift+Tab within it. Returns a
+// teardown function that removes the trap and restores focus to the
+// previously-focused element if it still exists.
+function trapFocus(modal, dialog) {
+    const previouslyFocused = document.activeElement;
+
+    const focusFirst = () => {
+        const focusable = getFocusable(modal);
+        if (focusable.length) {
+            focusable[0].focus();
+        } else {
+            dialog.setAttribute('tabindex', '-1');
+            dialog.focus();
+        }
+    };
+    focusFirst();
+
+    const keydownHandler = (e) => {
+        if (e.key !== 'Tab') return;
+        const focusable = getFocusable(modal);
+        if (!focusable.length) {
+            e.preventDefault();
+            return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (!modal.contains(document.activeElement)) {
+            // Focus escaped the modal (e.g. a deferred field rebuild
+            // destroyed the focused element); pull the next Tab back in.
+            e.preventDefault();
+            first.focus();
+        } else if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+        }
+    };
+    // Listen on document, not the modal: if focus lands outside the modal
+    // the modal's own listener would never see the Tab keydown.
+    document.addEventListener('keydown', keydownHandler);
+
+    return () => {
+        document.removeEventListener('keydown', keydownHandler);
+        if (previouslyFocused && document.body.contains(previouslyFocused)) {
+            previouslyFocused.focus();
+        }
+    };
+}
+
 /**
  * Creates a standardized modal with CSS classes
  * @param {Object} config - Modal configuration
@@ -32,14 +108,22 @@ function createModal({ icon, title, content, buttons = [] }) {
     modal.appendChild(dialog);
     document.body.appendChild(modal);
 
+    lockBodyScroll();
+    const releaseFocusTrap = trapFocus(modal, dialog);
+
     // Single teardown so every close path (button, background, Escape)
     // removes the document-level keydown listener. The previous version
     // only removed the listener on the Escape path, so opening +
     // dismissing modals via background-click or any button stacked
     // listeners that fired forever.
+    let closed = false;
     const closeModal = () => {
+        if (closed) return;
+        closed = true;
         if (modal.parentNode) modal.parentNode.removeChild(modal);
         document.removeEventListener('keydown', escapeHandler);
+        releaseFocusTrap();
+        unlockBodyScroll();
     };
     const escapeHandler = (e) => { if (e.key === 'Escape') closeModal(); };
     document.addEventListener('keydown', escapeHandler);
@@ -62,11 +146,11 @@ function createModal({ icon, title, content, buttons = [] }) {
 /**
  * Creates a confirmation modal
  */
-function createConfirmationModal({ icon, title, message, onConfirm, onCancel, isDestructive = false }) {
+function createConfirmationModal({ icon, title, message, onConfirm, onCancel, isDestructive = false, confirmText = null }) {
     const buttons = [
         {
             id: 'confirm-btn',
-            text: isDestructive ? 'Delete' : 'Confirm',
+            text: confirmText || (isDestructive ? 'Delete' : 'Confirm'),
             type: isDestructive ? 2 : 0, // 2 = danger, 0 = primary
             onClick: onConfirm
         },
@@ -413,3 +497,6 @@ window.createFormModal = createFormModal;
 window.showToast = showToast;
 window.showFormError = showFormError;
 window.hideFormError = hideFormError;
+window.lockBodyScroll = lockBodyScroll;
+window.unlockBodyScroll = unlockBodyScroll;
+window.trapFocus = trapFocus;

--- a/apps/football-h2h/js/sidebar.js
+++ b/apps/football-h2h/js/sidebar.js
@@ -21,12 +21,13 @@ function openSidebar() {
     const sidebar = document.getElementById('sidebar');
     const overlay = document.getElementById('sidebar-overlay');
     const toggleBtn = document.getElementById('sidebar-toggle');
-    
+
     sidebar.classList.add('open');
     overlay.classList.add('active');
     document.body.classList.add('sidebar-open');
     toggleBtn.setAttribute('aria-expanded', 'true');
     sidebarOpen = true;
+    document.addEventListener('keydown', sidebarTabTrapHandler);
 }
 
 // Close sidebar
@@ -34,12 +35,45 @@ function closeSidebar() {
     const sidebar = document.getElementById('sidebar');
     const overlay = document.getElementById('sidebar-overlay');
     const toggleBtn = document.getElementById('sidebar-toggle');
-    
+
     sidebar.classList.remove('open');
     overlay.classList.remove('active');
     document.body.classList.remove('sidebar-open');
     toggleBtn.setAttribute('aria-expanded', 'false');
     sidebarOpen = false;
+    document.removeEventListener('keydown', sidebarTabTrapHandler);
+    // Hand focus back to the toggle so keyboard users are not stranded
+    if (sidebar.contains(document.activeElement)) {
+        toggleBtn.focus();
+    }
+}
+
+// Keep Tab inside the open sidebar (it overlays the page content). Modals
+// stack above the sidebar and own the keyboard while open, so the trap
+// stands down whenever one is present.
+function sidebarTabTrapHandler(e) {
+    if (e.key !== 'Tab' || !sidebarOpen) return;
+    if (document.querySelector('.modal-overlay') ||
+        document.querySelector('#iconSelectorModal.active')) return;
+    const sidebar = document.getElementById('sidebar');
+    const focusable = Array.from(sidebar.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )).filter(el => el.offsetParent !== null);
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!sidebar.contains(document.activeElement)) {
+        // Focus is outside the sidebar (e.g. on the toggle or page body):
+        // pull the next Tab into the panel instead of the content behind it.
+        e.preventDefault();
+        first.focus();
+    } else if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+    }
 }
 
 
@@ -176,8 +210,11 @@ function getFilteredGames() {
             
         case 'custom':
             if (customStartDate && customEndDate) {
-                const fromDate = new Date(customStartDate);
-                const toDate = new Date(customEndDate);
+                // Parse as LOCAL dates to stay consistent with today/week/month filters
+                const [fy, fm, fd] = customStartDate.split('-').map(Number);
+                const [ty, tm, td] = customEndDate.split('-').map(Number);
+                const fromDate = new Date(fy, fm - 1, fd);
+                const toDate = new Date(ty, tm - 1, td);
                 toDate.setHours(23, 59, 59, 999); // Include the entire end date
                 
                 filteredGames = allGames.filter(game => {
@@ -439,11 +476,15 @@ document.addEventListener('DOMContentLoaded', function() {
     // This will be called by football-h2h.js when ready
     
     
-    // Handle escape key to close sidebar
+    // Handle escape key to close sidebar. A modal takes priority: when one
+    // is open, Escape closes only the topmost modal (its own handler), and
+    // a subsequent Escape closes the sidebar.
     document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape' && sidebarOpen) {
-            closeSidebar();
-        }
+        if (e.key !== 'Escape' || !sidebarOpen) return;
+        const modalOpen = document.querySelector('.modal-overlay') ||
+            document.querySelector('#iconSelectorModal.active');
+        if (modalOpen) return;
+        closeSidebar();
     });
 });
 


### PR DESCRIPTION
Exhaustive functional audit of football-h2h (PROMPTS.md improvement-pipeline round): full-app coverage map, a from-scratch living plan pair (330+ assertions, 29 sections, all green), 11 bug fixes, 3 owner-approved behavior features, 1 owner-decided feature removal, and copy/theme cleanups. All scoped to `apps/football-h2h/`.

## Complete diff, per file

### apps/football-h2h/index.html (+13/-21)
- Added `<meta name="color-scheme" content="dark">` so native popups (select dropdown lists) render dark in Chromium.
- Matchup dropdown default options: `— any —` (em dash, banned in UI copy) -> `Any` (both `#matchupTeam1` / `#matchupTeam2`).
- Game Date row: the container is now a `<label for="sidebar-date-input">` wrapping text + icon (was: label on the icon only), making the entire row open the date picker; inner `div`/`label` swapped to `span`s for valid label content.
- Removed the sidebar Backup and Restore buttons (owner decision: Export/Import covers data portability; Backup was an effective duplicate of Export).

### apps/football-h2h/js/football-h2h.js (+105/-66)
- `applyPlayerNameChanges`: header rebuilds now include the `#sort-player1`/`#sort-player2` sort-indicator spans they previously destroyed (player-column sort arrows never showed), call `updateSortIndicators()` after rebuilding, and refresh `#playerComparisonP1Header`/`P2Header` (renames previously didn't reach the Player Stats table until a tab switch).
- `updatePlayerIconDisplays`: same sort-indicator-preserving rebuild (second code path with the identical bug).
- `openIconSelector`/`closeIconSelector`: Escape-key handler (named, add/remove, no listener stacking) + shared scroll lock and focus trap for the static icon modal.
- `importData`: imports no longer apply immediately. After validation, a destructive confirmation modal ("Import Data?", confirm button labeled "Import") states the file's game count and the current data separately: "The selected file contains N games." + "Importing will replace your current M games." / "You currently have no saved games." (pluralized; wording revised after owner feedback that the first version read as if N described current data). A "Player names will change from ... to ..." line appears only when the incoming names differ (escaped). Cancel applies nothing; Confirm applies data, runs date migration, then the existing success modal. Error paths unchanged.
- New `migrateGameDates(gamesArray)`: the legacy assign-fake-dates migration extracted from `loadGames` (behavior-identical there) and now also run on import so dateless legacy games get dates immediately, without a reload.
- `buildSessionSummaryText`: em dashes removed from user-visible copy (`:` for the empty state, `,` before notes).
- `populateMatchupDropdowns` rebuild path: `Any` default option (matches the HTML change).
- Removed `toggleBackupMenu`/`closeBackupMenu` and the `window.toggleBackupMenu` export (dead after the Backup button removal; its only live behavior was falling through to `exportData`).

### apps/football-h2h/js/modalUtils.js (+93/-4)
- Shared scroll lock: `lockBodyScroll`/`unlockBodyScroll` with an open-modal counter (`body.modal-open` added on first open, removed only when the last modal closes; counts both `.modal-overlay` modals and the static icon modal).
- Shared focus trap: `trapFocus(modal, dialog)` focuses the first focusable (dialog `tabindex="-1"` fallback), traps Tab/Shift+Tab with wrap, pulls focus back inside if something (e.g. a rebuilt form field) drops it, and restores prior focus on close. Listener is document-level (a modal-bound listener never sees Tab once focus has escaped); removed on close.
- `createModal`: installs lock + trap on open; idempotent `closeModal` releases both on every close path.
- `createConfirmationModal`: new optional `confirmText` (the import modal's button previously fell through to the destructive default "Delete").
- Helpers exported on `window` per the file's existing convention.

### apps/football-h2h/js/backup.js (rewritten, +45/-220)
- Reduced to the silent 10-minute auto-backup writer only. `restoreFromBackup`, `restoreFromFile`, `backupToFile` and their `window` exports deleted (unreachable after the UI removal).
- Bugfix kept from the audit: `autoBackupToLocalStorage` read `getElementById('player1Name')` (an element that does not exist), so every auto-backup ever written stored empty player names; it now reads the `player1Name`/`player2Name` globals. (The restore-path variant of this same bug was fixed mid-audit and then removed along with the feature.)

### apps/football-h2h/js/sidebar.js (+50/-7)
- Custom date-range filter timezone bug: `new Date('YYYY-MM-DD')` parsed the bounds as UTC midnight while `setHours(23,59,59,999)` applied local time, silently excluding games later in the day on the range's last date for anyone west of GMT. Bounds now parse as local dates, consistent with the Today/Week/Month filters.
- Sidebar keyboard focus trap (owner-reported: Tab escaped to page content behind the overlay): `sidebarTabTrapHandler` attached on open / detached on close; pulls Tab into the panel, wraps at the ends, stands down whenever a modal is open (the modal's trap owns the keyboard), and `closeSidebar` returns focus to the toggle.
- Escape layering made modal-first: with a modal and the sidebar both open, the first Escape closes only the modal, the second closes the sidebar (previously one Escape closed both).

### apps/football-h2h/css/football-h2h.css (+4/-0)
- `body.modal-open { overflow: hidden; }` (the scroll-lock class; did not previously exist).

### apps/football-h2h/css/refresh.css (+19/-0)
- `.matchup-select`: `color-scheme: dark` (native dropdown list follows color-scheme, not box styles).
- `body.football-h2h-tracker .pagination-size select`: dark surface/border/text + `color-scheme: dark`, overriding the shared `assets/css/pagination.css` hardcoded white background (override app-scoped; the shared asset is untouched).
- `body.football-h2h-tracker select option`: explicit dark background/text for every dropdown list in the app (covers browsers that paint options from author styles).

### apps/football-h2h/css/sidebar.css (+6/-1)
- Removed `position: relative` from `.sidebar-date-icon-wrapper` (with comment): the invisible 100%x100% date input was absolutely positioned against the icon wrapper, so only the icon was clickable; its positioning context is now the whole row container.

## Bugs fixed along the way (not in the original scope)
- Import confirm button read "Delete" (destructive default) -> "Import" via the new `confirmText` option.
- Auto-backup stored empty player names (dead `getElementById`), silently for the feature's whole life.
- The sort-indicator clobber existed in a second function (`updatePlayerIconDisplays`) beyond the one the test plan caught; fixed in both.

## Judgment calls
- "Remove one of restore or backup... removing both is fine" was resolved as: remove BOTH buttons and the dead functions, keep the silent 10-minute localStorage snapshot as a no-UI safety net (recoverable via devtools). Say the word to drop the writer too.
- Escape layering (modal-first) is a deliberate behavior improvement, not a regression.
- Matchup default option copy chosen as "Any".
- The select-option CSS uses literal hex values (matching `--fh-surface-2`/`--fh-text`) rather than `var()` because option popups resolve custom properties unreliably on some Chromium versions.
- The custom date filter now interprets picked dates in the user's local timezone (matching the other filters); ranges previously interpreted as UTC days shift by the local offset.

## Explicitly untouched
- `assets/css/pagination.css` and `assets/js/pagination.js` (shared across apps): the white-background select is overridden app-locally instead.
- `apps/mario-kart/**` CSS that football-h2h imports (`forms.css`, `mario-kart-overrides.css`).
- The `#streakText` placeholder em dash in index.html (transient placeholder overwritten on every render, not prose copy).
- sync-system and all other apps.
- No per-app README exists for football-h2h (pre-existing; gym-tracker/mario-kart/rising-seasons have one, maptap-rivals/arena also don't). The root README's football-h2h row is accurate and mentions nothing removed. Left for a doc-coverage round.

## Testing
- `npm test`: 896/896 pass (unchanged baseline; re-run after every fix round).
- Living plan pair `.features/football-h2h-claude.md` + `-human.md` created from scratch this round (the app had none): 330+ assertions across 29 sections, all ticked across four recorded run reports (initial 3-chunk sweep: 292/315 with 12 fails -> fix round -> re-verification 15/16 + 1 orchestrator probe -> round-2 features 19/19 -> round-3 owner-feedback batch). Five real bugs from the sweep plus the owner's six live reports all browser-verified with coordinate hit-testing/DOM-fact probes at 1280/768/390.
- Headless-unverifiable items (native dropdown popup appearance, real-keyboard Tab feel, file-picker flows, clipboard, multi-device sync) are listed in the human plan's needs-a-human block (11 items).
