### PR TITLE
feat(mario-kart): course/map picker with ranked search and swappable data source

### DIFF
--- a/apps/mario-kart/README.md
+++ b/apps/mario-kart/README.md
@@ -16,6 +16,7 @@ Mario Kart Race Tracker is a feature-rich web application that allows you to:
 
 ### Core Functionality
 - **Race Recording**: Quick and easy race result entry with multiple input methods
+- **Course Selection**: Tag each race with the course/map you played on, via a searchable picker (an inline dropdown on mobile, a command-palette overlay on desktop). Course data is data-driven and easy to update (see "Updating Course Data" below)
 - **Player Management**: Customizable player names and emoji/icons
 - **Date Filtering**: View stats for specific time periods
 - **Undo/Redo**: Full history support for all actions
@@ -93,9 +94,59 @@ mario-kart/
 │   ├── main.js          # Main application logic
 │   ├── dataManager.js   # Data handling and storage
 │   ├── statistics.js    # Statistics calculations
+│   ├── courseData.js    # Course data source abstraction + ranked search
+│   ├── coursePicker.js  # Course picker UI (inline dropdown + desktop palette)
 │   └── ...              # Other feature modules
+├── data/
+│   └── courses.json     # Vendored course/map data (cups, courses, aliases)
+├── scripts/
+│   └── sync-courses.mjs # Validate / normalize / regenerate courses.json
 └── README.md            # This file
 ```
+
+## 🗺️ Updating Course Data
+
+Courses are vendored in `data/courses.json` and read through a swappable source (`js/courseData.js` → `CourseDataConfig`). There is no live API to break, so the list stays stable. Run all commands from the repo root.
+
+### Option A — add or edit a course by hand (most common)
+
+1. Open `apps/mario-kart/data/courses.json`.
+2. Pick the game under `games`: `mk8d` (Mario Kart 8 Deluxe) or `mkworld` (Mario Kart World).
+3. In that game's `cups` array, find the cup — or add a new one: `{ "id": "leaf", "name": "Leaf Cup", "courses": [] }`.
+4. Add the course to that cup's `courses` array:
+   ```json
+   { "id": "dry-bones-burnout", "name": "Dry Bones Burnout", "origin": "new", "aliases": ["dbb"] }
+   ```
+   - **id** — unique, kebab-case, stable. Never reuse an id for a different course. A course that appears in two cups must use the **same id and name** in both (that is how variants like Crown City merge into a single entry).
+   - **name** — exactly as shown in-game.
+   - **origin** — `"new"` if the track debuts in this game, otherwise the source game (e.g. `"Mario Kart 64"`). Drives the "New" filter and the preview's status.
+   - **aliases** — optional search shortcuts. Search already handles punctuation and word-initials (so "dk", "mk8", "rr" work without aliases); only add genuinely different spellings.
+5. (Optional) update that game's `source.lastSynced` date, and set `source.complete` to `true` once a game is fully entered.
+6. **Validate**: `npm run sync:mario-kart-courses -- --check` → must print `Validation passed.`
+7. **Test**: `npm test` (dataset-integrity checks live in `tests/courses.test.js`).
+8. **Verify in the app**: open Add Race → Course and confirm the course appears and is searchable.
+
+### Option B — regenerate with the sync script
+
+- Validate only (CI-friendly, non-zero exit on error): `npm run sync:mario-kart-courses -- --check`
+- Normalize the file and restamp every game's `lastSynced` to today: `node apps/mario-kart/scripts/sync-courses.mjs --write`
+- From a remote source (future): implement the mapping in `SOURCES.remote` inside `scripts/sync-courses.mjs`, then `MK_COURSES_URL=<url> node apps/mario-kart/scripts/sync-courses.mjs --source=remote --write`.
+
+### Pointing the app at a different data source
+
+Edit `js/courseData.js` → `CourseDataConfig`. Nothing else (picker, search, recents, favorites) needs to change:
+
+```js
+const CourseDataConfig = {
+  active: 'static', // 'static' reads the bundled data/courses.json
+  sources: {
+    static: { type: 'json', url: 'data/courses.json' }
+    // remote: { type: 'json', url: 'https://.../courses.json' }  // then set active: 'remote'
+  }
+};
+```
+
+> Note: MK8 Deluxe is currently `source.complete: false` — the 48 Booster Course Pass tracks are not vendored yet. Add them as new cups the same way.
 
 ## 🚀 Getting Started
 

--- a/apps/mario-kart/css/course-picker.css
+++ b/apps/mario-kart/css/course-picker.css
@@ -251,105 +251,123 @@
    DESKTOP COMMAND PALETTE (overlay, >= 760px) — a Spotlight-style course
    browser. Created in <body>, so the modal box also carries the
    `.course-picker` class to inherit the shared row styles above.
+   Tuned for a premium, playful-but-dark feel: compact chrome, whitespace
+   over dividers, a contained search field, a vivid selected row, and a
+   colorful preview card.
    ===================================================================== */
 .cp-modal-backdrop {
     position: fixed; inset: 0; z-index: 4000;
     display: flex; align-items: flex-start; justify-content: center;
-    padding: 9vh 16px 16px;
-    background: rgba(5, 6, 9, 0.62);
-    backdrop-filter: blur(3px);
-    -webkit-backdrop-filter: blur(3px);
+    padding: 8vh 16px 16px;
+    background: rgba(5, 6, 9, 0.66);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    overscroll-behavior: contain;
     animation: cpFade 0.12s ease;
 }
 @keyframes cpFade { from { opacity: 0; } to { opacity: 1; } }
 
 .cp-modal.course-picker {
-    width: min(760px, 94vw);
-    max-height: 78vh;
+    position: relative;
+    width: min(680px, 93vw);
+    max-height: 76vh;
     display: flex;
     flex-direction: column;
     background: var(--mk-surface-2, #181c26);
     border: 1px solid var(--mk-border-strong, #343a4f);
     border-radius: 16px;
-    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.6);
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.62);
     overflow: hidden;
+    overscroll-behavior: contain;
     animation: cpRise 0.14s ease;
 }
 @keyframes cpRise { from { transform: translateY(-8px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
 
-/* ---- Big search header: the focal point ---- */
-.cp-modal .cp-modal-header {
-    display: flex; align-items: center; gap: 14px;
-    padding: 20px 22px;
-    border-bottom: 1px solid var(--mk-border, #232838);
+/* A thin colorful accent across the top — the one playful "moment". */
+.cp-modal.course-picker::before {
+    content: "";
+    display: block;
+    height: 3px;
+    background: linear-gradient(90deg, #6366f1 0%, #818cf8 45%, #34d399 100%);
 }
-.cp-modal .cp-modal-icon { font-size: 1.35rem; opacity: 0.7; line-height: 1; flex: 0 0 auto; }
+
+/* ---- Search: a contained, premium field (no divider needed) ---- */
+.cp-modal .cp-modal-header {
+    display: flex; align-items: center; gap: 11px;
+    margin: 14px 14px 6px;
+    padding: 12px 15px;
+    background: var(--mk-surface, #12151d);
+    border: 1px solid var(--mk-border, #232838);
+    border-radius: 12px;
+    transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.cp-modal .cp-modal-header:focus-within {
+    border-color: var(--mk-accent, #818cf8);
+    box-shadow: 0 0 0 3px var(--mk-accent-soft, rgba(129, 140, 248, 0.18));
+}
+.cp-modal .cp-modal-icon { font-size: 1.05rem; opacity: 0.65; line-height: 1; flex: 0 0 auto; }
 .cp-modal .course-picker-search {
     flex: 1 1 auto; min-width: 0;
     padding: 0; margin: 0; border: none; outline: none; background: transparent;
     color: var(--mk-text, #f1f3f8);
-    font-size: 1.35rem; font-weight: 500; line-height: 1.4;
+    font-size: 1.12rem; font-weight: 500; line-height: 1.4;
 }
 .cp-modal .course-picker-search::placeholder { color: var(--mk-muted-2, #6f7785); font-weight: 400; }
 .cp-modal .cp-esc {
     flex: 0 0 auto;
-    font-size: 0.66rem; font-family: inherit; color: var(--mk-muted, #a4adbd);
+    font-size: 0.62rem; font-family: inherit; color: var(--mk-muted-2, #6f7785);
     background: var(--mk-surface-3, #232836);
-    border: 1px solid var(--mk-border, #232838);
-    border-radius: 5px; padding: 3px 7px; line-height: 1;
+    border-radius: 5px; padding: 3px 6px; line-height: 1;
 }
 
-/* ---- Sub-bar: quick filters + result count ---- */
+/* ---- Quick filters + count: light, secondary ---- */
 .cp-modal .cp-modal-subbar {
     display: flex; align-items: center; gap: 10px;
-    padding: 12px 22px;
-    border-bottom: 1px solid var(--mk-border, #232838);
+    padding: 4px 16px 6px;
 }
-.cp-modal .cp-filters { display: flex; flex-wrap: wrap; gap: 6px; flex: 1 1 auto; min-width: 0; }
+.cp-modal .cp-filters { display: flex; flex-wrap: wrap; gap: 5px; flex: 1 1 auto; min-width: 0; }
 .cp-modal .cp-filter {
-    padding: 5px 12px;
-    font-size: 0.76rem; font-weight: 600; line-height: 1.2;
-    color: var(--mk-muted, #a4adbd) !important;
-    background: var(--mk-surface-3, #232836);
-    border: 1px solid transparent; border-radius: 999px; cursor: pointer;
+    padding: 4px 11px;
+    font-size: 0.74rem; font-weight: 600; line-height: 1.2;
+    color: var(--mk-muted-2, #6f7785) !important;
+    background: transparent;
+    border: none; border-radius: 999px; cursor: pointer;
     transition: background 0.1s ease, color 0.1s ease;
 }
-.cp-modal .cp-filter:hover { color: var(--mk-text, #f1f3f8) !important; }
+.cp-modal .cp-filter:hover { color: var(--mk-text, #f1f3f8) !important; background: var(--mk-surface-3, #232836); }
 .cp-modal .cp-filter.is-on {
     color: #fff !important;
-    background: var(--mk-accent-strong, #6366f1);
-    border-color: var(--mk-accent, #818cf8);
+    background: linear-gradient(135deg, #6366f1, #818cf8);
 }
-.cp-modal .cp-count { flex: 0 0 auto; font-size: 0.76rem; color: var(--mk-muted-2, #6f7785); }
+.cp-modal .cp-count { flex: 0 0 auto; font-size: 0.74rem; color: var(--mk-muted-2, #6f7785); }
 
-/* ---- Empty-state guidance ---- */
+/* ---- Empty-state guidance: borderless, quiet ---- */
 .cp-modal .cp-hint {
-    padding: 11px 22px;
-    font-size: 0.78rem; line-height: 1.5;
+    padding: 2px 16px 8px;
+    font-size: 0.76rem; line-height: 1.5;
     color: var(--mk-muted-2, #6f7785);
-    border-bottom: 1px solid var(--mk-border, #232838);
 }
 .cp-modal .cp-hint b { color: var(--mk-muted, #a4adbd); font-weight: 600; }
 .cp-modal .cp-recent-searches {
     display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
-    padding: 11px 22px;
-    border-bottom: 1px solid var(--mk-border, #232838);
+    padding: 0 16px 10px;
 }
-.cp-modal .cp-rs-label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--mk-muted-2, #6f7785); margin-right: 4px; }
+.cp-modal .cp-rs-label { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--mk-muted-2, #6f7785); margin-right: 2px; }
 .cp-modal .cp-rs-chip {
-    padding: 4px 11px; font-size: 0.78rem; line-height: 1.2;
-    color: var(--mk-text, #f1f3f8) !important;
+    padding: 4px 10px; font-size: 0.76rem; line-height: 1.2;
+    color: var(--mk-muted, #a4adbd) !important;
     background: var(--mk-surface-3, #232836);
-    border: 1px solid var(--mk-border, #232838); border-radius: 999px; cursor: pointer;
+    border: none; border-radius: 999px; cursor: pointer;
 }
-.cp-modal .cp-rs-chip:hover { border-color: var(--mk-accent, #818cf8); }
+.cp-modal .cp-rs-chip:hover { color: var(--mk-text, #f1f3f8) !important; }
 
-/* ---- Two-column body: results (left) + live preview (right) ---- */
-.cp-modal .cp-modal-body { display: flex; min-height: 0; flex: 1 1 auto; }
+/* ---- Two-column body: results (left) + preview card (right) ---- */
+.cp-modal .cp-modal-body { display: flex; gap: 10px; min-height: 0; flex: 1 1 auto; padding: 2px 12px 12px; }
 .cp-modal .cp-results {
     flex: 1 1 auto; min-width: 0;
     overflow-y: auto;
-    padding: 8px;
+    overscroll-behavior: contain;
+    padding: 2px;
     scrollbar-width: thin;
     scrollbar-color: var(--mk-border-strong, #343a4f) transparent;
 }
@@ -357,60 +375,118 @@
 .cp-modal .cp-results::-webkit-scrollbar-track { background: transparent; }
 .cp-modal .cp-results::-webkit-scrollbar-thumb { background: var(--mk-border-strong, #343a4f); border-radius: 6px; border: 3px solid transparent; background-clip: padding-box; }
 
-/* Roomier rows in the palette (desktop has the space). */
-.cp-modal .cp-name { font-size: 0.98rem; }
-.cp-modal .cp-cup { font-size: 0.78rem; }
+/* Cup headers: more presence (accent tick + brighter), sticky while scrolling. */
+.cp-modal .cp-section-title {
+    position: sticky; top: -2px; z-index: 1;
+    display: flex; align-items: center; gap: 7px;
+    margin: 4px 0 2px;
+    padding: 7px 8px 6px;
+    font-size: 0.68rem; font-weight: 700; letter-spacing: 0.07em;
+    color: var(--mk-muted, #a4adbd); opacity: 1;
+    background: var(--mk-surface-2, #181c26);
+}
+.cp-modal .cp-section-title::before {
+    content: ""; flex: 0 0 auto;
+    width: 3px; height: 11px; border-radius: 2px;
+    background: linear-gradient(180deg, #818cf8, #6366f1);
+}
 
-.cp-modal .cp-preview {
-    flex: 0 0 290px;
-    border-left: 1px solid var(--mk-border, #232838);
-    background: var(--mk-surface, #12151d);
-    overflow-y: auto;
-    padding: 22px 20px;
+/* Rows: roomier, with a clear hover lift and a vivid selected state. */
+.cp-modal .cp-row { padding: 1px 1px 1px 0; margin-bottom: 1px; }
+.cp-modal .cp-row.cp-active { background: var(--mk-surface-3, #232836); }
+.cp-modal .cp-row.cp-selected {
+    background: linear-gradient(90deg, rgba(99, 102, 241, 0.30), rgba(129, 140, 248, 0.08));
+    border-left-color: var(--mk-accent, #818cf8);
+    box-shadow: inset 0 0 0 1px rgba(129, 140, 248, 0.25);
 }
-.cp-modal .cp-preview-empty { text-align: center; color: var(--mk-muted-2, #6f7785); padding-top: 30px; }
-.cp-modal .cp-preview-empty p { font-size: 0.84rem; line-height: 1.5; margin: 10px 0 0; }
-.cp-modal .cp-preview-emoji { font-size: 2.4rem; line-height: 1; }
-.cp-modal .cp-preview-card .cp-preview-emoji { margin-bottom: 12px; }
-.cp-modal .cp-preview-name {
-    font-size: 1.18rem; font-weight: 700; line-height: 1.25;
-    color: var(--mk-text, #f1f3f8); margin-bottom: 16px;
-}
-.cp-modal .cp-preview-meta { display: flex; flex-direction: column; gap: 9px; margin-bottom: 18px; }
-.cp-modal .cp-pv-row { display: flex; justify-content: space-between; gap: 12px; font-size: 0.82rem; line-height: 1.3; }
-.cp-modal .cp-pv-key { color: var(--mk-muted-2, #6f7785); }
-.cp-modal .cp-pv-val { color: var(--mk-text, #f1f3f8); text-align: right; }
-.cp-modal .cp-preview-fav {
-    width: 100%; margin-bottom: 8px; padding: 9px;
-    font-size: 0.82rem; font-weight: 600; cursor: pointer;
-    color: var(--mk-muted, #a4adbd) !important;
+.cp-modal .cp-row.cp-selected.cp-active { background: linear-gradient(90deg, rgba(99, 102, 241, 0.42), rgba(129, 140, 248, 0.14)); }
+.cp-modal .cp-name { font-size: 0.97rem; }
+.cp-modal .cp-cup { font-size: 0.76rem; color: var(--mk-muted, #a4adbd); }
+
+/* Game source reads as a distinct subtle chip so it never blends with the cup. */
+.cp-modal .cp-origin {
+    font-size: 0.66rem;
+    color: var(--mk-muted-2, #6f7785);
     background: var(--mk-surface-3, #232836);
-    border: 1px solid var(--mk-border, #232838); border-radius: 8px;
+    border-radius: 5px;
+    padding: 1px 6px;
 }
-.cp-modal .cp-preview-fav.is-fav { color: #f59e0b !important; border-color: rgba(245, 158, 11, 0.4); }
-.cp-modal .cp-preview-select {
-    width: 100%; padding: 11px;
-    font-size: 0.88rem; font-weight: 700; cursor: pointer;
-    color: #fff !important;
-    background: var(--mk-accent-strong, #6366f1);
+.cp-modal .cp-origin::before { content: none; }
+
+/* Favorite star feels part of the row: a hover-revealed hit area. */
+.cp-modal .cp-fav { width: 32px; height: 32px; border-radius: 8px; }
+
+/* ---- Preview card: compact, colorful, useful ---- */
+.cp-modal .cp-preview { flex: 0 0 236px; overflow-y: auto; overscroll-behavior: contain; }
+.cp-modal .cp-preview-empty {
+    background: var(--mk-surface, #12151d);
+    border-radius: 12px;
+    padding: 30px 16px; text-align: center;
+    color: var(--mk-muted-2, #6f7785);
+}
+.cp-modal .cp-preview-empty .cp-preview-emoji { font-size: 2rem; line-height: 1; }
+.cp-modal .cp-preview-empty p { font-size: 0.82rem; line-height: 1.5; margin: 12px 0 0; }
+
+.cp-modal .cp-pv {
+    background: var(--mk-surface, #12151d);
+    border-radius: 12px;
+    overflow: hidden;
+}
+.cp-modal .cp-pv-hero {
+    display: flex; align-items: center; gap: 9px;
+    padding: 13px 14px;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.40), rgba(129, 140, 248, 0.10));
+}
+.cp-modal .cp-pv-new .cp-pv-hero { background: linear-gradient(135deg, rgba(52, 211, 153, 0.34), rgba(52, 211, 153, 0.07)); }
+.cp-modal .cp-pv-emoji { font-size: 1.5rem; line-height: 1; }
+.cp-modal .cp-pv-status {
+    flex: 1 1 auto;
+    font-size: 0.66rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--mk-text, #f1f3f8);
+}
+.cp-modal .cp-preview-fav {
+    flex: 0 0 auto;
+    width: 30px; height: 30px; padding: 0;
+    font-size: 1rem; line-height: 1; cursor: pointer;
+    color: var(--mk-text, #f1f3f8) !important;
+    background: rgba(0, 0, 0, 0.22);
     border: none; border-radius: 8px;
 }
-.cp-modal .cp-preview-select:hover { background: var(--mk-accent, #818cf8); }
+.cp-modal .cp-preview-fav.is-fav { color: #f59e0b !important; }
+.cp-modal .cp-pv-name {
+    font-size: 1.05rem; font-weight: 700; line-height: 1.3;
+    color: var(--mk-text, #f1f3f8);
+    padding: 13px 14px 9px;
+}
+.cp-modal .cp-pv-tags { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 14px 13px; }
+.cp-modal .cp-pv-tag { font-size: 0.71rem; font-weight: 600; line-height: 1.3; padding: 4px 9px; border-radius: 6px; }
+.cp-modal .cp-pv-tag-cup { color: var(--mk-accent, #818cf8); background: var(--mk-accent-soft, rgba(129, 140, 248, 0.16)); }
+.cp-modal .cp-pv-tag-game { color: var(--mk-muted, #a4adbd); background: var(--mk-surface-3, #232836); }
+.cp-modal .cp-preview-select {
+    display: block; width: calc(100% - 28px); margin: 0 14px 14px;
+    padding: 11px; font-size: 0.86rem; font-weight: 700; cursor: pointer;
+    color: #fff !important;
+    background: linear-gradient(135deg, #6366f1, #818cf8);
+    border: none; border-radius: 9px;
+    transition: filter 0.1s ease;
+}
+.cp-modal .cp-preview-select:hover { filter: brightness(1.1); }
 
-/* ---- Footer keyboard legend ---- */
+/* ---- Footer keyboard legend: barely there ---- */
 .cp-modal .cp-modal-foot {
-    padding: 10px 22px;
-    border-top: 1px solid var(--mk-border, #232838);
-    font-size: 0.72rem; color: var(--mk-muted-2, #6f7785);
+    padding: 7px 16px 11px;
+    text-align: center;
+    font-size: 0.68rem; color: var(--mk-muted-2, #6f7785);
+    opacity: 0.5;
 }
 .cp-modal .cp-modal-foot kbd {
-    font-family: inherit; font-size: 0.68rem;
-    background: var(--mk-surface-3, #232836);
+    font-family: inherit; font-size: 0.66rem;
+    background: transparent;
     border: 1px solid var(--mk-border, #232838);
-    border-radius: 4px; padding: 1px 5px; margin: 0 1px;
+    border-radius: 4px; padding: 0 4px; margin: 0 1px;
 }
 
-/* On short viewports, let the list breathe by dropping the preview column. */
+/* On short viewports, drop the preview column so the list can breathe. */
 @media (max-height: 560px) {
     .cp-modal .cp-preview { display: none; }
 }

--- a/apps/mario-kart/css/course-picker.css
+++ b/apps/mario-kart/css/course-picker.css
@@ -1,0 +1,278 @@
+/* Course picker (sidebar race form).
+   Uses the app's visual-refresh palette (--mk-* tokens from refresh.css) so the
+   picker matches the dark Control Panel. Every text element pins its own
+   line-height because a global button rule sets an oversized line-height that
+   would otherwise collapse the multi-line rows on top of each other. */
+
+#sidebar-course-picker {
+    margin-bottom: 14px;
+}
+
+.cp-field-label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--mk-muted-2, #6f7785);
+    margin-bottom: 6px;
+}
+
+.course-picker { position: relative; }
+
+/* ---- Trigger (closed state) ---- */
+.course-picker-control { position: relative; }
+
+.course-picker .course-picker-trigger {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 10px 56px 10px 12px;
+    background: var(--mk-surface-2, #181c26);
+    border: 1px solid var(--mk-border, #232838);
+    border-radius: 8px;
+    color: var(--mk-text, #f1f3f8);
+    font-size: 0.9rem;
+    line-height: 1.3;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.course-picker .course-picker-trigger:hover,
+.course-picker .course-picker-trigger[aria-expanded="true"] {
+    border-color: var(--mk-accent, #818cf8);
+    background: var(--mk-surface-3, #232836);
+}
+
+.course-picker .cp-icon { font-size: 1rem; flex: 0 0 auto; line-height: 1; }
+
+.course-picker .cp-label {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1.3;
+}
+
+.course-picker .cp-label.cp-placeholder { color: var(--mk-muted, #a4adbd); }
+
+.course-picker .cp-caret {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--mk-muted, #a4adbd);
+    font-size: 0.75rem;
+    line-height: 1;
+    pointer-events: none;
+}
+
+.course-picker .cp-clear {
+    position: absolute;
+    right: 32px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 20px;
+    height: 20px;
+    line-height: 18px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: rgba(148, 163, 184, 0.22);
+    color: var(--mk-text, #f1f3f8);
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+
+.course-picker .cp-clear:hover { background: rgba(239, 68, 68, 0.28); }
+
+/* ---- Dropdown panel ---- */
+.course-picker .course-picker-panel {
+    position: absolute;
+    z-index: 50;
+    top: calc(100% + 6px);
+    left: 0;
+    right: 0;
+    max-height: 340px;
+    overflow-y: auto;
+    padding: 10px;
+    background: var(--mk-surface-2, #181c26);
+    border: 1px solid var(--mk-border-strong, #343a4f);
+    border-radius: 10px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+}
+
+.course-picker .course-picker-search {
+    width: 100%;
+    padding: 9px 11px;
+    margin-bottom: 8px;
+    background: var(--mk-surface, #12151d);
+    border: 1px solid var(--mk-border, #232838);
+    border-radius: 7px;
+    color: var(--mk-text, #f1f3f8);
+    font-size: 0.88rem;
+    line-height: 1.3;
+    box-sizing: border-box;
+}
+
+.course-picker .course-picker-search::placeholder { color: var(--mk-muted-2, #6f7785); }
+.course-picker .course-picker-search:focus {
+    outline: none;
+    border-color: var(--mk-accent, #818cf8);
+    box-shadow: 0 0 0 3px var(--mk-accent-soft, rgba(129, 140, 248, 0.14));
+}
+
+.course-picker .cp-count {
+    font-size: 0.72rem;
+    color: var(--mk-muted-2, #6f7785);
+    padding: 0 4px 6px;
+    line-height: 1.3;
+}
+
+/* ---- Quick-tap chips (recents / favorites) ---- */
+.course-picker .cp-chips { margin-bottom: 10px; }
+.course-picker .cp-chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 2px 2px 0;
+}
+
+.course-picker .cp-chip {
+    padding: 5px 10px;
+    background: var(--mk-surface-3, #232836);
+    border: 1px solid var(--mk-border, #232838);
+    border-radius: 999px;
+    color: var(--mk-text, #f1f3f8);
+    font-size: 0.78rem;
+    line-height: 1.2;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.course-picker .cp-chip:hover { border-color: var(--mk-accent, #818cf8); }
+.course-picker .cp-chip-on {
+    background: var(--mk-accent-soft, rgba(129, 140, 248, 0.14));
+    border-color: var(--mk-accent, #818cf8);
+}
+
+/* ---- Sections + rows ---- */
+.course-picker .cp-section { margin-bottom: 10px; }
+.course-picker .cp-section:last-child { margin-bottom: 0; }
+
+.course-picker .cp-section-title {
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    line-height: 1.4;
+    color: var(--mk-muted-2, #6f7785);
+    padding: 2px 4px;
+    margin-bottom: 4px;
+}
+
+.course-picker .cp-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: 7px;
+}
+
+.course-picker .cp-row.cp-active { background: var(--mk-accent-soft, rgba(129, 140, 248, 0.14)); }
+.course-picker .cp-row.cp-selected { background: var(--mk-accent-strong-soft, rgba(99, 102, 241, 0.32)); }
+
+.course-picker .cp-course {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 7px 8px;
+    background: transparent;
+    border: none;
+    border-radius: 7px;
+    color: var(--mk-text, #f1f3f8);
+    text-align: left;
+    line-height: 1.25;
+    cursor: pointer;
+}
+
+.course-picker .cp-name {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    line-height: 1.25;
+}
+
+.course-picker .cp-check { color: var(--mk-accent, #818cf8); font-size: 0.85rem; }
+
+.course-picker .cp-hl {
+    background: transparent;
+    color: var(--mk-accent, #818cf8);
+    font-weight: 700;
+}
+
+.course-picker .cp-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    line-height: 1.2;
+}
+
+.course-picker .cp-cup { font-size: 0.72rem; color: var(--mk-muted, #a4adbd); }
+
+.course-picker .cp-pill {
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    padding: 3px 6px;
+    border-radius: 4px;
+}
+
+.course-picker .cp-pill-new {
+    color: var(--mk-good, #34d399);
+    background: rgba(52, 211, 153, 0.14);
+}
+
+.course-picker .cp-pill-retro {
+    color: var(--mk-muted, #a4adbd);
+    background: rgba(148, 163, 184, 0.12);
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 600;
+}
+
+.course-picker .cp-fav {
+    flex: 0 0 auto;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: var(--mk-muted-2, #6f7785);
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.course-picker .cp-fav:hover { background: var(--mk-accent-soft, rgba(129, 140, 248, 0.14)); color: var(--mk-muted, #a4adbd); }
+.course-picker .cp-fav.is-fav { color: #f59e0b; }
+
+.course-picker .cp-empty {
+    padding: 16px 8px;
+    text-align: center;
+    color: var(--mk-muted, #a4adbd);
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+/* Course badge in race history (date cell / mobile card). */
+.race-course-label { color: var(--mk-muted, #a4adbd); }

--- a/apps/mario-kart/css/course-picker.css
+++ b/apps/mario-kart/css/course-picker.css
@@ -125,6 +125,18 @@
 .course-picker .course-picker-search::placeholder { color: var(--mk-muted-2, #6f7785); }
 .course-picker .cp-count { flex: 0 0 auto; font-size: 0.7rem; color: var(--mk-muted-2, #6f7785); line-height: 1.3; }
 
+/* Inline-field clear button (shared with the desktop palette). */
+.course-picker .cp-search-clear {
+    flex: 0 0 auto;
+    width: 22px; height: 22px; padding: 0;
+    display: inline-flex; align-items: center; justify-content: center;
+    border: none; border-radius: 50%; cursor: pointer;
+    background: rgba(148, 163, 184, 0.20);
+    color: var(--mk-text, #f1f3f8) !important;
+    font-size: 0.95rem; line-height: 1;
+}
+.course-picker .cp-search-clear:hover { background: rgba(148, 163, 184, 0.34); }
+
 .course-picker .cp-results { padding: 6px; }
 
 /* ---- Sections: quiet organizational anchors ---- */
@@ -202,6 +214,8 @@
 /* Line 2: cup (secondary) · game source (tertiary, subtle). */
 .course-picker .cp-sub { display: flex; align-items: center; gap: 7px; min-width: 0; line-height: 1.2; }
 .course-picker .cp-cup {
+    display: block;
+    line-height: 1.25;             /* pin: the row button has a huge global line-height */
     font-size: 0.74rem;
     color: var(--mk-muted, #a4adbd);
     overflow: hidden;
@@ -226,13 +240,13 @@
     flex: 0 0 auto;
     width: 30px; height: 30px; padding: 0;
     background: transparent; border: none; border-radius: 6px;
-    color: var(--mk-muted-2, #6f7785) !important;
+    color: var(--mk-muted, #a4adbd) !important;
     font-size: 0.95rem; line-height: 1; cursor: pointer;
-    opacity: 0.32;
+    opacity: 0.5;
     transition: opacity 0.1s ease, color 0.1s ease;
 }
 .course-picker .cp-row:hover .cp-fav,
-.course-picker .cp-row.cp-active .cp-fav { opacity: 0.85; }
+.course-picker .cp-row.cp-active .cp-fav { opacity: 1; }
 .course-picker .cp-fav:hover { color: var(--mk-text, #f1f3f8) !important; opacity: 1; }
 .course-picker .cp-fav.is-fav { color: #f59e0b !important; opacity: 1; }
 
@@ -251,9 +265,8 @@
    DESKTOP COMMAND PALETTE (overlay, >= 760px) — a Spotlight-style course
    browser. Created in <body>, so the modal box also carries the
    `.course-picker` class to inherit the shared row styles above.
-   Tuned for a premium, playful-but-dark feel: compact chrome, whitespace
-   over dividers, a contained search field, a vivid selected row, and a
-   colorful preview card.
+   Tuned for density + clarity: compact rows, clearly-separated states,
+   readable metadata, one accent gradient, restrained chrome.
    ===================================================================== */
 .cp-modal-backdrop {
     position: fixed; inset: 0; z-index: 4000;
@@ -269,88 +282,97 @@
 
 .cp-modal.course-picker {
     position: relative;
-    width: min(680px, 93vw);
-    max-height: 76vh;
+    width: min(640px, 93vw);
+    max-height: 78vh;
     display: flex;
     flex-direction: column;
     background: var(--mk-surface-2, #181c26);
     border: 1px solid var(--mk-border-strong, #343a4f);
-    border-radius: 16px;
-    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.62);
+    border-radius: 14px;
+    box-shadow: 0 28px 70px rgba(0, 0, 0, 0.6);
     overflow: hidden;
     overscroll-behavior: contain;
     animation: cpRise 0.14s ease;
 }
 @keyframes cpRise { from { transform: translateY(-8px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
 
-/* A thin colorful accent across the top — the one playful "moment". */
+/* A single thin accent line — the one playful flourish. */
 .cp-modal.course-picker::before {
-    content: "";
-    display: block;
-    height: 3px;
-    background: linear-gradient(90deg, #6366f1 0%, #818cf8 45%, #34d399 100%);
+    content: ""; display: block; height: 3px;
+    background: linear-gradient(90deg, #6366f1 0%, #818cf8 50%, #34d399 100%);
 }
 
-/* ---- Search: a contained, premium field (no divider needed) ---- */
+/* ---- Search: a contained, premium field ---- */
 .cp-modal .cp-modal-header {
-    display: flex; align-items: center; gap: 11px;
-    margin: 14px 14px 6px;
-    padding: 12px 15px;
+    display: flex; align-items: center; gap: 10px;
+    margin: 13px 13px 4px;
+    padding: 11px 14px;
     background: var(--mk-surface, #12151d);
     border: 1px solid var(--mk-border, #232838);
-    border-radius: 12px;
+    border-radius: 11px;
     transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }
 .cp-modal .cp-modal-header:focus-within {
     border-color: var(--mk-accent, #818cf8);
     box-shadow: 0 0 0 3px var(--mk-accent-soft, rgba(129, 140, 248, 0.18));
 }
-.cp-modal .cp-modal-icon { font-size: 1.05rem; opacity: 0.65; line-height: 1; flex: 0 0 auto; }
+.cp-modal .cp-modal-icon { font-size: 1.02rem; opacity: 0.6; line-height: 1; flex: 0 0 auto; }
 .cp-modal .course-picker-search {
     flex: 1 1 auto; min-width: 0;
     padding: 0; margin: 0; border: none; outline: none; background: transparent;
     color: var(--mk-text, #f1f3f8);
-    font-size: 1.12rem; font-weight: 500; line-height: 1.4;
+    font-size: 1.1rem; font-weight: 500; line-height: 1.4;
 }
 .cp-modal .course-picker-search::placeholder { color: var(--mk-muted-2, #6f7785); font-weight: 400; }
 .cp-modal .cp-esc {
     flex: 0 0 auto;
-    font-size: 0.62rem; font-family: inherit; color: var(--mk-muted-2, #6f7785);
+    font-size: 0.6rem; font-family: inherit; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--mk-muted-2, #6f7785);
     background: var(--mk-surface-3, #232836);
-    border-radius: 5px; padding: 3px 6px; line-height: 1;
+    border-radius: 4px; padding: 3px 6px; line-height: 1;
 }
 
-/* ---- Quick filters + count: light, secondary ---- */
+/* ---- Quick filters (with counts) + result count ---- */
 .cp-modal .cp-modal-subbar {
     display: flex; align-items: center; gap: 10px;
-    padding: 4px 16px 6px;
+    padding: 4px 14px 6px;
 }
 .cp-modal .cp-filters { display: flex; flex-wrap: wrap; gap: 5px; flex: 1 1 auto; min-width: 0; }
 .cp-modal .cp-filter {
-    padding: 4px 11px;
-    font-size: 0.74rem; font-weight: 600; line-height: 1.2;
-    color: var(--mk-muted-2, #6f7785) !important;
-    background: transparent;
-    border: none; border-radius: 999px; cursor: pointer;
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 4px 10px;
+    font-size: 0.76rem; font-weight: 600; line-height: 1.2;
+    color: var(--mk-muted, #a4adbd) !important;          /* readable when inactive */
+    background: var(--mk-surface-3, #232836);
+    border: 1px solid transparent; border-radius: 999px; cursor: pointer;
     transition: background 0.1s ease, color 0.1s ease;
 }
-.cp-modal .cp-filter:hover { color: var(--mk-text, #f1f3f8) !important; background: var(--mk-surface-3, #232836); }
+.cp-modal .cp-filter:hover { color: var(--mk-text, #f1f3f8) !important; }
+.cp-modal .cp-filter:focus-visible { outline: 2px solid var(--mk-accent, #818cf8); outline-offset: 2px; }
 .cp-modal .cp-filter.is-on {
     color: #fff !important;
-    background: linear-gradient(135deg, #6366f1, #818cf8);
+    background: var(--mk-accent-strong, #6366f1);
+    border-color: var(--mk-accent, #818cf8);
 }
-.cp-modal .cp-count { flex: 0 0 auto; font-size: 0.74rem; color: var(--mk-muted-2, #6f7785); }
-
-/* ---- Empty-state guidance: borderless, quiet ---- */
-.cp-modal .cp-hint {
-    padding: 2px 16px 8px;
-    font-size: 0.76rem; line-height: 1.5;
+.cp-modal .cp-filter-n {
+    font-size: 0.66rem; font-weight: 700;
     color: var(--mk-muted-2, #6f7785);
+    background: rgba(0, 0, 0, 0.22);
+    border-radius: 999px; padding: 0 5px; min-width: 14px; text-align: center;
 }
-.cp-modal .cp-hint b { color: var(--mk-muted, #a4adbd); font-weight: 600; }
+.cp-modal .cp-filter.is-on .cp-filter-n { color: #fff; background: rgba(255, 255, 255, 0.22); }
+.cp-modal .cp-count { flex: 0 0 auto; font-size: 0.74rem; color: var(--mk-muted, #a4adbd); }
+
+/* ---- Empty-state guidance ---- */
+.cp-modal .cp-hint {
+    padding: 2px 14px 8px;
+    font-size: 0.76rem; line-height: 1.5;
+    color: var(--mk-muted, #a4adbd);
+}
+.cp-modal .cp-hint b { color: var(--mk-text, #f1f3f8); font-weight: 600; }
 .cp-modal .cp-recent-searches {
     display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
-    padding: 0 16px 10px;
+    padding: 0 14px 8px;
 }
 .cp-modal .cp-rs-label { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--mk-muted-2, #6f7785); margin-right: 2px; }
 .cp-modal .cp-rs-chip {
@@ -361,132 +383,125 @@
 }
 .cp-modal .cp-rs-chip:hover { color: var(--mk-text, #f1f3f8) !important; }
 
-/* ---- Two-column body: results (left) + preview card (right) ---- */
-.cp-modal .cp-modal-body { display: flex; gap: 10px; min-height: 0; flex: 1 1 auto; padding: 2px 12px 12px; }
+/* ---- Clear (x) inside the search field ---- */
+.cp-modal .cp-search-clear { width: 22px; height: 22px; }
+
+/* ---- Two-column body: results (left) + preview (right) ---- */
+.cp-modal .cp-modal-body { display: flex; gap: 12px; min-height: 0; flex: 1 1 auto; padding: 2px 12px 12px; }
 .cp-modal .cp-results {
     flex: 1 1 auto; min-width: 0;
     overflow-y: auto;
     overscroll-behavior: contain;
     padding: 2px;
     scrollbar-width: thin;
-    scrollbar-color: var(--mk-border-strong, #343a4f) transparent;
+    scrollbar-color: var(--mk-muted-2, #6f7785) transparent;
 }
-.cp-modal .cp-results::-webkit-scrollbar { width: 10px; }
+.cp-modal .cp-results::-webkit-scrollbar { width: 12px; }
 .cp-modal .cp-results::-webkit-scrollbar-track { background: transparent; }
-.cp-modal .cp-results::-webkit-scrollbar-thumb { background: var(--mk-border-strong, #343a4f); border-radius: 6px; border: 3px solid transparent; background-clip: padding-box; }
+.cp-modal .cp-results::-webkit-scrollbar-thumb {
+    background: var(--mk-muted-2, #6f7785);    /* higher contrast = discoverable */
+    border-radius: 7px; border: 3px solid transparent; background-clip: padding-box;
+}
+.cp-modal .cp-results::-webkit-scrollbar-thumb:hover { background: var(--mk-muted, #a4adbd); background-clip: padding-box; }
 
-/* Cup headers: more presence (accent tick + brighter), sticky while scrolling. */
+/* Cup headers: clear presence (accent tick + bright label), sticky. */
 .cp-modal .cp-section-title {
     position: sticky; top: -2px; z-index: 1;
     display: flex; align-items: center; gap: 7px;
-    margin: 4px 0 2px;
-    padding: 7px 8px 6px;
-    font-size: 0.68rem; font-weight: 700; letter-spacing: 0.07em;
-    color: var(--mk-muted, #a4adbd); opacity: 1;
+    margin: 6px 0 2px;
+    padding: 6px 8px 5px;
+    font-size: 0.69rem; font-weight: 700; letter-spacing: 0.08em;
+    color: var(--mk-text, #f1f3f8);
     background: var(--mk-surface-2, #181c26);
 }
 .cp-modal .cp-section-title::before {
-    content: ""; flex: 0 0 auto;
-    width: 3px; height: 11px; border-radius: 2px;
-    background: linear-gradient(180deg, #818cf8, #6366f1);
+    content: ""; flex: 0 0 auto; width: 3px; height: 11px; border-radius: 2px;
+    background: var(--mk-accent, #818cf8);
 }
 
-/* Rows: roomier, with a clear hover lift and a vivid selected state. */
-.cp-modal .cp-row { padding: 1px 1px 1px 0; margin-bottom: 1px; }
+/* Rows: dense; states clearly separated (hover faint, selected vivid + bar). */
+.cp-modal .cp-row { padding-left: 0; margin-bottom: 1px; border-left: 3px solid transparent; }
+.cp-modal .cp-course { padding: 6px 8px; gap: 1px; }
+.cp-modal .cp-name { font-size: 0.93rem; }
+.cp-modal .cp-cup { font-size: 0.74rem; color: var(--mk-muted, #a4adbd); }
 .cp-modal .cp-row.cp-active { background: var(--mk-surface-3, #232836); }
 .cp-modal .cp-row.cp-selected {
-    background: linear-gradient(90deg, rgba(99, 102, 241, 0.30), rgba(129, 140, 248, 0.08));
+    background: rgba(99, 102, 241, 0.20);
     border-left-color: var(--mk-accent, #818cf8);
-    box-shadow: inset 0 0 0 1px rgba(129, 140, 248, 0.25);
 }
-.cp-modal .cp-row.cp-selected.cp-active { background: linear-gradient(90deg, rgba(99, 102, 241, 0.42), rgba(129, 140, 248, 0.14)); }
-.cp-modal .cp-name { font-size: 0.97rem; }
-.cp-modal .cp-cup { font-size: 0.76rem; color: var(--mk-muted, #a4adbd); }
+.cp-modal .cp-row.cp-selected .cp-name { color: #fff; }
+.cp-modal .cp-row.cp-selected.cp-active { background: rgba(99, 102, 241, 0.30); }
+.cp-modal .cp-check { color: var(--mk-accent, #818cf8); font-size: 0.9rem; }
+.cp-modal .cp-fav { width: 30px; height: 30px; border-radius: 8px; }
+.cp-modal .cp-fav:focus-visible { outline: 2px solid var(--mk-accent, #818cf8); outline-offset: -2px; }
 
-/* Game source reads as a distinct subtle chip so it never blends with the cup. */
-.cp-modal .cp-origin {
-    font-size: 0.66rem;
-    color: var(--mk-muted-2, #6f7785);
-    background: var(--mk-surface-3, #232836);
-    border-radius: 5px;
-    padding: 1px 6px;
-}
-.cp-modal .cp-origin::before { content: none; }
-
-/* Favorite star feels part of the row: a hover-revealed hit area. */
-.cp-modal .cp-fav { width: 32px; height: 32px; border-radius: 8px; }
-
-/* ---- Preview card: compact, colorful, useful ---- */
-.cp-modal .cp-preview { flex: 0 0 236px; overflow-y: auto; overscroll-behavior: contain; }
+/* ---- Preview: title-first, compact, readable ---- */
+.cp-modal .cp-preview { flex: 0 0 208px; overflow-y: auto; overscroll-behavior: contain; }
 .cp-modal .cp-preview-empty {
     background: var(--mk-surface, #12151d);
-    border-radius: 12px;
-    padding: 30px 16px; text-align: center;
-    color: var(--mk-muted-2, #6f7785);
+    border-radius: 11px;
+    padding: 28px 16px; text-align: center;
+    color: var(--mk-muted, #a4adbd);
 }
-.cp-modal .cp-preview-empty .cp-preview-emoji { font-size: 2rem; line-height: 1; }
-.cp-modal .cp-preview-empty p { font-size: 0.82rem; line-height: 1.5; margin: 12px 0 0; }
+.cp-modal .cp-preview-empty .cp-preview-emoji { font-size: 1.9rem; line-height: 1; }
+.cp-modal .cp-preview-empty p { font-size: 0.8rem; line-height: 1.5; margin: 11px 0 0; }
 
 .cp-modal .cp-pv {
     background: var(--mk-surface, #12151d);
-    border-radius: 12px;
-    overflow: hidden;
+    border-radius: 11px;
+    padding: 15px 15px 14px;
 }
-.cp-modal .cp-pv-hero {
-    display: flex; align-items: center; gap: 9px;
-    padding: 13px 14px;
-    background: linear-gradient(135deg, rgba(99, 102, 241, 0.40), rgba(129, 140, 248, 0.10));
-}
-.cp-modal .cp-pv-new .cp-pv-hero { background: linear-gradient(135deg, rgba(52, 211, 153, 0.34), rgba(52, 211, 153, 0.07)); }
-.cp-modal .cp-pv-emoji { font-size: 1.5rem; line-height: 1; }
-.cp-modal .cp-pv-status {
-    flex: 1 1 auto;
-    font-size: 0.66rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
-    color: var(--mk-text, #f1f3f8);
-}
-.cp-modal .cp-preview-fav {
-    flex: 0 0 auto;
-    width: 30px; height: 30px; padding: 0;
-    font-size: 1rem; line-height: 1; cursor: pointer;
-    color: var(--mk-text, #f1f3f8) !important;
-    background: rgba(0, 0, 0, 0.22);
-    border: none; border-radius: 8px;
-}
-.cp-modal .cp-preview-fav.is-fav { color: #f59e0b !important; }
 .cp-modal .cp-pv-name {
-    font-size: 1.05rem; font-weight: 700; line-height: 1.3;
+    font-size: 1.12rem; font-weight: 700; line-height: 1.25;
     color: var(--mk-text, #f1f3f8);
-    padding: 13px 14px 9px;
+    margin-bottom: 9px;
 }
-.cp-modal .cp-pv-tags { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 14px 13px; }
-.cp-modal .cp-pv-tag { font-size: 0.71rem; font-weight: 600; line-height: 1.3; padding: 4px 9px; border-radius: 6px; }
-.cp-modal .cp-pv-tag-cup { color: var(--mk-accent, #818cf8); background: var(--mk-accent-soft, rgba(129, 140, 248, 0.16)); }
-.cp-modal .cp-pv-tag-game { color: var(--mk-muted, #a4adbd); background: var(--mk-surface-3, #232836); }
+.cp-modal .cp-pv-status {
+    display: inline-block;
+    font-size: 0.64rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+    color: var(--mk-muted, #a4adbd);
+    background: var(--mk-surface-3, #232836);
+    border-radius: 5px; padding: 3px 7px; margin-bottom: 14px;
+}
+.cp-modal .cp-pv-status.is-new { color: var(--mk-good, #34d399); background: rgba(52, 211, 153, 0.14); }
+.cp-modal .cp-pv-meta { display: flex; flex-direction: column; gap: 8px; margin-bottom: 15px; }
+.cp-modal .cp-pv-row { display: flex; justify-content: space-between; gap: 10px; font-size: 0.82rem; line-height: 1.35; }
+.cp-modal .cp-pv-key { color: var(--mk-muted-2, #6f7785); flex: 0 0 auto; }
+.cp-modal .cp-pv-val { color: var(--mk-text, #f1f3f8); text-align: right; }
+.cp-modal .cp-preview-fav {
+    width: 100%; margin-bottom: 7px; padding: 8px;
+    font-size: 0.8rem; font-weight: 600; cursor: pointer;
+    color: var(--mk-muted, #a4adbd) !important;
+    background: var(--mk-surface-3, #232836);
+    border: 1px solid transparent; border-radius: 8px;
+}
+.cp-modal .cp-preview-fav:hover { color: var(--mk-text, #f1f3f8) !important; }
+.cp-modal .cp-preview-fav.is-fav { color: #f59e0b !important; background: rgba(245, 158, 11, 0.10); border-color: rgba(245, 158, 11, 0.35); }
 .cp-modal .cp-preview-select {
-    display: block; width: calc(100% - 28px); margin: 0 14px 14px;
-    padding: 11px; font-size: 0.86rem; font-weight: 700; cursor: pointer;
+    display: block; width: 100%; padding: 9px;
+    font-size: 0.83rem; font-weight: 700; cursor: pointer;
     color: #fff !important;
-    background: linear-gradient(135deg, #6366f1, #818cf8);
-    border: none; border-radius: 9px;
+    background: var(--mk-accent-strong, #6366f1);
+    border: none; border-radius: 8px;
     transition: filter 0.1s ease;
 }
 .cp-modal .cp-preview-select:hover { filter: brightness(1.1); }
+.cp-modal .cp-preview-select.is-selected { color: var(--mk-good, #34d399) !important; background: rgba(52, 211, 153, 0.12); }
 
 /* ---- Footer keyboard legend: barely there ---- */
 .cp-modal .cp-modal-foot {
-    padding: 7px 16px 11px;
+    padding: 7px 14px 10px;
     text-align: center;
-    font-size: 0.68rem; color: var(--mk-muted-2, #6f7785);
-    opacity: 0.5;
+    font-size: 0.67rem; color: var(--mk-muted-2, #6f7785);
+    opacity: 0.55;
 }
 .cp-modal .cp-modal-foot kbd {
-    font-family: inherit; font-size: 0.66rem;
+    font-family: inherit; font-size: 0.65rem;
     background: transparent;
     border: 1px solid var(--mk-border, #232838);
     border-radius: 4px; padding: 0 4px; margin: 0 1px;
 }
 
-/* On short viewports, drop the preview column so the list can breathe. */
 @media (max-height: 560px) {
     .cp-modal .cp-preview { display: none; }
 }

--- a/apps/mario-kart/css/course-picker.css
+++ b/apps/mario-kart/css/course-picker.css
@@ -1,12 +1,10 @@
-/* Course picker (sidebar race form).
-   Uses the app's visual-refresh palette (--mk-* tokens from refresh.css) so the
-   picker matches the dark Control Panel. Every text element pins its own
-   line-height because a global button rule sets an oversized line-height that
-   would otherwise collapse the multi-line rows on top of each other. */
+/* Course picker (sidebar race form) — command-palette styling.
+   One calm surface. The course NAME is the hero of every row; cup is secondary,
+   game source tertiary, badges/stars/headers/scrollbar are quiet support.
+   Uses the app's --mk-* dark palette (from refresh.css). Every text element
+   pins its own line-height to defeat a global oversized button line-height. */
 
-#sidebar-course-picker {
-    margin-bottom: 14px;
-}
+#sidebar-course-picker { margin-bottom: 14px; }
 
 .cp-field-label {
     display: block;
@@ -19,25 +17,22 @@
 }
 
 .course-picker { position: relative; }
-
-/* ---- Trigger (closed state) ---- */
 .course-picker-control { position: relative; }
 
+/* ---- Closed trigger: two-line, always informative ---- */
 .course-picker .course-picker-trigger {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
     width: 100%;
-    padding: 10px 56px 10px 12px;
+    padding: 9px 56px 9px 12px;
     background: var(--mk-surface-2, #181c26);
     border: 1px solid var(--mk-border, #232838);
-    border-radius: 8px;
+    border-radius: 9px;
     color: var(--mk-text, #f1f3f8);
-    font-size: 0.9rem;
-    line-height: 1.3;
     cursor: pointer;
     text-align: left;
-    transition: border-color 0.15s ease, background 0.15s ease;
+    transition: border-color 0.12s ease, background 0.12s ease;
 }
 
 .course-picker .course-picker-trigger:hover,
@@ -46,231 +41,206 @@
     background: var(--mk-surface-3, #232836);
 }
 
-.course-picker .cp-icon { font-size: 1rem; flex: 0 0 auto; line-height: 1; }
+.course-picker .cp-icon { font-size: 1.05rem; flex: 0 0 auto; line-height: 1; opacity: 0.9; }
 
-.course-picker .cp-label {
-    flex: 1 1 auto;
+.course-picker .cp-trigger-text { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+
+.course-picker .cp-trigger-primary {
+    font-size: 0.92rem;
+    font-weight: 600;
+    line-height: 1.25;
+    color: var(--mk-text, #f1f3f8);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    line-height: 1.3;
+}
+.course-picker .cp-trigger-primary.cp-empty-primary { font-weight: 500; color: var(--mk-muted, #a4adbd); }
+
+.course-picker .cp-trigger-secondary {
+    font-size: 0.72rem;
+    line-height: 1.2;
+    color: var(--mk-muted-2, #6f7785);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.course-picker .cp-label.cp-placeholder { color: var(--mk-muted, #a4adbd); }
-
 .course-picker .cp-caret {
-    position: absolute;
-    right: 12px;
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--mk-muted, #a4adbd);
-    font-size: 0.75rem;
-    line-height: 1;
-    pointer-events: none;
+    position: absolute; right: 12px; top: 50%; transform: translateY(-50%);
+    color: var(--mk-muted-2, #6f7785); font-size: 0.7rem; line-height: 1; pointer-events: none;
 }
 
 .course-picker .cp-clear {
-    position: absolute;
-    right: 32px;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 20px;
-    height: 20px;
-    line-height: 18px;
-    padding: 0;
-    border: none;
-    border-radius: 50%;
-    background: rgba(148, 163, 184, 0.22);
-    color: var(--mk-text, #f1f3f8);
-    font-size: 0.9rem;
-    cursor: pointer;
+    position: absolute; right: 32px; top: 50%; transform: translateY(-50%);
+    width: 20px; height: 20px; line-height: 18px; padding: 0;
+    border: none; border-radius: 50%;
+    background: rgba(148, 163, 184, 0.20); color: var(--mk-text, #f1f3f8);
+    font-size: 0.9rem; cursor: pointer;
 }
-
 .course-picker .cp-clear:hover { background: rgba(239, 68, 68, 0.28); }
 
-/* ---- Dropdown panel ---- */
+/* ---- Open panel: a single unified surface ---- */
 .course-picker .course-picker-panel {
     position: absolute;
     z-index: 50;
     top: calc(100% + 6px);
-    left: 0;
-    right: 0;
-    max-height: 340px;
+    left: 0; right: 0;
+    max-height: 360px;
     overflow-y: auto;
-    padding: 10px;
+    padding: 0;
     background: var(--mk-surface-2, #181c26);
     border: 1px solid var(--mk-border-strong, #343a4f);
-    border-radius: 10px;
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+    border-radius: 11px;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
+    /* Quiet scrollbar — present, never a focal point. */
+    scrollbar-width: thin;
+    scrollbar-color: var(--mk-border-strong, #343a4f) transparent;
 }
+.course-picker .course-picker-panel::-webkit-scrollbar { width: 9px; }
+.course-picker .course-picker-panel::-webkit-scrollbar-track { background: transparent; }
+.course-picker .course-picker-panel::-webkit-scrollbar-thumb {
+    background: var(--mk-border-strong, #343a4f);
+    border-radius: 6px;
+    border: 3px solid transparent;
+    background-clip: padding-box;
+}
+.course-picker .course-picker-panel::-webkit-scrollbar-thumb:hover { background: var(--mk-muted-2, #6f7785); background-clip: padding-box; }
 
+/* Integrated, borderless search — sits on the panel surface, sticky on scroll. */
+.course-picker .cp-search-wrap {
+    position: sticky; top: 0; z-index: 1;
+    display: flex; align-items: center; gap: 8px;
+    padding: 11px 12px;
+    background: var(--mk-surface-2, #181c26);
+    border-bottom: 1px solid var(--mk-border, #232838);
+}
+.course-picker .cp-search-icon { font-size: 0.82rem; opacity: 0.55; line-height: 1; flex: 0 0 auto; }
 .course-picker .course-picker-search {
-    width: 100%;
-    padding: 9px 11px;
-    margin-bottom: 8px;
-    background: var(--mk-surface, #12151d);
-    border: 1px solid var(--mk-border, #232838);
-    border-radius: 7px;
+    flex: 1 1 auto; min-width: 0;
+    padding: 0; margin: 0;
+    background: transparent; border: none; outline: none;
     color: var(--mk-text, #f1f3f8);
-    font-size: 0.88rem;
-    line-height: 1.3;
-    box-sizing: border-box;
+    font-size: 0.92rem; line-height: 1.4;
 }
-
 .course-picker .course-picker-search::placeholder { color: var(--mk-muted-2, #6f7785); }
-.course-picker .course-picker-search:focus {
-    outline: none;
-    border-color: var(--mk-accent, #818cf8);
-    box-shadow: 0 0 0 3px var(--mk-accent-soft, rgba(129, 140, 248, 0.14));
-}
+.course-picker .cp-count { flex: 0 0 auto; font-size: 0.7rem; color: var(--mk-muted-2, #6f7785); line-height: 1.3; }
 
-.course-picker .cp-count {
-    font-size: 0.72rem;
-    color: var(--mk-muted-2, #6f7785);
-    padding: 0 4px 6px;
-    line-height: 1.3;
-}
+.course-picker .cp-results { padding: 6px; }
 
-/* ---- Quick-tap chips (recents / favorites) ---- */
-.course-picker .cp-chips { margin-bottom: 10px; }
-.course-picker .cp-chip-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    padding: 2px 2px 0;
-}
-
-.course-picker .cp-chip {
-    padding: 5px 10px;
-    background: var(--mk-surface-3, #232836);
-    border: 1px solid var(--mk-border, #232838);
-    border-radius: 999px;
-    color: var(--mk-text, #f1f3f8);
-    font-size: 0.78rem;
-    line-height: 1.2;
-    cursor: pointer;
-    white-space: nowrap;
-}
-
-.course-picker .cp-chip:hover { border-color: var(--mk-accent, #818cf8); }
-.course-picker .cp-chip-on {
-    background: var(--mk-accent-soft, rgba(129, 140, 248, 0.14));
-    border-color: var(--mk-accent, #818cf8);
-}
-
-/* ---- Sections + rows ---- */
-.course-picker .cp-section { margin-bottom: 10px; }
+/* ---- Sections: quiet organizational anchors ---- */
+.course-picker .cp-section { margin-bottom: 4px; }
 .course-picker .cp-section:last-child { margin-bottom: 0; }
-
 .course-picker .cp-section-title {
-    font-size: 0.68rem;
-    font-weight: 700;
+    font-size: 0.64rem;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
     line-height: 1.4;
     color: var(--mk-muted-2, #6f7785);
-    padding: 2px 4px;
-    margin-bottom: 4px;
+    opacity: 0.75;
+    padding: 8px 8px 3px;
 }
 
+/* ---- Rows: identical structure everywhere ---- */
 .course-picker .cp-row {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 2px;
+    padding-left: 3px;                       /* room for the selected accent bar */
+    border-left: 3px solid transparent;
     border-radius: 7px;
+    transition: background 0.08s ease;
 }
-
-.course-picker .cp-row.cp-active { background: var(--mk-accent-soft, rgba(129, 140, 248, 0.14)); }
-.course-picker .cp-row.cp-selected { background: var(--mk-accent-strong-soft, rgba(99, 102, 241, 0.32)); }
+.course-picker .cp-row.cp-active { background: var(--mk-surface-3, #232836); }   /* hover / keyboard */
+.course-picker .cp-row.cp-selected {                                            /* persistent identity */
+    background: var(--mk-accent-soft, rgba(129, 140, 248, 0.14));
+    border-left-color: var(--mk-accent, #818cf8);
+}
+.course-picker .cp-row.cp-selected.cp-active { background: var(--mk-accent-strong-soft, rgba(99, 102, 241, 0.30)); }
 
 .course-picker .cp-course {
     flex: 1 1 auto;
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 3px;
-    padding: 7px 8px;
+    gap: 2px;
+    padding: 8px;
     background: transparent;
     border: none;
     border-radius: 7px;
-    color: var(--mk-text, #f1f3f8);
     text-align: left;
-    line-height: 1.25;
     cursor: pointer;
 }
 
+/* Line 1: name (hero) + inline NEW badge — one unified line, no layout shift. */
+.course-picker .cp-line1 { display: flex; align-items: center; gap: 7px; min-width: 0; }
 .course-picker .cp-name {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 0.88rem;
-    font-weight: 500;
-    line-height: 1.25;
-}
-
-.course-picker .cp-check { color: var(--mk-accent, #818cf8); font-size: 0.85rem; }
-
-.course-picker .cp-hl {
-    background: transparent;
-    color: var(--mk-accent, #818cf8);
-    font-weight: 700;
-}
-
-.course-picker .cp-meta {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 6px;
-    line-height: 1.2;
-}
-
-.course-picker .cp-cup { font-size: 0.72rem; color: var(--mk-muted, #a4adbd); }
-
-.course-picker .cp-pill {
-    font-size: 0.62rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    line-height: 1;
-    padding: 3px 6px;
-    border-radius: 4px;
-}
-
-.course-picker .cp-pill-new {
-    color: var(--mk-good, #34d399);
-    background: rgba(52, 211, 153, 0.14);
-}
-
-.course-picker .cp-pill-retro {
-    color: var(--mk-muted, #a4adbd);
-    background: rgba(148, 163, 184, 0.12);
-    text-transform: none;
-    letter-spacing: 0;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.92rem;
     font-weight: 600;
+    line-height: 1.3;
+    color: var(--mk-text, #f1f3f8);          /* brightest text in the row */
+}
+.course-picker .cp-hl { background: transparent; color: var(--mk-accent, #818cf8); font-weight: 700; }
+
+.course-picker .cp-badge {
+    flex: 0 0 auto;
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    line-height: 1;
+    padding: 3px 5px;
+    border-radius: 4px;
+    color: var(--mk-good, #34d399);
+    background: rgba(52, 211, 153, 0.13);
 }
 
+/* Line 2: cup (secondary) · game source (tertiary, subtle). */
+.course-picker .cp-sub { display: flex; align-items: center; gap: 7px; min-width: 0; line-height: 1.2; }
+.course-picker .cp-cup {
+    font-size: 0.74rem;
+    color: var(--mk-muted, #a4adbd);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.course-picker .cp-origin {
+    flex: 0 0 auto;
+    font-size: 0.68rem;
+    color: var(--mk-muted-2, #6f7785);
+    opacity: 0.85;
+}
+.course-picker .cp-origin::before { content: "· "; }
+
+/* Selected check — small accent confirmation before the star. */
+.course-picker .cp-check { flex: 0 0 auto; color: var(--mk-accent, #818cf8); font-size: 0.8rem; line-height: 1; padding: 0 2px; }
+
+/* Favorite star — subtle by default, brighter on hover/active, gold when on.
+   color uses !important: a global `button { color: ... !important }` in the
+   site CSS otherwise forces the star gray and defeats the gold favorite state. */
 .course-picker .cp-fav {
     flex: 0 0 auto;
-    width: 30px;
-    height: 30px;
-    padding: 0;
-    background: transparent;
-    border: none;
-    border-radius: 6px;
-    color: var(--mk-muted-2, #6f7785);
-    font-size: 1rem;
-    line-height: 1;
-    cursor: pointer;
+    width: 30px; height: 30px; padding: 0;
+    background: transparent; border: none; border-radius: 6px;
+    color: var(--mk-muted-2, #6f7785) !important;
+    font-size: 0.95rem; line-height: 1; cursor: pointer;
+    opacity: 0.32;
+    transition: opacity 0.1s ease, color 0.1s ease;
 }
+.course-picker .cp-row:hover .cp-fav,
+.course-picker .cp-row.cp-active .cp-fav { opacity: 0.85; }
+.course-picker .cp-fav:hover { color: var(--mk-text, #f1f3f8) !important; opacity: 1; }
+.course-picker .cp-fav.is-fav { color: #f59e0b !important; opacity: 1; }
 
-.course-picker .cp-fav:hover { background: var(--mk-accent-soft, rgba(129, 140, 248, 0.14)); color: var(--mk-muted, #a4adbd); }
-.course-picker .cp-fav.is-fav { color: #f59e0b; }
-
-.course-picker .cp-empty {
-    padding: 16px 8px;
+.course-picker .cp-noresult {
+    padding: 22px 12px;
     text-align: center;
     color: var(--mk-muted, #a4adbd);
-    font-size: 0.85rem;
+    font-size: 0.86rem;
     line-height: 1.4;
 }
 

--- a/apps/mario-kart/css/course-picker.css
+++ b/apps/mario-kart/css/course-picker.css
@@ -246,3 +246,171 @@
 
 /* Course badge in race history (date cell / mobile card). */
 .race-course-label { color: var(--mk-muted, #a4adbd); }
+
+/* =====================================================================
+   DESKTOP COMMAND PALETTE (overlay, >= 760px) — a Spotlight-style course
+   browser. Created in <body>, so the modal box also carries the
+   `.course-picker` class to inherit the shared row styles above.
+   ===================================================================== */
+.cp-modal-backdrop {
+    position: fixed; inset: 0; z-index: 4000;
+    display: flex; align-items: flex-start; justify-content: center;
+    padding: 9vh 16px 16px;
+    background: rgba(5, 6, 9, 0.62);
+    backdrop-filter: blur(3px);
+    -webkit-backdrop-filter: blur(3px);
+    animation: cpFade 0.12s ease;
+}
+@keyframes cpFade { from { opacity: 0; } to { opacity: 1; } }
+
+.cp-modal.course-picker {
+    width: min(760px, 94vw);
+    max-height: 78vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--mk-surface-2, #181c26);
+    border: 1px solid var(--mk-border-strong, #343a4f);
+    border-radius: 16px;
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.6);
+    overflow: hidden;
+    animation: cpRise 0.14s ease;
+}
+@keyframes cpRise { from { transform: translateY(-8px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+
+/* ---- Big search header: the focal point ---- */
+.cp-modal .cp-modal-header {
+    display: flex; align-items: center; gap: 14px;
+    padding: 20px 22px;
+    border-bottom: 1px solid var(--mk-border, #232838);
+}
+.cp-modal .cp-modal-icon { font-size: 1.35rem; opacity: 0.7; line-height: 1; flex: 0 0 auto; }
+.cp-modal .course-picker-search {
+    flex: 1 1 auto; min-width: 0;
+    padding: 0; margin: 0; border: none; outline: none; background: transparent;
+    color: var(--mk-text, #f1f3f8);
+    font-size: 1.35rem; font-weight: 500; line-height: 1.4;
+}
+.cp-modal .course-picker-search::placeholder { color: var(--mk-muted-2, #6f7785); font-weight: 400; }
+.cp-modal .cp-esc {
+    flex: 0 0 auto;
+    font-size: 0.66rem; font-family: inherit; color: var(--mk-muted, #a4adbd);
+    background: var(--mk-surface-3, #232836);
+    border: 1px solid var(--mk-border, #232838);
+    border-radius: 5px; padding: 3px 7px; line-height: 1;
+}
+
+/* ---- Sub-bar: quick filters + result count ---- */
+.cp-modal .cp-modal-subbar {
+    display: flex; align-items: center; gap: 10px;
+    padding: 12px 22px;
+    border-bottom: 1px solid var(--mk-border, #232838);
+}
+.cp-modal .cp-filters { display: flex; flex-wrap: wrap; gap: 6px; flex: 1 1 auto; min-width: 0; }
+.cp-modal .cp-filter {
+    padding: 5px 12px;
+    font-size: 0.76rem; font-weight: 600; line-height: 1.2;
+    color: var(--mk-muted, #a4adbd) !important;
+    background: var(--mk-surface-3, #232836);
+    border: 1px solid transparent; border-radius: 999px; cursor: pointer;
+    transition: background 0.1s ease, color 0.1s ease;
+}
+.cp-modal .cp-filter:hover { color: var(--mk-text, #f1f3f8) !important; }
+.cp-modal .cp-filter.is-on {
+    color: #fff !important;
+    background: var(--mk-accent-strong, #6366f1);
+    border-color: var(--mk-accent, #818cf8);
+}
+.cp-modal .cp-count { flex: 0 0 auto; font-size: 0.76rem; color: var(--mk-muted-2, #6f7785); }
+
+/* ---- Empty-state guidance ---- */
+.cp-modal .cp-hint {
+    padding: 11px 22px;
+    font-size: 0.78rem; line-height: 1.5;
+    color: var(--mk-muted-2, #6f7785);
+    border-bottom: 1px solid var(--mk-border, #232838);
+}
+.cp-modal .cp-hint b { color: var(--mk-muted, #a4adbd); font-weight: 600; }
+.cp-modal .cp-recent-searches {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+    padding: 11px 22px;
+    border-bottom: 1px solid var(--mk-border, #232838);
+}
+.cp-modal .cp-rs-label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--mk-muted-2, #6f7785); margin-right: 4px; }
+.cp-modal .cp-rs-chip {
+    padding: 4px 11px; font-size: 0.78rem; line-height: 1.2;
+    color: var(--mk-text, #f1f3f8) !important;
+    background: var(--mk-surface-3, #232836);
+    border: 1px solid var(--mk-border, #232838); border-radius: 999px; cursor: pointer;
+}
+.cp-modal .cp-rs-chip:hover { border-color: var(--mk-accent, #818cf8); }
+
+/* ---- Two-column body: results (left) + live preview (right) ---- */
+.cp-modal .cp-modal-body { display: flex; min-height: 0; flex: 1 1 auto; }
+.cp-modal .cp-results {
+    flex: 1 1 auto; min-width: 0;
+    overflow-y: auto;
+    padding: 8px;
+    scrollbar-width: thin;
+    scrollbar-color: var(--mk-border-strong, #343a4f) transparent;
+}
+.cp-modal .cp-results::-webkit-scrollbar { width: 10px; }
+.cp-modal .cp-results::-webkit-scrollbar-track { background: transparent; }
+.cp-modal .cp-results::-webkit-scrollbar-thumb { background: var(--mk-border-strong, #343a4f); border-radius: 6px; border: 3px solid transparent; background-clip: padding-box; }
+
+/* Roomier rows in the palette (desktop has the space). */
+.cp-modal .cp-name { font-size: 0.98rem; }
+.cp-modal .cp-cup { font-size: 0.78rem; }
+
+.cp-modal .cp-preview {
+    flex: 0 0 290px;
+    border-left: 1px solid var(--mk-border, #232838);
+    background: var(--mk-surface, #12151d);
+    overflow-y: auto;
+    padding: 22px 20px;
+}
+.cp-modal .cp-preview-empty { text-align: center; color: var(--mk-muted-2, #6f7785); padding-top: 30px; }
+.cp-modal .cp-preview-empty p { font-size: 0.84rem; line-height: 1.5; margin: 10px 0 0; }
+.cp-modal .cp-preview-emoji { font-size: 2.4rem; line-height: 1; }
+.cp-modal .cp-preview-card .cp-preview-emoji { margin-bottom: 12px; }
+.cp-modal .cp-preview-name {
+    font-size: 1.18rem; font-weight: 700; line-height: 1.25;
+    color: var(--mk-text, #f1f3f8); margin-bottom: 16px;
+}
+.cp-modal .cp-preview-meta { display: flex; flex-direction: column; gap: 9px; margin-bottom: 18px; }
+.cp-modal .cp-pv-row { display: flex; justify-content: space-between; gap: 12px; font-size: 0.82rem; line-height: 1.3; }
+.cp-modal .cp-pv-key { color: var(--mk-muted-2, #6f7785); }
+.cp-modal .cp-pv-val { color: var(--mk-text, #f1f3f8); text-align: right; }
+.cp-modal .cp-preview-fav {
+    width: 100%; margin-bottom: 8px; padding: 9px;
+    font-size: 0.82rem; font-weight: 600; cursor: pointer;
+    color: var(--mk-muted, #a4adbd) !important;
+    background: var(--mk-surface-3, #232836);
+    border: 1px solid var(--mk-border, #232838); border-radius: 8px;
+}
+.cp-modal .cp-preview-fav.is-fav { color: #f59e0b !important; border-color: rgba(245, 158, 11, 0.4); }
+.cp-modal .cp-preview-select {
+    width: 100%; padding: 11px;
+    font-size: 0.88rem; font-weight: 700; cursor: pointer;
+    color: #fff !important;
+    background: var(--mk-accent-strong, #6366f1);
+    border: none; border-radius: 8px;
+}
+.cp-modal .cp-preview-select:hover { background: var(--mk-accent, #818cf8); }
+
+/* ---- Footer keyboard legend ---- */
+.cp-modal .cp-modal-foot {
+    padding: 10px 22px;
+    border-top: 1px solid var(--mk-border, #232838);
+    font-size: 0.72rem; color: var(--mk-muted-2, #6f7785);
+}
+.cp-modal .cp-modal-foot kbd {
+    font-family: inherit; font-size: 0.68rem;
+    background: var(--mk-surface-3, #232836);
+    border: 1px solid var(--mk-border, #232838);
+    border-radius: 4px; padding: 1px 5px; margin: 0 1px;
+}
+
+/* On short viewports, let the list breathe by dropping the preview column. */
+@media (max-height: 560px) {
+    .cp-modal .cp-preview { display: none; }
+}

--- a/apps/mario-kart/data/courses.json
+++ b/apps/mario-kart/data/courses.json
@@ -1,0 +1,192 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "manual-seed",
+  "note": "Vendored course data. Edit by hand OR regenerate with scripts/sync-courses.mjs. Course names are factual game data; metadata (cups, origins, aliases) is curated for this tracker.",
+  "games": {
+    "mkworld": {
+      "label": "Mario Kart World",
+      "maxPositions": 24,
+      "source": {
+        "name": "Nintendo Life - Mario Kart World Complete Course List",
+        "url": "https://www.nintendolife.com/guides/mario-kart-world-complete-course-list-every-track",
+        "lastSynced": "2026-06-07",
+        "complete": true
+      },
+      "cups": [
+        {
+          "id": "mushroom",
+          "name": "Mushroom Cup",
+          "courses": [
+            { "id": "mario-bros-circuit", "name": "Mario Bros. Circuit", "origin": "new", "aliases": ["mario brothers circuit", "mbc"] },
+            { "id": "crown-city", "name": "Crown City", "origin": "new", "aliases": [] },
+            { "id": "whistlestop-summit", "name": "Whistlestop Summit", "origin": "new", "aliases": [] },
+            { "id": "dk-spaceport", "name": "DK Spaceport", "origin": "new", "aliases": ["donkey kong spaceport"] }
+          ]
+        },
+        {
+          "id": "flower",
+          "name": "Flower Cup",
+          "courses": [
+            { "id": "desert-hills", "name": "Desert Hills", "origin": "Mario Kart DS", "aliases": [] },
+            { "id": "shy-guy-bazaar", "name": "Shy Guy Bazaar", "origin": "Mario Kart 7", "aliases": [] },
+            { "id": "wario-stadium", "name": "Wario Stadium", "origin": "Mario Kart 64", "aliases": [] },
+            { "id": "airship-fortress", "name": "Airship Fortress", "origin": "Mario Kart DS", "aliases": [] }
+          ]
+        },
+        {
+          "id": "star",
+          "name": "Star Cup",
+          "courses": [
+            { "id": "dk-pass", "name": "DK Pass", "origin": "Mario Kart DS", "aliases": ["donkey kong pass"] },
+            { "id": "starview-peak", "name": "Starview Peak", "origin": "new", "aliases": [] },
+            { "id": "sky-high-sundae", "name": "Sky-High Sundae", "origin": "Mario Kart 8 Deluxe", "aliases": [] },
+            { "id": "wario-shipyard", "name": "Wario Shipyard", "origin": "Mario Kart 7", "aliases": [] }
+          ]
+        },
+        {
+          "id": "shell",
+          "name": "Shell Cup",
+          "courses": [
+            { "id": "koopa-troopa-beach", "name": "Koopa Troopa Beach", "origin": "Super Mario Kart", "aliases": ["ktb"] },
+            { "id": "faraway-oasis", "name": "Faraway Oasis", "origin": "new", "aliases": [] },
+            { "id": "crown-city", "name": "Crown City", "origin": "new", "aliases": [] },
+            { "id": "peach-stadium", "name": "Peach Stadium", "origin": "new", "aliases": [] }
+          ]
+        },
+        {
+          "id": "banana",
+          "name": "Banana Cup",
+          "courses": [
+            { "id": "peach-beach", "name": "Peach Beach", "origin": "Mario Kart: Double Dash!!", "aliases": [] },
+            { "id": "salty-salty-speedway", "name": "Salty Salty Speedway", "origin": "new", "aliases": [] },
+            { "id": "dino-dino-jungle", "name": "Dino Dino Jungle", "origin": "Mario Kart: Double Dash!!", "aliases": [] },
+            { "id": "great-block-ruins", "name": "Great ? Block Ruins", "origin": "new", "aliases": ["great question block ruins"] }
+          ]
+        },
+        {
+          "id": "leaf",
+          "name": "Leaf Cup",
+          "courses": [
+            { "id": "cheep-cheep-falls", "name": "Cheep Cheep Falls", "origin": "new", "aliases": [] },
+            { "id": "dandelion-depths", "name": "Dandelion Depths", "origin": "new", "aliases": [] },
+            { "id": "boo-cinema", "name": "Boo Cinema", "origin": "new", "aliases": [] },
+            { "id": "dry-bones-burnout", "name": "Dry Bones Burnout", "origin": "new", "aliases": [] }
+          ]
+        },
+        {
+          "id": "lightning",
+          "name": "Lightning Cup",
+          "courses": [
+            { "id": "moo-moo-meadows", "name": "Moo Moo Meadows", "origin": "Mario Kart Wii", "aliases": [] },
+            { "id": "choco-mountain", "name": "Choco Mountain", "origin": "Mario Kart 64", "aliases": [] },
+            { "id": "toads-factory", "name": "Toad's Factory", "origin": "Mario Kart Wii", "aliases": [] },
+            { "id": "bowsers-castle-world", "name": "Bowser's Castle", "origin": "new", "aliases": ["bc"] }
+          ]
+        },
+        {
+          "id": "special",
+          "name": "Special Cup",
+          "courses": [
+            { "id": "acorn-heights", "name": "Acorn Heights", "origin": "new", "aliases": [] },
+            { "id": "mario-circuit-world", "name": "Mario Circuit", "origin": "new", "aliases": [] },
+            { "id": "peach-stadium", "name": "Peach Stadium", "origin": "new", "aliases": [] },
+            { "id": "rainbow-road-world", "name": "Rainbow Road", "origin": "new", "aliases": ["rr"] }
+          ]
+        }
+      ]
+    },
+    "mk8d": {
+      "label": "Mario Kart 8 Deluxe",
+      "maxPositions": 12,
+      "source": {
+        "name": "Manual seed (base game nitro + retro cups)",
+        "url": "https://www.mariowiki.com/Mario_Kart_8_Deluxe",
+        "lastSynced": "2026-06-07",
+        "complete": false,
+        "todo": "Booster Course Pass (48 DLC courses across 12 cups) not yet vendored; extend via scripts/sync-courses.mjs."
+      },
+      "cups": [
+        {
+          "id": "mushroom",
+          "name": "Mushroom Cup",
+          "courses": [
+            { "id": "mario-kart-stadium", "name": "Mario Kart Stadium", "origin": "new", "aliases": [] },
+            { "id": "water-park", "name": "Water Park", "origin": "new", "aliases": [] },
+            { "id": "sweet-sweet-canyon", "name": "Sweet Sweet Canyon", "origin": "new", "aliases": [] },
+            { "id": "thwomp-ruins", "name": "Thwomp Ruins", "origin": "new", "aliases": [] }
+          ]
+        },
+        {
+          "id": "flower",
+          "name": "Flower Cup",
+          "courses": [
+            { "id": "mario-circuit", "name": "Mario Circuit", "origin": "new", "aliases": [] },
+            { "id": "toad-harbor", "name": "Toad Harbor", "origin": "new", "aliases": [] },
+            { "id": "twisted-mansion", "name": "Twisted Mansion", "origin": "new", "aliases": [] },
+            { "id": "shy-guy-falls", "name": "Shy Guy Falls", "origin": "new", "aliases": [] }
+          ]
+        },
+        {
+          "id": "star",
+          "name": "Star Cup",
+          "courses": [
+            { "id": "sunshine-airport", "name": "Sunshine Airport", "origin": "new", "aliases": [] },
+            { "id": "dolphin-shoals", "name": "Dolphin Shoals", "origin": "new", "aliases": [] },
+            { "id": "electrodrome", "name": "Electrodrome", "origin": "new", "aliases": [] },
+            { "id": "mount-wario", "name": "Mount Wario", "origin": "new", "aliases": [] }
+          ]
+        },
+        {
+          "id": "special",
+          "name": "Special Cup",
+          "courses": [
+            { "id": "cloudtop-cruise", "name": "Cloudtop Cruise", "origin": "new", "aliases": [] },
+            { "id": "bone-dry-dunes", "name": "Bone-Dry Dunes", "origin": "new", "aliases": [] },
+            { "id": "bowsers-castle", "name": "Bowser's Castle", "origin": "new", "aliases": ["bc"] },
+            { "id": "rainbow-road", "name": "Rainbow Road", "origin": "new", "aliases": ["rr"] }
+          ]
+        },
+        {
+          "id": "shell",
+          "name": "Shell Cup",
+          "courses": [
+            { "id": "moo-moo-meadows-8", "name": "Moo Moo Meadows", "origin": "Mario Kart Wii", "aliases": [] },
+            { "id": "mario-circuit-gba", "name": "Mario Circuit (GBA)", "origin": "Mario Kart: Super Circuit", "aliases": [] },
+            { "id": "cheep-cheep-beach", "name": "Cheep Cheep Beach", "origin": "Mario Kart DS", "aliases": [] },
+            { "id": "toads-turnpike", "name": "Toad's Turnpike", "origin": "Mario Kart 64", "aliases": [] }
+          ]
+        },
+        {
+          "id": "banana",
+          "name": "Banana Cup",
+          "courses": [
+            { "id": "dry-dry-desert", "name": "Dry Dry Desert", "origin": "Mario Kart: Double Dash!!", "aliases": [] },
+            { "id": "donut-plains-3", "name": "Donut Plains 3", "origin": "Super Mario Kart", "aliases": [] },
+            { "id": "royal-raceway", "name": "Royal Raceway", "origin": "Mario Kart 64", "aliases": [] },
+            { "id": "dk-jungle", "name": "DK Jungle", "origin": "Mario Kart 7", "aliases": ["donkey kong jungle"] }
+          ]
+        },
+        {
+          "id": "leaf",
+          "name": "Leaf Cup",
+          "courses": [
+            { "id": "wario-stadium-8", "name": "Wario Stadium", "origin": "Mario Kart DS", "aliases": [] },
+            { "id": "sherbet-land", "name": "Sherbet Land", "origin": "Mario Kart 64", "aliases": [] },
+            { "id": "music-park", "name": "Music Park", "origin": "Mario Kart 7", "aliases": [] },
+            { "id": "yoshi-valley", "name": "Yoshi Valley", "origin": "Mario Kart 64", "aliases": [] }
+          ]
+        },
+        {
+          "id": "lightning",
+          "name": "Lightning Cup",
+          "courses": [
+            { "id": "tick-tock-clock", "name": "Tick-Tock Clock", "origin": "Mario Kart DS", "aliases": [] },
+            { "id": "piranha-plant-slide", "name": "Piranha Plant Slide", "origin": "Mario Kart 7", "aliases": [] },
+            { "id": "grumble-volcano", "name": "Grumble Volcano", "origin": "Mario Kart Wii", "aliases": [] },
+            { "id": "rainbow-road-64", "name": "Rainbow Road (N64)", "origin": "Mario Kart 64", "aliases": ["rr 64"] }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/apps/mario-kart/index.html
+++ b/apps/mario-kart/index.html
@@ -111,6 +111,8 @@
       <link rel="stylesheet" href="css/mario-kart-overrides.css">
     <!-- Visual refresh layer — must load last so it wins specificity ties. -->
     <link rel="stylesheet" href="css/refresh.css">
+    <!-- Course picker (after refresh.css so its scoped rules win generic overrides). -->
+    <link rel="stylesheet" href="css/course-picker.css">
     <!-- CRITICAL: Load immediate sync FIRST to catch all localStorage calls -->
     <script src="../../sync-system/sync-immediate.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha384-bs/nf9FbdNouRbMiFcrcZfLXYPKiPaGVGplVbv7dLGECccEXDW+S3zjqSKR5ZEaD" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
@@ -168,6 +170,7 @@
                 </button>
                 <div class="sidebar-race-form" id="sidebar-race-form">
                     <div class="sidebar-race-error" id="sidebar-race-error"></div>
+                    <div id="sidebar-course-picker"><!-- Course picker injected by coursePicker.js --></div>
                     <div class="sidebar-race-inputs" id="sidebar-race-inputs">
                         <!-- Player inputs will be generated dynamically -->
                     </div>
@@ -573,6 +576,8 @@
     <script src="js/achievements.js"></script>
     <script src="js/statistics.js"></script>
     <script src="js/charts.js"></script>
+    <script src="js/courseData.js"></script>
+    <script src="js/coursePicker.js"></script>
     <script src="js/dataManager.js"></script>
     <script src="js/backup.js"></script>
     <script src="js/theme.js"></script>

--- a/apps/mario-kart/js/courseData.js
+++ b/apps/mario-kart/js/courseData.js
@@ -1,0 +1,248 @@
+// Course/map data source abstraction for the Mario Kart tracker.
+//
+// WHY THIS EXISTS
+// ----------------
+// There is no reliable, always-up-to-date public API for Mario Kart course
+// lists (the popular `mk8_node_api` only exposes drivers/karts/tires/gliders,
+// and Nintendo ships no official endpoint). So course data is *vendored* as a
+// static JSON file and read through this thin abstraction. The abstraction is
+// config-driven: today it loads a bundled JSON file; swapping to a remote URL
+// (e.g. a community dataset you host, or output of scripts/sync-courses.mjs)
+// is a one-line change in CourseDataConfig below. Nothing else in the app
+// needs to know where the data came from.
+//
+// Classic-script module (no ES modules): pure transforms + a browser loader
+// are attached to `window.CourseData` so main.js and the picker can use them,
+// and so the pure transforms are unit-testable in the vm test harness.
+
+(function () {
+    'use strict';
+
+    // ---- Configurable data sources. Swap `active` to change provider. --------
+    const CourseDataConfig = {
+        active: 'static',
+        sources: {
+            // Bundled JSON shipped with the app (default; always works offline).
+            static: { type: 'json', url: 'data/courses.json' }
+            // Future: point at a synced/remote dataset without touching any UI:
+            // remote: { type: 'json', url: 'https://data.shevato.com/mario-kart/courses.json' }
+        }
+    };
+
+    // ---- Pure transforms (no DOM, no network; safe to unit test) -------------
+
+    // Validate the raw dataset shape and return its `games` map. Throws on a
+    // structurally invalid file so problems surface loudly during sync/tests.
+    function normalizeDataset(raw) {
+        if (!raw || typeof raw !== 'object') throw new Error('courses dataset: not an object');
+        if (!raw.games || typeof raw.games !== 'object') throw new Error('courses dataset: missing games');
+        Object.keys(raw.games).forEach((gameKey) => {
+            const game = raw.games[gameKey];
+            if (!Array.isArray(game.cups)) throw new Error('courses dataset: ' + gameKey + ' missing cups[]');
+            game.cups.forEach((cup) => {
+                if (!cup || !cup.id || !cup.name || !Array.isArray(cup.courses)) {
+                    throw new Error('courses dataset: ' + gameKey + ' has a malformed cup');
+                }
+                cup.courses.forEach((c) => {
+                    if (!c || !c.id || !c.name) {
+                        throw new Error('courses dataset: ' + gameKey + '/' + cup.id + ' has a malformed course');
+                    }
+                });
+            });
+        });
+        return raw.games;
+    }
+
+    // Flatten a game node into a unique, cup-annotated course list. Courses that
+    // appear in more than one cup (e.g. Crown City / Peach Stadium in MK World)
+    // collapse to a single entry whose `cups` lists every cup it shows up in.
+    function flattenCourses(gameNode) {
+        const byId = new Map();
+        (gameNode.cups || []).forEach((cup) => {
+            (cup.courses || []).forEach((course) => {
+                const existing = byId.get(course.id);
+                if (existing) {
+                    if (existing.cups.indexOf(cup.name) === -1) existing.cups.push(cup.name);
+                    return;
+                }
+                byId.set(course.id, {
+                    id: course.id,
+                    name: course.name,
+                    origin: course.origin || 'new',
+                    aliases: Array.isArray(course.aliases) ? course.aliases.slice() : [],
+                    cups: [cup.name]
+                });
+            });
+        });
+        return Array.from(byId.values());
+    }
+
+    // Group a game node into [{ cup, courses }] preserving file order.
+    function groupByCup(gameNode) {
+        return (gameNode.cups || []).map((cup) => ({
+            id: cup.id,
+            name: cup.name,
+            courses: cup.courses.slice()
+        }));
+    }
+
+    // ---- Ranked search -------------------------------------------------------
+    // Punctuation-insensitive scoring so "mario bros circuit" matches
+    // "Mario Bros. Circuit", "rr" hits Rainbow Road via alias, and "mks"
+    // hits Mario Kart Stadium via word-initials. Higher score = better match.
+
+    function norm(s) { return String(s == null ? '' : s).toLowerCase(); }
+    function compact(s) { return norm(s).replace(/[^a-z0-9]+/g, ''); }
+    function wordsOf(s) { return norm(s).split(/[^a-z0-9]+/).filter(Boolean); }
+    function initialsOf(s) { return wordsOf(s).map((w) => w[0]).join(''); }
+
+    function scoreCourse(course, query) {
+        const qn = norm(query).trim();
+        const qc = compact(query);
+        if (!qn || !qc) return 1; // no query: everything matches equally
+
+        const cName = compact(course.name);
+        let score = 0;
+        const bump = (v) => { if (v > score) score = v; };
+
+        if (norm(course.name) === qn) bump(100);
+        if (cName.startsWith(qc)) bump(86);
+        if (wordsOf(course.name).some((w) => w.startsWith(qn))) bump(72);
+        if (qc.length >= 2 && initialsOf(course.name).startsWith(qc)) bump(66);
+        if (cName.indexOf(qc) !== -1) bump(50);
+
+        (course.aliases || []).forEach((a) => {
+            const ca = compact(a);
+            if (ca === qc) bump(64);
+            else if (ca.startsWith(qc)) bump(58);
+            else if (ca.indexOf(qc) !== -1) bump(38);
+        });
+
+        if (norm(course.origin).indexOf(qn) !== -1) bump(22);
+        if ((course.cups || []).some((cup) => norm(cup).indexOf(qn) !== -1)) bump(18);
+
+        return score;
+    }
+
+    // Ranked, filtered list (best first). Empty query keeps original order.
+    function rankCourses(courses, query) {
+        if (!norm(query).trim()) return courses.slice();
+        return courses
+            .map((c, i) => ({ c: c, i: i, s: scoreCourse(c, query) }))
+            .filter((r) => r.s > 0)
+            .sort((a, b) => (b.s - a.s) || a.c.name.localeCompare(b.c.name) || (a.i - b.i))
+            .map((r) => r.c);
+    }
+
+    // Back-compat name used by callers/tests; now ranked.
+    function searchCourses(courses, query) { return rankCourses(courses, query); }
+
+    function findCourse(courses, id) {
+        return courses.find((c) => c.id === id) || null;
+    }
+
+    // ---- Per-game-version recents & favorites (localStorage) -----------------
+    // Reuses the app's game-version-prefixed storage so MK8D and MK World keep
+    // independent recent/favorite lists.
+
+    function storageKey(base) {
+        return (typeof window !== 'undefined' && window.getStorageKey)
+            ? window.getStorageKey(base)
+            : 'marioKart' + base;
+    }
+
+    function readList(base) {
+        try {
+            const raw = window.localStorage.getItem(storageKey(base));
+            const parsed = raw ? JSON.parse(raw) : [];
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (e) {
+            return [];
+        }
+    }
+
+    function writeList(base, list) {
+        try {
+            window.localStorage.setItem(storageKey(base), JSON.stringify(list));
+        } catch (e) {
+            /* storage full / unavailable: recents are best-effort */
+        }
+    }
+
+    const RECENTS_KEY = 'RecentCourses';
+    const FAVS_KEY = 'FavoriteCourses';
+    const RECENTS_MAX = 6;
+
+    function getRecentIds() { return readList(RECENTS_KEY); }
+
+    function pushRecent(courseId) {
+        if (!courseId) return;
+        const next = [courseId].concat(getRecentIds().filter((id) => id !== courseId));
+        writeList(RECENTS_KEY, next.slice(0, RECENTS_MAX));
+    }
+
+    function getFavoriteIds() { return readList(FAVS_KEY); }
+
+    function isFavorite(courseId) { return getFavoriteIds().indexOf(courseId) !== -1; }
+
+    function toggleFavorite(courseId) {
+        if (!courseId) return false;
+        const favs = getFavoriteIds();
+        const idx = favs.indexOf(courseId);
+        if (idx === -1) {
+            favs.push(courseId);
+            writeList(FAVS_KEY, favs);
+            return true;
+        }
+        favs.splice(idx, 1);
+        writeList(FAVS_KEY, favs);
+        return false;
+    }
+
+    // ---- Browser loader (fetch + cache) --------------------------------------
+
+    const cache = {}; // gameVersion -> { courses, cups, source }
+
+    async function load(gameVersion) {
+        const gv = gameVersion || (window.getCurrentGameVersion ? window.getCurrentGameVersion() : 'mk8d');
+        if (cache[gv]) return cache[gv];
+
+        const source = CourseDataConfig.sources[CourseDataConfig.active];
+        const res = await fetch(source.url, { cache: 'no-cache' });
+        if (!res.ok) throw new Error('CourseData: failed to load ' + source.url + ' (' + res.status + ')');
+        const games = normalizeDataset(await res.json());
+        const gameNode = games[gv];
+        if (!gameNode) {
+            cache[gv] = { courses: [], cups: [], source: null };
+            return cache[gv];
+        }
+        cache[gv] = {
+            courses: flattenCourses(gameNode),
+            cups: groupByCup(gameNode),
+            source: gameNode.source || null,
+            label: gameNode.label || gv
+        };
+        return cache[gv];
+    }
+
+    // ---- Public surface ------------------------------------------------------
+    window.CourseData = {
+        config: CourseDataConfig,
+        // pure transforms (unit-tested)
+        normalizeDataset: normalizeDataset,
+        flattenCourses: flattenCourses,
+        groupByCup: groupByCup,
+        searchCourses: searchCourses,
+        rankCourses: rankCourses,
+        scoreCourse: scoreCourse,
+        findCourse: findCourse,
+        // browser data access
+        load: load,
+        // recents & favorites
+        getRecentIds: getRecentIds,
+        pushRecent: pushRecent,
+        getFavoriteIds: getFavoriteIds,
+        isFavorite: isFavorite,
+        toggleFavorite: toggleFavorite
+    };
+})();

--- a/apps/mario-kart/js/courseData.js
+++ b/apps/mario-kart/js/courseData.js
@@ -183,9 +183,20 @@
 
     const RECENTS_KEY = 'RecentCourses';
     const FAVS_KEY = 'FavoriteCourses';
+    const SEARCHES_KEY = 'RecentSearches';
     const RECENTS_MAX = 6;
 
     function getRecentIds() { return readList(RECENTS_KEY); }
+
+    // Recent *search terms* (distinct from recent courses) for the desktop palette.
+    function getRecentSearches() { return readList(SEARCHES_KEY); }
+
+    function pushRecentSearch(term) {
+        const t = String(term == null ? '' : term).trim();
+        if (t.length < 2) return; // ignore single keystrokes
+        const next = [t].concat(getRecentSearches().filter((x) => x.toLowerCase() !== t.toLowerCase()));
+        writeList(SEARCHES_KEY, next.slice(0, RECENTS_MAX));
+    }
 
     function pushRecent(courseId) {
         if (!courseId) return;
@@ -256,6 +267,8 @@
         // recents & favorites
         getRecentIds: getRecentIds,
         pushRecent: pushRecent,
+        getRecentSearches: getRecentSearches,
+        pushRecentSearch: pushRecentSearch,
         getFavoriteIds: getFavoriteIds,
         isFavorite: isFavorite,
         toggleFavorite: toggleFavorite

--- a/apps/mario-kart/js/courseData.js
+++ b/apps/mario-kart/js/courseData.js
@@ -118,8 +118,20 @@
             else if (ca.indexOf(qc) !== -1) bump(38);
         });
 
-        if (norm(course.origin).indexOf(qn) !== -1) bump(22);
-        if ((course.cups || []).some((cup) => norm(cup).indexOf(qn) !== -1)) bump(18);
+        // Game source: substring ("ship"->Wario Shipyard already via name) plus
+        // abbreviation/initials so "mk8" finds Mario Kart 8 Deluxe tracks and
+        // "mk7" finds Mario Kart 7 tracks. `game` is the effective source game
+        // (set on load: the current game for base-game tracks, else the origin).
+        const sourceGame = course.game || course.origin;
+        const cGame = compact(sourceGame);
+        if (cGame && cGame.indexOf(qc) !== -1) bump(24);
+        if (qc.length >= 2 && initialsOf(sourceGame).startsWith(qc)) bump(30);
+
+        // Cup match (name substring or initials, e.g. "sc"->Star/Special Cup).
+        (course.cups || []).forEach((cup) => {
+            if (norm(cup).indexOf(qn) !== -1) bump(18);
+            if (qc.length >= 2 && initialsOf(cup).startsWith(qc)) bump(16);
+        });
 
         return score;
     }
@@ -216,12 +228,15 @@
             cache[gv] = { courses: [], cups: [], source: null };
             return cache[gv];
         }
-        cache[gv] = {
-            courses: flattenCourses(gameNode),
-            cups: groupByCup(gameNode),
-            source: gameNode.source || null,
-            label: gameNode.label || gv
-        };
+        const label = gameNode.label || gv;
+        const courses = flattenCourses(gameNode);
+        // Tag each course with its source game so a base-game ("new") track is
+        // still findable by the game name/abbreviation (e.g. "mk8").
+        courses.forEach((c) => {
+            c.gameKey = gv;
+            c.game = (c.origin === 'new') ? label : c.origin;
+        });
+        cache[gv] = { courses: courses, cups: groupByCup(gameNode), source: gameNode.source || null, label: label };
         return cache[gv];
     }
 

--- a/apps/mario-kart/js/coursePicker.js
+++ b/apps/mario-kart/js/coursePicker.js
@@ -1,9 +1,8 @@
 // Course picker UI for the sidebar race form.
 //
-// An optional "which course did we play?" selector above the position inputs.
-// Designed to be fast: quick-tap chips for recent + favorite courses, a ranked
-// type-ahead search (fuzzy on name / alias / initials / origin), full keyboard
-// navigation, and a cup-grouped browse list. Selection is read back by
+// A command-palette style course selector: one calm surface, the course name
+// as the hero of every row, forgiving ranked search, recent/favorite/cup
+// groupings, and full keyboard navigation. Selection is read back by
 // dataManager.addRace() via window.CoursePicker.getSelected().
 //
 // Classic-script module. Data + ranking live in courseData.js; this file is
@@ -22,7 +21,7 @@
         selectedName: null,
         open: false,
         query: '',
-        options: [],      // ids in current keyboard-navigable order
+        options: [],      // ids in current keyboard-navigable (top-to-bottom) order
         active: -1        // index into options, -1 = none
     };
 
@@ -51,16 +50,22 @@
         if (state.selectedId) window.CourseData.pushRecent(state.selectedId);
     }
 
-    // ---- Rendering -----------------------------------------------------------
+    // ---- Closed trigger: two-line, always informative ------------------------
     function renderTrigger() {
         const c = container();
         if (!c) return;
-        const label = c.querySelector('.cp-label');
+        const primary = c.querySelector('.cp-trigger-primary');
+        const secondary = c.querySelector('.cp-trigger-secondary');
         const clearBtn = c.querySelector('.cp-clear');
         const trigger = c.querySelector('.course-picker-trigger');
-        if (label) {
-            label.textContent = state.selectedName || 'Select course (optional)';
-            label.classList.toggle('cp-placeholder', !state.selectedName);
+
+        if (state.selectedId) {
+            const course = state.byId[state.selectedId];
+            if (primary) { primary.textContent = state.selectedName; primary.classList.remove('cp-empty-primary'); }
+            if (secondary) secondary.textContent = (course && course.cups && course.cups.length) ? course.cups.join(' / ') : 'Selected';
+        } else {
+            if (primary) { primary.textContent = 'Choose a course'; primary.classList.add('cp-empty-primary'); }
+            if (secondary) secondary.textContent = 'Optional · tap to search';
         }
         if (clearBtn) clearBtn.hidden = !state.selectedId;
         if (trigger) trigger.setAttribute('aria-expanded', state.open ? 'true' : 'false');
@@ -77,35 +82,40 @@
             esc(name.slice(i + q.length));
     }
 
-    function originPill(course) {
-        if (!course.origin) return '';
-        if (course.origin === 'new') return '<span class="cp-pill cp-pill-new">New</span>';
-        return '<span class="cp-pill cp-pill-retro">' + esc(course.origin) + '</span>';
-    }
-
-    // A full browse/search row. `idx` is the keyboard index (or -1 for none).
+    // One uniform row for EVERY context (recent, favorite, cup browse, search).
+    // Line 1: course name (hero) + inline NEW badge. Line 2: cup (secondary) +
+    // game source (tertiary, retro only). Star sits at the row's right edge.
     function rowHtml(course, idx) {
+        const sel = course.id === state.selectedId;
         const fav = window.CourseData.isFavorite(course.id);
+        const isNew = course.origin === 'new';
         const cups = (course.cups && course.cups.length) ? esc(course.cups.join(' / ')) : '';
         return (
-            '<div class="cp-row' + (course.id === state.selectedId ? ' cp-selected' : '') +
-                (idx === state.active ? ' cp-active' : '') + '" role="option" id="cp-opt-' + idx +
-                '" aria-selected="' + (course.id === state.selectedId ? 'true' : 'false') + '">' +
+            '<div class="cp-row' + (sel ? ' cp-selected' : '') + (idx === state.active ? ' cp-active' : '') +
+                '" role="option" id="cp-opt-' + idx + '" aria-selected="' + (sel ? 'true' : 'false') + '">' +
                 '<button type="button" class="cp-course" data-id="' + esc(course.id) + '" data-idx="' + idx + '" tabindex="-1">' +
-                    '<span class="cp-name">' + highlight(course.name, state.query) +
-                        (course.id === state.selectedId ? '<span class="cp-check">✓</span>' : '') + '</span>' +
-                    '<span class="cp-meta">' + (cups ? '<span class="cp-cup">' + cups + '</span>' : '') + originPill(course) + '</span>' +
+                    '<span class="cp-line1">' +
+                        '<span class="cp-name">' + highlight(course.name, state.query) + '</span>' +
+                        (isNew ? '<span class="cp-badge">New</span>' : '') +
+                    '</span>' +
+                    '<span class="cp-sub">' +
+                        (cups ? '<span class="cp-cup">' + cups + '</span>' : '') +
+                        (!isNew && course.origin ? '<span class="cp-origin">' + esc(course.origin) + '</span>' : '') +
+                    '</span>' +
                 '</button>' +
+                (sel ? '<span class="cp-check" aria-hidden="true">✓</span>' : '') +
                 '<button type="button" class="cp-fav' + (fav ? ' is-fav' : '') + '" data-fav="' + esc(course.id) +
-                    '" tabindex="-1" title="' + (fav ? 'Remove favorite' : 'Add favorite') +
-                    '" aria-label="Toggle favorite">' + (fav ? '★' : '☆') + '</button>' +
+                    '" tabindex="-1" aria-label="' + (fav ? 'Remove favorite' : 'Add favorite') + '">' +
+                    (fav ? '★' : '☆') + '</button>' +
             '</div>'
         );
     }
 
-    function chipHtml(course) {
-        return '<button type="button" class="cp-chip' + (course.id === state.selectedId ? ' cp-chip-on' : '') +
-            '" data-id="' + esc(course.id) + '" tabindex="-1">' + esc(course.name) + '</button>';
+    function sectionHtml(title, courses, startIdx) {
+        let html = '<div class="cp-section"><div class="cp-section-title">' + esc(title) + '</div>';
+        let idx = startIdx;
+        courses.forEach((course) => { html += rowHtml(course, idx); idx++; });
+        return { html: html + '</div>', next: idx };
     }
 
     // Build results for the current query and refresh `state.options`.
@@ -119,53 +129,39 @@
         let idx = 0;
         let html = '';
 
+        const push = (courses) => courses.forEach((c) => options.push(c.id));
+
         if (!q) {
-            // Quick-tap chips for recents + favorites (not in keyboard order).
             const recents = window.CourseData.getRecentIds().map((id) => state.byId[id]).filter(Boolean);
             const favs = window.CourseData.getFavoriteIds().map((id) => state.byId[id]).filter(Boolean);
             if (recents.length) {
-                html += '<div class="cp-chips"><div class="cp-section-title">Recent</div>' +
-                    '<div class="cp-chip-row">' + recents.map(chipHtml).join('') + '</div></div>';
+                const s = sectionHtml('Recent', recents, idx); html += s.html; push(recents); idx = s.next;
             }
             if (favs.length) {
-                html += '<div class="cp-chips"><div class="cp-section-title">Favorites</div>' +
-                    '<div class="cp-chip-row">' + favs.map(chipHtml).join('') + '</div></div>';
+                const s = sectionHtml('Favorites', favs, idx); html += s.html; push(favs); idx = s.next;
             }
-            // Cup-grouped browse list (keyboard navigable).
             state.cups.forEach((cup) => {
-                html += '<div class="cp-section"><div class="cp-section-title">' + esc(cup.name) + '</div>';
-                cup.courses.forEach((c) => {
-                    const course = state.byId[c.id] || c;
-                    html += rowHtml(course, idx);
-                    options.push(course.id);
-                    idx++;
-                });
-                html += '</div>';
+                const courses = cup.courses.map((c) => state.byId[c.id] || c);
+                const s = sectionHtml(cup.name, courses, idx); html += s.html; push(courses); idx = s.next;
             });
             if (count) count.hidden = true;
         } else {
             const matches = window.CourseData.rankCourses(state.courses, q);
             if (matches.length) {
-                html += '<div class="cp-section">';
-                matches.forEach((course) => {
-                    html += rowHtml(course, idx);
-                    options.push(course.id);
-                    idx++;
-                });
-                html += '</div>';
+                matches.forEach((course) => { html += rowHtml(course, idx); options.push(course.id); idx++; });
+                html = '<div class="cp-section">' + html + '</div>';
             } else {
-                html = '<div class="cp-empty">No courses match &ldquo;' + esc(q) + '&rdquo;</div>';
+                html = '<div class="cp-noresult">No courses match &ldquo;' + esc(q) + '&rdquo;</div>';
             }
             if (count) {
                 count.hidden = false;
-                count.textContent = matches.length + (matches.length === 1 ? ' course' : ' courses');
+                count.textContent = matches.length + (matches.length === 1 ? ' result' : ' results');
             }
         }
 
         results.innerHTML = html;
         state.options = options;
-        // Keep active in range; default to first option when searching.
-        if (q && options.length) state.active = 0;
+        if (q && options.length) state.active = 0;       // first hit pre-armed for Enter
         else if (state.active >= options.length) state.active = options.length - 1;
         syncActive();
     }
@@ -178,7 +174,6 @@
         results.querySelectorAll('.cp-row').forEach((row) => {
             const on = row.id === 'cp-opt-' + state.active;
             row.classList.toggle('cp-active', on);
-            row.setAttribute('aria-selected', on || row.classList.contains('cp-selected') ? 'true' : 'false');
             if (on) {
                 if (search) search.setAttribute('aria-activedescendant', row.id);
                 if (row.scrollIntoView) row.scrollIntoView({ block: 'nearest' });
@@ -285,8 +280,6 @@
             renderResults();
             return;
         }
-        const chip = e.target.closest('.cp-chip');
-        if (chip) { const c = state.byId[chip.getAttribute('data-id')]; if (c) setSelected(c); return; }
         const courseBtn = e.target.closest('.cp-course');
         if (courseBtn) { const c = state.byId[courseBtn.getAttribute('data-id')]; if (c) setSelected(c); }
     }
@@ -307,15 +300,21 @@
                 '<div class="course-picker-control">' +
                     '<button type="button" class="course-picker-trigger" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="cp-field-label">' +
                         '<span class="cp-icon" aria-hidden="true">🗺️</span>' +
-                        '<span class="cp-label cp-placeholder">Select course (optional)</span>' +
+                        '<span class="cp-trigger-text">' +
+                            '<span class="cp-trigger-primary cp-empty-primary">Choose a course</span>' +
+                            '<span class="cp-trigger-secondary">Optional · tap to search</span>' +
+                        '</span>' +
                         '<span class="cp-caret" aria-hidden="true">▾</span>' +
                     '</button>' +
-                    '<button type="button" class="cp-clear" title="Clear course" aria-label="Clear course" hidden>×</button>' +
+                    '<button type="button" class="cp-clear" aria-label="Clear course" hidden>×</button>' +
                 '</div>' +
                 '<div class="course-picker-panel" role="listbox" aria-label="Courses" hidden>' +
-                    '<input type="text" class="course-picker-search" role="combobox" aria-expanded="true" aria-autocomplete="list" ' +
-                        'placeholder="Search course, cup or game..." autocomplete="off" spellcheck="false">' +
-                    '<div class="cp-count" hidden></div>' +
+                    '<div class="cp-search-wrap">' +
+                        '<span class="cp-search-icon" aria-hidden="true">🔍</span>' +
+                        '<input type="text" class="course-picker-search" role="combobox" aria-expanded="true" aria-autocomplete="list" ' +
+                            'placeholder="Search course, cup or game" autocomplete="off" spellcheck="false">' +
+                        '<span class="cp-count" hidden></span>' +
+                    '</div>' +
                     '<div class="cp-results"></div>' +
                 '</div>' +
             '</div>';

--- a/apps/mario-kart/js/coursePicker.js
+++ b/apps/mario-kart/js/coursePicker.js
@@ -1,0 +1,357 @@
+// Course picker UI for the sidebar race form.
+//
+// An optional "which course did we play?" selector above the position inputs.
+// Designed to be fast: quick-tap chips for recent + favorite courses, a ranked
+// type-ahead search (fuzzy on name / alias / initials / origin), full keyboard
+// navigation, and a cup-grouped browse list. Selection is read back by
+// dataManager.addRace() via window.CoursePicker.getSelected().
+//
+// Classic-script module. Data + ranking live in courseData.js; this file is
+// presentation + interaction only, so it stays out of the vm unit tests.
+
+(function () {
+    'use strict';
+
+    const esc = (s) => (window.escapeHtml ? window.escapeHtml(String(s)) : String(s));
+
+    let state = {
+        courses: [],      // flattened, cup-annotated
+        cups: [],         // grouped (browse order)
+        byId: {},         // id -> course
+        selectedId: null,
+        selectedName: null,
+        open: false,
+        query: '',
+        options: [],      // ids in current keyboard-navigable order
+        active: -1        // index into options, -1 = none
+    };
+
+    let outsideHandler = null;
+
+    function container() { return document.getElementById('sidebar-course-picker'); }
+    function panelEl() { const c = container(); return c && c.querySelector('.course-picker-panel'); }
+    function searchEl() { const c = container(); return c && c.querySelector('.course-picker-search'); }
+    function resultsEl() { const c = container(); return c && c.querySelector('.cp-results'); }
+
+    // ---- Public API ----------------------------------------------------------
+    function getSelected() {
+        return state.selectedId ? { id: state.selectedId, name: state.selectedName } : null;
+    }
+
+    function setSelected(course) {
+        state.selectedId = course ? course.id : null;
+        state.selectedName = course ? course.name : null;
+        closePanel();
+        renderTrigger();
+    }
+
+    function clear() { setSelected(null); }
+
+    function commit() {
+        if (state.selectedId) window.CourseData.pushRecent(state.selectedId);
+    }
+
+    // ---- Rendering -----------------------------------------------------------
+    function renderTrigger() {
+        const c = container();
+        if (!c) return;
+        const label = c.querySelector('.cp-label');
+        const clearBtn = c.querySelector('.cp-clear');
+        const trigger = c.querySelector('.course-picker-trigger');
+        if (label) {
+            label.textContent = state.selectedName || 'Select course (optional)';
+            label.classList.toggle('cp-placeholder', !state.selectedName);
+        }
+        if (clearBtn) clearBtn.hidden = !state.selectedId;
+        if (trigger) trigger.setAttribute('aria-expanded', state.open ? 'true' : 'false');
+    }
+
+    // Highlight the matched run of the query within a course name.
+    function highlight(name, query) {
+        const q = String(query || '').trim().toLowerCase();
+        if (!q) return esc(name);
+        const i = name.toLowerCase().indexOf(q);
+        if (i === -1) return esc(name);
+        return esc(name.slice(0, i)) +
+            '<mark class="cp-hl">' + esc(name.slice(i, i + q.length)) + '</mark>' +
+            esc(name.slice(i + q.length));
+    }
+
+    function originPill(course) {
+        if (!course.origin) return '';
+        if (course.origin === 'new') return '<span class="cp-pill cp-pill-new">New</span>';
+        return '<span class="cp-pill cp-pill-retro">' + esc(course.origin) + '</span>';
+    }
+
+    // A full browse/search row. `idx` is the keyboard index (or -1 for none).
+    function rowHtml(course, idx) {
+        const fav = window.CourseData.isFavorite(course.id);
+        const cups = (course.cups && course.cups.length) ? esc(course.cups.join(' / ')) : '';
+        return (
+            '<div class="cp-row' + (course.id === state.selectedId ? ' cp-selected' : '') +
+                (idx === state.active ? ' cp-active' : '') + '" role="option" id="cp-opt-' + idx +
+                '" aria-selected="' + (course.id === state.selectedId ? 'true' : 'false') + '">' +
+                '<button type="button" class="cp-course" data-id="' + esc(course.id) + '" data-idx="' + idx + '" tabindex="-1">' +
+                    '<span class="cp-name">' + highlight(course.name, state.query) +
+                        (course.id === state.selectedId ? '<span class="cp-check">✓</span>' : '') + '</span>' +
+                    '<span class="cp-meta">' + (cups ? '<span class="cp-cup">' + cups + '</span>' : '') + originPill(course) + '</span>' +
+                '</button>' +
+                '<button type="button" class="cp-fav' + (fav ? ' is-fav' : '') + '" data-fav="' + esc(course.id) +
+                    '" tabindex="-1" title="' + (fav ? 'Remove favorite' : 'Add favorite') +
+                    '" aria-label="Toggle favorite">' + (fav ? '★' : '☆') + '</button>' +
+            '</div>'
+        );
+    }
+
+    function chipHtml(course) {
+        return '<button type="button" class="cp-chip' + (course.id === state.selectedId ? ' cp-chip-on' : '') +
+            '" data-id="' + esc(course.id) + '" tabindex="-1">' + esc(course.name) + '</button>';
+    }
+
+    // Build results for the current query and refresh `state.options`.
+    function renderResults() {
+        const results = resultsEl();
+        const count = container() && container().querySelector('.cp-count');
+        if (!results) return;
+
+        const q = state.query.trim();
+        const options = [];
+        let idx = 0;
+        let html = '';
+
+        if (!q) {
+            // Quick-tap chips for recents + favorites (not in keyboard order).
+            const recents = window.CourseData.getRecentIds().map((id) => state.byId[id]).filter(Boolean);
+            const favs = window.CourseData.getFavoriteIds().map((id) => state.byId[id]).filter(Boolean);
+            if (recents.length) {
+                html += '<div class="cp-chips"><div class="cp-section-title">Recent</div>' +
+                    '<div class="cp-chip-row">' + recents.map(chipHtml).join('') + '</div></div>';
+            }
+            if (favs.length) {
+                html += '<div class="cp-chips"><div class="cp-section-title">Favorites</div>' +
+                    '<div class="cp-chip-row">' + favs.map(chipHtml).join('') + '</div></div>';
+            }
+            // Cup-grouped browse list (keyboard navigable).
+            state.cups.forEach((cup) => {
+                html += '<div class="cp-section"><div class="cp-section-title">' + esc(cup.name) + '</div>';
+                cup.courses.forEach((c) => {
+                    const course = state.byId[c.id] || c;
+                    html += rowHtml(course, idx);
+                    options.push(course.id);
+                    idx++;
+                });
+                html += '</div>';
+            });
+            if (count) count.hidden = true;
+        } else {
+            const matches = window.CourseData.rankCourses(state.courses, q);
+            if (matches.length) {
+                html += '<div class="cp-section">';
+                matches.forEach((course) => {
+                    html += rowHtml(course, idx);
+                    options.push(course.id);
+                    idx++;
+                });
+                html += '</div>';
+            } else {
+                html = '<div class="cp-empty">No courses match &ldquo;' + esc(q) + '&rdquo;</div>';
+            }
+            if (count) {
+                count.hidden = false;
+                count.textContent = matches.length + (matches.length === 1 ? ' course' : ' courses');
+            }
+        }
+
+        results.innerHTML = html;
+        state.options = options;
+        // Keep active in range; default to first option when searching.
+        if (q && options.length) state.active = 0;
+        else if (state.active >= options.length) state.active = options.length - 1;
+        syncActive();
+    }
+
+    // Reflect state.active into the DOM + aria, and scroll it into view.
+    function syncActive() {
+        const results = resultsEl();
+        const search = searchEl();
+        if (!results) return;
+        results.querySelectorAll('.cp-row').forEach((row) => {
+            const on = row.id === 'cp-opt-' + state.active;
+            row.classList.toggle('cp-active', on);
+            row.setAttribute('aria-selected', on || row.classList.contains('cp-selected') ? 'true' : 'false');
+            if (on) {
+                if (search) search.setAttribute('aria-activedescendant', row.id);
+                if (row.scrollIntoView) row.scrollIntoView({ block: 'nearest' });
+            }
+        });
+        if (state.active < 0 && search) search.removeAttribute('aria-activedescendant');
+    }
+
+    function moveActive(delta) {
+        const n = state.options.length;
+        if (!n) return;
+        if (state.active < 0) state.active = delta > 0 ? 0 : n - 1;
+        else state.active = (state.active + delta + n) % n;
+        syncActive();
+    }
+
+    function selectActive() {
+        const id = state.options[state.active];
+        if (id && state.byId[id]) setSelected(state.byId[id]);
+    }
+
+    // ---- Open / close --------------------------------------------------------
+    function openPanel() {
+        const panel = panelEl();
+        const search = searchEl();
+        if (!panel) return;
+        state.open = true;
+        state.query = '';
+        state.active = -1;
+        panel.hidden = false;
+        renderTrigger();
+        if (search) search.value = '';
+        renderResults();
+        if (search) setTimeout(() => search.focus(), 20);
+
+        outsideHandler = (e) => {
+            const c = container();
+            if (c && !c.contains(e.target)) closePanel();
+        };
+        document.addEventListener('mousedown', outsideHandler, true);
+    }
+
+    function closePanel() {
+        const panel = panelEl();
+        state.open = false;
+        if (panel) panel.hidden = true;
+        renderTrigger();
+        if (outsideHandler) {
+            document.removeEventListener('mousedown', outsideHandler, true);
+            outsideHandler = null;
+        }
+    }
+
+    function togglePanel() { state.open ? closePanel() : openPanel(); }
+
+    // ---- Wiring --------------------------------------------------------------
+    function wire(c) {
+        const trigger = c.querySelector('.course-picker-trigger');
+        if (trigger) trigger.addEventListener('click', togglePanel);
+
+        const clearBtn = c.querySelector('.cp-clear');
+        if (clearBtn) clearBtn.addEventListener('click', (e) => { e.stopPropagation(); clear(); });
+
+        const search = c.querySelector('.course-picker-search');
+        if (search) {
+            search.addEventListener('input', (e) => { state.query = e.target.value; state.active = -1; renderResults(); });
+            search.addEventListener('keydown', onKeydown);
+        }
+
+        const panel = c.querySelector('.course-picker-panel');
+        if (panel) {
+            panel.addEventListener('click', onPanelClick);
+            panel.addEventListener('mousemove', onPanelHover);
+            panel.addEventListener('wheel', (e) => e.stopPropagation(), { passive: true });
+            panel.addEventListener('touchmove', (e) => e.stopPropagation(), { passive: true });
+        }
+    }
+
+    function onKeydown(e) {
+        switch (e.key) {
+            case 'ArrowDown': e.preventDefault(); moveActive(1); break;
+            case 'ArrowUp': e.preventDefault(); moveActive(-1); break;
+            case 'Home': e.preventDefault(); state.active = 0; syncActive(); break;
+            case 'End': e.preventDefault(); state.active = state.options.length - 1; syncActive(); break;
+            case 'Enter':
+                e.preventDefault();
+                if (state.active >= 0) selectActive();
+                else if (state.options.length) { state.active = 0; selectActive(); }
+                break;
+            case 'Escape':
+                e.preventDefault();
+                closePanel();
+                { const t = container() && container().querySelector('.course-picker-trigger'); if (t) t.focus(); }
+                break;
+            default: break;
+        }
+    }
+
+    function onPanelClick(e) {
+        const favBtn = e.target.closest('.cp-fav');
+        if (favBtn) {
+            e.stopPropagation();
+            window.CourseData.toggleFavorite(favBtn.getAttribute('data-fav'));
+            renderResults();
+            return;
+        }
+        const chip = e.target.closest('.cp-chip');
+        if (chip) { const c = state.byId[chip.getAttribute('data-id')]; if (c) setSelected(c); return; }
+        const courseBtn = e.target.closest('.cp-course');
+        if (courseBtn) { const c = state.byId[courseBtn.getAttribute('data-id')]; if (c) setSelected(c); }
+    }
+
+    function onPanelHover(e) {
+        const courseBtn = e.target.closest('.cp-course');
+        if (!courseBtn) return;
+        const idx = parseInt(courseBtn.getAttribute('data-idx'), 10);
+        if (!isNaN(idx) && idx !== state.active) { state.active = idx; syncActive(); }
+    }
+
+    function renderShell() {
+        const c = container();
+        if (!c) return;
+        c.innerHTML =
+            '<label class="cp-field-label" id="cp-field-label">Course</label>' +
+            '<div class="course-picker">' +
+                '<div class="course-picker-control">' +
+                    '<button type="button" class="course-picker-trigger" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="cp-field-label">' +
+                        '<span class="cp-icon" aria-hidden="true">🗺️</span>' +
+                        '<span class="cp-label cp-placeholder">Select course (optional)</span>' +
+                        '<span class="cp-caret" aria-hidden="true">▾</span>' +
+                    '</button>' +
+                    '<button type="button" class="cp-clear" title="Clear course" aria-label="Clear course" hidden>×</button>' +
+                '</div>' +
+                '<div class="course-picker-panel" role="listbox" aria-label="Courses" hidden>' +
+                    '<input type="text" class="course-picker-search" role="combobox" aria-expanded="true" aria-autocomplete="list" ' +
+                        'placeholder="Search course, cup or game..." autocomplete="off" spellcheck="false">' +
+                    '<div class="cp-count" hidden></div>' +
+                    '<div class="cp-results"></div>' +
+                '</div>' +
+            '</div>';
+        wire(c);
+        renderTrigger();
+    }
+
+    // (Re)load data for the active game version and rebuild the picker.
+    async function init() {
+        const c = container();
+        if (!c || !window.CourseData) return;
+        try {
+            const gv = window.getCurrentGameVersion ? window.getCurrentGameVersion() : 'mk8d';
+            const data = await window.CourseData.load(gv);
+            state.courses = data.courses || [];
+            state.cups = data.cups || [];
+            state.byId = {};
+            state.courses.forEach((course) => { state.byId[course.id] = course; });
+            state.selectedId = null;
+            state.selectedName = null;
+            state.open = false;
+            state.query = '';
+            state.active = -1;
+            renderShell();
+        } catch (e) {
+            console.warn('CoursePicker: course data unavailable', e);
+            c.innerHTML = '';
+        }
+    }
+
+    window.CoursePicker = {
+        init: init,
+        refresh: init,
+        getSelected: getSelected,
+        setSelected: setSelected,
+        clear: clear,
+        commit: commit
+    };
+})();

--- a/apps/mario-kart/js/coursePicker.js
+++ b/apps/mario-kart/js/coursePicker.js
@@ -122,33 +122,30 @@
         return esc(name.slice(0, i)) + '<mark class="cp-hl">' + esc(name.slice(i, i + q.length)) + '</mark>' + esc(name.slice(i + q.length));
     }
 
+    // Uniform, dense row: name (hero) + cup (secondary) + favorite star. Game
+    // origin and new/returning status live in the preview, not on every row, so
+    // the list scans cleanly and every row has the same shape.
     function rowHtml(course, idx) {
         const sel = course.id === state.selectedId;
         const fav = window.CourseData.isFavorite(course.id);
-        const isNew = course.origin === 'new';
         const cups = (course.cups && course.cups.length) ? esc(course.cups.join(' / ')) : '';
         return (
             '<div class="cp-row' + (sel ? ' cp-selected' : '') + (idx === state.active ? ' cp-active' : '') +
                 '" role="option" id="cp-opt-' + idx + '" aria-selected="' + (sel ? 'true' : 'false') + '">' +
                 '<button type="button" class="cp-course" data-id="' + esc(course.id) + '" data-idx="' + idx + '" tabindex="-1">' +
-                    '<span class="cp-line1">' +
-                        '<span class="cp-name">' + highlight(course.name, state.query) + '</span>' +
-                        (isNew ? '<span class="cp-badge">New</span>' : '') +
-                    '</span>' +
-                    '<span class="cp-sub">' +
-                        (cups ? '<span class="cp-cup">' + cups + '</span>' : '') +
-                        (!isNew && course.origin ? '<span class="cp-origin">' + esc(course.origin) + '</span>' : '') +
-                    '</span>' +
+                    '<span class="cp-name">' + highlight(course.name, state.query) + '</span>' +
+                    (cups ? '<span class="cp-cup">' + cups + '</span>' : '') +
                 '</button>' +
                 (sel ? '<span class="cp-check" aria-hidden="true">✓</span>' : '') +
                 '<button type="button" class="cp-fav' + (fav ? ' is-fav' : '') + '" data-fav="' + esc(course.id) +
-                    '" tabindex="-1" aria-label="' + (fav ? 'Remove favorite' : 'Add favorite') + '">' + (fav ? '★' : '☆') + '</button>' +
+                    '" tabindex="-1" aria-label="' + (fav ? 'Remove favorite from ' : 'Add favorite ') + esc(course.name) + '">' +
+                    (fav ? '★' : '☆') + '</button>' +
             '</div>'
         );
     }
 
     function sectionHtml(title, courses, startIdx) {
-        let html = '<div class="cp-section"><div class="cp-section-title">' + esc(title) + '</div>';
+        let html = '<div class="cp-section" role="group" aria-label="' + esc(title) + '"><div class="cp-section-title">' + esc(title) + '</div>';
         let idx = startIdx;
         courses.forEach((course) => { html += rowHtml(course, idx); idx++; });
         return { html: html + '</div>', next: idx };
@@ -191,10 +188,8 @@
 
         if (!q) {
             if (state.filter === 'all') {
-                const recents = window.CourseData.getRecentIds().map((id) => state.byId[id]).filter(Boolean);
-                const favs = window.CourseData.getFavoriteIds().map((id) => state.byId[id]).filter(Boolean);
-                if (recents.length) { const s = sectionHtml('Recent', recents, idx); html += s.html; recents.forEach((c) => options.push(c.id)); idx = s.next; }
-                if (favs.length) { const s = sectionHtml('Favorites', favs, idx); html += s.html; favs.forEach((c) => options.push(c.id)); idx = s.next; }
+                // Cups only — no inline Recent/Favorites sections, so a track never
+                // appears twice. Recent & Favorites live on the filter tabs.
                 state.cups.forEach((cup) => {
                     const courses = cup.courses.map((c) => state.byId[c.id] || c);
                     const s = sectionHtml(cup.name, courses, idx); html += s.html; courses.forEach((c) => options.push(c.id)); idx = s.next;
@@ -223,6 +218,9 @@
         state.options = options;
         if (q && options.length) state.active = 0;
         else if (state.active >= options.length) state.active = options.length - 1;
+
+        const clr = root() && root().querySelector('.cp-search-clear');
+        if (clr) clr.hidden = !state.query;
 
         if (state.mode === 'modal') { renderFilters(); renderEmptyAside(); }
         syncActive();
@@ -261,11 +259,15 @@
     function renderFilters() {
         const wrap = state.modalRoot && state.modalRoot.querySelector('.cp-filters');
         if (!wrap) return;
-        // Keep it to the four essentials — individual games stay reachable by
-        // typing ("mk7", "wii", ...), so they don't need their own chips.
-        const chips = [['all', 'All'], ['favorites', 'Favorites'], ['recent', 'Recent'], ['new', 'New']];
-        wrap.innerHTML = chips.map(([f, label]) =>
-            '<button type="button" class="cp-filter' + (state.filter === f ? ' is-on' : '') + '" data-filter="' + esc(f) + '">' + esc(label) + '</button>'
+        // Four essentials, each with a live count so their meaning is concrete.
+        // Individual games stay reachable by typing ("mk7", "wii", ...).
+        const favN = window.CourseData.getFavoriteIds().map((id) => state.byId[id]).filter(Boolean).length;
+        const recN = window.CourseData.getRecentIds().map((id) => state.byId[id]).filter(Boolean).length;
+        const newN = state.courses.filter((c) => c.origin === 'new').length;
+        const chips = [['all', 'All', state.courses.length], ['favorites', 'Favorites', favN], ['recent', 'Recent', recN], ['new', 'New', newN]];
+        wrap.innerHTML = chips.map(([f, label, n]) =>
+            '<button type="button" class="cp-filter' + (state.filter === f ? ' is-on' : '') + '" data-filter="' + esc(f) + '">' +
+                esc(label) + '<span class="cp-filter-n">' + n + '</span></button>'
         ).join('');
     }
 
@@ -294,20 +296,19 @@
         const isNew = course.origin === 'new';
         const game = course.game || (isNew ? '' : course.origin);
         const cups = (course.cups && course.cups.length) ? esc(course.cups.join(' / ')) : '—';
+        const sel = course.id === state.selectedId;
         return (
-            '<div class="cp-pv ' + (isNew ? 'cp-pv-new' : 'cp-pv-retro') + '">' +
-                '<div class="cp-pv-hero">' +
-                    '<span class="cp-pv-emoji">' + (isNew ? '✨' : '🏁') + '</span>' +
-                    '<span class="cp-pv-status">' + (isNew ? 'New track' : 'Returning') + '</span>' +
-                    '<button type="button" class="cp-preview-fav' + (fav ? ' is-fav' : '') + '" data-fav="' + esc(course.id) +
-                        '" aria-label="' + (fav ? 'Remove favorite' : 'Add favorite') + '">' + (fav ? '★' : '☆') + '</button>' +
-                '</div>' +
+            '<div class="cp-pv">' +
                 '<div class="cp-pv-name">' + esc(course.name) + '</div>' +
-                '<div class="cp-pv-tags">' +
-                    '<span class="cp-pv-tag cp-pv-tag-cup">' + cups + '</span>' +
-                    (game ? '<span class="cp-pv-tag cp-pv-tag-game">' + esc(game) + '</span>' : '') +
+                '<span class="cp-pv-status' + (isNew ? ' is-new' : '') + '">' + (isNew ? 'New track' : 'Returning') + '</span>' +
+                '<div class="cp-pv-meta">' +
+                    '<div class="cp-pv-row"><span class="cp-pv-key">Cup</span><span class="cp-pv-val">' + cups + '</span></div>' +
+                    (game ? '<div class="cp-pv-row"><span class="cp-pv-key">Game</span><span class="cp-pv-val">' + esc(game) + '</span></div>' : '') +
                 '</div>' +
-                '<button type="button" class="cp-preview-select" data-id="' + esc(course.id) + '">Select this course</button>' +
+                '<button type="button" class="cp-preview-fav' + (fav ? ' is-fav' : '') + '" data-fav="' + esc(course.id) + '">' +
+                    (fav ? '★ Favorited' : '☆ Add favorite') + '</button>' +
+                '<button type="button" class="cp-preview-select' + (sel ? ' is-selected' : '') + '" data-id="' + esc(course.id) + '">' +
+                    (sel ? '✓ Selected' : 'Select') + '</button>' +
             '</div>'
         );
     }
@@ -347,8 +348,9 @@
                 '<div class="cp-modal-header">' +
                     '<span class="cp-modal-icon" aria-hidden="true">🔍</span>' +
                     '<input type="text" class="course-picker-search" role="combobox" aria-expanded="true" aria-autocomplete="list" ' +
-                        'placeholder="Search courses, cups, games, or abbreviations" autocomplete="off" spellcheck="false">' +
-                    '<kbd class="cp-esc">Esc</kbd>' +
+                        'placeholder="Search courses…" autocomplete="off" spellcheck="false">' +
+                    '<button type="button" class="cp-search-clear" aria-label="Clear search" hidden>×</button>' +
+                    '<kbd class="cp-esc" title="Close">esc</kbd>' +
                 '</div>' +
                 '<div class="cp-modal-subbar">' +
                     '<div class="cp-filters"></div>' +
@@ -436,6 +438,13 @@
     }
 
     function handleClickWithin(e) {
+        const clearBtn = e.target.closest('.cp-search-clear');
+        if (clearBtn) {
+            e.stopPropagation();
+            const s = searchEl();
+            if (s) { s.value = ''; state.query = ''; state.active = -1; renderResults(); s.focus(); }
+            return true;
+        }
         const fav = e.target.closest('.cp-fav, .cp-preview-fav');
         if (fav) {
             e.stopPropagation();
@@ -511,7 +520,8 @@
                     '<div class="cp-search-wrap">' +
                         '<span class="cp-search-icon" aria-hidden="true">🔍</span>' +
                         '<input type="text" class="course-picker-search" role="combobox" aria-expanded="true" aria-autocomplete="list" ' +
-                            'placeholder="Search course, cup or game" autocomplete="off" spellcheck="false">' +
+                            'placeholder="Search courses…" autocomplete="off" spellcheck="false">' +
+                        '<button type="button" class="cp-search-clear" aria-label="Clear search" hidden>×</button>' +
                         '<span class="cp-count" hidden></span>' +
                     '</div>' +
                     '<div class="cp-results"></div>' +

--- a/apps/mario-kart/js/coursePicker.js
+++ b/apps/mario-kart/js/coursePicker.js
@@ -1,54 +1,52 @@
 // Course picker UI for the sidebar race form.
 //
-// A command-palette style course selector: one calm surface, the course name
-// as the hero of every row, forgiving ranked search, recent/favorite/cup
-// groupings, and full keyboard navigation. Selection is read back by
-// dataManager.addRace() via window.CoursePicker.getSelected().
+// Two experiences, one data layer:
+//   - Mobile: a compact inline dropdown anchored under the field.
+//   - Desktop: a centered Spotlight-style command palette overlay with a large
+//     search, quick filters, recent searches, a two-column results + live
+//     preview layout, and full keyboard navigation.
 //
-// Classic-script module. Data + ranking live in courseData.js; this file is
-// presentation + interaction only, so it stays out of the vm unit tests.
+// Selection is read back by dataManager.addRace() via getSelected().
+// Classic-script module. Data + ranking live in courseData.js.
 
 (function () {
     'use strict';
 
     const esc = (s) => (window.escapeHtml ? window.escapeHtml(String(s)) : String(s));
+    const DESKTOP_MQ = '(min-width: 760px)';
+    function isDesktop() { return !!(window.matchMedia && window.matchMedia(DESKTOP_MQ).matches); }
 
     let state = {
-        courses: [],      // flattened, cup-annotated
-        cups: [],         // grouped (browse order)
-        byId: {},         // id -> course
-        selectedId: null,
-        selectedName: null,
-        open: false,
-        query: '',
-        options: [],      // ids in current keyboard-navigable (top-to-bottom) order
-        active: -1        // index into options, -1 = none
+        courses: [], cups: [], byId: {},
+        selectedId: null, selectedName: null,
+        open: false, mode: 'inline',     // 'inline' | 'modal'
+        modalRoot: null,
+        query: '', filter: 'all',        // all | favorites | recent | new | game:<name>
+        options: [], active: -1
     };
 
     let outsideHandler = null;
+    let resizeHandler = null;
 
     function container() { return document.getElementById('sidebar-course-picker'); }
-    function panelEl() { const c = container(); return c && c.querySelector('.course-picker-panel'); }
-    function searchEl() { const c = container(); return c && c.querySelector('.course-picker-search'); }
-    function resultsEl() { const c = container(); return c && c.querySelector('.cp-results'); }
+    function root() { return state.mode === 'modal' ? state.modalRoot : container(); }
+    function searchEl() { const r = root(); return r && r.querySelector('.course-picker-search'); }
+    function resultsEl() { const r = root(); return r && r.querySelector('.cp-results'); }
+    function countEl() { const r = root(); return r && r.querySelector('.cp-count'); }
 
     // ---- Public API ----------------------------------------------------------
     function getSelected() {
         return state.selectedId ? { id: state.selectedId, name: state.selectedName } : null;
     }
-
     function setSelected(course) {
+        if (course && state.query.trim()) window.CourseData.pushRecentSearch(state.query);
         state.selectedId = course ? course.id : null;
         state.selectedName = course ? course.name : null;
         closePanel();
         renderTrigger();
     }
-
     function clear() { setSelected(null); }
-
-    function commit() {
-        if (state.selectedId) window.CourseData.pushRecent(state.selectedId);
-    }
+    function commit() { if (state.selectedId) window.CourseData.pushRecent(state.selectedId); }
 
     // ---- Closed trigger: two-line, always informative ------------------------
     function renderTrigger() {
@@ -58,7 +56,6 @@
         const secondary = c.querySelector('.cp-trigger-secondary');
         const clearBtn = c.querySelector('.cp-clear');
         const trigger = c.querySelector('.course-picker-trigger');
-
         if (state.selectedId) {
             const course = state.byId[state.selectedId];
             if (primary) { primary.textContent = state.selectedName; primary.classList.remove('cp-empty-primary'); }
@@ -71,20 +68,15 @@
         if (trigger) trigger.setAttribute('aria-expanded', state.open ? 'true' : 'false');
     }
 
-    // Highlight the matched run of the query within a course name.
+    // ---- Shared row rendering ------------------------------------------------
     function highlight(name, query) {
         const q = String(query || '').trim().toLowerCase();
         if (!q) return esc(name);
         const i = name.toLowerCase().indexOf(q);
         if (i === -1) return esc(name);
-        return esc(name.slice(0, i)) +
-            '<mark class="cp-hl">' + esc(name.slice(i, i + q.length)) + '</mark>' +
-            esc(name.slice(i + q.length));
+        return esc(name.slice(0, i)) + '<mark class="cp-hl">' + esc(name.slice(i, i + q.length)) + '</mark>' + esc(name.slice(i + q.length));
     }
 
-    // One uniform row for EVERY context (recent, favorite, cup browse, search).
-    // Line 1: course name (hero) + inline NEW badge. Line 2: cup (secondary) +
-    // game source (tertiary, retro only). Star sits at the row's right edge.
     function rowHtml(course, idx) {
         const sel = course.id === state.selectedId;
         const fav = window.CourseData.isFavorite(course.id);
@@ -105,8 +97,7 @@
                 '</button>' +
                 (sel ? '<span class="cp-check" aria-hidden="true">✓</span>' : '') +
                 '<button type="button" class="cp-fav' + (fav ? ' is-fav' : '') + '" data-fav="' + esc(course.id) +
-                    '" tabindex="-1" aria-label="' + (fav ? 'Remove favorite' : 'Add favorite') + '">' +
-                    (fav ? '★' : '☆') + '</button>' +
+                    '" tabindex="-1" aria-label="' + (fav ? 'Remove favorite' : 'Add favorite') + '">' + (fav ? '★' : '☆') + '</button>' +
             '</div>'
         );
     }
@@ -118,68 +109,95 @@
         return { html: html + '</div>', next: idx };
     }
 
-    // Build results for the current query and refresh `state.options`.
+    // ---- Filters (desktop) ---------------------------------------------------
+    function distinctGames() {
+        const seen = [];
+        state.courses.forEach((c) => { const g = c.game || c.origin; if (g && g !== 'new' && seen.indexOf(g) === -1) seen.push(g); });
+        return seen;
+    }
+    function filterLabel(f) {
+        if (f === 'all') return 'All courses';
+        if (f === 'favorites') return 'Favorites';
+        if (f === 'recent') return 'Recent';
+        if (f === 'new') return 'New tracks';
+        if (f.indexOf('game:') === 0) return f.slice(5);
+        return f;
+    }
+    function filteredCourses() {
+        const f = state.filter;
+        if (f === 'favorites') return window.CourseData.getFavoriteIds().map((id) => state.byId[id]).filter(Boolean);
+        if (f === 'recent') return window.CourseData.getRecentIds().map((id) => state.byId[id]).filter(Boolean);
+        if (f === 'new') return state.courses.filter((c) => c.origin === 'new');
+        if (f.indexOf('game:') === 0) { const g = f.slice(5); return state.courses.filter((c) => (c.game || c.origin) === g); }
+        return state.courses;
+    }
+
+    // ---- Results (shared by both modes) --------------------------------------
     function renderResults() {
         const results = resultsEl();
-        const count = container() && container().querySelector('.cp-count');
+        const count = countEl();
         if (!results) return;
 
         const q = state.query.trim();
+        const base = filteredCourses();
         const options = [];
         let idx = 0;
         let html = '';
 
-        const push = (courses) => courses.forEach((c) => options.push(c.id));
-
         if (!q) {
-            const recents = window.CourseData.getRecentIds().map((id) => state.byId[id]).filter(Boolean);
-            const favs = window.CourseData.getFavoriteIds().map((id) => state.byId[id]).filter(Boolean);
-            if (recents.length) {
-                const s = sectionHtml('Recent', recents, idx); html += s.html; push(recents); idx = s.next;
+            if (state.filter === 'all') {
+                const recents = window.CourseData.getRecentIds().map((id) => state.byId[id]).filter(Boolean);
+                const favs = window.CourseData.getFavoriteIds().map((id) => state.byId[id]).filter(Boolean);
+                if (recents.length) { const s = sectionHtml('Recent', recents, idx); html += s.html; recents.forEach((c) => options.push(c.id)); idx = s.next; }
+                if (favs.length) { const s = sectionHtml('Favorites', favs, idx); html += s.html; favs.forEach((c) => options.push(c.id)); idx = s.next; }
+                state.cups.forEach((cup) => {
+                    const courses = cup.courses.map((c) => state.byId[c.id] || c);
+                    const s = sectionHtml(cup.name, courses, idx); html += s.html; courses.forEach((c) => options.push(c.id)); idx = s.next;
+                });
+            } else {
+                const s = sectionHtml(filterLabel(state.filter), base, idx);
+                html += base.length ? s.html : '<div class="cp-noresult">Nothing here yet.</div>';
+                base.forEach((c) => options.push(c.id)); idx = s.next;
             }
-            if (favs.length) {
-                const s = sectionHtml('Favorites', favs, idx); html += s.html; push(favs); idx = s.next;
+            if (count) {
+                if (state.filter === 'all') { count.hidden = true; }
+                else { count.hidden = false; count.textContent = base.length + (base.length === 1 ? ' course' : ' courses'); }
             }
-            state.cups.forEach((cup) => {
-                const courses = cup.courses.map((c) => state.byId[c.id] || c);
-                const s = sectionHtml(cup.name, courses, idx); html += s.html; push(courses); idx = s.next;
-            });
-            if (count) count.hidden = true;
         } else {
-            const matches = window.CourseData.rankCourses(state.courses, q);
+            const matches = window.CourseData.rankCourses(base, q);
             if (matches.length) {
                 matches.forEach((course) => { html += rowHtml(course, idx); options.push(course.id); idx++; });
                 html = '<div class="cp-section">' + html + '</div>';
             } else {
                 html = '<div class="cp-noresult">No courses match &ldquo;' + esc(q) + '&rdquo;</div>';
             }
-            if (count) {
-                count.hidden = false;
-                count.textContent = matches.length + (matches.length === 1 ? ' result' : ' results');
-            }
+            if (count) { count.hidden = false; count.textContent = matches.length + (matches.length === 1 ? ' result' : ' results'); }
         }
 
         results.innerHTML = html;
         state.options = options;
-        if (q && options.length) state.active = 0;       // first hit pre-armed for Enter
+        if (q && options.length) state.active = 0;
         else if (state.active >= options.length) state.active = options.length - 1;
+
+        if (state.mode === 'modal') { renderFilters(); renderEmptyAside(); }
         syncActive();
     }
 
-    // Reflect state.active into the DOM + aria, and scroll it into view.
     function syncActive() {
         const results = resultsEl();
         const search = searchEl();
-        if (!results) return;
-        results.querySelectorAll('.cp-row').forEach((row) => {
-            const on = row.id === 'cp-opt-' + state.active;
-            row.classList.toggle('cp-active', on);
-            if (on) {
-                if (search) search.setAttribute('aria-activedescendant', row.id);
-                if (row.scrollIntoView) row.scrollIntoView({ block: 'nearest' });
-            }
-        });
-        if (state.active < 0 && search) search.removeAttribute('aria-activedescendant');
+        if (results) {
+            results.querySelectorAll('.cp-row').forEach((row) => {
+                const on = row.id === 'cp-opt-' + state.active;
+                row.classList.toggle('cp-active', on);
+                if (on) {
+                    if (search) search.setAttribute('aria-activedescendant', row.id);
+                    if (row.scrollIntoView) row.scrollIntoView({ block: 'nearest' });
+                }
+            });
+            if (state.active < 0 && search) search.removeAttribute('aria-activedescendant');
+        }
+        if (state.mode === 'modal') updatePreview();
     }
 
     function moveActive(delta) {
@@ -189,69 +207,166 @@
         else state.active = (state.active + delta + n) % n;
         syncActive();
     }
-
     function selectActive() {
         const id = state.options[state.active];
         if (id && state.byId[id]) setSelected(state.byId[id]);
     }
 
+    // ---- Desktop palette: filters, empty hints, preview ----------------------
+    function renderFilters() {
+        const wrap = state.modalRoot && state.modalRoot.querySelector('.cp-filters');
+        if (!wrap) return;
+        const chips = [['all', 'All'], ['favorites', 'Favorites'], ['recent', 'Recent'], ['new', 'New']]
+            .concat(distinctGames().map((g) => ['game:' + g, g]));
+        wrap.innerHTML = chips.map(([f, label]) =>
+            '<button type="button" class="cp-filter' + (state.filter === f ? ' is-on' : '') + '" data-filter="' + esc(f) + '">' + esc(label) + '</button>'
+        ).join('');
+    }
+
+    function renderEmptyAside() {
+        const hint = state.modalRoot && state.modalRoot.querySelector('.cp-hint');
+        const rs = state.modalRoot && state.modalRoot.querySelector('.cp-recent-searches');
+        const showEmpty = !state.query.trim();
+        if (hint) hint.hidden = !showEmpty;
+        if (rs) {
+            const searches = window.CourseData.getRecentSearches();
+            if (showEmpty && searches.length) {
+                rs.hidden = false;
+                rs.innerHTML = '<span class="cp-rs-label">Recent searches</span>' +
+                    searches.map((t) => '<button type="button" class="cp-rs-chip" data-search="' + esc(t) + '">' + esc(t) + '</button>').join('');
+            } else { rs.hidden = true; rs.innerHTML = ''; }
+        }
+    }
+
+    function previewHtml(course) {
+        if (!course) {
+            return '<div class="cp-preview-empty">' +
+                '<div class="cp-preview-emoji">🗺️</div>' +
+                '<p>Hover or arrow through courses to preview details here.</p></div>';
+        }
+        const fav = window.CourseData.isFavorite(course.id);
+        const isNew = course.origin === 'new';
+        const game = course.game || (isNew ? '' : course.origin);
+        const rows = [
+            ['Cup', course.cups && course.cups.length ? course.cups.join(' / ') : '—'],
+            ['Game', game || '—'],
+            ['Status', isNew ? 'New track' : 'Returning track']
+        ];
+        return (
+            '<div class="cp-preview-card">' +
+                '<div class="cp-preview-emoji">' + (isNew ? '✨' : '🏁') + '</div>' +
+                '<div class="cp-preview-name">' + esc(course.name) + '</div>' +
+                '<div class="cp-preview-meta">' +
+                    rows.map(([k, v]) => '<div class="cp-pv-row"><span class="cp-pv-key">' + esc(k) + '</span><span class="cp-pv-val">' + esc(v) + '</span></div>').join('') +
+                '</div>' +
+                '<button type="button" class="cp-preview-fav' + (fav ? ' is-fav' : '') + '" data-fav="' + esc(course.id) + '">' +
+                    (fav ? '★ Favorited' : '☆ Add favorite') + '</button>' +
+                '<button type="button" class="cp-preview-select" data-id="' + esc(course.id) + '">Select course</button>' +
+            '</div>'
+        );
+    }
+    function updatePreview() {
+        const pv = state.modalRoot && state.modalRoot.querySelector('.cp-preview');
+        if (!pv) return;
+        const id = state.options[state.active];
+        pv.innerHTML = previewHtml(id ? state.byId[id] : null);
+    }
+
     // ---- Open / close --------------------------------------------------------
-    function openPanel() {
-        const panel = panelEl();
+    function openPanel() { isDesktop() ? openModal() : openInline(); }
+
+    function openInline() {
+        state.mode = 'inline';
+        state.filter = 'all';
+        const panel = container() && container().querySelector('.course-picker-panel');
         const search = searchEl();
         if (!panel) return;
-        state.open = true;
-        state.query = '';
-        state.active = -1;
+        state.open = true; state.query = ''; state.active = -1;
         panel.hidden = false;
         renderTrigger();
         if (search) search.value = '';
         renderResults();
         if (search) setTimeout(() => search.focus(), 20);
-
-        outsideHandler = (e) => {
-            const c = container();
-            if (c && !c.contains(e.target)) closePanel();
-        };
-        document.addEventListener('mousedown', outsideHandler, true);
+        bindDismiss();
     }
 
-    function closePanel() {
-        const panel = panelEl();
-        state.open = false;
-        if (panel) panel.hidden = true;
-        renderTrigger();
-        if (outsideHandler) {
-            document.removeEventListener('mousedown', outsideHandler, true);
-            outsideHandler = null;
-        }
-    }
+    function openModal() {
+        state.mode = 'modal';
+        state.open = true; state.query = ''; state.active = -1; state.filter = 'all';
 
-    function togglePanel() { state.open ? closePanel() : openPanel(); }
+        const overlay = document.createElement('div');
+        overlay.className = 'cp-modal-backdrop';
+        overlay.innerHTML =
+            '<div class="cp-modal course-picker" role="dialog" aria-modal="true" aria-label="Find a course">' +
+                '<div class="cp-modal-header">' +
+                    '<span class="cp-modal-icon" aria-hidden="true">🔍</span>' +
+                    '<input type="text" class="course-picker-search" role="combobox" aria-expanded="true" aria-autocomplete="list" ' +
+                        'placeholder="Search courses, cups, games, or abbreviations" autocomplete="off" spellcheck="false">' +
+                    '<kbd class="cp-esc">Esc</kbd>' +
+                '</div>' +
+                '<div class="cp-modal-subbar">' +
+                    '<div class="cp-filters"></div>' +
+                    '<span class="cp-count" hidden></span>' +
+                '</div>' +
+                '<div class="cp-hint">Search by <b>course</b>, <b>cup</b>, <b>game</b>, or <b>abbreviation</b> — try &ldquo;DK&rdquo;, &ldquo;Mushroom Cup&rdquo;, or &ldquo;MK8&rdquo;.</div>' +
+                '<div class="cp-recent-searches" hidden></div>' +
+                '<div class="cp-modal-body">' +
+                    '<div class="cp-results" role="listbox" aria-label="Courses"></div>' +
+                    '<aside class="cp-preview"></aside>' +
+                '</div>' +
+                '<div class="cp-modal-foot"><kbd>↑</kbd><kbd>↓</kbd> navigate · <kbd>↵</kbd> select · <kbd>esc</kbd> close</div>' +
+            '</div>';
+        document.body.appendChild(overlay);
+        state.modalRoot = overlay;
 
-    // ---- Wiring --------------------------------------------------------------
-    function wire(c) {
-        const trigger = c.querySelector('.course-picker-trigger');
-        if (trigger) trigger.addEventListener('click', togglePanel);
-
-        const clearBtn = c.querySelector('.cp-clear');
-        if (clearBtn) clearBtn.addEventListener('click', (e) => { e.stopPropagation(); clear(); });
-
-        const search = c.querySelector('.course-picker-search');
+        const search = overlay.querySelector('.course-picker-search');
         if (search) {
             search.addEventListener('input', (e) => { state.query = e.target.value; state.active = -1; renderResults(); });
             search.addEventListener('keydown', onKeydown);
         }
+        overlay.querySelector('.cp-results').addEventListener('mousemove', onPanelHover);
+        overlay.addEventListener('click', onModalClick);
 
-        const panel = c.querySelector('.course-picker-panel');
-        if (panel) {
-            panel.addEventListener('click', onPanelClick);
-            panel.addEventListener('mousemove', onPanelHover);
-            panel.addEventListener('wheel', (e) => e.stopPropagation(), { passive: true });
-            panel.addEventListener('touchmove', (e) => e.stopPropagation(), { passive: true });
-        }
+        renderTrigger();
+        renderResults();
+        if (search) setTimeout(() => search.focus(), 20);
+        bindDismiss();
     }
 
+    function closePanel() {
+        if (outsideHandler) { document.removeEventListener('mousedown', outsideHandler, true); outsideHandler = null; }
+        if (resizeHandler) { window.removeEventListener('resize', resizeHandler); resizeHandler = null; }
+        if (state.mode === 'modal') {
+            if (state.modalRoot && state.modalRoot.parentNode) state.modalRoot.parentNode.removeChild(state.modalRoot);
+            state.modalRoot = null;
+        } else {
+            const panel = container() && container().querySelector('.course-picker-panel');
+            if (panel) panel.hidden = true;
+        }
+        state.mode = 'inline';
+        state.open = false;
+        renderTrigger();
+    }
+
+    function togglePanel() { state.open ? closePanel() : openPanel(); }
+
+    function bindDismiss() {
+        outsideHandler = (e) => {
+            if (state.mode === 'modal') {
+                // close when clicking the backdrop (outside the modal box)
+                if (e.target === state.modalRoot) closePanel();
+                return;
+            }
+            const c = container();
+            if (c && !c.contains(e.target)) closePanel();
+        };
+        document.addEventListener('mousedown', outsideHandler, true);
+        // If the viewport crosses the desktop/mobile boundary, reset cleanly.
+        resizeHandler = () => { if (state.open && isDesktop() !== (state.mode === 'modal')) closePanel(); };
+        window.addEventListener('resize', resizeHandler);
+    }
+
+    // ---- Events --------------------------------------------------------------
     function onKeydown(e) {
         switch (e.key) {
             case 'ArrowDown': e.preventDefault(); moveActive(1); break;
@@ -264,24 +379,39 @@
                 else if (state.options.length) { state.active = 0; selectActive(); }
                 break;
             case 'Escape':
-                e.preventDefault();
-                closePanel();
+                e.preventDefault(); closePanel();
                 { const t = container() && container().querySelector('.course-picker-trigger'); if (t) t.focus(); }
                 break;
             default: break;
         }
     }
 
-    function onPanelClick(e) {
-        const favBtn = e.target.closest('.cp-fav');
-        if (favBtn) {
+    function handleClickWithin(e) {
+        const fav = e.target.closest('.cp-fav, .cp-preview-fav');
+        if (fav) {
             e.stopPropagation();
-            window.CourseData.toggleFavorite(favBtn.getAttribute('data-fav'));
+            window.CourseData.toggleFavorite(fav.getAttribute('data-fav'));
             renderResults();
+            return true;
+        }
+        const selectBtn = e.target.closest('.cp-preview-select');
+        if (selectBtn) { const c = state.byId[selectBtn.getAttribute('data-id')]; if (c) setSelected(c); return true; }
+        const courseBtn = e.target.closest('.cp-course');
+        if (courseBtn) { const c = state.byId[courseBtn.getAttribute('data-id')]; if (c) setSelected(c); return true; }
+        return false;
+    }
+
+    function onModalClick(e) {
+        const filterBtn = e.target.closest('.cp-filter');
+        if (filterBtn) { state.filter = filterBtn.getAttribute('data-filter'); state.active = -1; renderResults(); return; }
+        const rsChip = e.target.closest('.cp-rs-chip');
+        if (rsChip) {
+            const term = rsChip.getAttribute('data-search');
+            const s = searchEl();
+            if (s) { s.value = term; state.query = term; state.active = -1; renderResults(); s.focus(); }
             return;
         }
-        const courseBtn = e.target.closest('.cp-course');
-        if (courseBtn) { const c = state.byId[courseBtn.getAttribute('data-id')]; if (c) setSelected(c); }
+        handleClickWithin(e);
     }
 
     function onPanelHover(e) {
@@ -289,6 +419,26 @@
         if (!courseBtn) return;
         const idx = parseInt(courseBtn.getAttribute('data-idx'), 10);
         if (!isNaN(idx) && idx !== state.active) { state.active = idx; syncActive(); }
+    }
+
+    // ---- Inline shell + wiring ----------------------------------------------
+    function wireInline(c) {
+        const trigger = c.querySelector('.course-picker-trigger');
+        if (trigger) trigger.addEventListener('click', togglePanel);
+        const clearBtn = c.querySelector('.cp-clear');
+        if (clearBtn) clearBtn.addEventListener('click', (e) => { e.stopPropagation(); clear(); });
+        const search = c.querySelector('.course-picker-search');
+        if (search) {
+            search.addEventListener('input', (e) => { state.query = e.target.value; state.active = -1; renderResults(); });
+            search.addEventListener('keydown', onKeydown);
+        }
+        const panel = c.querySelector('.course-picker-panel');
+        if (panel) {
+            panel.addEventListener('click', (e) => { handleClickWithin(e); });
+            panel.addEventListener('mousemove', onPanelHover);
+            panel.addEventListener('wheel', (e) => e.stopPropagation(), { passive: true });
+            panel.addEventListener('touchmove', (e) => e.stopPropagation(), { passive: true });
+        }
     }
 
     function renderShell() {
@@ -318,11 +468,10 @@
                     '<div class="cp-results"></div>' +
                 '</div>' +
             '</div>';
-        wire(c);
+        wireInline(c);
         renderTrigger();
     }
 
-    // (Re)load data for the active game version and rebuild the picker.
     async function init() {
         const c = container();
         if (!c || !window.CourseData) return;
@@ -333,11 +482,9 @@
             state.cups = data.cups || [];
             state.byId = {};
             state.courses.forEach((course) => { state.byId[course.id] = course; });
-            state.selectedId = null;
-            state.selectedName = null;
-            state.open = false;
-            state.query = '';
-            state.active = -1;
+            if (state.open) closePanel();
+            state.selectedId = null; state.selectedName = null;
+            state.query = ''; state.active = -1; state.filter = 'all';
             renderShell();
         } catch (e) {
             console.warn('CoursePicker: course data unavailable', e);
@@ -346,11 +493,7 @@
     }
 
     window.CoursePicker = {
-        init: init,
-        refresh: init,
-        getSelected: getSelected,
-        setSelected: setSelected,
-        clear: clear,
-        commit: commit
+        init: init, refresh: init,
+        getSelected: getSelected, setSelected: setSelected, clear: clear, commit: commit
     };
 })();

--- a/apps/mario-kart/js/coursePicker.js
+++ b/apps/mario-kart/js/coursePicker.js
@@ -27,6 +27,51 @@
 
     let outsideHandler = null;
     let resizeHandler = null;
+    let savedBodyOverflow = null;
+
+    // Stop the page behind the desktop modal from scrolling.
+    function lockScroll() {
+        if (savedBodyOverflow === null) {
+            savedBodyOverflow = document.body.style.overflow || '';
+            document.body.style.overflow = 'hidden';
+        }
+    }
+    function unlockScroll() {
+        if (savedBodyOverflow !== null) {
+            document.body.style.overflow = savedBodyOverflow;
+            savedBodyOverflow = null;
+        }
+    }
+
+    // Visible, tabbable elements inside the modal (course/fav rows are
+    // tabindex=-1 by design — they're reached via arrow keys, not Tab).
+    function getFocusable() {
+        if (!state.modalRoot) return [];
+        const sel = 'a[href], button:not([disabled]):not([tabindex="-1"]), input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])';
+        return Array.prototype.slice.call(state.modalRoot.querySelectorAll(sel))
+            .filter((el) => el.offsetParent !== null || el === document.activeElement);
+    }
+
+    // Trap Tab within the modal and let Esc close it from anywhere inside.
+    function onModalKeydown(e) {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            closePanel();
+            const t = container() && container().querySelector('.course-picker-trigger');
+            if (t) t.focus();
+            return;
+        }
+        if (e.key !== 'Tab') return;
+        const fs = getFocusable();
+        if (!fs.length) { e.preventDefault(); return; }
+        const first = fs[0], last = fs[fs.length - 1];
+        const a = document.activeElement;
+        if (e.shiftKey) {
+            if (a === first || !state.modalRoot.contains(a)) { e.preventDefault(); last.focus(); }
+        } else {
+            if (a === last || !state.modalRoot.contains(a)) { e.preventDefault(); first.focus(); }
+        }
+    }
 
     function container() { return document.getElementById('sidebar-course-picker'); }
     function root() { return state.mode === 'modal' ? state.modalRoot : container(); }
@@ -216,8 +261,9 @@
     function renderFilters() {
         const wrap = state.modalRoot && state.modalRoot.querySelector('.cp-filters');
         if (!wrap) return;
-        const chips = [['all', 'All'], ['favorites', 'Favorites'], ['recent', 'Recent'], ['new', 'New']]
-            .concat(distinctGames().map((g) => ['game:' + g, g]));
+        // Keep it to the four essentials — individual games stay reachable by
+        // typing ("mk7", "wii", ...), so they don't need their own chips.
+        const chips = [['all', 'All'], ['favorites', 'Favorites'], ['recent', 'Recent'], ['new', 'New']];
         wrap.innerHTML = chips.map(([f, label]) =>
             '<button type="button" class="cp-filter' + (state.filter === f ? ' is-on' : '') + '" data-filter="' + esc(f) + '">' + esc(label) + '</button>'
         ).join('');
@@ -242,26 +288,26 @@
         if (!course) {
             return '<div class="cp-preview-empty">' +
                 '<div class="cp-preview-emoji">🗺️</div>' +
-                '<p>Hover or arrow through courses to preview details here.</p></div>';
+                '<p>Hover or arrow a course to preview it.</p></div>';
         }
         const fav = window.CourseData.isFavorite(course.id);
         const isNew = course.origin === 'new';
         const game = course.game || (isNew ? '' : course.origin);
-        const rows = [
-            ['Cup', course.cups && course.cups.length ? course.cups.join(' / ') : '—'],
-            ['Game', game || '—'],
-            ['Status', isNew ? 'New track' : 'Returning track']
-        ];
+        const cups = (course.cups && course.cups.length) ? esc(course.cups.join(' / ')) : '—';
         return (
-            '<div class="cp-preview-card">' +
-                '<div class="cp-preview-emoji">' + (isNew ? '✨' : '🏁') + '</div>' +
-                '<div class="cp-preview-name">' + esc(course.name) + '</div>' +
-                '<div class="cp-preview-meta">' +
-                    rows.map(([k, v]) => '<div class="cp-pv-row"><span class="cp-pv-key">' + esc(k) + '</span><span class="cp-pv-val">' + esc(v) + '</span></div>').join('') +
+            '<div class="cp-pv ' + (isNew ? 'cp-pv-new' : 'cp-pv-retro') + '">' +
+                '<div class="cp-pv-hero">' +
+                    '<span class="cp-pv-emoji">' + (isNew ? '✨' : '🏁') + '</span>' +
+                    '<span class="cp-pv-status">' + (isNew ? 'New track' : 'Returning') + '</span>' +
+                    '<button type="button" class="cp-preview-fav' + (fav ? ' is-fav' : '') + '" data-fav="' + esc(course.id) +
+                        '" aria-label="' + (fav ? 'Remove favorite' : 'Add favorite') + '">' + (fav ? '★' : '☆') + '</button>' +
                 '</div>' +
-                '<button type="button" class="cp-preview-fav' + (fav ? ' is-fav' : '') + '" data-fav="' + esc(course.id) + '">' +
-                    (fav ? '★ Favorited' : '☆ Add favorite') + '</button>' +
-                '<button type="button" class="cp-preview-select" data-id="' + esc(course.id) + '">Select course</button>' +
+                '<div class="cp-pv-name">' + esc(course.name) + '</div>' +
+                '<div class="cp-pv-tags">' +
+                    '<span class="cp-pv-tag cp-pv-tag-cup">' + cups + '</span>' +
+                    (game ? '<span class="cp-pv-tag cp-pv-tag-game">' + esc(game) + '</span>' : '') +
+                '</div>' +
+                '<button type="button" class="cp-preview-select" data-id="' + esc(course.id) + '">Select this course</button>' +
             '</div>'
         );
     }
@@ -326,7 +372,9 @@
         }
         overlay.querySelector('.cp-results').addEventListener('mousemove', onPanelHover);
         overlay.addEventListener('click', onModalClick);
+        overlay.addEventListener('keydown', onModalKeydown); // Tab trap + Esc
 
+        lockScroll();
         renderTrigger();
         renderResults();
         if (search) setTimeout(() => search.focus(), 20);
@@ -334,6 +382,7 @@
     }
 
     function closePanel() {
+        unlockScroll();
         if (outsideHandler) { document.removeEventListener('mousedown', outsideHandler, true); outsideHandler = null; }
         if (resizeHandler) { window.removeEventListener('resize', resizeHandler); resizeHandler = null; }
         if (state.mode === 'modal') {

--- a/apps/mario-kart/js/dataManager.js
+++ b/apps/mario-kart/js/dataManager.js
@@ -98,6 +98,14 @@ function addRace() {
         raceObject[player] = raceData[player];
     });
 
+    // Optional course/map (from the course picker). Stored as id + name so
+    // history stays readable even if the course later leaves the dataset.
+    const selectedCourse = window.CoursePicker ? window.CoursePicker.getSelected() : null;
+    if (selectedCourse) {
+        raceObject.courseId = selectedCourse.id;
+        raceObject.course = selectedCourse.name;
+    }
+
     races.push(raceObject);
     
     // Save action for undo/redo
@@ -115,6 +123,12 @@ function addRace() {
         const input = document.getElementById(player);
         if (input) input.value = '';
     });
+
+    // Remember the picked course as "recent" and reset the picker for next time.
+    if (window.CoursePicker) {
+        window.CoursePicker.commit();
+        window.CoursePicker.clear();
+    }
 
     updateDisplay();
     updateAchievements();

--- a/apps/mario-kart/js/gameVersionManager.js
+++ b/apps/mario-kart/js/gameVersionManager.js
@@ -68,7 +68,12 @@ function switchGameVersion(version) {
     if (window.generateSidebarRaceInputs) {
         window.generateSidebarRaceInputs();
     }
-    
+
+    // Rebuild the course picker for the newly selected game's course list.
+    if (window.CoursePicker) {
+        window.CoursePicker.refresh();
+    }
+
     // Recreate visualization bars with new position limits
     if (window.createAllBars) {
         window.createAllBars();

--- a/apps/mario-kart/js/main.js
+++ b/apps/mario-kart/js/main.js
@@ -1117,10 +1117,11 @@ function updateRaceHistoryTable(filteredRaces) {
                 : '<td><span style="color: #718096;">—</span></td>';
         }).join('');
 
+        const courseLabel = race.course ? `<br><small class="race-course-label">🗺️ ${escapeHtml(race.course)}</small>` : '';
         return `
         <tr>
             <td>${raceNumber}</td>
