### PR TITLE
fix(football-h2h): visual audit 2026-06-07 — mobile table restore, theme-trap fixes, FAB/toast/header fixes, indigo unification

### DIFF
--- a/apps/football-h2h/css/football-h2h.css
+++ b/apps/football-h2h/css/football-h2h.css
@@ -348,7 +348,9 @@
     left: 0;
     right: 0;
     height: 3px;
-    background: linear-gradient(90deg, #34d399 0%, #10b981 100%);
+    /* Unified indigo accent so the add-game and player-settings panels read
+       as one family (was green here, pink on player-settings). */
+    background: linear-gradient(90deg, #818cf8 0%, #6366f1 100%);
 }
 
 .sidebar-game-form.open {
@@ -392,7 +394,10 @@
 
 .sidebar-submit-game {
     background: linear-gradient(135deg, #34d399 0%, #10b981 100%);
-    color: white;
+    /* color pinned with !important across all states so the sitewide theme
+       trap (assets/css/main.css button{color:#555!important}) can't gray the
+       label or turn it red on hover/active. */
+    color: white !important;
     border: none;
     border-radius: 0.5rem;
     padding: 0.75rem 1rem;
@@ -409,8 +414,10 @@
     min-width: 120px;
 }
 
-.sidebar-submit-game:hover {
+.sidebar-submit-game:hover,
+.sidebar-submit-game:hover:active {
     background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+    color: white !important;
     box-shadow: 0 4px 12px rgba(52, 211, 153, 0.4);
     transform: translateY(-1px);
 }
@@ -433,8 +440,13 @@
     min-width: 100px;
 }
 
-.sidebar-cancel-game:hover {
+.sidebar-cancel-game:hover,
+.sidebar-cancel-game:hover:active {
     background: #4b5563;
+    /* re-pin color: the base !important does not carry into this :hover
+       block, so the trap's button:hover{color:#ce1b28!important} would win
+       here without an explicit pin. */
+    color: white !important;
     box-shadow: 0 4px 8px rgba(107, 114, 128, 0.4);
     transform: translateY(-1px);
 }
@@ -470,7 +482,8 @@
     left: 0;
     right: 0;
     height: 3px;
-    background: linear-gradient(90deg, #f472b6 0%, #a78bfa 100%);
+    /* Unified indigo accent (was pink) to match the add-game panel. */
+    background: linear-gradient(90deg, #818cf8 0%, #6366f1 100%);
 }
 
 .player-settings-section {
@@ -482,12 +495,18 @@
 }
 
 .player-settings-section .section-title {
-    font-size: 1rem;
-    font-weight: 600;
-    color: #f7fafc;
-    margin-bottom: 1rem;
-    border-bottom: 1px solid #4a5568;
-    padding-bottom: 0.5rem;
+    /* Restyled to the sidebar's uppercase muted section-label idiom; the
+       authoritative pin lives in refresh.css (loads last, beats the blanket
+       .section-title rule). Kept here in sync for the non-refresh path. */
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #a4adbd;
+    margin-bottom: 0.75rem;
+    border-bottom: none;
+    padding-bottom: 0;
+    text-align: left;
 }
 
 .player-input-group {
@@ -629,7 +648,9 @@
     border: none;
     border-radius: 0.5rem;
     background: #374151;
-    color: #e2e8f0;
+    /* color pinned !important across inactive/hover/active so the sitewide
+       theme trap can't gray the tabs or turn them red on hover. */
+    color: #e2e8f0 !important;
     cursor: pointer;
     transition: all 0.3s ease;
     font-weight: 500;
@@ -638,14 +659,19 @@
     justify-content: center;
 }
 
-.category-btn:hover {
+.category-btn:hover,
+.category-btn:hover:active {
     background: #4a5568;
-    color: #f7fafc;
+    color: #f7fafc !important;
 }
 
 .category-btn.active {
     background: #818cf8;
-    color: white;
+    color: white !important;
+}
+.category-btn.active:hover,
+.category-btn.active:hover:active {
+    color: white !important;
 }
 
 .icon-grid {

--- a/apps/football-h2h/css/refresh.css
+++ b/apps/football-h2h/css/refresh.css
@@ -309,6 +309,34 @@ body.football-h2h-tracker .table-container {
     border: 1px solid var(--fh-border) !important;
     border-radius: var(--fh-radius-sm) !important;
     box-shadow: none !important;
+    /* football-h2h.css line 1072 sets `overflow: hidden`, which clips the
+       Actions column off the right edge when long (25-char) player names
+       blow up the nowrap headers. Switch to horizontal scroll so every
+       column stays reachable. */
+    overflow-x: auto !important;
+    overflow-y: visible !important;
+    -webkit-overflow-scrolling: touch;
+}
+
+/* Keep 7 columns legible: never let the table collapse below a width where
+   cells are readable. With overflow-x:auto on the container, narrow
+   viewports get a horizontal scroll instead of an unreadable squeeze. */
+body.football-h2h-tracker .games-table {
+    min-width: 680px;
+}
+
+/* Long player names in the score headers must not push the Actions column
+   out of reach. Clamp the two player-name headers and ellipsize, keeping
+   the sort indicator visible. */
+body.football-h2h-tracker .games-table thead th {
+    white-space: nowrap;
+}
+body.football-h2h-tracker .games-table thead th.sortable-header,
+body.football-h2h-tracker .games-table thead th#player1TeamHeader,
+body.football-h2h-tracker .games-table thead th#player2TeamHeader {
+    max-width: 180px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 body.football-h2h-tracker .games-table thead {
@@ -751,36 +779,46 @@ body.football-h2h-tracker textarea:focus {
 }
 
 /* ---------- Game History row action buttons (edit / delete) ----------
-   The default styling was a 40px solid gradient blue + 40px solid red
-   slab per row — visually heavy and dominated the table. Refine to a
-   compact 28px icon chip with a quiet ghost surface; the delete chip
-   only goes red on hover so unstyled rows don't shout. Both chips lift
-   subtly on hover for clear interactive feedback. */
+   The live rows render `.edit-btn` / `.delete-btn` (js/football-h2h.js
+   renderGamesTableWithData). The shared mario-kart forms.css paints those
+   as solid blue / red slabs whose non-!important `color` loses to the
+   sitewide theme trap (assets/css/main.css `button{color:#555!important}`),
+   leaving gray labels that go red on hover. This block — the intended ghost
+   chip design that previously targeted dead `.btn-icon.edit/.delete`
+   classes — is retargeted onto the live `.edit-btn/.delete-btn` selectors
+   with !important pins on color/background across base/:hover/:hover:active
+   so both forms.css and the theme trap are beaten. */
 
 body.football-h2h-tracker .games-table .action-buttons,
-body.football-h2h-tracker .games-table td .action-buttons {
+body.football-h2h-tracker .games-table td .action-buttons,
+body.football-h2h-tracker .games-table td.actions {
     display: inline-flex !important;
     gap: 0.3rem !important;
     align-items: center;
     justify-content: center;
     margin: 0 !important;
-    padding: 0 !important;
+    padding: 0.7rem 0.9rem !important;
     background: transparent !important;
     border: none !important;
 }
+body.football-h2h-tracker .games-table td.actions {
+    white-space: nowrap;
+}
 
-body.football-h2h-tracker .games-table .btn-icon,
-body.football-h2h-tracker .games-table .btn-icon.edit,
-body.football-h2h-tracker .games-table .btn-icon.delete {
-    width: 28px !important;
-    height: 28px !important;
+body.football-h2h-tracker .games-table .edit-btn,
+body.football-h2h-tracker .games-table .delete-btn {
+    width: 30px !important;
+    height: 30px !important;
+    min-width: 30px !important;
     padding: 0 !important;
+    margin: 0 !important;
     background: rgba(255, 255, 255, 0.04) !important;
     border: 1px solid var(--fh-border) !important;
     border-radius: 7px !important;
     color: var(--fh-muted) !important;
     box-shadow: none !important;
-    font-size: 0.78rem !important;
+    font-size: 0.9rem !important;
+    line-height: 1 !important;
     cursor: pointer;
     display: inline-flex !important;
     align-items: center !important;
@@ -790,19 +828,14 @@ body.football-h2h-tracker .games-table .btn-icon.delete {
                 box-shadow 0.15s ease !important;
 }
 
-body.football-h2h-tracker .games-table .btn-icon i {
-    color: inherit !important;
-    font-size: 0.78rem !important;
-    line-height: 1 !important;
-    width: auto !important;
-    height: auto !important;
-}
-
-/* Edit chip — soft indigo accent. Outline at rest, fills on hover. */
-body.football-h2h-tracker .games-table .btn-icon.edit {
+/* Edit chip — soft indigo accent. Outline at rest, fills on hover.
+   :hover:active is pinned too so the theme trap's red active state can't
+   bleed through. */
+body.football-h2h-tracker .games-table .edit-btn {
     color: #93c5fd !important;
 }
-body.football-h2h-tracker .games-table .btn-icon.edit:hover {
+body.football-h2h-tracker .games-table .edit-btn:hover,
+body.football-h2h-tracker .games-table .edit-btn:hover:active {
     background: rgba(59, 130, 246, 0.18) !important;
     border-color: rgba(96, 165, 250, 0.55) !important;
     color: #dbeafe !important;
@@ -811,10 +844,11 @@ body.football-h2h-tracker .games-table .btn-icon.edit:hover {
 }
 
 /* Delete chip — neutral ghost at rest, danger-red on hover only. */
-body.football-h2h-tracker .games-table .btn-icon.delete {
+body.football-h2h-tracker .games-table .delete-btn {
     color: var(--fh-muted) !important;
 }
-body.football-h2h-tracker .games-table .btn-icon.delete:hover {
+body.football-h2h-tracker .games-table .delete-btn:hover,
+body.football-h2h-tracker .games-table .delete-btn:hover:active {
     background: rgba(248, 113, 113, 0.18) !important;
     border-color: rgba(248, 113, 113, 0.55) !important;
     color: #fecaca !important;
@@ -822,10 +856,12 @@ body.football-h2h-tracker .games-table .btn-icon.delete:hover {
     box-shadow: 0 4px 10px -4px rgba(248, 113, 113, 0.45) !important;
 }
 
-body.football-h2h-tracker .games-table .btn-icon:active {
+body.football-h2h-tracker .games-table .edit-btn:active,
+body.football-h2h-tracker .games-table .delete-btn:active {
     transform: translateY(0) scale(0.98);
 }
-body.football-h2h-tracker .games-table .btn-icon:focus-visible {
+body.football-h2h-tracker .games-table .edit-btn:focus-visible,
+body.football-h2h-tracker .games-table .delete-btn:focus-visible {
     outline: 2px solid var(--fh-accent) !important;
     outline-offset: 2px !important;
 }
@@ -1125,4 +1161,173 @@ body.football-h2h-tracker .session-summary-text {
 body.football-h2h-tracker .sidebar-action-btn.summary-btn {
     width: 100%;
     margin-bottom: 0.5rem;
+}
+
+/* ---------- FIX: restore the game history table at <=900px ----------
+   apps/mario-kart/css/mario-kart-overrides.css:609-617 hides .table-container
+   and shows .mobile-cards below 900px for Mario Kart's table->cards swap.
+   Football H2H imports that sheet but renders NO .mobile-cards markup, so
+   tablet + mobile users saw NO game history (and no #noGames notice) at all.
+   Restore the table here, app-scoped, with horizontal scroll so the 7
+   columns stay legible. (We do NOT touch the shared mario-kart file.) */
+@media (max-width: 900px) {
+    body.football-h2h-tracker .table-container {
+        display: block !important;
+        overflow-x: auto !important;
+        overflow-y: visible !important;
+        -webkit-overflow-scrolling: touch;
+        max-width: 100%;
+    }
+    /* Flexbox intrinsic-width propagation guard: body and .app-container are
+       flex containers, and flex items default to min-width:auto, so the
+       680px-min-width table inflated the wrapper chain
+       (.app-container 762px > .main-wrapper/.game-history 725px) and pushed
+       every section (stat cards included) onto an oversized canvas that body
+       then clipped at the viewport edge. min-width:0 makes the chain respect
+       the viewport so the table scrolls INSIDE its container. */
+    body.football-h2h-tracker .app-container,
+    body.football-h2h-tracker .main-wrapper,
+    body.football-h2h-tracker .game-history {
+        min-width: 0 !important;
+        max-width: 100% !important;
+    }
+    /* Smaller floating sidebar toggle on phones (owner request 2026-06-07):
+       the 48px box sat on top of the centered app title at narrow widths.
+       40px keeps the >=40px touch target; the title also gets symmetric side
+       padding below so it can never run under the toggle. (!important needed:
+       the shared mario-kart-overrides pins 48px at <=768 with !important.) */
+    body.football-h2h-tracker .sidebar-toggle {
+        width: 40px !important;
+        height: 40px !important;
+        top: 58px !important;
+        left: 10px !important;
+        border-radius: 10px !important;
+    }
+    body.football-h2h-tracker .sidebar-toggle svg {
+        width: 18px !important;
+        height: 18px !important;
+    }
+    body.football-h2h-tracker .app-title {
+        padding-left: 56px;
+        padding-right: 56px;
+    }
+    /* #noGames lives inside .table-container; restoring the container above
+       brings the empty-state notice back too. Its block/none visibility is
+       still governed by the inline style the render code sets. */
+    /* Mario Kart's .mobile-cards is shown by the shared override but has no
+       markup here; keep it collapsed so it can't reserve empty space. */
+    body.football-h2h-tracker .mobile-cards {
+        display: none !important;
+    }
+}
+
+/* ---------- FIX: back-to-top FAB above the modal backdrop ----------
+   The sitewide back-to-top button (assets/js/back-to-top.js) only enters its
+   anchored "modal mode" (z-index 11001, above the panel) for containers that
+   carry `data-back-to-top`. The icon-selector modal opts in and is fine. But
+   the dynamic confirm/success/import dialogs (.modal-overlay, z-index 1000)
+   do NOT opt in, so when the page behind them is scrolled past the FAB's
+   400px threshold the FAB stays in window mode at z-index 9000 and floats
+   ABOVE the dialog backdrop. Hide it whenever a .modal-overlay is open. The
+   icon-selector modal uses .modal.active (not .modal-overlay), so its
+   intended FAB behaviour is untouched. */
+body.football-h2h-tracker:has(.modal-overlay) .back-to-top {
+    display: none !important;
+}
+
+/* ---------- FIX: off-palette button cleanup (align to indigo) ---------- */
+
+/* Custom-range Apply button: a bare <button> with no override, so it fell
+   to the sitewide theme trap (gray ghost, red on hover). Give it the app's
+   primary-action look (same indigo family as Add Game), pinned across
+   base/:hover/:hover:active so the trap can't recolour it. */
+body.football-h2h-tracker .custom-date-range button {
+    background: linear-gradient(135deg, var(--fh-accent), var(--fh-accent-strong)) !important;
+    color: #ffffff !important;
+    border: 1px solid transparent !important;
+    border-radius: 10px !important;
+    padding: 0.5rem 1.1rem !important;
+    font-weight: 600 !important;
+    font-size: 0.88rem !important;
+    box-shadow: 0 4px 14px rgba(99, 102, 241, 0.28) !important;
+    cursor: pointer;
+    transition: filter 0.15s ease, transform 0.08s ease, box-shadow 0.15s ease;
+}
+body.football-h2h-tracker .custom-date-range button:hover,
+body.football-h2h-tracker .custom-date-range button:hover:active {
+    color: #ffffff !important;
+    filter: brightness(1.06);
+    transform: translateY(-1px);
+    box-shadow: 0 8px 22px -6px rgba(99, 102, 241, 0.55) !important;
+}
+
+/* Session-summary Copy button (#copy-summary-btn, a .modal-btn-primary that
+   ships purple #8b5cf6): retint to the app's indigo so the modal primaries
+   match the sidebar primary family. color:white is already pinned upstream. */
+body.football-h2h-tracker #copy-summary-btn.modal-btn-primary {
+    background: linear-gradient(135deg, var(--fh-accent), var(--fh-accent-strong)) !important;
+    box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3) !important;
+}
+body.football-h2h-tracker #copy-summary-btn.modal-btn-primary:hover {
+    background: linear-gradient(135deg, var(--fh-accent-strong), #4f46e5) !important;
+    box-shadow: 0 6px 16px rgba(99, 102, 241, 0.4) !important;
+}
+
+/* Icon-selector modal header accent: the underline strip mixed green +
+   indigo + magenta. Align to a clean indigo so it matches the unified
+   accent used by the sidebar panels and buttons. */
+body.football-h2h-tracker #iconSelectorModal .modal-header::after {
+    background: linear-gradient(90deg, var(--fh-accent), var(--fh-accent-strong)) !important;
+}
+
+/* ---------- FIX: player-settings panel headings ----------
+   "Player Names" / "Player Icons" used a large centered .section-title. The
+   blanket `body.football-h2h-tracker .section-title` rule above (1.15rem,
+   left) plus football-h2h.css collide here. Pin them, last-sheet + body
+   prefix, to the sidebar's uppercase muted section-label idiom (matching
+   PLAYER SETTINGS / ACTIONS / DATE FILTER). */
+body.football-h2h-tracker .player-settings-section .section-title {
+    font-size: 0.7rem !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.14em !important;
+    text-transform: uppercase !important;
+    color: var(--fh-muted-2) !important;
+    margin: 0 0 0.75rem !important;
+    border-bottom: none !important;
+    padding-bottom: 0 !important;
+    text-align: left !important;
+}
+
+/* ---------- FIX: add-game form field consistency ----------
+   The goal/team groups read as boxed field groups; Note and Penalty Result
+   sat bare. Give every field group in the add-game form the same quiet
+   boxed surface so the form reads as one set of consistent fields. */
+body.football-h2h-tracker .sidebar-game-form .sidebar-game-goals .sidebar-player-input,
+body.football-h2h-tracker .sidebar-game-form .sidebar-game-goals .sidebar-penalty-section,
+body.football-h2h-tracker .sidebar-game-form .sidebar-game-goals .sidebar-note-section,
+body.football-h2h-tracker .sidebar-game-form .sidebar-game-teams > .sidebar-player-input {
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid var(--fh-border);
+    border-radius: 10px;
+    padding: 0.7rem 0.8rem;
+    margin-bottom: 0.7rem;
+}
+
+/* ---------- FIX: toast positioning at small viewports ----------
+   showToast (modalUtils.js) sets top:80px / max-width:400px inline. At 390px
+   that 400px overflows the viewport and the toast crowds the app title.
+   Override with !important (beats inline non-important) to sit below the site
+   header, fit the viewport, and wrap readably. */
+@media (max-width: 480px) {
+    body.football-h2h-tracker .toast {
+        top: 64px !important;
+        left: 50% !important;
+        right: auto !important;
+        transform: translateX(-50%) !important;
+        max-width: calc(100vw - 24px) !important;
+        width: max-content !important;
+        white-space: normal !important;
+        text-align: center;
+        padding: 12px 18px !important;
+    }
 }

--- a/apps/football-h2h/js/football-h2h.js
+++ b/apps/football-h2h/js/football-h2h.js
@@ -1104,7 +1104,7 @@ function exportData() {
     createSuccessModal({
         icon: '📤',
         title: 'Export Complete',
-        message: `Successfully exported ${games.length} games to <strong>${exportFileDefaultName}</strong>`
+        message: `Successfully exported ${games.length} ${games.length === 1 ? 'game' : 'games'} to <strong>${exportFileDefaultName}</strong>`
     });
 }
 
@@ -1180,7 +1180,7 @@ function importData() {
                     createSuccessModal({
                         icon: '📥',
                         title: 'Import Successful',
-                        message: `Successfully imported ${games.length} games!`
+                        message: `Successfully imported ${games.length} ${games.length === 1 ? 'game' : 'games'}!`
                     });
                 },
                 onCancel: () => {}
@@ -1666,8 +1666,15 @@ function renderGamesTableWithData(gamesData) {
         }
         
         const noteHtml = game.note ? `<div class="game-note">${escapeHtml(game.note)}</div>` : '';
+        // Display-only fallback: games saved before gameNumber existed would
+        // otherwise print "undefined". Show the positional number (1-based
+        // index in the full games list, the same value the migration assigns).
+        // Not persisted; purely what is rendered.
+        const displayGameNumber = game.gameNumber != null
+            ? game.gameNumber
+            : games.findIndex(m => m.id === game.id) + 1;
         row.innerHTML = `
-            <td class="game-number">${game.gameNumber}</td>
+            <td class="game-number">${displayGameNumber}</td>
             <td class="game-date">${formattedDate}<br><small>${formattedTime}</small>${noteHtml}</td>
             <td class="player-score player1-score ${player1ScoreClass}">
                 <span class="score-number">${game.player1Goals}</span>${player1PenaltyText}

--- a/apps/football-h2h/js/sidebar.js
+++ b/apps/football-h2h/js/sidebar.js
@@ -246,7 +246,7 @@ function displayFilteredGames(filteredGames) {
     const filteredCount = filteredGames.length;
     
     if (filteredCount < totalCount && window.showToast) {
-        window.showToast(`Showing ${filteredCount} of ${totalCount} games`, 'info');
+        window.showToast(`Showing ${filteredCount} of ${totalCount} ${totalCount === 1 ? 'game' : 'games'}`, 'info');
     }
 }
 
@@ -466,9 +466,9 @@ function initializeSidebar() {
     
     // Initialize undo/redo buttons
     updateUndoRedoButtons();
-    
-    // Open sidebar automatically on page load
-    openSidebar();
+
+    // Sidebar starts CLOSED (owner decision 2026-06-07: it used to auto-open
+    // on every load, covering the content; users open it via the toggle).
 }
 
 // Initialize sidebar on page load (fallback)


### PR DESCRIPTION
Visual audit round for Football H2H (2026-06-07): 44 view-x-state rows screenshotted and judged across 1280/768/390 (plus 360/1024 where fragile); 4 defect clusters fixed, 6 polish items applied, 32 rows confirmed good and left untouched. All changes are scoped to `apps/football-h2h/` — the shared mario-kart CSS and sitewide assets are explicitly untouched.

## Changes by file

### `apps/football-h2h/css/refresh.css` (+261/-25)

**Bugfix — game history table invisible at <=900px.** The shared `mario-kart-overrides.css` hides `.table-container` below 900px for Mario Kart's table-to-cards swap, but this app renders no `.mobile-cards` markup, so tablet/phone users saw NO game history (and no empty-state notice) at all. Restored app-scoped with `display:block` + horizontal scroll, a 680px `min-width` on the table so 7 columns stay legible, and `min-width:0` on the flex wrapper chain (`.app-container`/`.main-wrapper`/`.game-history`) so the table scrolls inside its container instead of inflating the page canvas. `.mobile-cards` kept collapsed. Judgment call: fixed in this app's sheet rather than touching the shared mario-kart file.

**Bugfix — row edit/delete buttons gray with red hovers.** The intended ghost-chip design targeted dead `.btn-icon.edit/.delete` classes; live rows render `.edit-btn`/`.delete-btn`, which fell through to mario-kart slabs plus the sitewide theme trap (`main.css button{color:#555!important}`, red hover). Retargeted the ghost-chip block onto the live selectors with `!important` pins across base/`:hover`/`:hover:active`; 30px chips, indigo edit accent, danger-red delete hover only.

**Bugfix — back-to-top FAB floating above dialog backdrops.** Dynamic confirm/success/import dialogs (`.modal-overlay`, z-index 1000) don't opt into the FAB's modal mode, so the z-index-9000 FAB sat on top of them. `body:has(.modal-overlay) .back-to-top{display:none}`; the icon-selector modal (`.modal.active`) keeps its intended FAB behavior.

**Bugfix — toast overlapping the app title at 390px.** `showToast` inline-styles `top:80px/max-width:400px`, overflowing narrow viewports; `!important` override sits it below the site header, viewport-fitted, wrapping.

**Mobile header.** 40px sidebar toggle below 900px (was a 48px box covering the centered title; >=40px touch target kept) and symmetric 56px title padding so the title can never run under it.

**Header overflow.** Long (25-char) player names blew up nowrap table headers and clipped the Actions column; headers clamped to 180px with ellipsis, container switched from `overflow:hidden` to `overflow-x:auto`.

**Polish — accent unification.** Custom-range Apply (was theme-trap gray/red), session-summary Copy (was purple), and icon-selector header strip (was green/indigo/magenta mix) all aligned to the app's indigo accent family.

**Polish.** Player Names / Player Icons headings restyled to the sidebar's uppercase muted section-label idiom; Note and Penalty Result groups in the add-game form given the same quiet boxed surface as the goal/team groups.

### `apps/football-h2h/css/football-h2h.css` (+38/-18)

- Sidebar panel top accent strips unified to indigo (add-game was green, player-settings pink).
- Theme-trap pins (`color: ... !important` incl. `:hover:active`) on sidebar Save, Cancel, and icon-modal category tabs, which previously grayed/red-hovered.
- `.player-settings-section .section-title` restyled in this sheet too, kept in sync with the authoritative refresh.css pin (refresh.css loads last).

### `apps/football-h2h/js/football-h2h.js` (+10/-3)

- **Bugfix:** Game # column printed a literal "undefined" for games saved before `gameNumber` existed. Display-only fallback to the 1-based positional index (the same value the migration assigns); nothing is persisted.
- Export/import success modals pluralize "game(s)".

### `apps/football-h2h/js/sidebar.js` (+4/-4)

- Sidebar no longer auto-opens on every page load (owner decision 2026-06-07; it covered the content). Users open it via the toggle; closed is now the default at every viewport.
- Date-filter toast pluralizes "game(s)".

## Explicitly untouched

- `apps/mario-kart/css/mario-kart-overrides.css` and all shared/sitewide CSS/JS — every fix is app-scoped under `body.football-h2h-tracker`.
- The 32 view-x-state rows judged GOOD (incl. all 12 group-C rows): no changes.
- A probe-reported "background scrolls behind dialogs" claim was disproved as a probe artifact; no scroll-lock change was made.

## Testing

- `npm test`: 896/896 pass.
- Visual plan run (`.features/football-h2h-claude.md`, 2026-06-07 visual round): 44 view-x-state rows captured + judged; 16 new Part B visual assertions all ticked; fixes re-screenshotted at 1280/768/390.