-            <td>${formatDateForDisplay(race.date)}${race.timestamp ? '<br><small>' + race.timestamp + '</small>' : ''}</td>
+            <td>${formatDateForDisplay(race.date)}${race.timestamp ? '<br><small>' + race.timestamp + '</small>' : ''}${courseLabel}</td>
             ${playerCells}
             <td>
                 <button class="edit-btn" onclick="editRace(${globalIndex})" title="Edit race">✏️</button>
@@ -1204,6 +1205,7 @@ function updateMobileRaceCards(filteredRaces, racesToDisplay, filteredIndexMap, 
                 <span class="race-number">Race #${raceNumber}</span>
                 <span class="race-date">${formatDateForDisplay(race.date)}${race.timestamp ? ', ' + race.timestamp : ''}</span>
             </div>
+            ${race.course ? `<div class="race-card-course"><small class="race-course-label">🗺️ ${escapeHtml(race.course)}</small></div>` : ''}
             <div class="race-positions">
                 ${playerPositions}
             </div>
@@ -1532,7 +1534,12 @@ document.addEventListener('DOMContentLoaded', function() {
     if (window.updateMaxPositions) {
         window.updateMaxPositions();
     }
-    
+
+    // Build the course picker for the current game version (async, optional).
+    if (window.CoursePicker) {
+        window.CoursePicker.init();
+    }
+
     // Initialize global pagination instance for Mario Kart
     if (window.GlobalPaginationManager) {
         window.GlobalPaginationManager.createInstance('mario-kart-races', {

--- a/apps/mario-kart/scripts/sync-courses.mjs
+++ b/apps/mario-kart/scripts/sync-courses.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Course-data sync / validation tool.
+//
+// WHY: there is no official Mario Kart course API and the best community API
+// (mk8_node_api) has no course data, so course lists are vendored as
+// data/courses.json. This script keeps that file honest and gives a single
+// place to (re)generate it from a configurable source as games update -- so
+// nobody has to hand-maintain the list forever.
+//
+// USAGE
+//   node apps/mario-kart/scripts/sync-courses.mjs --check         # validate only (CI-friendly, non-zero on error)
+//   node apps/mario-kart/scripts/sync-courses.mjs --write         # normalize + restamp lastSynced, write file
+//   node apps/mario-kart/scripts/sync-courses.mjs --source=remote # pull from a configured remote provider (see SOURCES)
+//
+// The default source is `vendored` (use the file as the source of truth and
+// just re-validate/normalize). Adding a real upstream is a matter of writing
+// one adapter in SOURCES below -- nothing else changes.
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_FILE = join(__dirname, '..', 'data', 'courses.json');
+
+// ---- Source adapters. Each returns the `games` object in our schema. --------
+const SOURCES = {
+    // Treat the vendored file itself as the source of truth (default).
+    async vendored() {
+        const raw = JSON.parse(await readFile(DATA_FILE, 'utf8'));
+        return raw.games;
+    },
+
+    // Example remote adapter -- wire a real upstream here when one exists.
+    // It must map whatever shape the upstream returns into our { cups: [...] }
+    // schema. Left as an explicit, documented stub so the seam is obvious.
+    async remote() {
+        const url = process.env.MK_COURSES_URL;
+        if (!url) throw new Error('remote source needs MK_COURSES_URL env var');
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`remote fetch failed: ${res.status}`);
+        const upstream = await res.json();
+        // TODO: map `upstream` -> { mkworld: { cups: [...] }, mk8d: { cups: [...] } }
+        // For now we assume the upstream already matches our schema's `games`.
+        return upstream.games || upstream;
+    }
+};
+
+// ---- Validation: the same invariants the app and tests rely on. -------------
+function validate(games) {
+    const errors = [];
+    if (!games || typeof games !== 'object') {
+        return ['dataset has no `games` object'];
+    }
+    for (const [gameKey, game] of Object.entries(games)) {
+        if (!Array.isArray(game.cups) || game.cups.length === 0) {
+            errors.push(`${gameKey}: missing or empty cups[]`);
+            continue;
+        }
+        const seen = new Map(); // courseId -> first cup it appeared in
+        for (const cup of game.cups) {
+            if (!cup.id || !cup.name || !Array.isArray(cup.courses)) {
+                errors.push(`${gameKey}: malformed cup ${JSON.stringify(cup.id || cup.name || '?')}`);
+                continue;
+            }
+            for (const c of cup.courses) {
+                if (!c.id || !c.name) {
+                    errors.push(`${gameKey}/${cup.id}: course missing id or name`);
+                    continue;
+                }
+                // Same id in two cups is allowed (course variants, e.g. Crown City)
+                // but the NAME must match so the dedupe in the app is coherent.
+                if (seen.has(c.id) && seen.get(c.id) !== c.name) {
+                    errors.push(`${gameKey}: course id "${c.id}" reused with different names`);
+                }
+                seen.set(c.id, c.name);
+            }
+        }
+    }
+    return errors;
+}
+
+function summarize(games) {
+    return Object.entries(games).map(([k, g]) => {
+        const courses = new Set();
+        g.cups.forEach((cup) => cup.courses.forEach((c) => courses.add(c.id)));
+        const complete = g.source && g.source.complete ? 'complete' : 'partial';
+        return `  ${k}: ${g.cups.length} cups, ${courses.size} unique courses (${complete})`;
+    }).join('\n');
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+    const check = args.includes('--check');
+    const write = args.includes('--write');
+    const sourceArg = (args.find((a) => a.startsWith('--source=')) || '--source=vendored').split('=')[1];
+
+    const source = SOURCES[sourceArg];
+    if (!source) {
+        console.error(`Unknown source "${sourceArg}". Known: ${Object.keys(SOURCES).join(', ')}`);
+        process.exit(2);
+    }
+
+    const games = await source();
+    const errors = validate(games);
+
+    console.log(`Source: ${sourceArg}`);
+    console.log(summarize(games));
+
+    if (errors.length) {
+        console.error(`\n${errors.length} validation error(s):`);
+        errors.forEach((e) => console.error('  - ' + e));
+        process.exit(1);
+    }
+    console.log('\nValidation passed.');
+
+    if (write) {
+        const today = new Date().toISOString().slice(0, 10);
+        for (const game of Object.values(games)) {
+            if (game.source) game.source.lastSynced = today;
+        }
+        const out = { schemaVersion: 1, generatedBy: `sync:${sourceArg}`, games };
+        await writeFile(DATA_FILE, JSON.stringify(out, null, 2) + '\n', 'utf8');
+        console.log(`\nWrote ${DATA_FILE} (lastSynced=${today}).`);
+    } else if (!check) {
+        console.log('\n(dry run -- pass --write to update the file, --check for CI validation)');
+    }
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/apps/mario-kart/tests/courses.test.js
+++ b/apps/mario-kart/tests/courses.test.js
@@ -171,6 +171,16 @@ test('recents: most-recent-first, de-duplicated, capped', () => {
   assert.equal(new Set(recents).size, recents.length);
 });
 
+test('recent searches: trimmed, deduped, most-recent-first, ignores single chars', () => {
+  const CourseData = loadCourseData();
+  CourseData.pushRecentSearch('x');        // too short, ignored
+  CourseData.pushRecentSearch('dk');
+  CourseData.pushRecentSearch(' Mushroom ');
+  CourseData.pushRecentSearch('DK');       // dedupe (case-insensitive), moves to front
+  const searches = CourseData.getRecentSearches();
+  assert.deepEqual(searches, ['DK', 'Mushroom']);
+});
+
 test('favorites: toggle on then off', () => {
   const CourseData = loadCourseData();
   assert.equal(CourseData.isFavorite('rainbow-road'), false);

--- a/apps/mario-kart/tests/courses.test.js
+++ b/apps/mario-kart/tests/courses.test.js
@@ -127,6 +127,26 @@ test('rankCourses: punctuation-insensitive and initials matching', () => {
   assert.ok(CourseData.rankCourses(flat8, 'mks').some((c) => c.id === 'mario-kart-stadium'));
 });
 
+test('rankCourses: forgiving abbreviations (dk / ship / mk8)', () => {
+  const CourseData = loadCourseData();
+  const world = CourseData.flattenCourses(dataset.games.mkworld);
+  const mk8 = CourseData.flattenCourses(dataset.games.mk8d);
+  // "dk" -> DK Spaceport (word-initial)
+  assert.ok(CourseData.rankCourses(world, 'dk').some((c) => c.id === 'dk-spaceport'));
+  // "ship" -> Wario Shipyard (substring)
+  assert.ok(CourseData.rankCourses(world, 'ship').some((c) => c.id === 'wario-shipyard'));
+  // "mk8" -> a Mario Kart 8 Deluxe-sourced track via game initials
+  assert.ok(CourseData.rankCourses(world, 'mk8').some((c) => c.origin === 'Mario Kart 8 Deluxe'));
+});
+
+test('scoreCourse: base-game track is findable by its source game', () => {
+  const CourseData = loadCourseData();
+  // Simulates a loaded base-game track tagged with game = "Mario Kart 8 Deluxe".
+  const track = { id: 'x', name: 'Thwomp Ruins', origin: 'new', aliases: [], cups: ['Mushroom Cup'], game: 'Mario Kart 8 Deluxe' };
+  assert.ok(CourseData.scoreCourse(track, 'mk8') > 0, '"mk8" should match via game initials');
+  assert.equal(CourseData.scoreCourse(track, 'zzzzz'), 0);
+});
+
 test('scoreCourse: non-matching query scores zero', () => {
   const CourseData = loadCourseData();
   const flat = CourseData.flattenCourses(dataset.games.mk8d);

--- a/apps/mario-kart/tests/courses.test.js
+++ b/apps/mario-kart/tests/courses.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+// Tests for the course-data layer: the vendored dataset's integrity and the
+// pure transforms in js/courseData.js (loaded the same classic-script way the
+// other mario-kart tests use).
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const JS_DIR = path.join(__dirname, '..', 'js');
+const DATA_FILE = path.join(__dirname, '..', 'data', 'courses.json');
+
+const dataset = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+
+// Load courseData.js into a vm with a window + localStorage stub and return
+// the resulting window.CourseData surface.
+function loadCourseData() {
+  const map = new Map();
+  const sandbox = {
+    console,
+    JSON,
+    Array,
+    Object,
+    String,
+    Number,
+    Boolean,
+    Map,
+    window: {},
+    localStorage: {
+      getItem: (k) => (map.has(k) ? map.get(k) : null),
+      setItem: (k, v) => map.set(k, String(v)),
+      removeItem: (k) => map.delete(k),
+      clear: () => map.clear(),
+    },
+  };
+  sandbox.window.localStorage = sandbox.localStorage;
+  // App prefixes course storage by game version; a stub is enough here.
+  sandbox.window.getStorageKey = (base) => 'marioKartWorld' + base;
+  const ctx = vm.createContext(sandbox);
+  const src = fs.readFileSync(path.join(JS_DIR, 'courseData.js'), 'utf8');
+  vm.runInContext(src, ctx, { filename: 'courseData.js' });
+  return ctx.window.CourseData;
+}
+
+// --- Dataset integrity -----------------------------------------------------
+
+test('courses.json: every game has non-empty cups and well-formed courses', () => {
+  for (const [gameKey, game] of Object.entries(dataset.games)) {
+    assert.ok(Array.isArray(game.cups) && game.cups.length > 0, `${gameKey} has cups`);
+    assert.ok(typeof game.maxPositions === 'number', `${gameKey} has maxPositions`);
+    for (const cup of game.cups) {
+      assert.ok(cup.id && cup.name, `${gameKey} cup has id+name`);
+      assert.ok(Array.isArray(cup.courses) && cup.courses.length > 0, `${gameKey}/${cup.id} has courses`);
+      for (const c of cup.courses) {
+        assert.ok(c.id && c.name, `${gameKey}/${cup.id} course has id+name`);
+      }
+    }
+  }
+});
+
+test('courses.json: a reused course id always carries the same name', () => {
+  for (const [gameKey, game] of Object.entries(dataset.games)) {
+    const names = new Map();
+    for (const cup of game.cups) {
+      for (const c of cup.courses) {
+        if (names.has(c.id)) {
+          assert.equal(names.get(c.id), c.name, `${gameKey}: id ${c.id} reused with mismatched name`);
+        }
+        names.set(c.id, c.name);
+      }
+    }
+  }
+});
+
+// --- Pure transforms -------------------------------------------------------
+
+test('flattenCourses: dedupes a course that appears in two cups, merging cups[]', () => {
+  const CourseData = loadCourseData();
+  const flat = CourseData.flattenCourses(dataset.games.mkworld);
+  const ids = flat.map((c) => c.id);
+  assert.equal(new Set(ids).size, ids.length, 'flattened list has no duplicate ids');
+
+  // Crown City appears in both Mushroom Cup and Shell Cup in MK World.
+  const crownCity = flat.find((c) => c.id === 'crown-city');
+  assert.ok(crownCity, 'crown-city present');
+  assert.equal(crownCity.cups.length, 2, 'crown-city lists both cups');
+});
+
+test('groupByCup: preserves cup order and course counts', () => {
+  const CourseData = loadCourseData();
+  const groups = CourseData.groupByCup(dataset.games.mk8d);
+  assert.equal(groups[0].name, dataset.games.mk8d.cups[0].name);
+  assert.equal(groups[0].courses.length, dataset.games.mk8d.cups[0].courses.length);
+});
+
+test('searchCourses: matches name, alias, and origin case-insensitively', () => {
+  const CourseData = loadCourseData();
+  const flat = CourseData.flattenCourses(dataset.games.mkworld);
+
+  assert.ok(CourseData.searchCourses(flat, 'rainbow').some((c) => c.id === 'rainbow-road-world'), 'by name');
+  assert.ok(CourseData.searchCourses(flat, 'mbc').some((c) => c.id === 'mario-bros-circuit'), 'by alias');
+  assert.ok(CourseData.searchCourses(flat, 'mario kart 7').length > 0, 'by origin');
+  assert.equal(CourseData.searchCourses(flat, '').length, flat.length, 'empty query returns all');
+  assert.equal(CourseData.searchCourses(flat, 'zzzzz').length, 0, 'no match returns empty');
+});
+
+test('rankCourses: prefix beats substring, exact beats prefix', () => {
+  const CourseData = loadCourseData();
+  const flat = CourseData.flattenCourses(dataset.games.mk8d);
+  const ranked = CourseData.rankCourses(flat, 'mario');
+  // "Mario Circuit" / "Mario Kart Stadium" (word-start) must outrank a course
+  // that only contains "mario" via origin/alias.
+  assert.ok(ranked.length > 1);
+  assert.ok(/^Mario/.test(ranked[0].name), `expected a Mario* course first, got ${ranked[0].name}`);
+});
+
+test('rankCourses: punctuation-insensitive and initials matching', () => {
+  const CourseData = loadCourseData();
+  const flat = CourseData.flattenCourses(dataset.games.mkworld);
+  // "Mario Bros. Circuit" found by typing without the period.
+  assert.equal(CourseData.rankCourses(flat, 'mario bros circuit')[0].id, 'mario-bros-circuit');
+  // Initials: "mks" -> Mario Kart Stadium (mk8d set).
+  const flat8 = CourseData.flattenCourses(dataset.games.mk8d);
+  assert.ok(CourseData.rankCourses(flat8, 'mks').some((c) => c.id === 'mario-kart-stadium'));
+});
+
+test('scoreCourse: non-matching query scores zero', () => {
+  const CourseData = loadCourseData();
+  const flat = CourseData.flattenCourses(dataset.games.mk8d);
+  assert.equal(CourseData.scoreCourse(flat[0], 'zzzzz'), 0);
+});
+
+test('normalizeDataset: rejects a structurally invalid dataset', () => {
+  const CourseData = loadCourseData();
+  assert.throws(() => CourseData.normalizeDataset({}), /missing games/);
+  assert.throws(() => CourseData.normalizeDataset({ games: { x: {} } }), /missing cups/);
+});
+
+// --- Recents & favorites ---------------------------------------------------
+
+test('recents: most-recent-first, de-duplicated, capped', () => {
+  const CourseData = loadCourseData();
+  CourseData.pushRecent('a');
+  CourseData.pushRecent('b');
+  CourseData.pushRecent('a'); // re-selecting a moves it to front, no dupe
+  const recents = CourseData.getRecentIds();
+  assert.deepEqual(recents.slice(0, 2), ['a', 'b']);
+  assert.equal(new Set(recents).size, recents.length);
+});
+
+test('favorites: toggle on then off', () => {
+  const CourseData = loadCourseData();
+  assert.equal(CourseData.isFavorite('rainbow-road'), false);
+  assert.equal(CourseData.toggleFavorite('rainbow-road'), true);
+  assert.equal(CourseData.isFavorite('rainbow-road'), true);
+  assert.equal(CourseData.toggleFavorite('rainbow-road'), false);
+  assert.equal(CourseData.isFavorite('rainbow-road'), false);
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:mario-kart": "node --test apps/mario-kart/tests/",
     "test:arena": "node --test apps/arena/tests/",
     "test:sync": "node --test sync-system/tests/",
+    "sync:mario-kart-courses": "node apps/mario-kart/scripts/sync-courses.mjs",
     "build:rising-seasons": "node apps/rising-seasons/scripts/build-data.js",
     "build:rising-seasons:pages": "node apps/rising-seasons/scripts/build-show-pages.js",
     "build:gym-tracker:pages": "node apps/gym-tracker/scripts/build-exercise-pages.cjs",


### PR DESCRIPTION
## What & why

Adds an optional **course/map picker** to the Mario Kart race form so a race can record *which track it was played on*, plus a foundation to keep course data fresh without hand-maintaining lists forever. There is no reliable public API for Mario Kart course lists (the popular `mk8_node_api` only has drivers/karts; Nintendo ships no endpoint), so course data is **vendored as JSON behind a config-driven source abstraction** that can later point at a remote/synced feed without any UI change.

This is a first, self-contained slice: data + abstraction + picker UI + sync script + tests. It does not yet wire course data into stats/filters (course is captured and displayed only).

## Files changed (complete diff)

### New — data & data layer
- **`apps/mario-kart/data/courses.json`** — vendored dataset. Mario Kart World (8 cups, 30 unique courses) and MK8 Deluxe base game (8 cups, 32 courses). Each course has `id`, `name`, `origin`, `aliases`; courses appearing in two cups (Crown City, Peach Stadium) share one `id` (variants). Per-game `source` metadata (`url`, `lastSynced`, `complete`). MK8D is flagged `complete:false` (Booster Course Pass not yet vendored).
- **`apps/mario-kart/js/courseData.js`** — `window.CourseData`: config-driven loader (`CourseDataConfig.active`, static JSON now, remote later), pure transforms (`normalizeDataset`, `flattenCourses` with variant-dedupe-and-cup-merge, `groupByCup`), **ranked fuzzy search** (`rankCourses`/`scoreCourse`: exact > prefix > word-start > initials > alias > substring; punctuation-insensitive so "mario bros circuit" matches "Mario Bros. Circuit", "mks" matches Mario Kart Stadium), and per-game-version **recents + favorites** in prefixed localStorage. `searchCourses` retained as a ranked back-compat alias.

### New — UI
- **`apps/mario-kart/js/coursePicker.js`** — `window.CoursePicker`: searchable, cup-grouped dropdown in the sidebar race form. Quick-tap **recent/favorite chips**, live **result count**, **match highlighting**, **New**/retro **origin pills**, selected ✓, **full keyboard navigation** (Arrow/Home/End/Enter/Escape) with active-row highlight + scroll, hover-syncs-active, **click-outside-to-close**, and ARIA combobox/listbox semantics. Async + optional — never blocks race entry if data fails to load.
- **`apps/mario-kart/css/course-picker.css`** — styles for the trigger, panel, search, chips, rows, pills, highlight, and the history course badge. Uses the app's `--mk-*` dark palette (loaded after `refresh.css` so scoped rules win). Every text element pins its own `line-height` to defeat a global button `line-height` that otherwise collapsed multi-line rows.

### New — tooling & tests
- **`apps/mario-kart/scripts/sync-courses.mjs`** — validate (`--check`, CI-friendly), normalize + restamp `lastSynced` (`--write`), and a documented **remote-source seam** (`--source=remote`, `MK_COURSES_URL`) for future automation. Validates required fields, non-empty cups, and that a reused course id always carries the same name.
- **`apps/mario-kart/tests/courses.test.js`** — 11 tests: dataset integrity, variant dedupe/merge, `groupByCup` order, ranking (prefix beats substring, punctuation/initials), `scoreCourse` zero on no-match, `normalizeDataset` rejection, recents ordering/cap, favorites toggle.

### Modified
- **`apps/mario-kart/index.html`** — adds `course-picker.css` link (after `refresh.css`), the `#sidebar-course-picker` container in the race form, and `courseData.js` + `coursePicker.js` script tags (before `dataManager.js`).
- **`apps/mario-kart/js/dataManager.js`** — `addRace` captures `courseId`/`course` from the picker onto the race object (optional, backward compatible), then commits the recent + clears the picker on success.
- **`apps/mario-kart/js/main.js`** — initializes the picker on `DOMContentLoaded`; renders a "🗺️ course" badge under the date in the history table and in mobile cards (guarded — absent when no course).
- **`apps/mario-kart/js/gameVersionManager.js`** — repopulates the picker on MK8D ↔ MK World switch.
- **`package.json`** — adds `sync:mario-kart-courses` script.

## Deliberate non-changes / scope
- The race **data model is only additively extended** (`course`/`courseId` optional); existing races and import/export are untouched and still valid.
- Course data is **not yet** used in statistics, achievements, filters, or the edit-race modal — capture + display only, by design for this first slice.
- MK8D Booster Course Pass (48 DLC courses) intentionally not vendored yet; the sync script is the path to add them.

## Judgment calls
- **Vendored JSON + abstraction + sync script** over consuming a live API (none exists for courses), runtime scraping (fragile/CORS on a static host), or an admin tool (overkill for ~60 rows). Keeps it offline-reliable with a one-line swap to a remote source later.
- Course stored as **id + name** so history stays readable even if a course later leaves the dataset.
- Picker styled against the literal `--mk-*` refresh palette rather than the `theme.css` vars, because the dark sidebar is painted by `refresh.css` literals (the theme vars resolve light) — caught via computed-style probing during mobile verification.

## Testing
- `npm test` — **907/907 pass** (11 new course tests + existing suite).
- `npm run sync:mario-kart-courses -- --check` — passes (mkworld 8 cups/30 courses complete; mk8d 8 cups/32 courses partial).
- Screenshot-verified on desktop (1280) and mobile (390): picker open, ranked search with highlighting + result count, keyboard ArrowDown moving the active row (verified active = "Dolphin Shoals" at index 3), recent/favorite chips, MK World game-switch repopulation (Crown City showing merged "Mushroom Cup / Shell Cup"), and the history course badge after saving a race.---

## Update — command-palette redesign (2nd commit)

Reworked the selector per a design review (scanability / lower cognitive load). Same files as above; behavioral/visual refinements:

- **`coursePicker.js`** — two-line informative closed trigger (course name + cup, or "Choose a course / Optional"); one unified panel surface with integrated borderless sticky search + result count; a single uniform row used everywhere (recents/favorites no longer chips); inline NEW badge that never shifts layout; unmistakable persistent selected state (accent bar + tint + check) distinct from hover/keyboard-active; removed repetitive `title` tooltips (aria-labels kept).
- **`courseData.js`** — `scoreCourse` now also matches the **source game** (substring + initials), and `load()` tags each course with its effective game, so "mk8" finds Mario Kart 8 Deluxe tracks while "dk"/"ship" keep working.
- **`course-picker.css`** — command-palette restyle: course name is the hero (brightest/boldest), cup secondary, game tertiary; quiet section headers; thin unobtrusive scrollbar; favorite star subtle by default and **gold when active** (forced with `!important` to beat a global `button { color … !important }` that was graying it — caught via computed-style probe).
- **`tests/courses.test.js`** — +3 tests (abbreviation/game-source scoring). Full suite green (**909**).

Re-verified desktop + mobile: two-line closed trigger, command-palette open list, forgiving "mk8" search (16 results), gold favorite (probe: `rgb(245,158,11)`), and keyboard-active distinct from selected.---

## Update — desktop command-palette course browser (3rd commit)

The picker is now responsive: **mobile keeps the inline dropdown**; **desktop (≥760px) opens a centered Spotlight-style overlay**.

- **`coursePicker.js`** — `open()` branches to inline vs modal; both share row rendering, ranking, filters, and keyboard logic. Desktop modal: large teaching search header, empty-state hint + Recent Searches chips, quick filters (All / Favorites / Recent / New / per source game) combinable with the query, live result count, two-column results + **live preview pane** (cup / game / status / favorite toggle / Select), keyboard legend, backdrop+Esc close, and a viewport-boundary guard. The modal is appended to `<body>` (escapes the sidebar transform/overflow) and carries `.course-picker` so shared row styles apply.
- **`courseData.js`** — recent-search-term history (`getRecentSearches` / `pushRecentSearch`), per game version.
- **`course-picker.css`** — full palette styling (backdrop, big search, filter/recent chips, two-column body, preview card, footer). Inline mobile styles unchanged.
- **`tests/courses.test.js`** — +1 (recent-search history). Suite green (**910**).

Verified at 1280px (empty state, "rainbow" search with live preview, Favorites filter showing "3 courses" with gold stars) and 390px (still the inline dropdown — `modal-in-body=false`).---

## Update — desktop polish + containment (4th commit)

- **Scroll containment**: background page scroll is locked while the palette is open (restored on close), and `overscroll-behavior: contain` stops scroll from chaining out of the results/preview.
- **Focus trap**: Tab / Shift+Tab cycle within the modal (wrap first↔last); Esc closes from anywhere inside. Arrow-key-driven course/favorite rows (`tabindex="-1"`) are excluded from the tab ring. Verified: 5 tabbables, both wrap directions, `body.overflow=hidden`.
- **Visual refinement** (per design feedback): contained premium search field, dividers replaced by whitespace, chips trimmed to All/Favorites/Recent/New and quietened, sticky accent-tick cup headers, game source as a distinct pill, vivid accent-gradient selected row, a richer/narrower preview card with a colored hero + tag chips + gradient Select, a barely-there footer, and a thin gradient accent bar across the modal top. Mobile inline dropdown unchanged.

Suite green (910).---

## Update — density & clarity pass (5th commit)

Acting on a detailed UX review of the desktop palette (wins shared with mobile):

- **No more duplicates**: default list is cups-only; Recent & Favorites are filter tabs, now with **live counts** (All/Favorites/Recent/New).
- **Denser, uniform rows**: name (hero) + cup only. Removed the per-row NEW badge and game-origin pill (noise + inconsistency); origin/status moved to the preview. Fixed an inflated row height (pinned the cup line-height vs the global button line-height).
- **Separated states**: faint hover/active vs a vivid selected (accent tint + left bar + brighter name + check, no glow); brighter sticky cup headers with an accent tick; more discoverable favorite star.
- **Search**: shorter placeholder, in-field clear (×) button, lowercase "esc".
- **Preview is title-first**: large name, small new/returning pill (no banner), readable labeled Cup/Game rows, subtle favorite, modest Select (reads "Selected" for the current course). Panel + modal narrowed (640px).
- **Polish/a11y**: fewer gradients/glows, whitespace over dividers, higher-contrast secondary text, wider/higher-contrast scrollbar, focus-visible outlines, `role="group"` + aria-labels on cup sections.

Verified desktop (empty / search + selected preview) and mobile (inline, denser rows, clear + count). Suite green (910).---

## How to update course data

Courses are vendored in `apps/mario-kart/data/courses.json` and read through a swappable source (`js/courseData.js` → `CourseDataConfig`). No live API to break. Run commands from the repo root. (Also documented in `apps/mario-kart/README.md`.)

**Option A — add/edit a course by hand (most common)**
1. Open `apps/mario-kart/data/courses.json`.
2. Pick the game under `games`: `mk8d` or `mkworld`.
3. In that game's `cups` array, find the cup (or add `{ "id": "...", "name": "... Cup", "courses": [] }`).
4. Add the course to the cup's `courses`:
   ```json
   { "id": "dry-bones-burnout", "name": "Dry Bones Burnout", "origin": "new", "aliases": ["dbb"] }
   ```
   - `id`: unique, kebab-case, stable — never reuse for a different course. A course in two cups must use the **same id and name** in both (that is how variants like Crown City merge).
   - `origin`: `"new"`, or the source game (e.g. `"Mario Kart 64"`) — drives the New filter + preview.
   - `aliases`: optional; search already handles punctuation/initials ("dk", "mk8", "rr").
5. (Optional) bump that game's `source.lastSynced` / set `source.complete: true`.
6. Validate: `npm run sync:mario-kart-courses -- --check` → `Validation passed.`
7. Test: `npm test` (integrity checks in `tests/courses.test.js`).
8. Verify in-app: Add Race → Course → confirm it appears/searches.

**Option B — sync script**
- Validate (CI): `npm run sync:mario-kart-courses -- --check`
- Normalize + restamp `lastSynced` + write: `node apps/mario-kart/scripts/sync-courses.mjs --write`
- Remote (future): implement `SOURCES.remote` in `scripts/sync-courses.mjs`, then `MK_COURSES_URL=<url> node apps/mario-kart/scripts/sync-courses.mjs --source=remote --write`.

**Swap the data source** — edit `js/courseData.js` → `CourseDataConfig.active` (`'static'` → a `'remote'` entry with a `url`). Picker/search/recents/favorites need no changes.

> MK8 Deluxe is `source.complete: false` (the 48 Booster Course Pass tracks aren't vendored yet) — add them as new cups the same way.