### PR TITLE
feat(gym-tracker): scheduling display, richer welcome tour, single-tap feel, slim rest timer, sticky modal header + workout/nav fixes

### DIFF
--- a/apps/gym-tracker/README.md
+++ b/apps/gym-tracker/README.md
@@ -13,12 +13,15 @@ A comprehensive, mobile-first workout tracking application built with vanilla Ja
 - **Custom Exercises**: Create and manage your own custom exercises
 - **Workout History**: Complete history of all workouts with detailed stats, numbered pagination, and clickable workout details
 - **Progress Tracking**: View previous workout data (all sets) during current workout for progression
-- **Calendar View**: Visual representation of workout days with progress indicators (week starts Monday)
+- **Calendar View**: Visual representation of workout days with progress indicators (first day of week is configurable, Sunday or Monday)
+- **Program Scheduling**: Assign weekdays to a program; the days show on the program tiles, as markers on the calendar, and as a week strip at the top of the workout screen
+- **Welcome Tour**: A single scrollable onboarding modal that explains the core features, with quick links into Programs, Workout, Calendar, and Settings; replayable any time from Settings
+- **Quick Start**: A floating "Start workout" button on desktop (visible across views; hidden on the active-workout screen) that starts or resumes a workout from anywhere
 - **Achievements**: Unlock achievements for reaching milestones (daily, weekly, monthly, lifetime)
 
 ### 📊 Analytics & Stats
 
-- Weekly workout tracking (Monday-Sunday)
+- Weekly workout tracking (respects the configured first day of week)
 - Exercise frequency analysis
 - Personal records tracking (max weight, reps, volume per exercise)
 - Workout history with filtering and sorting
@@ -28,6 +31,7 @@ A comprehensive, mobile-first workout tracking application built with vanilla Ja
 ### ⚙️ Settings & Customization
 
 - Weight unit selection (kg/lb)
+- First day of week (Sunday or Monday)
 - Configurable rest timer
 - Post-workout metrics (heart rate, calories)
 - Dark theme optimized for gym use with improved text contrast
@@ -265,7 +269,6 @@ Users can create custom exercises with:
 
 ## Future Enhancements
 
-- [ ] Plate calculator for barbell exercises
 - [ ] Workout templates/presets
 - [ ] Exercise form videos/GIFs
 - [ ] Social features (share workouts)
@@ -274,11 +277,8 @@ Users can create custom exercises with:
 - [ ] Integration with fitness trackers
 - [ ] Progressive overload suggestions
 - [ ] Deload week tracking
-- [ ] Body measurements tracking
 - [ ] Nutrition logging
 - [ ] Workout reminders/notifications
-- [ ] Exercise superset grouping
-- [ ] Rest timer auto-start between sets
 
 ## Development
 

--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -895,6 +895,17 @@ body.gym-tracker #footer {
     font-size: 0.9rem;
 }
 
+/* Feature A: program tile schedule line — muted secondary, wraps with 7 days
+   so it never overflows a narrow tile. */
+.program-stats .stat.program-schedule-stat {
+    color: var(--text-secondary);
+    flex-wrap: wrap;
+    min-width: 0;
+}
+.program-stats .stat.program-schedule-stat i {
+    color: var(--text-secondary);
+}
+
 /* History card metric row — tabular numbers + muted icon so stats scan fast */
 #history-list .workout-card-stats {
     gap: 0.9rem 1.1rem;
@@ -1653,6 +1664,35 @@ body.modal-open {
                 0 3px 10px rgba(34, 197, 94, 0.35) !important;
 }
 
+/* Two-row workout header on narrow screens.
+   At full width the six header controls (end + unit toggle + plate/edit/pause/
+   finish) plus the program name + timer don't fit on one row; .workout-info
+   collapsed to 0 and the timer overlapped the unit toggle. Below 640px we wrap
+   into two rows: row 1 = end button + info (name + timer, left-aligned),
+   row 2 = the full action cluster. */
+@media (max-width: 640px) {
+    .workout-header {
+        flex-wrap: wrap;
+        align-items: center;
+        row-gap: 0.5rem;
+    }
+
+    .workout-info {
+        /* Sit next to the end button on row 1, take the remaining width. */
+        flex: 1 1 auto;
+        align-items: flex-start;
+        text-align: left;
+    }
+
+    .workout-header-actions {
+        /* Force onto its own row, right-aligned, allowed to wrap if even this
+           row runs out of room on the very narrowest devices. */
+        flex: 1 0 100%;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+    }
+}
+
 /* Mobile adjustments for workout header */
 @media (max-width: 400px) {
     .workout-header {
@@ -1722,6 +1762,17 @@ body.modal-open {
     padding-bottom: 90px; /* Extra space for bottom nav on mobile */
 }
 
+/* #17: when the between-exercise rest bar is visible on mobile it sits fixed
+   above the nav and would otherwise cover the last exercise's sets / Add-set /
+   finish row. Reserve room so the last actionable row clears the bar when
+   scrolled to the bottom. Sized for the slim bar (~44px) + its 12px gap above
+   the nav + the existing nav clearance, plus breathing room. */
+@media (max-width: 767px) {
+    body.gt-rest-bar-visible .workout-content {
+        padding-bottom: 168px;
+    }
+}
+
 /* Ensure exercise cards don't scroll behind the taller sticky header
    (site header ~52px + workout header ~80px + margin ≈ 140px).
    scroll-margin-top applies on scrollIntoView(); the scroll-padding-top
@@ -1769,6 +1820,70 @@ body.gym-tracker #active-workout .superset-block {
 @keyframes rest-bar-in {
     from { opacity: 0; transform: translate(-50%, 16px) scale(0.97); }
     to   { opacity: 1; transform: translate(-50%, 0) scale(1); }
+}
+
+/* On mobile the rest bar anchors LEFT and stops its right edge clear of the
+   back-to-top arrow (44px circle at right: 1.25rem), leaving a corner pocket so
+   the arrow can sit low beside it instead of being pushed above it. The right
+   inset = arrow right-offset (1.25rem) + arrow width (44px) + a gap (0.75rem),
+   so the bar never touches the arrow circle. The default rest-bar-in keyframe
+   translates by -50% and would yank this now-left-anchored bar off-screen, so
+   the mobile rule uses rest-bar-in-mobile (no translateX) instead. */
+@media (max-width: 767px) {
+    body.gym-tracker .rest-timer-bar {
+        left: 0.5rem;
+        right: calc(1.25rem + 44px + 0.75rem + env(safe-area-inset-right, 0px));
+        transform: none;
+        width: auto;
+        max-width: none;
+        animation-name: rest-bar-in-mobile;
+        /* #17: slim strip just above the nav. Slimmer bar -> tighter gap.
+           Right inset (arrow pocket) is intentionally unchanged. */
+        bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 12px);
+        border-radius: 12px;
+        box-shadow:
+            0 1px 0 rgba(255, 255, 255, 0.06) inset,
+            0 6px 18px rgba(0, 0, 0, 0.5);
+    }
+
+    /* #17: condense the inner layout into a slim strip. */
+    body.gym-tracker .rest-timer-bar-inner {
+        gap: 0.55rem;
+        padding: 0.4rem 0.55rem 0.5rem;
+    }
+    body.gym-tracker .rest-timer-info {
+        gap: 0.4rem;
+        font-size: 0.8rem;
+    }
+    body.gym-tracker .rest-timer-info i {
+        width: 18px;
+        height: 18px;
+        font-size: 0.8rem;
+    }
+    body.gym-tracker .rest-timer-label {
+        font-size: 0.58rem;
+    }
+    body.gym-tracker .rest-timer-value {
+        font-size: 1.1rem;
+        padding-left: 0.2rem;
+    }
+    body.gym-tracker .rest-timer-actions {
+        gap: 0.3rem;
+    }
+    body.gym-tracker .rest-timer-action-btn {
+        height: 30px;
+        min-width: 44px;
+        padding: 0 0.6rem;
+        font-size: 0.74rem;
+    }
+    body.gym-tracker .rest-timer-progress {
+        height: 3px;
+    }
+}
+
+@keyframes rest-bar-in-mobile {
+    from { opacity: 0; transform: translateY(16px) scale(0.97); }
+    to   { opacity: 1; transform: none; }
 }
 
 .rest-timer-bar.rest-timer-done {
@@ -1967,7 +2082,9 @@ body.gym-tracker #active-workout .superset-block {
     .rest-countdown-chip.rest-countdown-chip--urgent { animation: none; }
 }
 
-/* In-card rest countdown chip — dominant timer element in the rest row. */
+/* In-card rest countdown chip — dominant timer element in the rest row.
+   Item R2-3: one element, two states. Active (default below) is the live
+   colored countdown; --idle is the static gray between-set duration. */
 .rest-countdown-chip {
     display: inline-flex;
     align-items: center;
@@ -1980,6 +2097,14 @@ body.gym-tracker #active-workout .superset-block {
     border-radius: 999px;
     padding: 0.3rem 0.9rem;
     line-height: 1.4;
+}
+
+/* Idle: static gray duration, same size/position as the active countdown. */
+body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
+    color: var(--gt-muted);
+    background: rgba(255, 255, 255, 0.05);
+    border-color: rgba(255, 255, 255, 0.12);
+    animation: none;
 }
 
 /* Plate-hints toggle button — same sizing as other header btn-icons. */
@@ -3195,26 +3320,62 @@ body.gym-tracker #active-workout .superset-block {
 }
 
 /* Toast Notifications */
+/* Item R2-2/R2-8: the toast container is always pointer-transparent so an
+   empty (or finished) toast never blocks taps on the back-to-top arrow or
+   any control beneath it. */
+#toast-container {
+    pointer-events: none;
+}
+
+/* Item R2-8: restyled toast — design-system card surface, border, subtle
+   slide/fade. Non-interactive by default so it never intercepts taps; only
+   the optional action button re-enables pointer events. */
 .toast {
     position: fixed;
-    top: 80px;
-    right: 20px;
+    /* Sit clear of the fixed site header + the sticky workout header so a
+       toast never covers the workout controls (Item R2-8). */
+    top: 116px;
+    right: 16px;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
     background: var(--bg-card);
     color: var(--text-primary);
-    padding: var(--spacing-md) var(--spacing-lg);
+    padding: 0.7rem 1rem;
     border-radius: var(--radius-lg);
+    border: 1px solid var(--border-color);
+    border-left: 4px solid var(--accent-primary);
     box-shadow: var(--shadow-xl);
     z-index: 10100;
     opacity: 0;
-    transform: translateX(400px);
-    transition: all var(--transition-slow);
-    border-left: 4px solid var(--accent-primary);
-    max-width: 400px;
+    transform: translateY(-12px);
+    transition: opacity var(--transition-base), transform var(--transition-base);
+    max-width: min(360px, calc(100vw - 32px));
+    font-size: 0.9rem;
+    line-height: 1.4;
+    pointer-events: none;
+}
+
+.toast .toast-message {
+    font-variant-numeric: tabular-nums;
+}
+
+/* On mobile the workout header wraps to two rows and is taller, so the toast
+   sits lower to never cover its controls (Item R2-8). The JS-set inline `top`
+   only widens the initial offset; pin it lower here with !important so a toast
+   never lands on the header buttons. */
+@media (max-width: 600px) {
+    body.gym-tracker .toast {
+        top: 192px !important;
+        left: 16px;
+        right: 16px;
+        max-width: none;
+    }
 }
 
 .toast.show {
     opacity: 1;
-    transform: translateX(0);
+    transform: translateY(0);
 }
 
 .toast.toast-success {
@@ -3237,6 +3398,7 @@ body.gym-tracker #active-workout .superset-block {
 
 .toast .toast-action {
     flex-shrink: 0;
+    pointer-events: auto;
     background: transparent;
     color: var(--accent-primary);
     border: 1px solid var(--accent-primary);
@@ -6955,11 +7117,11 @@ button.calendar-day {
     transition: all 0.2s ease;
 }
 
-.quick-program-item[onclick] {
+.quick-program-item[data-action] {
     cursor: pointer;
 }
 
-.quick-program-item[onclick]:hover {
+.quick-program-item[data-action]:hover {
     background: var(--bg-hover);
     border-color: var(--accent-primary);
     transform: translateX(4px);
@@ -8007,7 +8169,109 @@ button.calendar-day {
  * First-run onboarding modal
  * ============================================================ */
 .onboarding-modal-content {
-    max-width: 460px;
+    max-width: 560px;
+    display: flex;
+    flex-direction: column;
+    max-height: 88vh;
+}
+
+/* Scrollable body — header + footer stay fixed outside the scroll. */
+.onboarding-body {
+    overflow-y: auto;
+    max-height: 70vh;
+    flex: 1 1 auto;
+}
+
+.onboarding-intro {
+    margin: 0 0 var(--spacing-md) 0;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.onboarding-section {
+    margin-bottom: var(--spacing-lg);
+}
+
+.onboarding-section:last-child {
+    margin-bottom: 0;
+}
+
+.onboarding-section-title {
+    margin: 0 0 var(--spacing-sm) 0;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent-primary);
+}
+
+.onboarding-items {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.onboarding-item {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+}
+
+.onboarding-item-icon {
+    flex: 0 0 auto;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--gradient-primary);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+}
+
+.onboarding-item-body {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.onboarding-item-title {
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 2px 0;
+    font-size: 0.95rem;
+}
+
+.onboarding-item-desc {
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.45;
+}
+
+.onboarding-item-cta {
+    flex: 0 0 auto;
+    align-self: center;
+}
+
+@media (max-width: 767px) {
+    .onboarding-body {
+        max-height: 68vh;
+    }
+    .onboarding-item {
+        gap: var(--spacing-sm);
+    }
+    .onboarding-item-cta {
+        align-self: flex-start;
+    }
 }
 
 .onboarding-steps {
@@ -9171,6 +9435,26 @@ button.calendar-day {
 }
 
 /* Summary stat grid */
+/* Item R2-8: inline "log a set first" message inside the finish modal. */
+.finish-inline-message {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-bottom: var(--spacing-md);
+    padding: 0.75rem 0.9rem;
+    border-radius: var(--radius-md);
+    background: rgba(245, 158, 11, 0.12);
+    border: 1px solid rgba(245, 158, 11, 0.4);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+.finish-inline-message i {
+    color: #f59e0b;
+    font-size: 1.05rem;
+    flex-shrink: 0;
+}
+
 .workout-summary {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -9495,3 +9779,540 @@ button.calendar-day {
     outline-offset: 2px;
 }
 
+
+/* On mobile the back-to-top arrow tucks LOW, hugging just above the fixed
+   bottom-nav band, in ONE fixed position for every view and every state. It
+   reads like the desktop corner button, but referenced to the nav top instead
+   of the screen bottom. The arrow no longer lifts when the between-exercise
+   rest bar appears: the rest bar is narrowed on mobile (see .rest-timer-bar
+   override) to leave a right-corner pocket, so the two sit side by side, both
+   low, rather than stacked.
+
+   The tuck offset above --bottom-nav-height is chosen so the arrow's 44px
+   circle clears the nav's top edge by a real ~16-20px gap at 390x844 (the nav
+   renders ~2px taller than the 64px variable, so the gap runs slightly tight
+   of the nominal value). The arrow's `bottom` is intentionally NOT pinned
+   !important sitewide, so this gym-scoped override wins; other apps/pages are
+   untouched. Desktop (no bottom-nav) keeps the sitewide corner position. */
+@media (max-width: 767px) {
+    body.gym-tracker .back-to-top {
+        bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 1.25rem);
+    }
+}
+
+/* ============================================================
+   Wave 2 additions (Items 3, 4, 5, 7, 8, 9)
+   New interactive elements pin their own hover/focus colors so the
+   sitewide button:hover red can't bleed in.
+   ============================================================ */
+
+/* Item 3: Edit-program header button — purple/secondary accent. */
+.workout-header .btn-icon-edit-program {
+    background: rgba(108, 99, 255, 0.10) !important;
+    border-color: rgba(108, 99, 255, 0.30) !important;
+    color: #8b85ff !important;
+}
+.workout-header .btn-icon-edit-program:hover,
+.workout-header .btn-icon-edit-program:focus-visible {
+    background: rgba(108, 99, 255, 0.20) !important;
+    border-color: rgba(108, 99, 255, 0.55) !important;
+    color: #a39dff !important;
+}
+
+/* Item 8: per-session unit toggle (kg | lbs) in the workout header. */
+.workout-unit-toggle {
+    display: inline-flex;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: var(--bg-elevated);
+    height: 44px;
+}
+.workout-unit-btn {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    color: var(--text-secondary);
+    font: inherit;
+    font-weight: 600;
+    font-size: 0.85rem;
+    padding: 0 0.7rem;
+    min-width: 40px;
+    cursor: pointer;
+    transition: background var(--transition-base), color var(--transition-base);
+}
+.workout-unit-btn + .workout-unit-btn {
+    border-left: 1px solid var(--border-color);
+}
+.workout-unit-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+.workout-unit-btn.is-active {
+    background: #6c63ff;
+    color: #ffffff;
+}
+.workout-unit-btn.is-active:hover {
+    background: #5b53e6;
+    color: #ffffff;
+}
+.workout-unit-btn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 2px rgba(108, 99, 255, 0.55);
+}
+
+/* Item 4: Return-to-workout button in the program editor footer. */
+.btn.btn-return-workout {
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    border: 1px solid transparent;
+    color: #ffffff;
+    box-shadow: 0 3px 10px rgba(34, 197, 94, 0.3);
+}
+.btn.btn-return-workout:hover,
+.btn.btn-return-workout:focus-visible {
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    border-color: transparent;
+    color: #ffffff;
+    filter: brightness(1.07);
+    box-shadow: 0 5px 14px rgba(34, 197, 94, 0.45);
+}
+
+/* Item 5: Leave-workout modal primary action. */
+.btn.btn-leave-workout {
+    background: rgba(251, 191, 36, 0.14);
+    border: 1px solid rgba(251, 191, 36, 0.5);
+    color: #f0b429;
+}
+.btn.btn-leave-workout:hover,
+.btn.btn-leave-workout:focus-visible {
+    background: rgba(251, 191, 36, 0.24);
+    border-color: rgba(251, 191, 36, 0.7);
+    color: #fbbf24;
+}
+
+/* Item R3-4: the chosen-feel toggle icon on the exercise header. Colors are
+   pinned with !important to defeat the sitewide main.css `button` color/hover
+   rules. Tapping cycles good -> bad -> none. */
+.feel-toggle {
+    appearance: none;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    margin-left: 0.4rem;
+    padding: 0;
+    font-size: 0.95em;
+    vertical-align: middle;
+    line-height: 1;
+    box-shadow: none !important;
+    transition: color var(--transition-base), transform var(--transition-base);
+}
+/* Pin on BOTH the button and its <i>: main.css `button { color:#555 !important }`
+   does not reach the <i> directly, but raising specificity on the icon keeps
+   the green reliable regardless of inheritance order. */
+.feel-toggle-good,
+.feel-toggle-good i { color: #22c55e !important; }
+.feel-toggle-good:hover,
+.feel-toggle-good:focus-visible,
+.feel-toggle-good:hover i,
+.feel-toggle-good:focus-visible i { color: #16a34a !important; }
+.feel-toggle-good:hover,
+.feel-toggle-good:focus-visible { transform: scale(1.1); }
+.feel-toggle:focus-visible { outline: none; }
+
+/* Item 7: last-feel icon next to the exercise name. */
+.feel-history {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 0.4rem;
+    font-size: 0.9em;
+    vertical-align: middle;
+}
+/* !important + the <i> target so the sitewide main.css `h3 { color:#555 }`
+   inheritance (the history icon lives inside the exercise-header <h3>) cannot
+   wash the smiley back to gray. Good stays green. */
+.feel-history-good,
+.feel-history-good i { color: #22c55e !important; }
+
+/* Item R3-4: the feel picker modal. The intro copy + the single "Felt good"
+   icon button (the only choice) + "Not yet". */
+.feel-intro-lead {
+    margin: 0 0 var(--spacing-md);
+    color: var(--text-secondary);
+    text-align: center;
+}
+.feel-modal-choices {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+}
+/* Pinned colors with !important to defeat the sitewide button color/hover. */
+.feel-modal-btn {
+    appearance: none;
+    flex: 1 1 0;
+    max-width: 160px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem 0.75rem;
+    border-radius: var(--radius-lg);
+    border: 1.5px solid transparent;
+    cursor: pointer;
+    font-size: 2.2rem;
+    box-shadow: none !important;
+    transition: background var(--transition-base), border-color var(--transition-base),
+                color var(--transition-base), transform var(--transition-base);
+}
+.feel-modal-btn-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+.feel-modal-btn-good {
+    background: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.5);
+    color: #22c55e !important;
+}
+.feel-modal-btn-good i { color: #22c55e !important; }
+.feel-modal-btn-good:hover,
+.feel-modal-btn-good:focus-visible {
+    background: rgba(34, 197, 94, 0.22);
+    border-color: rgba(34, 197, 94, 0.8);
+    color: #16a34a !important;
+    transform: translateY(-2px);
+}
+.feel-modal-btn-good:hover i,
+.feel-modal-btn-good:focus-visible i { color: #16a34a !important; }
+.feel-modal-btn:focus-visible { outline: none; }
+
+/* Item 9: weekday chips in the program editor. */
+.program-schedule-days {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.35rem;
+}
+.schedule-day-chip {
+    appearance: none;
+    border: 1px solid var(--border-color);
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: 0.82rem;
+    font-weight: 600;
+    padding: 0.35rem 0.6rem;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: background var(--transition-base), border-color var(--transition-base),
+                color var(--transition-base);
+}
+.schedule-day-chip:hover {
+    background: var(--bg-hover);
+    border-color: var(--border-light);
+    color: var(--text-primary);
+}
+.schedule-day-chip.is-on {
+    background: #6c63ff;
+    border-color: #6c63ff;
+    color: #ffffff;
+}
+.schedule-day-chip.is-on:hover {
+    background: #5b53e6;
+    border-color: #5b53e6;
+    color: #ffffff;
+}
+.schedule-day-chip:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.35);
+}
+.program-schedule-label {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 0.2rem;
+}
+
+/* Item 9: calendar schedule marker (distinct from the workout dot/PR star).
+   Positioned bottom-left to avoid overlapping the day number (top-right),
+   PR star (top-left) and workout dot (bottom-center). */
+.calendar-day-schedule {
+    position: absolute;
+    bottom: 0.3rem;
+    left: 0.35rem;
+    font-size: 0.55rem;
+    color: #8b85ff;
+    opacity: 0.85;
+    pointer-events: none;
+}
+.calendar-day.selected .calendar-day-schedule,
+.calendar-day.today .calendar-day-schedule {
+    color: #b9b4ff;
+}
+.calendar-scheduled-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin: 0.5rem 0;
+}
+.calendar-scheduled-item {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    padding: 0.4rem 0.55rem;
+    border: 1px dashed rgba(108, 99, 255, 0.4);
+    border-radius: var(--radius-md);
+    background: rgba(108, 99, 255, 0.07);
+}
+.calendar-scheduled-item i { color: #8b85ff; }
+.legend-schedule-cue { color: #8b85ff; }
+
+/* ============================================================
+   Round 2 Wave B additions
+   ============================================================ */
+
+/* Item R2-6: week strip on the workout selection screen. */
+.week-strip {
+    margin: 0 0 1.25rem;
+    padding: 0.85rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+}
+.week-strip-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 0.4rem;
+}
+.week-strip-day {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 0;
+    padding: 0.4rem 0.25rem;
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid transparent;
+}
+.week-strip-day.is-today {
+    background: rgba(108, 99, 255, 0.12);
+    border-color: rgba(108, 99, 255, 0.45);
+}
+.week-strip-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+.week-strip-day.is-today .week-strip-label { color: #b3adff; }
+.week-strip-entries {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    width: 100%;
+    align-items: center;
+    min-height: 1.1rem;
+}
+.week-strip-empty { color: var(--text-muted, #666); font-size: 0.85rem; }
+.week-strip-program {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    max-width: 100%;
+    padding: 0.2rem 0.3rem;
+    border: none;
+    border-radius: var(--radius-sm, 6px);
+    background: rgba(108, 99, 255, 0.10) !important;
+    color: var(--text-primary) !important;
+    cursor: pointer;
+    font-size: 0.66rem;
+    line-height: 1.1;
+    transition: background var(--transition-fast);
+}
+.week-strip-program:hover {
+    background: rgba(108, 99, 255, 0.22) !important;
+    color: var(--text-primary) !important;
+}
+.week-strip-program:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 1px;
+}
+.week-strip-day.is-today .week-strip-program {
+    background: rgba(108, 99, 255, 0.28) !important;
+    font-weight: 600;
+}
+.week-strip-day.is-today .week-strip-program:hover {
+    background: rgba(108, 99, 255, 0.4) !important;
+}
+.week-strip-dot {
+    flex: 0 0 auto;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #8b85ff;
+}
+.week-strip-program-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Item R2-9: unsaved-settings guard modal. Pin button colors so the sitewide
+   button:hover red cannot bleed into these controls. */
+.unsaved-settings-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-md) var(--spacing-lg);
+}
+#unsaved-settings-save,
+#unsaved-settings-save:hover,
+#unsaved-settings-save:focus {
+    background: var(--accent-primary) !important;
+    color: #ffffff !important;
+}
+#unsaved-settings-save:hover { filter: brightness(1.08); }
+#unsaved-settings-discard:hover,
+#unsaved-settings-discard:focus {
+    color: var(--text-primary) !important;
+    background: var(--bg-hover) !important;
+}
+
+/* Item R2-9: settings save control in a sticky header bar, always visible
+   while the settings form scrolls under it. Mirrors the workout header's
+   offset so it sits fully below the fixed site header. */
+.settings-view-header {
+    position: sticky;
+    top: 3.25rem;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.6rem;
+    margin-bottom: var(--spacing-lg);
+    padding: 0.7rem 0.85rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+}
+/* Solid bright title inside the card-surfaced sticky header (the sitewide
+   gradient-clip h1 has too little contrast on the card background). */
+.settings-view-header h1 {
+    background: none !important;
+    -webkit-background-clip: border-box !important;
+    background-clip: border-box !important;
+    -webkit-text-fill-color: #ffffff !important;
+    color: #ffffff !important;
+    font-size: 1.5rem !important;
+    line-height: 1.2;
+}
+@media (min-width: 768px) {
+    .settings-view-header h1 { font-size: 1.85rem !important; }
+}
+.settings-view-header .btn-save-settings {
+    margin: 0;
+    white-space: nowrap;
+    width: 100%;
+    justify-content: center;
+}
+/* Desktop: title and Save on one row. */
+@media (min-width: 768px) {
+    .settings-view-header {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        gap: var(--spacing-md);
+        padding: 0.65rem 0.85rem;
+    }
+    .settings-view-header .btn-save-settings {
+        width: auto;
+        flex: 0 0 auto;
+    }
+}
+
+/* Item R2-7: mid-workout program editor sticky header action bar. */
+.program-modal-workout-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.program-modal-workout-actions[hidden] { display: none; }
+.program-modal-workout-actions .btn { white-space: nowrap; }
+
+/* In workout mode: pin the header to the top of the scrolling modal content,
+   hide the footer save/return cluster and the corner X (the two header actions
+   are the only controls). */
+#program-modal.program-editor-workout-mode .program-modal-header {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+#program-modal.program-editor-workout-mode .modal-close {
+    display: none;
+}
+#program-modal.program-editor-workout-mode .program-form-actions {
+    display: none;
+}
+/* Pin the header action button colors so the sitewide button red can't bleed. */
+#program-modal-save-resume,
+#program-modal-save-resume:hover,
+#program-modal-save-resume:focus {
+    background: var(--accent-primary) !important;
+    color: #ffffff !important;
+}
+#program-modal-save-resume:hover {
+    filter: brightness(1.08);
+}
+#program-modal-cancel-workout:hover,
+#program-modal-cancel-workout:focus {
+    color: var(--text-primary) !important;
+    background: var(--bg-hover) !important;
+}
+
+/* Feature B: normal create/edit mode also pins Save + Cancel in a sticky
+   header at the top of the scrolling modal. Mirrors the R2-7 workout-mode
+   layout for normal entry. */
+.program-modal-normal-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.program-modal-normal-actions[hidden] { display: none; }
+.program-modal-normal-actions .btn { white-space: nowrap; }
+
+/* Pin the header in normal mode too (the R2-7 rule only stickies workout mode).
+   Both modes now use the header for actions, so the header is always sticky. */
+#program-modal .program-modal-header {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+
+/* The bottom form actions are now redundant in both modes — the header carries
+   Save + Cancel. Hide the footer cluster for this modal entirely. */
+#program-modal .program-form-actions {
+    display: none;
+}
+
+/* Pin the header Save button accent color against the sitewide red button bleed
+   (mirrors #program-modal-save-resume). .btn-save-program already gets the
+   primary gradient, but assert it here in the header context too. */
+.program-modal-normal-actions .btn-save-program,
+.program-modal-normal-actions .btn-save-program:hover,
+.program-modal-normal-actions .btn-save-program:focus {
+    background: var(--gradient-primary) !important;
+    color: #ffffff !important;
+}

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -588,30 +588,25 @@ body.gym-tracker .exercise-entry.exercise-collapsed .exercise-body {
     display: none;
 }
 
-/* Per-exercise rest adjusters (between-set + after-exercise) */
+/* Item R2-3: between-set rest chip row (idle gray duration / live countdown). */
 body.gym-tracker .rest-row {
     margin-bottom: 0.5rem;
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
     gap: 0.4rem;
 }
 
-body.gym-tracker .rest-adjuster {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    background: var(--gt-surface-2);
-    border: 1px solid var(--gt-border);
-    border-radius: 20px;
-    padding: 0.15rem 0.4rem;
+body.gym-tracker .rest-row .rest-countdown-chip {
+    grid-column: 2;
+    grid-row: 1;
 }
 
-body.gym-tracker .rest-adj-label {
-    font-size: 0.68rem;
-    color: var(--gt-muted-2);
-    white-space: nowrap;
-    padding: 0 0.15rem;
+body.gym-tracker .rest-row .btn-icon-plates--per-ex {
+    grid-column: 3;
+    grid-row: 1;
+    justify-self: end;
+    margin-left: 0;
 }
 
 /* Per-exercise plate-hints toggle (inline in rest-row) */
@@ -645,66 +640,6 @@ body.gym-tracker .btn-icon-plates--per-ex.btn-icon-plates--off:hover {
     border-color: var(--gt-border);
     color: var(--gt-muted) !important;
     opacity: 0.6;
-}
-
-body.gym-tracker .rest-adjuster--display-only {
-    opacity: 0.75;
-}
-
-/* Hide both rest-adjuster pills while a between-set rest is active for this exercise. */
-body.gym-tracker .rest-row--resting .rest-adjuster {
-    display: none;
-}
-
-/* While resting, switch the row to a 3-column grid so the countdown chip is
-   truly centered whether or not the plate-hints toggle is present. The toggle
-   keeps its right-edge slot; its flex-era margin-left:auto is cancelled. */
-body.gym-tracker .rest-row--resting {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-}
-
-body.gym-tracker .rest-row--resting .rest-countdown-chip {
-    grid-column: 2;
-    grid-row: 1;
-}
-
-body.gym-tracker .rest-row--resting .btn-icon-plates--per-ex {
-    grid-column: 3;
-    grid-row: 1;
-    justify-self: end;
-    margin-left: 0;
-}
-
-body.gym-tracker .rest-adj-btn {
-    background: none;
-    border: none;
-    color: var(--gt-muted) !important;
-    font-size: 0.72rem;
-    font-weight: 600;
-    cursor: pointer;
-    padding: 0.1rem 0.25rem;
-    min-width: 28px;
-    min-height: 28px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 999px;
-    transition: color var(--transition-fast), background var(--transition-fast);
-}
-body.gym-tracker .rest-adj-btn:hover {
-    color: var(--gt-accent);
-    background: var(--gt-accent-soft);
-}
-
-body.gym-tracker .rest-adj-value {
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--gt-muted);
-    font-variant-numeric: tabular-nums;
-    min-width: 2.5rem;
-    text-align: center;
 }
 
 /* Uniform rest-between message in sticky workout header */
@@ -1341,7 +1276,12 @@ body.gym-tracker .settings-section {
     gap: 1rem;
     margin-bottom: 1rem;
     position: relative;
-    overflow: hidden;
+    /* R3-8: must NOT clip content. overflow:hidden here cropped the open
+       Time format / Week start DarkSelect popups (their second option fell
+       below the section box and became invisible/unclickable). The decorative
+       ::before gradient is self-rounded (inset:0 + border-radius:inherit), so
+       it stays within the rounded card without the parent clipping. */
+    overflow: visible;
 }
 
 body.gym-tracker .settings-section::before {
@@ -1351,6 +1291,9 @@ body.gym-tracker .settings-section::before {
     background: linear-gradient(135deg, rgba(129,140,248,0.03) 0%, transparent 50%);
     pointer-events: none;
     border-radius: inherit;
+    /* Clip the gradient to the rounded card on its own, independent of the
+       section's overflow (which must stay visible for popups). */
+    overflow: hidden;
 }
 
 /* Section header inside settings */
@@ -1535,12 +1478,57 @@ body.gym-tracker .onboarding-step-desc {
 }
 
 /* CTA button within step */
-body.gym-tracker .onboarding-step-cta .btn {
+body.gym-tracker .onboarding-step-cta .btn,
+body.gym-tracker .onboarding-item-cta .btn {
     height: 34px;
     padding: 0 0.9rem;
     font-size: 0.82rem;
     font-weight: 600;
     border-radius: 8px;
+}
+
+/* Rich tour: section headings + grouped item cards (mirror .onboarding-step*) */
+body.gym-tracker .onboarding-section-title {
+    color: var(--gt-accent) !important;
+}
+
+body.gym-tracker .onboarding-intro {
+    color: var(--gt-muted) !important;
+}
+
+body.gym-tracker .onboarding-item {
+    background: var(--gt-surface-2);
+    border: 1px solid var(--gt-border);
+    border-radius: 12px;
+    padding: 0.85rem 1rem;
+    gap: 0.9rem;
+    transition: border-color 0.15s ease;
+}
+
+body.gym-tracker .onboarding-item:hover {
+    border-color: var(--gt-border-strong);
+}
+
+body.gym-tracker .onboarding-item-icon {
+    width: 34px;
+    height: 34px;
+    background: var(--gt-accent-soft);
+    border: 1px solid rgba(129,140,248,0.3);
+    color: var(--gt-accent) !important;
+    border-radius: 50%;
+}
+
+body.gym-tracker .onboarding-item-title {
+    font-size: 0.92rem;
+    font-weight: 700;
+    color: var(--gt-text) !important;
+    margin-bottom: 0.1rem;
+}
+
+body.gym-tracker .onboarding-item-desc {
+    font-size: 0.82rem;
+    color: var(--gt-muted) !important;
+    line-height: 1.4;
 }
 
 /* Footer with Skip button */
@@ -1621,6 +1609,14 @@ body.gym-tracker .exercise-entry:hover {
 body.gym-tracker .exercise-entry.exercise-complete {
     border-color: rgba(52,211,153,0.35);
     box-shadow: 0 0 0 1px rgba(52,211,153,0.12) inset, var(--gt-shadow-card);
+}
+
+/* Item R3-5: a collapsed AND complete exercise gets a slight green tint so it
+   reads as "done" at a glance, distinct from collapsed-but-incomplete blocks.
+   Expanded complete exercises keep the plain card background (no regression). */
+body.gym-tracker .exercise-entry.exercise-complete.exercise-collapsed {
+    background: rgba(52,211,153,0.08);
+    border-color: rgba(52,211,153,0.45);
 }
 
 /* Exercise entry header */
@@ -2333,12 +2329,15 @@ body.gym-tracker .program-exercise-row.gt-exercise-added {
     animation: gt-exercise-added-glow 1.5s ease forwards;
 }
 
-/* Shared back-to-top button: ride above the mobile bottom-nav (same offset
-   the app's old scroll-top button used), so it never covers the nav's More
-   button. Desktop (>=768px) keeps the shared default corner position; the
-   bottom-nav is hidden there. */
+/* Shared back-to-top button: on mobile it tucks LOW, hugging just above the
+   bottom-nav, in one fixed position for every view and state (no longer lifts
+   when the rest bar appears; the rest bar is narrowed to leave a corner pocket
+   so the two sit side by side). Kept in sync with the rule in gym-tracker.css;
+   this file loads later, so it must carry the same value or it would silently
+   revert the position. Desktop (>=768px) keeps the shared default corner
+   position; the bottom-nav is hidden there. */
 @media (max-width: 767.98px) {
     body.gym-tracker .back-to-top {
-        bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 0.75rem);
+        bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 1.25rem);
     }
 }

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -195,11 +195,6 @@
                     <p class="subtitle">Track your fitness journey</p>
                 </div>
 
-                <button type="button" id="home-workout-fab" class="workout-fab" hidden aria-label="Start workout">
-                    <i class="fas fa-play" aria-hidden="true"></i>
-                    <span class="workout-fab-label">Start workout</span>
-                </button>
-
                 <!-- Active Program -->
                 <section class="section">
                     <div id="active-program-card" class="program-card">
@@ -278,8 +273,23 @@
                 <!-- Create/Edit Program Modal -->
                 <div id="program-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="program-modal-title">
                     <div class="modal-content" data-back-to-top>
-                        <div class="modal-header">
+                        <div class="modal-header program-modal-header">
                             <h2 id="program-modal-title">Create Program</h2>
+                            <!-- Item R2-7: in workout mode these two actions live in
+                                 the sticky header; the footer save/return are hidden. -->
+                            <div class="program-modal-workout-actions" id="program-modal-workout-actions" hidden>
+                                <button type="button" class="btn btn-ghost" id="program-modal-cancel-workout">Cancel</button>
+                                <button type="button" class="btn btn-primary" id="program-modal-save-resume">
+                                    <i class="fas fa-check"></i> Save and resume workout
+                                </button>
+                            </div>
+                            <!-- Feature B: normal create/edit actions, pinned in the sticky header. -->
+                            <div class="program-modal-normal-actions" id="program-modal-normal-actions" hidden>
+                                <button type="button" class="btn btn-ghost modal-close">Cancel</button>
+                                <button type="submit" class="btn btn-primary btn-save-program" form="program-form">
+                                    <i class="fas fa-check"></i> Save Program
+                                </button>
+                            </div>
                             <button class="modal-close" aria-label="Close">&times;</button>
                         </div>
                         <div class="modal-body">
@@ -298,6 +308,12 @@
                                 <div class="form-group">
                                     <label for="program-description">Description (Optional)</label>
                                     <textarea id="program-description" placeholder="Program details..." rows="3"></textarea>
+                                </div>
+
+                                <div class="form-group program-schedule-group">
+                                    <span class="program-schedule-label">Scheduled days (optional)</span>
+                                    <div id="program-schedule-days" class="program-schedule-days" role="group" aria-label="Scheduled days of the week"></div>
+                                    <p class="form-hint">Pick the days you plan to run this program. They show as markers in the calendar.</p>
                                 </div>
 
                                 <div class="form-group rest-mode-group">
@@ -339,6 +355,9 @@
 
                                 <div class="form-actions program-form-actions">
                                     <button type="button" class="btn btn-ghost modal-close">Cancel</button>
+                                    <button type="button" class="btn btn-return-workout" id="return-to-workout-btn" hidden>
+                                        <i class="fas fa-circle-arrow-left"></i> Return to workout
+                                    </button>
                                     <button type="submit" class="btn btn-primary btn-save-program">
                                         <i class="fas fa-check"></i> Save Program
                                     </button>
@@ -461,8 +480,15 @@
                             </div>
                         </div>
                         <div class="workout-header-actions">
+                            <div class="workout-unit-toggle" id="workout-unit-toggle" role="group" aria-label="Weight unit for this session">
+                                <button type="button" class="workout-unit-btn" id="workout-unit-kg" data-unit="kg" aria-pressed="false">kg</button>
+                                <button type="button" class="workout-unit-btn" id="workout-unit-lb" data-unit="lb" aria-pressed="false">lbs</button>
+                            </div>
                             <button class="btn-icon btn-icon-plates" id="plate-hints-toggle-btn" title="Set default plate hints on/off for all exercises" aria-label="Toggle default plate calculator hints" aria-pressed="true">
                                 <i class="fas fa-dumbbell"></i>
+                            </button>
+                            <button class="btn-icon btn-icon-edit-program" id="edit-program-btn" title="Edit program" aria-label="Pause and edit this program">
+                                <i class="fas fa-sliders"></i>
                             </button>
                             <button class="btn-icon btn-icon-pause" id="pause-workout-btn" title="Pause Workout" aria-label="Pause workout and save progress">
                                 <i class="fas fa-pause"></i>
@@ -513,6 +539,10 @@
                             </div>
                             <div class="modal-body">
                                 <form id="finish-workout-form">
+                                    <div class="finish-inline-message" id="finish-inline-message" role="alert" hidden>
+                                        <i class="fas fa-circle-info" aria-hidden="true"></i>
+                                        <span>Log at least one set before finishing your workout.</span>
+                                    </div>
                                     <div class="workout-summary">
                                         <div class="summary-stat">
                                             <span class="summary-stat-icon"><i class="fas fa-clock" aria-hidden="true"></i></span>
@@ -1045,8 +1075,11 @@
 
             <!-- SETTINGS VIEW -->
             <div id="settings-view" class="view">
-                <div class="view-header">
+                <div class="view-header settings-view-header">
                     <h1>Settings</h1>
+                    <button type="submit" form="settings-form" class="btn btn-save-settings" id="save-settings-btn" disabled>
+                        <i class="fas fa-check"></i> Save Settings
+                    </button>
                 </div>
 
                 <form id="settings-form" class="settings-form">
@@ -1096,6 +1129,39 @@
                                 <span class="toggle-slider" aria-hidden="true"></span>
                             </label>
                         </div>
+                        <div class="setting-item">
+                            <label for="timer-first-warning">First warning sound <small>(seconds left, 0 = off)</small></label>
+                            <input type="number" id="timer-first-warning" min="0" max="120" step="1" inputmode="numeric" placeholder="10">
+                        </div>
+                        <div class="setting-item">
+                            <label for="timer-countdown-start">Countdown start <small>(seconds left)</small></label>
+                            <input type="number" id="timer-countdown-start" min="1" max="60" step="1" inputmode="numeric" placeholder="5">
+                        </div>
+                    </section>
+
+                    <section class="settings-section">
+                        <header class="settings-section-header">
+                            <i class="fas fa-calendar-days settings-section-icon"></i>
+                            <div>
+                                <h2>Calendar</h2>
+                                <p class="settings-section-sub">How the planned weekly split appears in the calendar.</p>
+                            </div>
+                        </header>
+                        <div class="setting-item">
+                            <label for="first-day-of-week">Week starts on</label>
+                            <select id="first-day-of-week">
+                                <option value="0">Sunday</option>
+                                <option value="1">Monday</option>
+                            </select>
+                        </div>
+                        <div class="setting-item setting-item-toggle">
+                            <label for="show-program-schedule" class="setting-toggle-label">Show program schedule</label>
+                            <label class="toggle-switch" aria-label="Show program schedule toggle">
+                                <input type="checkbox" id="show-program-schedule">
+                                <span class="toggle-slider" aria-hidden="true"></span>
+                            </label>
+                        </div>
+                        <p class="settings-help-text">Adds your scheduled days to the calendar and the workout screen.</p>
                     </section>
 
                     <section class="settings-section">
@@ -1144,12 +1210,6 @@
                         </div>
                         <input type="file" id="import-file-input" accept=".json" style="display: none;">
                     </section>
-
-                    <div class="settings-actions">
-                        <button type="submit" class="btn btn-save-settings" id="save-settings-btn" disabled>
-                            <i class="fas fa-check"></i> Save Settings
-                        </button>
-                    </div>
                 </form>
             </div>
 
@@ -1193,12 +1253,37 @@
                 </div>
             </div>
         </main>
+
+        <!-- Global floating workout button (desktop only via CSS). Lives at
+             app-container level so it persists across all views, not just the
+             dashboard. Show/hide + label managed by app.updateGlobalFab(). -->
+        <button type="button" id="home-workout-fab" class="workout-fab" hidden aria-label="Start workout">
+            <i class="fas fa-play" aria-hidden="true"></i>
+            <span class="workout-fab-label">Start workout</span>
+        </button>
     </div>
 
     <div data-include="footer"></div>
 
     <!-- Toast Container -->
     <div id="toast-container"></div>
+
+    <!-- Item R2-9: Unsaved settings guard modal -->
+    <div id="unsaved-settings-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="unsaved-settings-title" aria-hidden="true">
+        <div class="modal-content small">
+            <div class="modal-header">
+                <h2 id="unsaved-settings-title">Unsaved settings</h2>
+                <button class="modal-close" id="unsaved-settings-close" aria-label="Close">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p>You have changes that have not been saved. What would you like to do?</p>
+            </div>
+            <div class="modal-footer unsaved-settings-actions">
+                <button type="button" class="btn btn-ghost" id="unsaved-settings-discard">Discard changes</button>
+                <button type="button" class="btn btn-primary" id="unsaved-settings-save">Save and leave</button>
+            </div>
+        </div>
+    </div>
 
     <!-- Onboarding Welcome Modal (first launch) -->
     <div id="onboarding-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="onboarding-title" aria-hidden="true">
@@ -1207,37 +1292,168 @@
                 <h2 id="onboarding-title">Welcome to Gym Tracker 💪</h2>
                 <button class="modal-close" id="onboarding-dismiss" aria-label="Close welcome">&times;</button>
             </div>
-            <div class="modal-body">
-                <p style="margin-top:0">Three quick steps to log your first workout:</p>
-                <ol class="onboarding-steps">
-                    <li class="onboarding-step">
-                        <span class="onboarding-step-number">1</span>
-                        <div class="onboarding-step-body">
-                            <p class="onboarding-step-title">Create a program</p>
-                            <p class="onboarding-step-desc">Name it (e.g. "Push Day") — it's a reusable template.</p>
-                        </div>
-                        <div class="onboarding-step-cta">
-                            <button class="btn btn-primary" id="onboarding-go-programs">Go</button>
-                        </div>
-                    </li>
-                    <li class="onboarding-step">
-                        <span class="onboarding-step-number">2</span>
-                        <div class="onboarding-step-body">
-                            <p class="onboarding-step-title">Add exercises</p>
-                            <p class="onboarding-step-desc">Pick from the built-in database or create your own.</p>
-                        </div>
-                    </li>
-                    <li class="onboarding-step">
-                        <span class="onboarding-step-number">3</span>
-                        <div class="onboarding-step-body">
-                            <p class="onboarding-step-title">Start a workout</p>
-                            <p class="onboarding-step-desc">Log sets, track progress, celebrate PRs 🏆</p>
-                        </div>
-                    </li>
-                </ol>
+            <div class="modal-body onboarding-body">
+                <p class="onboarding-intro">A quick tour of everything Gym Tracker can do, from building your first program to reviewing the trends after months of training.</p>
+
+                <section class="onboarding-section">
+                    <h3 class="onboarding-section-title">Getting started</h3>
+                    <ul class="onboarding-items">
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-dumbbell" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Create a program</p>
+                                <p class="onboarding-item-desc">Name it for the day or goal, like "Push" or "Leg Day". A program is a reusable template you build once and run every session.</p>
+                            </div>
+                            <div class="onboarding-item-cta">
+                                <button class="btn btn-primary" id="onboarding-go-programs">Go</button>
+                            </div>
+                        </li>
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-list-check" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Add exercises</p>
+                                <p class="onboarding-item-desc">Choose from hundreds of built-in exercises, filtered by muscle group or equipment. Don't see yours? Create a custom exercise in seconds.</p>
+                            </div>
+                        </li>
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-play" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Start a workout</p>
+                                <p class="onboarding-item-desc">Pick your program on the Workout tab and tap Start. Log each set as you go, weight and reps, right at the rack. Tap once to commit a planned set, or freestyle it.</p>
+                            </div>
+                            <div class="onboarding-item-cta">
+                                <button class="btn btn-primary" id="onboarding-go-workout">Go</button>
+                            </div>
+                        </li>
+                    </ul>
+                </section>
+
+                <section class="onboarding-section">
+                    <h3 class="onboarding-section-title">Plan smarter</h3>
+                    <ul class="onboarding-items">
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-calendar-days" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Schedule your program days</p>
+                                <p class="onboarding-item-desc">Assign weekdays to each program (Mon/Wed/Fri, for example). Scheduled days show as markers on the Calendar and as a week strip at the top of the workout screen.</p>
+                            </div>
+                        </li>
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-stopwatch" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Rest timers, your way</p>
+                                <p class="onboarding-item-desc">Set one rest time for the whole program (uniform mode) or a different rest per exercise (custom mode). A countdown bar runs between exercises so you never lose track.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </section>
+
+                <section class="onboarding-section">
+                    <h3 class="onboarding-section-title">During your workout</h3>
+                    <ul class="onboarding-items">
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-trophy" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">PR badges</p>
+                                <p class="onboarding-item-desc">Beat your all-time best weight or reps on any exercise and the set gets a gold PR badge on the spot. Your finish summary shows how many PRs you hit that session.</p>
+                            </div>
+                        </li>
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-calculator" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Plate calculator hints</p>
+                                <p class="onboarding-item-desc">For barbell exercises, a small hint below the weight field tells you exactly which plates to load on each side. Configure your bar weight and available plates in Settings.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </section>
+
+                <section class="onboarding-section">
+                    <h3 class="onboarding-section-title">After the workout</h3>
+                    <ul class="onboarding-items">
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-calendar-check" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Calendar</p>
+                                <p class="onboarding-item-desc">Every completed session lands on the Calendar. See your training history at a glance, tap any day to review what you lifted, and spot gaps in your consistency.</p>
+                            </div>
+                            <div class="onboarding-item-cta">
+                                <button class="btn btn-primary" id="onboarding-go-calendar">Open</button>
+                            </div>
+                        </li>
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-chart-bar" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Insights</p>
+                                <p class="onboarding-item-desc">A 4-week volume breakdown by muscle group shows where you are training hard and where you are skipping. A 12-month heatmap gives the full picture of your consistency.</p>
+                            </div>
+                        </li>
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-ruler" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Measurements</p>
+                                <p class="onboarding-item-desc">Log body weight, body fat %, and tape measurements (chest, waist, hips, arms, thighs). Each metric shows a sparkline and a 30-day delta so you can see the trend, not just the number.</p>
+                            </div>
+                        </li>
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-medal" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Achievements</p>
+                                <p class="onboarding-item-desc">Milestone badges for total workouts, volume lifted, weekly streaks, and more. Categories collapse so you can focus on what is in reach. They update automatically after every session.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </section>
+
+                <section class="onboarding-section">
+                    <h3 class="onboarding-section-title">Your data</h3>
+                    <ul class="onboarding-items">
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-sliders" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Units and preferences</p>
+                                <p class="onboarding-item-desc">Switch between kg and lbs at any time. Set your first day of the week, toggle sound and vibration cues for the rest timer, and configure the plate calculator in Settings.</p>
+                            </div>
+                            <div class="onboarding-item-cta">
+                                <button class="btn btn-primary" id="onboarding-go-settings">Open</button>
+                            </div>
+                        </li>
+                        <li class="onboarding-item">
+                            <span class="onboarding-item-icon"><i class="fas fa-file-export" aria-hidden="true"></i></span>
+                            <div class="onboarding-item-body">
+                                <p class="onboarding-item-title">Export and import</p>
+                                <p class="onboarding-item-desc">Your data lives on your device. Export a full JSON backup any time from Settings, and import it back on any browser. No account needed, no lock-in.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </section>
             </div>
             <div class="modal-footer" style="display:flex;justify-content:flex-end;padding:var(--spacing-md) var(--spacing-lg);gap:var(--spacing-sm);">
                 <button class="btn btn-ghost" id="onboarding-skip">Skip tour</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Feel picker (Item R3-4): the modal is the actual chooser, shown once
+         per exercise per session when all sets hit max reps. -->
+    <div id="feel-intro-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="feel-intro-title">
+        <div class="modal-content small feel-intro-modal-content">
+            <div class="modal-header">
+                <h2 id="feel-intro-title">All sets at max reps!</h2>
+                <button class="modal-close" id="feel-modal-skip" aria-label="Skip">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p class="feel-intro-lead">Felt strong on every set? Mark it so you know to try more weight next time.</p>
+                <div class="feel-modal-choices" role="group" aria-label="How did this exercise feel">
+                    <button type="button" class="feel-modal-btn feel-modal-btn-good" id="feel-modal-good"
+                        aria-label="Felt good, consider more weight next time">
+                        <i class="fas fa-face-smile" aria-hidden="true"></i>
+                        <span class="feel-modal-btn-label">Felt good</span>
+                    </button>
+                </div>
+            </div>
+            <div class="modal-footer" style="display:flex;justify-content:center;">
+                <button class="btn btn-ghost" id="feel-modal-skip-btn">Not yet</button>
             </div>
         </div>
     </div>
@@ -1261,6 +1477,25 @@
             <div class="modal-footer">
                 <button class="btn btn-ghost" id="confirm-modal-cancel">Cancel</button>
                 <button class="btn btn-danger" id="confirm-modal-confirm">Delete</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Leave-workout confirmation (back-navigation trap, Item 5) -->
+    <div id="leave-workout-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="leave-workout-modal-title">
+        <div class="modal-content small confirm-modal-content">
+            <div class="confirm-modal-icon">
+                <i class="fas fa-triangle-exclamation"></i>
+            </div>
+            <div class="modal-header">
+                <h2 id="leave-workout-modal-title">Leave workout?</h2>
+            </div>
+            <div class="modal-body">
+                <p>You have an active workout. Leaving now pauses it so you can resume later.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-ghost" id="leave-workout-stay">Stay</button>
+                <button type="button" class="btn btn-leave-workout" id="leave-workout-pause-leave">Pause and leave</button>
             </div>
         </div>
     </div>

--- a/apps/gym-tracker/js/app.js
+++ b/apps/gym-tracker/js/app.js
@@ -17,9 +17,10 @@ import { AchievementService } from './services/AchievementService.js';
 
 import { EXERCISE_DATABASE, loadExerciseDatabase } from '../data/exercises-db.js';
 import { showToast, debugLog } from './utils/helpers.js';
-import { trapModalFocus } from './utils/modal-focus.js';
+import { trapModalFocus, closeModalSafely } from './utils/modal-focus.js';
 import { mountSyncStatusPill } from './utils/sync-status.js';
 import { emit, EVENTS } from './utils/event-bus.js';
+import { sameId } from './utils/id-utils.js';
 
 class GymTrackerApp {
     constructor() {
@@ -71,6 +72,7 @@ class GymTrackerApp {
 
         // Set up event listeners
         this.setupEventListeners();
+        this.wireGlobalFab();
 
         // Initialize view controllers
         await this.initializeViews();
@@ -116,9 +118,12 @@ class GymTrackerApp {
         const modal = document.getElementById('onboarding-modal');
         if (!modal) return;
 
-        const close = () => {
-            modal.classList.remove('active');
-            modal.setAttribute('aria-hidden', 'true');
+        // Move focus OUT of the modal BEFORE it goes aria-hidden, otherwise
+        // the just-clicked CTA sits under aria-hidden and the browser logs
+        // "Blocked aria-hidden on an element because its descendant retained
+        // focus" (the R3-6 fix; closeModalSafely handles the focus shuffle).
+        const close = (restoreTo) => {
+            closeModalSafely(modal, restoreTo);
             storageService.markOnboardingSeen();
         };
 
@@ -128,10 +133,25 @@ class GymTrackerApp {
 
         document.getElementById('onboarding-dismiss')?.addEventListener('click', close, { once: true });
         document.getElementById('onboarding-skip')?.addEventListener('click', close, { once: true });
-        document.getElementById('onboarding-go-programs')?.addEventListener('click', () => {
-            close();
-            this.showView('programs');
-        }, { once: true });
+
+        const goTo = (id, view) => {
+            document.getElementById(id)?.addEventListener('click', () => {
+                close();
+                this.showView(view);
+                // The modal's body-scroll lock restores the pre-modal scroll
+                // offset on a deferred microtask as it tears down, which would
+                // otherwise land the destination view at that old offset
+                // (showView's synchronous scroll-to-top runs BEFORE the restore).
+                // Re-assert top on the next frame, after that teardown, so a CTA
+                // always lands at the top of its view. Dismiss/Skip intentionally
+                // keep the restore since they stay on the current view.
+                requestAnimationFrame(() => window.scrollTo(0, 0));
+            }, { once: true });
+        };
+        goTo('onboarding-go-programs', 'programs');
+        goTo('onboarding-go-workout', 'workout');
+        goTo('onboarding-go-calendar', 'calendar');
+        goTo('onboarding-go-settings', 'settings');
     }
 
     /**
@@ -378,7 +398,15 @@ class GymTrackerApp {
 
             e.preventDefault();
             const view = navBtn.dataset.view;
-            this.showView(view);
+            // Tapping the nav item for the view you're already on must still
+            // do something sensible rather than no-op (showView early-returns
+            // on same-view). Mobile-only "Workout" tap mid-session is the case
+            // that prompted this: re-assert + reveal the active workout.
+            if (view === this.currentView) {
+                this.reassertCurrentView(view);
+            } else {
+                this.showView(view);
+            }
         });
 
         // Empty-state CTAs across views (Dashboard, History, Workout) are
@@ -436,6 +464,15 @@ class GymTrackerApp {
             return;
         }
 
+        // Item R2-9: a leaving view may guard navigation (e.g. Settings with
+        // unsaved changes). The guard returns true to proceed now, or false to
+        // defer: it owns re-invoking showView once the user resolves its prompt.
+        const leavingCtrl = this.viewControllers[this.currentView];
+        if (leavingCtrl && typeof leavingCtrl.beforeLeave === 'function') {
+            const proceed = leavingCtrl.beforeLeave(viewName);
+            if (proceed === false) return;
+        }
+
         // Hide all views
         document.querySelectorAll('.view').forEach(view => {
             view.classList.remove('active');
@@ -478,6 +515,30 @@ class GymTrackerApp {
     }
 
     /**
+     * Re-assert the view the user is already on (tapping its own nav item).
+     * showView early-returns on same-view, so a visible nav tap would
+     * otherwise be a no-op. For 'workout' mid-session, reveal the active
+     * workout and jump to the current exercise (first incomplete); with no
+     * active workout, scroll the picker to the top. Other views just scroll
+     * to the top.
+     */
+    reassertCurrentView(viewName) {
+        if (viewName === 'workout') {
+            const workout = this.viewControllers.workout;
+            if (workout?.hasActiveWorkout()) {
+                // render() reveals the active-workout screen via the
+                // hasActiveWorkout gate; jump to the current exercise (the
+                // first incomplete one) — where the user is actually lifting.
+                // The back-to-top arrow stays the plain scroll-to-top.
+                workout.render();
+                workout.scrollToCurrentExercise();
+                return;
+            }
+        }
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
+    /**
      * Handle view change
      */
     onViewChange(viewName) {
@@ -485,6 +546,94 @@ class GymTrackerApp {
         if (this.viewControllers[viewName] && this.viewControllers[viewName].render) {
             this.viewControllers[viewName].render();
         }
+        // Keep the global floating workout button in sync on every view.
+        this.updateGlobalFab();
+    }
+
+    /**
+     * Wire the app-level floating workout button once. It lives at
+     * app-container level (not inside the dashboard view) so it persists
+     * across all views on desktop. Mobile keeps it hidden via CSS.
+     */
+    wireGlobalFab() {
+        const fab = document.getElementById('home-workout-fab');
+        if (!fab || fab.dataset.wired) return;
+        fab.addEventListener('click', () => this.handleGlobalFabClick());
+        fab.dataset.wired = '1';
+        this.updateGlobalFab();
+    }
+
+    /**
+     * Show/hide + label the global FAB based on current state:
+     *   - Hidden when there are no programs (nothing to start).
+     *   - Hidden on the active-workout screen (the user is already there).
+     *   - "Resume workout" (green) when a paused session exists.
+     *   - "Start workout" otherwise.
+     */
+    updateGlobalFab() {
+        const fab = document.getElementById('home-workout-fab');
+        if (!fab) return;
+
+        const hasPrograms = this.programs.length > 0;
+        const paused = storageService.getActiveWorkout();
+        const onActiveWorkout = this.currentView === 'workout'
+            && document.getElementById('active-workout')?.classList.contains('active');
+
+        if (!hasPrograms || onActiveWorkout) {
+            fab.hidden = true;
+            return;
+        }
+
+        fab.hidden = false;
+        const label = fab.querySelector('.workout-fab-label');
+        const icon = fab.querySelector('i');
+
+        if (paused && paused.paused) {
+            fab.classList.add('workout-fab--resume');
+            if (label) label.textContent = 'Resume workout';
+            if (icon) {
+                icon.classList.remove('fa-play');
+                icon.classList.add('fa-play-circle');
+            }
+            fab.setAttribute('aria-label', 'Resume paused workout');
+        } else {
+            fab.classList.remove('workout-fab--resume');
+            if (label) label.textContent = 'Start workout';
+            if (icon) {
+                icon.classList.remove('fa-play-circle');
+                icon.classList.add('fa-play');
+            }
+            fab.setAttribute('aria-label', 'Start workout');
+        }
+    }
+
+    /**
+     * Start or resume a workout from anywhere:
+     *   - Paused → resume the saved session.
+     *   - Exactly one program with exercises → auto-start it.
+     *   - Otherwise → route to the workout view's program picker.
+     */
+    handleGlobalFabClick() {
+        window.scrollTo(0, 0);
+        const workoutCtrl = this.viewControllers.workout;
+        const paused = storageService.getActiveWorkout();
+
+        if (paused && paused.paused) {
+            this.showView('workout');
+            setTimeout(() => workoutCtrl?.resumeWorkout(), 100);
+            return;
+        }
+
+        if (this.programs.length === 1) {
+            const only = this.programs[0];
+            if (only.exercises && only.exercises.length > 0) {
+                this.showView('workout');
+                setTimeout(() => workoutCtrl?.startWorkout(only.id), 100);
+                return;
+            }
+        }
+
+        this.showView('workout');
     }
 
     /**
@@ -601,7 +750,7 @@ class GymTrackerApp {
      * Get program by ID
      */
     getProgramById(id) {
-        return this.programs.find(p => p.id === id);
+        return this.programs.find(p => sameId(p.id, id));
     }
 
     /**

--- a/apps/gym-tracker/js/models/Program.js
+++ b/apps/gym-tracker/js/models/Program.js
@@ -19,6 +19,12 @@ export class Program {
         this.restMode = data.restMode === 'uniform' ? 'uniform' : 'custom';
         // Active only when restMode === 'uniform'.
         this.uniformRestSeconds = clampInt(data.uniformRestSeconds, 0, 900, 90);
+
+        // Scheduled weekday indices (0 = Sunday .. 6 = Saturday) the user plans
+        // to run this program on. Surfaced as markers in the calendar. Legacy
+        // programs without this key default to [] (no schedule). Sanitized to a
+        // deduped, sorted array of valid 0-6 integers.
+        this.scheduleDays = normalizeScheduleDays(data.scheduleDays);
     }
 
     addExercise(exerciseId, exerciseName, targetSets = 3, targetReps = 10, notes = '', restSeconds = null, restAfterSeconds = null) {
@@ -73,6 +79,7 @@ export class Program {
             exercises: this.exercises,
             restMode: this.restMode,
             uniformRestSeconds: this.uniformRestSeconds,
+            scheduleDays: this.scheduleDays,
             createdAt: this.createdAt,
             updatedAt: this.updatedAt
         };
@@ -80,6 +87,17 @@ export class Program {
 
     static fromJSON(json) {
         return new Program(json);
+    }
+
+    /**
+     * Deep, independent copy of a program (same id). Used to STAGE edits in the
+     * editor: the modal mutates the clone, and only saving commits it back into
+     * the stored list, so Cancel/X discard every change. The JSON round-trip
+     * deep-copies the exercises array so editing the clone's exercises cannot
+     * touch the original's.
+     */
+    static clone(program) {
+        return new Program(JSON.parse(JSON.stringify(program.toJSON())));
     }
 }
 
@@ -175,6 +193,21 @@ function normalizeExercise(ex) {
     });
 
     return normalized;
+}
+
+/**
+ * Coerce raw scheduleDays into a deduped, ascending array of valid weekday
+ * indices (0-6). Anything non-array or out of range is dropped. Legacy data
+ * (undefined) yields [].
+ */
+function normalizeScheduleDays(value) {
+    if (!Array.isArray(value)) return [];
+    const seen = new Set();
+    for (const raw of value) {
+        const n = Number(raw);
+        if (Number.isInteger(n) && n >= 0 && n <= 6) seen.add(n);
+    }
+    return [...seen].sort((a, b) => a - b);
 }
 
 function normalizeSetRow(s) {

--- a/apps/gym-tracker/js/models/Settings.js
+++ b/apps/gym-tracker/js/models/Settings.js
@@ -22,6 +22,19 @@ export class Settings {
             ? data.vibrationAlerts
             : (legacy !== undefined ? legacy : true);
 
+        // Rest-timer sound markers (Item R2-1: free numeric, not fixed options).
+        //   timerFirstWarningSeconds: a single early heads-up tone fires when
+        //     this many seconds remain. 0 = Off, capped at 120. Default 10.
+        //   timerCountdownSeconds: per-second pips + urgent styling begin when
+        //     this many seconds remain. Minimum 1, capped at 60. Default 5
+        //     (the prior hard-coded value).
+        // Legacy data (including the old fixed-option values) loads unchanged
+        // because those values fall inside the new accepted ranges.
+        this.timerFirstWarningSeconds = Settings.normalizeFirstWarningSeconds(
+            data.timerFirstWarningSeconds);
+        this.timerCountdownSeconds = Settings.normalizeCountdownSeconds(
+            data.timerCountdownSeconds);
+
         // Plate calculator config. `barWeight` and `plates` are stored in
         // the user's `weightUnit`. Defaults match the most common gym
         // setup: a 20 kg / 45 lb bar plus a standard plate stack.
@@ -51,6 +64,11 @@ export class Settings {
         this.exercisePlateHints = (typeof data.exercisePlateHints === 'object' && data.exercisePlateHints !== null)
             ? { ...data.exercisePlateHints }
             : {};
+
+        // Whether the calendar overlays each program's scheduled weekdays.
+        // Defaults to true (on) so the planned split is visible out of the box;
+        // legacy settings without this key load with the default.
+        this.showProgramSchedule = data.showProgramSchedule !== false;
     }
 
     toJSON() {
@@ -61,12 +79,48 @@ export class Settings {
             firstDayOfWeek: this.firstDayOfWeek,
             soundAlerts: this.soundAlerts,
             vibrationAlerts: this.vibrationAlerts,
+            timerFirstWarningSeconds: this.timerFirstWarningSeconds,
+            timerCountdownSeconds: this.timerCountdownSeconds,
             barWeight: this.barWeight,
             plates: this.plates,
             timeFormat: this.timeFormat,
             plateHintsEnabled: this.plateHintsEnabled,
             exercisePlateHints: this.exercisePlateHints,
+            showProgramSchedule: this.showProgramSchedule,
         };
+    }
+
+    /**
+     * Coerce a stored timer-marker value to one of the allowed options,
+     * falling back to `fallback` for missing/invalid legacy data. Retained for
+     * any callers passing an explicit option list; the free-numeric markers
+     * (Item R2-1) use the range helpers below.
+     */
+    static normalizeTimerSeconds(value, allowed, fallback) {
+        const n = Number(value);
+        return allowed.includes(n) ? n : fallback;
+    }
+
+    /**
+     * Item R2-1: normalize the first-warning marker to an integer in [0, 120].
+     * 0 means Off. Missing/invalid input falls back to the default (10).
+     */
+    static normalizeFirstWarningSeconds(value) {
+        if (value === undefined || value === null || value === '') return 10;
+        const n = Math.round(Number(value));
+        if (!Number.isFinite(n) || n < 0) return 10;
+        return Math.min(n, 120);
+    }
+
+    /**
+     * Item R2-1: normalize the countdown-start marker to an integer in [1, 60].
+     * Missing/invalid input falls back to the default (5).
+     */
+    static normalizeCountdownSeconds(value) {
+        if (value === undefined || value === null || value === '') return 5;
+        const n = Math.round(Number(value));
+        if (!Number.isFinite(n) || n < 1) return 5;
+        return Math.min(n, 60);
     }
 
     static fromJSON(json) {

--- a/apps/gym-tracker/js/models/WorkoutExercise.js
+++ b/apps/gym-tracker/js/models/WorkoutExercise.js
@@ -23,6 +23,11 @@ export class WorkoutExercise {
         // session so the workout view's render + rest-timer logic can
         // tell which exercises are linked into a superset.
         this.groupId = data.groupId || null;
+        // "How did it feel" marking, revealed once a committed set reaches the
+        // slot's max target reps. 'good' = consider more weight next time.
+        // null = no marking. Legacy 'bad' is preserved here for data integrity
+        // but never produced and never rendered. Toggleable until save.
+        this.feel = data.feel === 'good' || data.feel === 'bad' ? data.feel : null;
     }
 
     get totalVolume() {
@@ -55,6 +60,7 @@ export class WorkoutExercise {
             order: this.order,
             completed: this.completed,
             stickyValues: this.stickyValues,
+            feel: this.feel,
         };
     }
 

--- a/apps/gym-tracker/js/models/WorkoutSession.js
+++ b/apps/gym-tracker/js/models/WorkoutSession.js
@@ -25,6 +25,13 @@ export class WorkoutSession {
         this.maxHeartRate = data.maxHeartRate || null;
         this.caloriesBurned = data.caloriesBurned || null;
 
+        // Temporary per-session weight unit (Item 8). Display + entry unit for
+        // THIS workout only; canonical Set weights stay in the account unit.
+        // null means "follow the account unit". Survives pause/resume via JSON.
+        this.sessionUnit = data.sessionUnit === 'kg' || data.sessionUnit === 'lb'
+            ? data.sessionUnit
+            : null;
+
         // Pause/Resume state
         this.paused = data.paused || false;
         this.pausedAt = data.pausedAt || null;
@@ -102,6 +109,7 @@ export class WorkoutSession {
             avgHeartRate: this.avgHeartRate,
             maxHeartRate: this.maxHeartRate,
             caloriesBurned: this.caloriesBurned,
+            sessionUnit: this.sessionUnit,
             paused: this.paused,
             pausedAt: this.pausedAt,
             elapsedBeforePause: this.elapsedBeforePause,

--- a/apps/gym-tracker/js/services/AnalyticsService.js
+++ b/apps/gym-tracker/js/services/AnalyticsService.js
@@ -351,8 +351,13 @@ export class AnalyticsService {
      *
      * A set is only a PR if there is at least one prior set for the
      * exercise — the first session seeds the baseline and never counts.
+     *
+     * `currentSessionPriorSets` are the earlier committed sets of the
+     * in-progress session for the same exercise. Including them prevents a
+     * second set at the same new max from re-triggering the PR already earned
+     * by the first set this session.
      */
-    static isSetPR(exerciseId, newSet, sessions) {
+    static isSetPR(exerciseId, newSet, sessions, currentSessionPriorSets = []) {
         if (!newSet) return null;
         const priorSets = [];
         sessions.forEach(s => {
@@ -362,6 +367,7 @@ export class AnalyticsService {
                 }
             });
         });
+        (currentSessionPriorSets || []).forEach(set => priorSets.push(set));
         if (priorSets.length === 0) return null;
 
         const isDuration = (newSet.duration || 0) > 0 && (newSet.weight || 0) === 0;

--- a/apps/gym-tracker/js/services/StorageService.js
+++ b/apps/gym-tracker/js/services/StorageService.js
@@ -2,6 +2,8 @@
  * StorageService
  * Manages all data storage operations (localStorage + Firebase sync)
  */
+import { sameId } from '../utils/id-utils.js';
+
 export class StorageService {
     constructor() {
         this.keys = {
@@ -87,7 +89,7 @@ export class StorageService {
 
     getProgramById(id) {
         const programs = this.getPrograms();
-        return programs.find(p => p.id === id);
+        return programs.find(p => sameId(p.id, id));
     }
 
     saveProgram(program) {

--- a/apps/gym-tracker/js/utils/exercise-feel.js
+++ b/apps/gym-tracker/js/utils/exercise-feel.js
@@ -1,0 +1,86 @@
+/**
+ * Pure helpers for the "how did it feel" marking (Item 7).
+ */
+
+/**
+ * Whether a committed set qualifies the exercise for the feel prompt: it must
+ * be a reps-based set (not a duration set) and reach the slot's max target reps.
+ *
+ * `slotRepsMax` is the repsMax of the matching program slot (or the exercise's
+ * representative target when per-slot data is unavailable). Returns false for
+ * duration sets so the feature is skipped there.
+ */
+export function setReachesMaxReps(set, slotRepsMax) {
+    if (!set) return false;
+    if (set.duration && set.duration > 0) return false;
+    const reps = Number(set.reps) || 0;
+    const target = Number(slotRepsMax) || 0;
+    return target > 0 && reps >= target;
+}
+
+/**
+ * Strict gating for the feel prompt (Item R2-4): the prompt appears ONLY when
+ * every target set of the exercise is completed AND every completed set reached
+ * the max of its rep range. Duration exercises never qualify.
+ *
+ * @param {object[]} sets       committed sets of the session exercise.
+ * @param {number}   targetSets number of planned sets for the exercise.
+ * @param {(set:object, arrIdx:number) => number} slotMaxOf resolves the slot's
+ *        max target reps (repsMax, or the singular target when min==max) for a
+ *        given committed set. Receives the set and its array index.
+ * @returns {boolean}
+ */
+export function allSetsReachMax(sets, targetSets, slotMaxOf) {
+    const target = Math.max(1, Number(targetSets) || 0);
+    if (!Array.isArray(sets) || sets.length < target) return false;
+    // Any duration set disqualifies the whole exercise.
+    if (sets.some(s => s && s.duration && s.duration > 0)) return false;
+    return sets.every((set, arrIdx) => setReachesMaxReps(set, slotMaxOf(set, arrIdx)));
+}
+
+/**
+ * Item R3-4: whether the feel picker modal should appear for `exerciseIndex`.
+ * It shows at most once per exercise per session: only when the exercise newly
+ * satisfies the all-sets-at-max condition AND it has not already been shown.
+ * `shownMap` is a plain object of exerciseIndex -> true (mutated by the caller
+ * when it actually shows the modal).
+ */
+export function shouldShowFeelModal(shownMap, exerciseIndex, reachesMax) {
+    if (!reachesMax) return false;
+    return !(shownMap && shownMap[exerciseIndex]);
+}
+
+/**
+ * Item R3-4: the next feel value when toggling the header icon. The cycle is
+ * good <-> none (null): 'good' clears the mark, anything else marks 'good'.
+ */
+export function nextFeel(current) {
+    return current === 'good' ? null : 'good';
+}
+
+/**
+ * The most recent 'good' feel marking for `exerciseId` across completed
+ * sessions, or null when there is none. Legacy 'bad' markings are ignored so
+ * they never surface an icon. Sessions are ordered by their chronological key
+ * (most recent first) by the caller-supplied `tsOf`.
+ */
+export function latestFeelForExercise(sessions, exerciseId, tsOf) {
+    if (!Array.isArray(sessions) || exerciseId == null) return null;
+    const ts = typeof tsOf === 'function' ? tsOf : (s) => s.sortTimestamp || s.date;
+    let best = null;
+    let bestTs = null;
+    for (const session of sessions) {
+        if (!session || session.completed === false) continue;
+        const exercises = session.exercises || [];
+        for (const ex of exercises) {
+            if (ex.exerciseId !== exerciseId) continue;
+            if (ex.feel !== 'good') continue;
+            const t = new Date(ts(session)).getTime();
+            if (bestTs === null || t > bestTs) {
+                bestTs = t;
+                best = ex.feel;
+            }
+        }
+    }
+    return best;
+}

--- a/apps/gym-tracker/js/utils/helpers.js
+++ b/apps/gym-tracker/js/utils/helpers.js
@@ -313,9 +313,11 @@ export function showToast(message, type = 'info', duration = 3000, opts = {}) {
 
     document.body.appendChild(toast);
 
-    // Stack toasts vertically by calculating offset based on existing toasts
+    // Stack toasts vertically by calculating offset based on existing toasts.
+    // Initial top clears the fixed site header + sticky workout header so a
+    // toast never covers the workout controls (Item R2-8).
     const existingToasts = document.querySelectorAll('.toast.show');
-    let offset = 80; // Initial top position
+    let offset = 116; // Initial top position
     existingToasts.forEach(existingToast => {
         const rect = existingToast.getBoundingClientRect();
         offset = Math.max(offset, rect.bottom + 10);
@@ -452,54 +454,124 @@ export function vibrate(duration = 50) {
  * this would fire. Users who have never tapped anything get silence.
  */
 let _audioCtx = null;
+
+/**
+ * Return a usable AudioContext, recreating it if the cached one was closed.
+ * On iOS/Android the context can transition to `closed` or `interrupted`
+ * (phone call, screen lock, audio focus loss). A `closed` context can never
+ * play again, so it must be discarded and replaced; an `interrupted` /
+ * `suspended` one only needs `resume()`. Returns null when Web Audio is
+ * unavailable (older iOS WebView).
+ */
+function getAudioContext() {
+    const Ctx = window.AudioContext || window.webkitAudioContext;
+    if (!Ctx) return null;
+    if (_audioCtx && _audioCtx.state === 'closed') {
+        _audioCtx = null;
+    }
+    if (!_audioCtx) {
+        _audioCtx = new Ctx();
+    }
+    return _audioCtx;
+}
+
+/**
+ * Emit the tones for `soundType` on `ctx`, scheduling everything relative to
+ * the context's current time. Split out so it can run either immediately or
+ * after an async `resume()` resolves.
+ */
+function emitTones(ctx, soundType) {
+    const now = ctx.currentTime;
+    const play = (freq, startAt, dur = 0.15, vol = 0.18) => {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        // Short attack/decay envelope so it doesn't click.
+        gain.gain.setValueAtTime(0, now + startAt);
+        gain.gain.linearRampToValueAtTime(vol, now + startAt + 0.01);
+        gain.gain.linearRampToValueAtTime(0, now + startAt + dur);
+        osc.connect(gain).connect(ctx.destination);
+        osc.start(now + startAt);
+        osc.stop(now + startAt + dur + 0.02);
+    };
+
+    if (soundType === 'rest-done') {
+        play(800, 0);
+        play(1200, 0.18);
+    } else if (soundType === 'pr') {
+        play(1400, 0, 0.22, 0.22);
+        play(1800, 0.12, 0.18, 0.18);
+    } else if (soundType === 'timer-warn') {
+        // First-warning cue: a single mid sine tone, clearly distinct from
+        // the per-second square pip used for the final countdown.
+        play(1046, 0, 0.28, 0.2);
+    } else if (soundType === 'timer-low') {
+        // Brief square pip at 880 Hz (matches Arena timerLow).
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const filt = ctx.createBiquadFilter();
+        osc.type = 'square';
+        osc.frequency.value = 880;
+        filt.type = 'lowpass';
+        filt.frequency.value = 2200;
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(0.07, now + 0.005);
+        gain.gain.linearRampToValueAtTime(0, now + 0.07);
+        osc.connect(filt).connect(gain).connect(ctx.destination);
+        osc.start(now);
+        osc.stop(now + 0.09);
+    } else {
+        play(800, 0);
+    }
+}
+
 export function playSound(soundType = 'success') {
     try {
-        const Ctx = window.AudioContext || window.webkitAudioContext;
-        if (!Ctx) return;
-        if (!_audioCtx) _audioCtx = new Ctx();
-        if (_audioCtx.state === 'suspended') _audioCtx.resume();
-
-        const now = _audioCtx.currentTime;
-        const play = (freq, startAt, dur = 0.15, vol = 0.18) => {
-            const osc = _audioCtx.createOscillator();
-            const gain = _audioCtx.createGain();
-            osc.type = 'sine';
-            osc.frequency.value = freq;
-            // Short attack/decay envelope so it doesn't click.
-            gain.gain.setValueAtTime(0, now + startAt);
-            gain.gain.linearRampToValueAtTime(vol, now + startAt + 0.01);
-            gain.gain.linearRampToValueAtTime(0, now + startAt + dur);
-            osc.connect(gain).connect(_audioCtx.destination);
-            osc.start(now + startAt);
-            osc.stop(now + startAt + dur + 0.02);
-        };
-
-        if (soundType === 'rest-done') {
-            play(800, 0);
-            play(1200, 0.18);
-        } else if (soundType === 'pr') {
-            play(1400, 0, 0.22, 0.22);
-            play(1800, 0.12, 0.18, 0.18);
-        } else if (soundType === 'timer-low') {
-            // Brief square pip at 880 Hz (matches Arena timerLow).
-            const osc = _audioCtx.createOscillator();
-            const gain = _audioCtx.createGain();
-            const filt = _audioCtx.createBiquadFilter();
-            osc.type = 'square';
-            osc.frequency.value = 880;
-            filt.type = 'lowpass';
-            filt.frequency.value = 2200;
-            const now2 = _audioCtx.currentTime;
-            gain.gain.setValueAtTime(0, now2);
-            gain.gain.linearRampToValueAtTime(0.07, now2 + 0.005);
-            gain.gain.linearRampToValueAtTime(0, now2 + 0.07);
-            osc.connect(filt).connect(gain).connect(_audioCtx.destination);
-            osc.start(now2);
-            osc.stop(now2 + 0.09);
-        } else {
-            play(800, 0);
+        const ctx = getAudioContext();
+        if (!ctx) return;
+        // resume() is async; a suspended/interrupted context that isn't awaited
+        // swallows the first scheduled tone. Schedule after it resolves so the
+        // first sound following a suspension still plays. currentTime advances
+        // once resumed, so emitTones reads it fresh inside the callback.
+        if (ctx.state !== 'running' && typeof ctx.resume === 'function') {
+            const resumed = ctx.resume();
+            if (resumed && typeof resumed.then === 'function') {
+                resumed.then(() => emitTones(ctx, soundType)).catch(() => {});
+                return;
+            }
         }
+        emitTones(ctx, soundType);
     } catch {
         // Intentionally swallow — audio is a nice-to-have, never critical.
     }
+}
+
+/**
+ * Proactively recover the audio context when the tab/app returns to the
+ * foreground. Mobile browsers suspend or interrupt the context while
+ * backgrounded; resuming on `visibilitychange` means the next timer/PR
+ * sound during a workout isn't lost. Safe to call when Web Audio is
+ * unavailable (no-ops).
+ */
+export function resumeAudioContext() {
+    try {
+        // Only RESUME an already-created context — never create one here.
+        // getAudioContext() lazily news up a context, and this runs from the
+        // visibilitychange listener (no user gesture), which makes Chrome log
+        // "The AudioContext was not allowed to start...". The context is
+        // created on the first real sound during a workout (a user gesture).
+        const ctx = _audioCtx;
+        if (ctx && ctx.state !== 'closed' && ctx.state !== 'running' && typeof ctx.resume === 'function') {
+            ctx.resume().catch(() => {});
+        }
+    } catch {
+        // no-op
+    }
+}
+
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') resumeAudioContext();
+    });
 }

--- a/apps/gym-tracker/js/utils/id-utils.js
+++ b/apps/gym-tracker/js/utils/id-utils.js
@@ -1,0 +1,13 @@
+/**
+ * Shared id-comparison helper.
+ *
+ * Program (and session) ids are generated numerically (Program.js uses
+ * generateNumericId()), but ids that arrive from the DOM — `dataset.*`
+ * attributes, drag payloads, URL state — are always strings. Imported or
+ * legacy data may also carry string ids. Comparing the two with `===`
+ * silently fails (1 !== "1"). `sameId` normalizes both sides to strings so
+ * numeric and string ids match regardless of where they came from.
+ */
+export function sameId(a, b) {
+    return String(a) === String(b);
+}

--- a/apps/gym-tracker/js/utils/modal-focus.js
+++ b/apps/gym-tracker/js/utils/modal-focus.js
@@ -168,3 +168,37 @@ export function openModal(modalEl) {
     modalEl.classList.add('active');
     trapModalFocus(modalEl);
 }
+
+/**
+ * R3-6: close a modal without leaving focus on a descendant while the modal
+ * is being hidden / marked aria-hidden. Browsers log
+ * "Blocked aria-hidden on an element because its descendant retained focus"
+ * when an element with `aria-hidden="true"` (or one being hidden) still
+ * contains document.activeElement. Move focus OUT first, then hide.
+ *
+ * `restoreTo` (optional) is where focus should land after closing; defaults
+ * to document.body. Pass the destination view container when navigating away.
+ */
+export function closeModalSafely(modalEl, restoreTo) {
+    if (!modalEl) return;
+    // If focus is on (or inside) the modal, drop it before the modal goes
+    // aria-hidden / display:none, so no focused element sits under aria-hidden.
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && modalEl.contains(active)) {
+        active.blur();
+    }
+    modalEl.classList.remove('active');
+    if (modalEl.hasAttribute('aria-hidden')) {
+        modalEl.setAttribute('aria-hidden', 'true');
+    }
+    const target = restoreTo instanceof HTMLElement ? restoreTo : document.body;
+    if (typeof target.focus === 'function') {
+        // body needs tabindex to be focusable for keyboard users; a transient
+        // -1 tabindex is the standard trick and is removed on blur.
+        if (target === document.body && !target.hasAttribute('tabindex')) {
+            target.setAttribute('tabindex', '-1');
+            target.addEventListener('blur', () => target.removeAttribute('tabindex'), { once: true });
+        }
+        target.focus({ preventScroll: true });
+    }
+}

--- a/apps/gym-tracker/js/utils/pr-session.js
+++ b/apps/gym-tracker/js/utils/pr-session.js
@@ -1,0 +1,79 @@
+/**
+ * Pure helpers for in-session PR badge bookkeeping (Item R2-10).
+ *
+ * Within a single workout session a later set can beat an earlier PR for the
+ * SAME exercise. Only the best (latest, higher) set keeps its badge; the
+ * earlier badge is superseded. The finish-modal PR count counts each
+ * superseded chain ONCE per exercise, not once per PR moment.
+ *
+ * The slot map is keyed `"<exerciseIndex>:<slot>"`; values are PR payloads.
+ * `exerciseIndex` is recovered as the substring before the first ":".
+ */
+
+/** Exercise index portion of a `"<exerciseIndex>:<slot>"` key. */
+export function exerciseKeyOf(slotKey) {
+    const i = String(slotKey).indexOf(':');
+    return i === -1 ? String(slotKey) : String(slotKey).slice(0, i);
+}
+
+/**
+ * Record a brand-new PR at `slotKey` into `slots`, removing any earlier PR
+ * badge for the SAME exercise (it has been superseded). Mutates and returns
+ * `slots` for convenience.
+ */
+export function recordPrSupersede(slots, slotKey, pr) {
+    const exKey = exerciseKeyOf(slotKey);
+    for (const key of Object.keys(slots)) {
+        if (key !== slotKey && exerciseKeyOf(key) === exKey) {
+            delete slots[key];
+        }
+    }
+    slots[slotKey] = pr;
+    return slots;
+}
+
+/**
+ * Number of UNIQUE superseded PR chains in `slots` — i.e. the count of
+ * distinct exercises that have a surviving badge. This is the value shown in
+ * the finish modal (a 100 -> 110 sequence counts as 1).
+ */
+export function uniquePrChainCount(slots) {
+    const exercises = new Set();
+    for (const key of Object.keys(slots)) exercises.add(exerciseKeyOf(key));
+    return exercises.size;
+}
+
+/**
+ * Recompute the entire session PR slot map FROM SCRATCH (Item R3-7).
+ *
+ * Derived PR state must always equal a fresh recomputation, so after ANY set
+ * edit or delete the caller rebuilds the whole map rather than patching a
+ * single slot. Each exercise's committed sets are evaluated in SLOT order
+ * against history plus the earlier sets of the same exercise this session, so:
+ *   - editing away a superseding set restores the earlier set's badge;
+ *   - deleting a set restores any badge it had superseded;
+ *   - a new PR created mid-list resequences correctly (slot order, not
+ *     insertion order).
+ *
+ * @param {Array<{exerciseId:*, sets:object[]}>} exercises session exercises.
+ * @param {(exerciseId:*, set:object, priorSessionSets:object[]) => (object|null)} isPr
+ *        resolves a PR payload (or null) for a set given the exercise id and
+ *        the earlier same-exercise sets of this session. History baseline is
+ *        captured by the closure.
+ * @returns {Object<string, object>} fresh `"<exerciseIndex>:<slot>"` -> PR map.
+ */
+export function recomputePrSlots(exercises, isPr) {
+    const slots = {};
+    (exercises || []).forEach((exercise, exerciseIndex) => {
+        const ordered = (exercise.sets || [])
+            .map((set, i) => ({ set, slot: set.slot != null ? set.slot : i }))
+            .sort((a, b) => a.slot - b.slot);
+        const priorSessionSets = [];
+        for (const { set, slot } of ordered) {
+            const pr = isPr(exercise.exerciseId, set, priorSessionSets);
+            if (pr) recordPrSupersede(slots, `${exerciseIndex}:${slot}`, pr);
+            priorSessionSets.push(set);
+        }
+    });
+    return slots;
+}

--- a/apps/gym-tracker/js/utils/program-schedule.js
+++ b/apps/gym-tracker/js/utils/program-schedule.js
@@ -1,0 +1,45 @@
+/**
+ * Pure helpers for the program day-of-week schedule shown in the calendar
+ * (Item 9).
+ */
+
+/**
+ * Return the programs scheduled for a given weekday index (0 = Sunday ..
+ * 6 = Saturday). Each program contributes when its scheduleDays includes the
+ * weekday. Programs with an empty/absent schedule never match.
+ */
+export function programsScheduledOnWeekday(programs, weekday) {
+    if (!Array.isArray(programs)) return [];
+    return programs.filter(p =>
+        Array.isArray(p.scheduleDays) && p.scheduleDays.includes(weekday)
+    );
+}
+
+/**
+ * Order the seven weekday indices starting from `firstDay` (0 = Sunday,
+ * 1 = Monday). Used to lay out the weekday chips in the program editor so
+ * they honor the user's first-day-of-week preference.
+ */
+export function weekdayOrder(firstDay = 1) {
+    const start = Number.isInteger(firstDay) && firstDay >= 0 && firstDay <= 6 ? firstDay : 1;
+    return Array.from({ length: 7 }, (_, i) => (start + i) % 7);
+}
+
+/**
+ * Item R2-6: build the seven day cells for the workout-screen week strip,
+ * ordered per `firstDay`, anchored on the week containing `today`. Each cell
+ * carries its weekday index (0 = Sun .. 6 = Sat), the matching programs, and an
+ * isToday flag. `programs` is the full program list; matching reuses the same
+ * scheduleDays rule as the calendar so the two views never diverge.
+ *
+ * `today` defaults to now; passing it explicitly keeps the helper pure/testable.
+ */
+export function weekStrip(programs, firstDay = 0, today = new Date()) {
+    const order = weekdayOrder(firstDay);
+    const todayWeekday = today.getDay();
+    return order.map((weekday) => ({
+        weekday,
+        isToday: weekday === todayWeekday,
+        programs: programsScheduledOnWeekday(programs, weekday),
+    }));
+}

--- a/apps/gym-tracker/js/utils/rest-cues.js
+++ b/apps/gym-tracker/js/utils/rest-cues.js
@@ -1,0 +1,35 @@
+/**
+ * Pure, DOM-free predicates for the workout rest flow. Extracted from
+ * workout-view so they can be unit-tested directly.
+ */
+
+/**
+ * Decide what audio/haptic cues fire at `remaining` seconds, given the
+ * configured first-warning and countdown-start thresholds. Returns
+ * { warn, urgent }:
+ *   warn   — true only on the single first-warning second (one early tone).
+ *   urgent — true throughout the per-second countdown window.
+ *
+ * The first warning is suppressed when Off (0) or when it would land at or
+ * inside the countdown window, so it never overlaps the per-second pips.
+ */
+export function restTickCues(remaining, firstWarningSeconds, countdownSeconds) {
+    const countdown = countdownSeconds > 0 ? countdownSeconds : 5;
+    const urgent = remaining <= countdown && remaining > 0;
+    const warn = firstWarningSeconds > countdown && remaining === firstWarningSeconds;
+    return { warn, urgent };
+}
+
+/**
+ * True when no exercise in the session still needs more committed sets, i.e.
+ * the whole workout is done. Superset-agnostic: it checks every exercise has
+ * reached its target set count. Used to suppress the after-last-exercise rest
+ * timer and trigger scroll-to-top.
+ */
+export function isWorkoutComplete(exercises) {
+    if (!exercises || exercises.length === 0) return false;
+    return exercises.every(ex => {
+        const target = Math.max(1, ex.targetSets || 3);
+        return (ex.sets?.length || 0) >= target;
+    });
+}

--- a/apps/gym-tracker/js/utils/session-merge.js
+++ b/apps/gym-tracker/js/utils/session-merge.js
@@ -1,0 +1,82 @@
+/**
+ * Pure, DOM-free session/program reconciliation. Used when the user edits a
+ * program mid-workout (Item 3 + 4) and returns: the paused session must pick
+ * up the program's edits without clobbering already-committed work.
+ *
+ * Merge rules (spec Item 4):
+ *   - exercises with committed sets keep their committed data untouched;
+ *   - target sets/reps/rest updates apply to exercises WITHOUT committed sets;
+ *   - exercises added to the program are appended to the session;
+ *   - exercises removed from the program are dropped from the session ONLY if
+ *     they have zero committed sets.
+ *
+ * Inputs are plain JSON-ish objects (the shapes produced by
+ * WorkoutExercise.toJSON and a normalized program exercise). The function is
+ * non-mutating: it returns a fresh array of session-exercise plain objects.
+ * The caller rehydrates them into WorkoutExercise instances.
+ *
+ * `makeSessionExercise(progEx)` builds a brand-new session exercise object
+ * from a program exercise (injected so this module stays free of model imports).
+ */
+export function mergeSessionWithProgram(sessionExercises, programExercises, makeSessionExercise) {
+    const sessionList = Array.isArray(sessionExercises) ? sessionExercises : [];
+    const programList = Array.isArray(programExercises) ? programExercises : [];
+
+    const hasCommitted = (ex) => Array.isArray(ex.sets) && ex.sets.length > 0;
+
+    // Index the program's exercises by id. A program can legitimately list the
+    // same exercise twice; we match positionally within that id bucket so two
+    // entries of the same movement stay distinct.
+    const progBuckets = new Map();
+    for (const p of programList) {
+        const arr = progBuckets.get(p.exerciseId) || [];
+        arr.push(p);
+        progBuckets.set(p.exerciseId, arr);
+    }
+    const progCursor = new Map();
+
+    const result = [];
+    const consumedProg = new Set();
+
+    for (const sx of sessionList) {
+        const bucket = progBuckets.get(sx.exerciseId) || [];
+        const cursor = progCursor.get(sx.exerciseId) || 0;
+        const match = bucket[cursor] || null;
+        if (match) {
+            progCursor.set(sx.exerciseId, cursor + 1);
+            consumedProg.add(match);
+        }
+
+        if (hasCommitted(sx)) {
+            // Keep the committed exercise verbatim. Even if removed from the
+            // program, it survives because it holds logged sets.
+            result.push(sx);
+            continue;
+        }
+
+        if (!match) {
+            // No committed sets and no longer in the program -> drop it.
+            continue;
+        }
+
+        // No committed sets: adopt the program's current targets/rest while
+        // preserving session-only fields the user may have set (feel, notes).
+        result.push({
+            ...sx,
+            exerciseName: match.exerciseName,
+            targetSets: match.targetSets,
+            targetReps: match.targetReps,
+            restSeconds: match.restSeconds,
+            restAfterSeconds: match.restAfterSeconds,
+            groupId: match.groupId || null,
+        });
+    }
+
+    // Append program exercises that weren't matched to any session exercise.
+    for (const p of programList) {
+        if (consumedProg.has(p)) continue;
+        result.push(makeSessionExercise(p));
+    }
+
+    return result;
+}

--- a/apps/gym-tracker/js/views/calendar-view.js
+++ b/apps/gym-tracker/js/views/calendar-view.js
@@ -7,6 +7,7 @@ import { app } from '../app.js';
 import { AnalyticsService } from '../services/AnalyticsService.js';
 import { formatDate, escapeHtml } from '../utils/helpers.js';
 import { DarkSelect } from '../utils/dark-select.js';
+import { programsScheduledOnWeekday, weekdayOrder } from '../utils/program-schedule.js';
 
 const MONTH_NAMES = [
     'January', 'February', 'March', 'April', 'May', 'June',
@@ -164,14 +165,26 @@ class CalendarView {
         const sessionsByDate = AnalyticsService.getSessionsByDate(sessions);
         const progressDates = AnalyticsService.getProgressDates(sessions);
 
+        // Item 9: program schedule overlay (toggle in Settings, default on).
+        const showSchedule = this.app.settings?.showProgramSchedule !== false;
+        const programs = this.app.programs || [];
+
+        // Item R2-5: weekday column order follows the user's firstDayOfWeek
+        // preference (0 = Sunday, 1 = Monday; default Sunday).
+        const firstDay = this.app.settings?.firstDayOfWeek === 1 ? 1 : 0;
+        const order = weekdayOrder(firstDay);
+        const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
         const todayKey = formatISO(new Date());
         const firstDayOfMonth = new Date(this.viewYear, this.viewMonth, 1).getDay();
-        const firstWeekday = firstDayOfMonth === 0 ? 6 : firstDayOfMonth - 1;
+        // Leading blanks before day 1: how far the month's first weekday sits
+        // from the configured first column.
+        const firstWeekday = (firstDayOfMonth - firstDay + 7) % 7;
         const daysInMonth = new Date(this.viewYear, this.viewMonth + 1, 0).getDate();
 
         let html = '';
-        ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].forEach(d => {
-            html += `<div class="calendar-day-header">${d}</div>`;
+        order.forEach(d => {
+            html += `<div class="calendar-day-header">${dayLabels[d]}</div>`;
         });
 
         // Leading empty placeholders
@@ -184,6 +197,12 @@ class CalendarView {
             const isFuture = new Date(dateStr) > new Date(todayKey);
             const dayHasWorkout = sessionsByDate.has(dateStr);
             const dayHasProgress = progressDates.has(dateStr);
+            // Item 9: weekday of this cell (0 = Sun) -> scheduled programs.
+            const weekday = new Date(this.viewYear, this.viewMonth, day).getDay();
+            const scheduledPrograms = showSchedule
+                ? programsScheduledOnWeekday(programs, weekday)
+                : [];
+            const dayHasSchedule = scheduledPrograms.length > 0;
 
             // Filter: dim days that don't match the filter
             let dimmed = false;
@@ -194,6 +213,7 @@ class CalendarView {
             if (isFuture) classes.push('future');
             if (dayHasWorkout) classes.push('has-workout');
             if (dayHasProgress) classes.push('has-progress');
+            if (dayHasSchedule) classes.push('has-schedule');
             if (isToday) classes.push('today');
             if (isSelected) classes.push('selected');
             if (dimmed) classes.push('dim');
@@ -201,6 +221,7 @@ class CalendarView {
             const ariaParts = [`${MONTH_NAMES[this.viewMonth]} ${day}`];
             if (dayHasWorkout) ariaParts.push('workout logged');
             if (dayHasProgress) ariaParts.push('personal record');
+            if (dayHasSchedule) ariaParts.push('program scheduled');
             if (isToday) ariaParts.push('today');
 
             html += `
@@ -208,6 +229,7 @@ class CalendarView {
                     <span class="calendar-day-num">${day}</span>
                     ${dayHasWorkout ? '<span class="calendar-day-dot" aria-hidden="true"></span>' : ''}
                     ${dayHasProgress ? '<span class="calendar-day-pr" aria-hidden="true"><i class="fas fa-star"></i></span>' : ''}
+                    ${dayHasSchedule ? '<span class="calendar-day-schedule" aria-hidden="true"><i class="fas fa-calendar-day"></i></span>' : ''}
                 </button>
             `;
         }
@@ -239,9 +261,14 @@ class CalendarView {
             return dt.getFullYear() === this.viewYear && dt.getMonth() === this.viewMonth;
         });
 
+        const showSchedule = this.app.settings?.showProgramSchedule !== false;
+        const monthHasSchedule = showSchedule
+            && (this.app.programs || []).some(p => Array.isArray(p.scheduleDays) && p.scheduleDays.length > 0);
+
         const items = [];
         if (monthHasWorkout) items.push('<span class="legend-item"><span class="legend-cue legend-dot-cue"></span>Workout</span>');
         if (monthHasProgress) items.push('<span class="legend-item"><span class="legend-cue legend-pr-cue"><i class="fas fa-star"></i></span>New PR</span>');
+        if (monthHasSchedule) items.push('<span class="legend-item"><span class="legend-cue legend-schedule-cue"><i class="fas fa-calendar-day"></i></span>Scheduled</span>');
         container.innerHTML = items.join('');
     }
 
@@ -261,6 +288,26 @@ class CalendarView {
             weekday: 'long', month: 'short', day: 'numeric', year: 'numeric',
         });
 
+        // Item 9: programs scheduled on this weekday (when the toggle is on).
+        // Parse the selected date as a LOCAL calendar date so the weekday
+        // matches the grid (which uses local Date construction). new Date(iso)
+        // would interpret YYYY-MM-DD as UTC midnight and can shift a day.
+        const showSchedule = this.app.settings?.showProgramSchedule !== false;
+        const [sy, sm, sd] = this.selectedDate.split('-').map(Number);
+        const weekday = new Date(sy, sm - 1, sd).getDay();
+        const scheduled = showSchedule
+            ? programsScheduledOnWeekday(this.app.programs || [], weekday)
+            : [];
+        const scheduledHTML = scheduled.length > 0
+            ? `<div class="calendar-scheduled-list">
+                ${scheduled.map(p => `
+                    <div class="calendar-scheduled-item">
+                        <i class="fas fa-calendar-day" aria-hidden="true"></i>
+                        <span>Scheduled: ${escapeHtml(p.name)}</span>
+                    </div>`).join('')}
+               </div>`
+            : '';
+
         if (daySessions.length === 0) {
             container.innerHTML = `
                 <div class="calendar-detail-card empty">
@@ -270,6 +317,7 @@ class CalendarView {
                             <div class="calendar-detail-sub">No workout logged</div>
                         </div>
                     </div>
+                    ${scheduledHTML}
                     <p class="calendar-detail-empty">
                         <i class="fas fa-bed"></i> Rest day — nothing recorded for this date.
                     </p>
@@ -290,6 +338,7 @@ class CalendarView {
                         <div class="calendar-detail-sub">${daySessions.length} workout${daySessions.length === 1 ? '' : 's'}${isPR ? ' · <span class="pr-tag"><i class=\"fas fa-star\"></i> New PR</span>' : ''}</div>
                     </div>
                 </div>
+                ${scheduledHTML}
                 ${daySessions.map(s => this.renderSessionSummary(s, unit)).join('')}
             </div>
         `;

--- a/apps/gym-tracker/js/views/home-view.js
+++ b/apps/gym-tracker/js/views/home-view.js
@@ -8,6 +8,7 @@ import { formatDate, formatWeight, showConfirmModal, showToast, formatSessionDat
 import { orderPrograms } from '../utils/program-order.js';
 import { renderPausedBannerHTML, wirePausedBannerActions } from './paused-banner.js';
 import { AnalyticsService } from '../services/AnalyticsService.js';
+import { sameId } from '../utils/id-utils.js';
 
 class HomeView {
     constructor() {
@@ -17,15 +18,7 @@ class HomeView {
 
     init() {
         this.app.viewControllers.home = this;
-        this.wireFab();
         this.wireHomeActions();
-    }
-
-    wireFab() {
-        const fab = document.getElementById('home-workout-fab');
-        if (!fab || fab.dataset.wired) return;
-        fab.addEventListener('click', () => this.handleFabClick());
-        fab.dataset.wired = '1';
     }
 
     /**
@@ -54,11 +47,11 @@ class HomeView {
                     break;
                 case 'start-program':
                     e.preventDefault();
-                    this.startWorkoutWithProgram(Number(target.dataset.programId));
+                    this.startWorkoutWithProgram(target.dataset.programId);
                     break;
                 case 'edit-program':
                     e.preventDefault();
-                    this.app.viewControllers.programs?.editProgram(Number(target.dataset.programId));
+                    this.app.viewControllers.programs?.editProgram(target.dataset.programId);
                     break;
                 case 'show-session':
                     e.preventDefault();
@@ -85,7 +78,7 @@ class HomeView {
         this.renderWeekSummary();
         this.renderRecentWorkouts();
         this.renderRecentAchievements();
-        this.renderFab();
+        this.app.updateGlobalFab();
     }
 
     /**
@@ -149,71 +142,6 @@ class HomeView {
             const startDate = parseLocalDate(stats.weekStart);
             caption.textContent = `Week of ${startDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`;
         }
-    }
-
-    /**
-     * The FAB has three states:
-     *   - Hidden when there are no programs yet (nothing to start).
-     *   - "Resume workout" (green) when a paused session exists.
-     *   - "Start workout" (primary) otherwise.
-     * Clicking either state jumps to the workout view; resume re-hydrates.
-     */
-    renderFab() {
-        const fab = document.getElementById('home-workout-fab');
-        if (!fab) return;
-        const hasPrograms = this.app.programs.length > 0;
-        const paused = storageService.getActiveWorkout();
-
-        if (!hasPrograms) {
-            fab.hidden = true;
-            return;
-        }
-
-        fab.hidden = false;
-        const label = fab.querySelector('.workout-fab-label');
-        const icon = fab.querySelector('i');
-
-        if (paused && paused.paused) {
-            fab.classList.add('workout-fab--resume');
-            if (label) label.textContent = 'Resume workout';
-            if (icon) {
-                icon.classList.remove('fa-play');
-                icon.classList.add('fa-play-circle');
-            }
-            fab.setAttribute('aria-label', 'Resume paused workout');
-        } else {
-            fab.classList.remove('workout-fab--resume');
-            if (label) label.textContent = 'Start workout';
-            if (icon) {
-                icon.classList.remove('fa-play-circle');
-                icon.classList.add('fa-play');
-            }
-            fab.setAttribute('aria-label', 'Start workout');
-        }
-    }
-
-    /**
-     * If paused → go to workout view and let it resume automatically.
-     * If exactly one program → auto-start it.
-     * Otherwise → route to the workout view's program picker.
-     */
-    handleFabClick() {
-        // Starting (or resuming) a workout is a context switch: land the
-        // user at the top of the page, not wherever they had scrolled to.
-        window.scrollTo(0, 0);
-        const paused = storageService.getActiveWorkout();
-        if (paused && paused.paused) {
-            this.resumeWorkout();
-            return;
-        }
-        if (this.app.programs.length === 1) {
-            const only = this.app.programs[0];
-            if (only.exercises && only.exercises.length > 0) {
-                this.startWorkoutWithProgram(only.id);
-                return;
-            }
-        }
-        this.app.showView('workout');
     }
 
     renderPausedWorkoutBanner() {
@@ -283,7 +211,7 @@ class HomeView {
                 <h3>Your Programs</h3>
                 <div class="quick-programs">
                     ${programs.map(program => {
-                        const isPaused = pausedWorkout && pausedWorkout.paused && pausedWorkout.programId === program.id;
+                        const isPaused = pausedWorkout && pausedWorkout.paused && sameId(pausedWorkout.programId, program.id);
                         const hasExercises = program.exercises.length > 0;
 
                         if (isPaused) {

--- a/apps/gym-tracker/js/views/programs-view.js
+++ b/apps/gym-tracker/js/views/programs-view.js
@@ -9,6 +9,8 @@ import { trapModalFocus } from '../utils/modal-focus.js';
 import { storageService } from '../services/StorageService.js';
 import { DarkSelect } from '../utils/dark-select.js';
 import { orderPrograms } from '../utils/program-order.js';
+import { weekdayOrder } from '../utils/program-schedule.js';
+import { sameId } from '../utils/id-utils.js';
 
 class ProgramsView {
     constructor() {
@@ -202,13 +204,15 @@ class ProgramsView {
 
     handleDrop(e, targetId) {
         e.preventDefault();
-        const fromIdRaw = e.dataTransfer.getData('text/plain');
-        const fromId = Number(fromIdRaw);
-        if (!fromId || fromId === targetId) return;
+        const fromId = e.dataTransfer.getData('text/plain');
+        if (!fromId || sameId(fromId, targetId)) return;
 
+        // `order` holds canonical program ids (numeric for real data, string
+        // for imported); fromId/targetId come from the DOM as strings. Match
+        // type-insensitively so reordering works for both id kinds.
         const order = this.getCustomOrderedIds();
-        const fromIdx = order.indexOf(fromId);
-        const toIdx = order.indexOf(targetId);
+        const fromIdx = order.findIndex(id => sameId(id, fromId));
+        const toIdx = order.findIndex(id => sameId(id, targetId));
         if (fromIdx < 0 || toIdx < 0) return;
 
         const [moved] = order.splice(fromIdx, 1);
@@ -247,7 +251,19 @@ class ProgramsView {
 
         container.classList.toggle('is-custom-order', isCustom);
 
-        container.innerHTML = ordered.map((program, index) => `
+        const firstDay = this.app.settings?.firstDayOfWeek === 1 ? 1 : 0;
+        const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+        container.innerHTML = ordered.map((program, index) => {
+            const hasSchedule = Array.isArray(program.scheduleDays) && program.scheduleDays.length > 0;
+            let scheduleText = '';
+            if (hasSchedule) {
+                const days = new Set(program.scheduleDays);
+                scheduleText = days.size === 7
+                    ? 'Every day'
+                    : weekdayOrder(firstDay).filter(d => days.has(d)).map(d => dayLabels[d]).join(', ');
+            }
+            return `
             <div class="program-card ${isCustom ? 'is-draggable' : ''}"
                  data-program-id="${program.id}"
                  ${isCustom ? 'draggable="true"' : ''}>
@@ -265,6 +281,12 @@ class ProgramsView {
                         <i class="fas fa-dumbbell"></i>
                         ${program.exercises.length} ${program.exercises.length === 1 ? 'exercise' : 'exercises'}
                     </div>
+                    ${hasSchedule ? `
+                    <div class="stat program-schedule-stat">
+                        <i class="fas fa-calendar-day"></i>
+                        ${scheduleText}
+                    </div>
+                    ` : ''}
                 </div>
                 <div class="program-actions">
                     <button class="btn btn-secondary" data-action="edit-program" data-program-id="${program.id}">
@@ -278,11 +300,12 @@ class ProgramsView {
                     </button>
                 </div>
             </div>
-        `).join('');
+        `;
+        }).join('');
 
         // Wire up drag-and-drop on every card so a drag from any sort mode flips to custom
         container.querySelectorAll('.program-card').forEach(card => {
-            const id = Number(card.dataset.programId);
+            const id = card.dataset.programId;
             // Make every card a valid drop target & drag source
             card.draggable = true;
             card.addEventListener('dragstart', (e) => this.handleDragStart(e, id));
@@ -309,7 +332,7 @@ class ProgramsView {
         container.addEventListener('click', (e) => {
             const btn = e.target.closest('[data-action]');
             if (!btn || !container.contains(btn)) return;
-            const id = Number(btn.dataset.programId);
+            const id = btn.dataset.programId;
             switch (btn.dataset.action) {
                 case 'edit-program':
                     e.preventDefault();
@@ -337,7 +360,13 @@ class ProgramsView {
         this.showExercisesError(false);
 
         if (programId) {
-            this.currentProgram = this.app.getProgramById(programId);
+            // R3-3: edit a STAGED deep clone, never the live stored object.
+            // Every in-modal mutation (name, exercises, schedule, rest) writes
+            // to this.currentProgram, so editing the stored reference directly
+            // meant Cancel/X (which never call save) still leaked changes into
+            // memory and into the resumed workout. The clone is committed back
+            // into app.programs only by saveProgram(); Cancel discards it.
+            this.currentProgram = Program.clone(this.app.getProgramById(programId));
             title.textContent = 'Edit Program';
             document.getElementById('program-name').value = this.currentProgram.name;
             document.getElementById('program-description').value = this.currentProgram.description;
@@ -355,8 +384,137 @@ class ProgramsView {
         }
 
         this.syncRestModeUI();
+        this.syncScheduleDaysUI();
+        this.syncReturnToWorkoutButton();
         modal.classList.add('active');
         trapModalFocus(modal);
+
+        // #15: the scroll container retains its previous scrollTop when the
+        // modal is reopened, so a mid-workout "Edit program" could surface the
+        // bottom of the form. Reset to the top once the modal is visible. Scroll
+        // height isn't final synchronously on reveal, so do it after a frame.
+        const resetScroll = () => {
+            const content = modal.querySelector('.modal-content');
+            if (content) content.scrollTop = 0;
+            const body = modal.querySelector('.modal-body');
+            if (body) body.scrollTop = 0;
+        };
+        resetScroll();
+        requestAnimationFrame(resetScroll);
+    }
+
+    /**
+     * Item R2-7: in workout mode the program editor shows a single primary
+     * action ("Save and resume workout") plus "Cancel" in the modal's sticky
+     * header; the footer save/return buttons are hidden. Normal entry keeps the
+     * footer buttons and a non-sticky header (the round-1 layout).
+     */
+    syncReturnToWorkoutButton() {
+        const workoutMode = !!this.enteredFromWorkout;
+        const modal = document.getElementById('program-modal');
+        if (modal) modal.classList.toggle('program-editor-workout-mode', workoutMode);
+
+        // Legacy round-1 return button stays hidden now (its role moved into the
+        // header's "Save and resume workout"), but keep it harmless if present.
+        const legacyReturn = document.getElementById('return-to-workout-btn');
+        if (legacyReturn) legacyReturn.hidden = true;
+
+        const actions = document.getElementById('program-modal-workout-actions');
+        if (actions) actions.hidden = !workoutMode;
+
+        // Feature B: normal-mode header actions are the inverse of workout mode.
+        const normalActions = document.getElementById('program-modal-normal-actions');
+        if (normalActions) normalActions.hidden = workoutMode;
+
+        const saveResume = document.getElementById('program-modal-save-resume');
+        if (saveResume && !saveResume.dataset.wired) {
+            saveResume.addEventListener('click', () => this.returnToWorkout());
+            saveResume.dataset.wired = '1';
+        }
+        const cancelWorkout = document.getElementById('program-modal-cancel-workout');
+        if (cancelWorkout && !cancelWorkout.dataset.wired) {
+            cancelWorkout.addEventListener('click', () => this.cancelWorkoutEdit());
+            cancelWorkout.dataset.wired = '1';
+        }
+    }
+
+    /**
+     * Item R2-7: Cancel in workout mode discards any in-modal program edits and
+     * resumes the paused workout directly (not back to the programs list).
+     */
+    cancelWorkoutEdit() {
+        const modal = document.getElementById('program-modal');
+        if (modal) {
+            modal.classList.remove('active');
+            modal.classList.remove('program-editor-workout-mode');
+        }
+        this.enteredFromWorkout = false;
+        const actions = document.getElementById('program-modal-workout-actions');
+        if (actions) actions.hidden = true;
+        const workoutCtrl = this.app.viewControllers.workout;
+        if (!workoutCtrl) return;
+        this.app.showView('workout');
+        setTimeout(() => workoutCtrl.resumeWorkout(), 100);
+    }
+
+    /**
+     * Item 4: save any committed edits (the modal's save already persisted the
+     * program), close the editor, and resume the paused workout, re-syncing the
+     * session plan with the edited program.
+     */
+    returnToWorkout() {
+        // Persist the current in-modal edits before leaving so the resumed
+        // session merges against the latest program state. saveProgram is a
+        // no-op (modal stays open) when validation fails.
+        const programId = this.currentProgram?.id;
+        this.saveProgram();
+        // If the modal is still open, the save was rejected (validation) — stay.
+        const modalOpen = document.getElementById('program-modal')?.classList.contains('active');
+        if (modalOpen) return;
+
+        this.enteredFromWorkout = false;
+        const workoutCtrl = this.app.viewControllers.workout;
+        if (!workoutCtrl) return;
+        this.app.showView('workout');
+        // Resume and re-sync the paused session with the edited program.
+        setTimeout(() => workoutCtrl.resumeWorkout({ resyncProgramId: programId }), 100);
+    }
+
+    /**
+     * Item 9: render the 7 weekday chips, reflecting currentProgram.scheduleDays.
+     * Chips are laid out starting from the user's firstDayOfWeek preference.
+     */
+    syncScheduleDaysUI() {
+        const container = document.getElementById('program-schedule-days');
+        if (!container || !this.currentProgram) return;
+        const selected = new Set(this.currentProgram.scheduleDays || []);
+        const firstDay = this.app.settings?.firstDayOfWeek === 1 ? 1 : 0;
+        const order = weekdayOrder(firstDay);
+        const labels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        const fullLabels = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+        container.innerHTML = order.map(d => {
+            const on = selected.has(d);
+            return `
+                <button type="button" class="schedule-day-chip${on ? ' is-on' : ''}"
+                    data-schedule-day="${d}"
+                    aria-pressed="${on ? 'true' : 'false'}"
+                    aria-label="${fullLabels[d]}">
+                    ${labels[d]}
+                </button>`;
+        }).join('');
+
+        if (!container.dataset.wired) {
+            container.addEventListener('click', (e) => {
+                const chip = e.target.closest('[data-schedule-day]');
+                if (!chip || !this.currentProgram) return;
+                const day = Number(chip.dataset.scheduleDay);
+                const days = new Set(this.currentProgram.scheduleDays || []);
+                if (days.has(day)) days.delete(day); else days.add(day);
+                this.currentProgram.scheduleDays = [...days].sort((a, b) => a - b);
+                this.syncScheduleDaysUI();
+            });
+            container.dataset.wired = '1';
+        }
     }
 
     /** Push currentProgram.restMode + uniformRestSeconds into the toggle UI. */
@@ -780,21 +938,44 @@ class ProgramsView {
         const row = ex.sets[setIndex];
         if (!row) return;
         const val = Math.max(1, Math.min(100, Math.round(Number(rawValue) || 1)));
+        // #16: a plain value edit must NOT re-render #program-exercises-list.
+        // The change event fires on TAB-out (blur); a full re-render destroys
+        // and rebuilds the input being left, so the browser's native "focus the
+        // next tabbable element" lands on a detached node and jumps elsewhere.
+        // Update the model in place; if clamping moved the SIBLING field, write
+        // only that sibling's input value via a targeted selector — no rebuild.
+        let siblingChanged = null; // 'min' | 'max' when the other field was clamped
         if (minOrMax === 'min') {
             const wasSingle = row.repsMin === row.repsMax;
             row.repsMin = val;
             if (wasSingle) {
                 // Single-mode: keep repsMax in sync so the range UI stays closed.
                 row.repsMax = val;
+                siblingChanged = 'max';
             } else if (row.repsMax < row.repsMin) {
                 row.repsMax = row.repsMin;
+                siblingChanged = 'max';
             }
         } else {
             row.repsMax = val;
-            if (row.repsMin > row.repsMax) row.repsMin = row.repsMax;
+            if (row.repsMin > row.repsMax) {
+                row.repsMin = row.repsMax;
+                siblingChanged = 'min';
+            }
         }
         this.currentProgram.updatedAt = new Date().toISOString();
-        this.renderProgramExercises();
+
+        if (siblingChanged === 'max') {
+            const maxInput = document.querySelector(
+                `#program-exercises-list [data-action="set-reps-max"][data-exercise-index="${exerciseIndex}"][data-set-index="${setIndex}"]`
+            );
+            if (maxInput) maxInput.value = row.repsMax;
+        } else if (siblingChanged === 'min') {
+            const minInput = document.querySelector(
+                `#program-exercises-list [data-action="set-reps-min"][data-exercise-index="${exerciseIndex}"][data-set-index="${setIndex}"]`
+            );
+            if (minInput) minInput.value = row.repsMin;
+        }
     }
 
     wireExerciseDragAndDrop(container) {
@@ -986,7 +1167,17 @@ class ProgramsView {
      * Cancel button, X button, and after a successful save.
      */
     closeProgramModal() {
-        document.getElementById('program-modal').classList.remove('active');
+        const modal = document.getElementById('program-modal');
+        modal.classList.remove('active');
+        modal.classList.remove('program-editor-workout-mode');
+        // Item 4: closing via Cancel/X (not the Return button) abandons the
+        // workout-edit context. The paused workout stays resumable from the
+        // banner; we just stop offering the in-editor return button.
+        this.enteredFromWorkout = false;
+        const returnBtn = document.getElementById('return-to-workout-btn');
+        if (returnBtn) returnBtn.hidden = true;
+        const actions = document.getElementById('program-modal-workout-actions');
+        if (actions) actions.hidden = true;
         if (this.returnToView) {
             const target = this.returnToView;
             this.returnToView = null;
@@ -1001,6 +1192,9 @@ class ProgramsView {
             name: `${source.name} (Copy)`,
             description: source.description,
             exercises: source.exercises.map(ex => ({ ...ex })),
+            scheduleDays: [...(source.scheduleDays || [])],
+            restMode: source.restMode,
+            uniformRestSeconds: source.uniformRestSeconds,
         });
         this.app.programs.push(copy);
         this.app.savePrograms();
@@ -1009,7 +1203,7 @@ class ProgramsView {
     }
 
     async deleteProgram(programId) {
-        const program = this.app.programs.find(p => p.id === programId);
+        const program = this.app.programs.find(p => sameId(p.id, programId));
         if (!program) return;
 
         const exerciseCount = program.exercises.length;
@@ -1025,7 +1219,7 @@ class ProgramsView {
         });
 
         if (confirmed) {
-            const index = this.app.programs.findIndex(p => p.id === programId);
+            const index = this.app.programs.findIndex(p => sameId(p.id, programId));
             if (index >= 0) {
                 this.app.programs.splice(index, 1);
                 this.app.savePrograms();

--- a/apps/gym-tracker/js/views/settings-view.js
+++ b/apps/gym-tracker/js/views/settings-view.js
@@ -4,6 +4,8 @@
 import { app } from '../app.js';
 import { showToast, downloadJSON, showConfirmModal } from '../utils/helpers.js';
 import { DarkSelect } from '../utils/dark-select.js';
+import { Settings } from '../models/Settings.js';
+import { closeModalSafely } from '../utils/modal-focus.js';
 
 function validateImportData(data) {
     if (!data) {
@@ -67,6 +69,32 @@ class SettingsView {
         const vibrationAlertsInput = document.getElementById('vibration-alerts');
         if (vibrationAlertsInput) {
             vibrationAlertsInput.addEventListener('change', () => this.checkDirty());
+        }
+
+        // Timer sound markers — free numeric inputs (Item R2-1).
+        const firstWarnInput = document.getElementById('timer-first-warning');
+        if (firstWarnInput) {
+            firstWarnInput.addEventListener('input', () => this.checkDirty());
+        }
+        const countdownInput = document.getElementById('timer-countdown-start');
+        if (countdownInput) {
+            countdownInput.addEventListener('input', () => this.checkDirty());
+        }
+
+        // Calendar: first-day-of-week select (Item R2-5).
+        const firstDaySelect = document.getElementById('first-day-of-week');
+        if (firstDaySelect && !firstDaySelect.dataset.darkSelectInit) {
+            this.firstDayDropdown = new DarkSelect(firstDaySelect);
+            firstDaySelect.dataset.darkSelectInit = '1';
+        }
+        if (firstDaySelect) {
+            firstDaySelect.addEventListener('change', () => this.checkDirty());
+        }
+
+        // Calendar: show-program-schedule toggle.
+        const scheduleToggle = document.getElementById('show-program-schedule');
+        if (scheduleToggle) {
+            scheduleToggle.addEventListener('change', () => this.checkDirty());
         }
 
         // Plate calculator inputs — react on input, refresh preview, mark dirty.
@@ -138,6 +166,29 @@ class SettingsView {
             });
         }
 
+        // Item R2-9: unsaved-changes guard modal actions.
+        const unsavedModal = document.getElementById('unsaved-settings-modal');
+        if (unsavedModal && !unsavedModal.dataset.wired) {
+            const close = () => { closeModalSafely(unsavedModal); this.pendingLeaveView = null; };
+            document.getElementById('unsaved-settings-close')?.addEventListener('click', close);
+            document.getElementById('unsaved-settings-save')?.addEventListener('click', () => {
+                const target = this.pendingLeaveView;
+                this.pendingLeaveView = null;
+                closeModalSafely(unsavedModal);
+                this.saveSettings();
+                if (target) this.app.showView(target);
+            });
+            document.getElementById('unsaved-settings-discard')?.addEventListener('click', () => {
+                const target = this.pendingLeaveView;
+                this.pendingLeaveView = null;
+                closeModalSafely(unsavedModal);
+                // Restore the saved values so re-entering Settings shows them.
+                this.render();
+                if (target) this.app.showView(target);
+            });
+            unsavedModal.dataset.wired = '1';
+        }
+
         // Delete cloud data — wipes the user's Firestore document so
         // signing in on a fresh device is a clean slate. Local data
         // remains untouched (the user can wipe that with Clear All Data
@@ -191,6 +242,24 @@ class SettingsView {
         const vibrationAlertsInput = document.getElementById('vibration-alerts');
         if (vibrationAlertsInput) vibrationAlertsInput.checked = settings.vibrationAlerts !== false;
 
+        const firstWarnInput = document.getElementById('timer-first-warning');
+        if (firstWarnInput) {
+            firstWarnInput.value = String(settings.timerFirstWarningSeconds ?? 10);
+        }
+        const countdownInput = document.getElementById('timer-countdown-start');
+        if (countdownInput) {
+            countdownInput.value = String(settings.timerCountdownSeconds ?? 5);
+        }
+
+        const firstDaySelect = document.getElementById('first-day-of-week');
+        if (firstDaySelect) {
+            firstDaySelect.value = String(settings.firstDayOfWeek === 1 ? 1 : 0);
+            if (this.firstDayDropdown) this.firstDayDropdown.sync();
+        }
+
+        const scheduleToggle = document.getElementById('show-program-schedule');
+        if (scheduleToggle) scheduleToggle.checked = settings.showProgramSchedule !== false;
+
         // Plate calculator
         const barInput = document.getElementById('bar-weight');
         if (barInput) barInput.value = settings.barWeight ?? '';
@@ -210,6 +279,10 @@ class SettingsView {
             timeFormat: document.getElementById('time-format')?.value ?? '',
             soundAlerts: document.getElementById('sound-alerts')?.checked ? '1' : '0',
             vibrationAlerts: document.getElementById('vibration-alerts')?.checked ? '1' : '0',
+            timerFirstWarning: document.getElementById('timer-first-warning')?.value ?? '',
+            timerCountdownStart: document.getElementById('timer-countdown-start')?.value ?? '',
+            firstDayOfWeek: document.getElementById('first-day-of-week')?.value ?? '',
+            showProgramSchedule: document.getElementById('show-program-schedule')?.checked ? '1' : '0',
             barWeight: document.getElementById('bar-weight')?.value ?? '',
             plates: document.getElementById('plates-input')?.value ?? '',
         };
@@ -240,14 +313,37 @@ class SettingsView {
             : `Accepted: ${parsed.map(p => `${p}${unit}`).join(', ')}`;
     }
 
+    /** True when any form value differs from the last saved snapshot. */
+    isDirty() {
+        if (!this.savedSnapshot) return false;
+        const current = this.snapshotForm();
+        return Object.keys(this.savedSnapshot)
+            .some(k => this.savedSnapshot[k] !== current[k]);
+    }
+
     /** Compare current form against saved snapshot and toggle Save button. */
     checkDirty() {
         const btn = document.getElementById('save-settings-btn');
         if (!btn || !this.savedSnapshot) return;
-        const current = this.snapshotForm();
-        const dirty = Object.keys(this.savedSnapshot)
-            .some(k => this.savedSnapshot[k] !== current[k]);
-        btn.disabled = !dirty;
+        btn.disabled = !this.isDirty();
+    }
+
+    /**
+     * Item R2-9: navigation guard. When leaving Settings with unsaved diffs,
+     * pop the confirm modal and defer the navigation (return false). The modal
+     * actions re-invoke showView for the deferred target. No diffs => proceed.
+     */
+    beforeLeave(targetView) {
+        if (!this.isDirty()) return true;
+        this.pendingLeaveView = targetView;
+        const modal = document.getElementById('unsaved-settings-modal');
+        if (modal) {
+            // Make the dialog visible to assistive tech while open; the static
+            // aria-hidden="true" in markup is restored on close.
+            modal.setAttribute('aria-hidden', 'false');
+            modal.classList.add('active');
+        }
+        return false;
     }
 
     saveSettings() {
@@ -264,6 +360,23 @@ class SettingsView {
         const vibrationAlertsInput = document.getElementById('vibration-alerts');
         if (vibrationAlertsInput) settings.vibrationAlerts = vibrationAlertsInput.checked;
 
+        const firstWarnInput = document.getElementById('timer-first-warning');
+        if (firstWarnInput) {
+            settings.timerFirstWarningSeconds = Settings.normalizeFirstWarningSeconds(
+                firstWarnInput.value);
+        }
+        const countdownInput = document.getElementById('timer-countdown-start');
+        if (countdownInput) {
+            settings.timerCountdownSeconds = Settings.normalizeCountdownSeconds(
+                countdownInput.value);
+        }
+
+        const firstDaySelect = document.getElementById('first-day-of-week');
+        if (firstDaySelect) settings.firstDayOfWeek = firstDaySelect.value === '1' ? 1 : 0;
+
+        const scheduleToggle = document.getElementById('show-program-schedule');
+        if (scheduleToggle) settings.showProgramSchedule = scheduleToggle.checked;
+
         const barInput = document.getElementById('bar-weight');
         if (barInput && barInput.value !== '') {
             const bar = Number(barInput.value);
@@ -274,6 +387,12 @@ class SettingsView {
 
         this.app.saveSettings();
         showToast('Settings saved successfully', 'success');
+
+        // Item R2-1: reflect the normalized (clamped / defaulted) marker values
+        // back into the inputs so the user sees exactly what persisted instead
+        // of stale invalid text.
+        if (firstWarnInput) firstWarnInput.value = String(settings.timerFirstWarningSeconds);
+        if (countdownInput) countdownInput.value = String(settings.timerCountdownSeconds);
 
         // Form is now clean again — snapshot the just-saved values and disable Save
         this.savedSnapshot = this.snapshotForm();

--- a/apps/gym-tracker/js/views/workout-view.js
+++ b/apps/gym-tracker/js/views/workout-view.js
@@ -8,12 +8,18 @@ import { WorkoutExercise } from '../models/WorkoutExercise.js';
 import { Set } from '../models/Set.js';
 import { timerService } from '../services/TimerService.js';
 import { storageService } from '../services/StorageService.js';
-import { showToast, showConfirmModal, formatMuscleGroup, vibrate, playSound, escapeHtml, debugLog } from '../utils/helpers.js';
+import { showToast, showConfirmModal, formatMuscleGroup, vibrate, playSound, escapeHtml, debugLog, convertWeight } from '../utils/helpers.js';
 import { trapModalFocus } from '../utils/modal-focus.js';
 import { renderPausedBannerHTML, wirePausedBannerActions } from './paused-banner.js';
 import { orderPrograms } from '../utils/program-order.js';
+import { sameId } from '../utils/id-utils.js';
 import { AnalyticsService } from '../services/AnalyticsService.js';
 import { calculatePlates, formatPlateStack } from '../utils/plate-calculator.js';
+import { restTickCues, isWorkoutComplete } from '../utils/rest-cues.js';
+import { allSetsReachMax, latestFeelForExercise, nextFeel, shouldShowFeelModal } from '../utils/exercise-feel.js';
+import { recordPrSupersede, uniquePrChainCount, recomputePrSlots } from '../utils/pr-session.js';
+import { mergeSessionWithProgram } from '../utils/session-merge.js';
+import { weekStrip } from '../utils/program-schedule.js';
 
 const PLATE_LOADED_EQUIPMENT = new globalThis.Set(['barbell', 'trap-bar', 'machine', 'plate', 'sled']);
 
@@ -28,26 +34,36 @@ class WorkoutView {
         this.activeRestExerciseIndex = -1;
         // Last second value for which we played the timer-low ping (guards duplicates).
         this.lastPingedRestSecond = -1;
-        // PRs logged during the current session — surfaced in the finish modal.
-        this.sessionPrCount = 0;
-        // Slot-keyed record of sets that triggered a PR this session so the
-        // row can render a gold outline even after rerender. Plain object
-        // on purpose: this module imports `Set` from models/Set.js, which
-        // shadows the built-in Set.
+        // Slot-keyed record of sets that hold a surviving PR badge this session
+        // so the row can render a gold outline even after rerender. Item R2-10:
+        // within a session only the best set per exercise keeps its entry here
+        // (earlier PRs are superseded). The finish-modal PR count is derived
+        // from this map via uniquePrChainCount. Plain object on purpose: this
+        // module imports `Set` from models/Set.js, which shadows the built-in.
         this.sessionPrSlots = {};
         // Feature 3: per-exercise collapsed state (index → bool). Exercises
         // marked exercise-complete auto-collapse; the rest start expanded.
         this.collapsedExercises = {};
-        // Feature 5: per-exercise rest override for this session (index → seconds).
-        // Overrides apply to both between-set and between-exercise rest for that exercise.
-        this.exerciseRestOverrides = {};
         // Tracks which exercises were complete before the last deleteSet call,
         // used to reset the manual-expand suppression when going complete->incomplete.
         this._prevCompleteState = {};
         // Timer type for the currently active rest: 'set' (between-set, chip only)
         // or 'exercise' (between-exercise, bottom bar).
         this._activeRestType = null;
+        // Item R3-4: per-session bookkeeping of exercise indices for which the
+        // feel modal has already been shown, so it appears at most once per
+        // exercise per session.
+        this._feelModalShown = {};
         this.init();
+    }
+
+    /**
+     * Item R2-10: PRs surfaced in the finish modal — the number of UNIQUE
+     * exercises with a surviving PR badge (a 100 -> 110 chain counts once).
+     * Derived from sessionPrSlots so supersede bookkeeping has one source.
+     */
+    get sessionPrCount() {
+        return uniquePrChainCount(this.sessionPrSlots || {});
     }
 
     init() {
@@ -99,7 +115,7 @@ class WorkoutView {
             switch (action) {
                 case 'start-workout':
                     e.preventDefault();
-                    this.startWorkout(Number(target.dataset.programId));
+                    this.startWorkout(target.dataset.programId);
                     break;
                 case 'commit-planned-set':
                     e.preventDefault();
@@ -140,13 +156,13 @@ class WorkoutView {
                     e.preventDefault();
                     this.toggleExerciseCollapse(exerciseIndex);
                     break;
-                case 'set-rest-override':
-                    e.preventDefault();
-                    this.setRestOverride(exerciseIndex, Number(target.dataset.seconds));
-                    break;
                 case 'toggle-exercise-plate-hints':
                     e.preventDefault();
                     this.toggleExercisePlateHints(exerciseIndex);
+                    break;
+                case 'cycle-feel':
+                    e.preventDefault();
+                    this.cycleExerciseFeel(exerciseIndex);
                     break;
             }
         });
@@ -189,30 +205,165 @@ class WorkoutView {
         // Plate-hints toggle
         const plateToggleBtn = document.getElementById('plate-hints-toggle-btn');
         if (plateToggleBtn) plateToggleBtn.addEventListener('click', () => this.togglePlateHints());
+
+        // Edit-program button (Item 3): instant pause + open the program editor.
+        const editProgramBtn = document.getElementById('edit-program-btn');
+        if (editProgramBtn) editProgramBtn.addEventListener('click', () => this.editProgramFromWorkout());
+
+        // Session unit toggle (Item 8): kg | lbs for this workout only.
+        document.querySelectorAll('#workout-unit-toggle .workout-unit-btn').forEach(btn => {
+            btn.addEventListener('click', () => this.setSessionUnit(btn.dataset.unit));
+        });
+    }
+
+    /** The unit weights are DISPLAYED/ENTERED in for this session. */
+    sessionUnit() {
+        return this.currentWorkoutSession?.sessionUnit || this.app.settings.weightUnit;
+    }
+
+    /** True when the session display unit differs from the account unit. */
+    unitsDiffer() {
+        return this.sessionUnit() !== this.app.settings.weightUnit;
+    }
+
+    /** Convert a canonical (account-unit) weight into the session display unit. */
+    toSessionWeight(weight) {
+        if (weight === '' || weight === null || weight === undefined) return weight;
+        return convertWeight(Number(weight), this.app.settings.weightUnit, this.sessionUnit());
+    }
+
+    /** Convert a session-unit input value back to the canonical account unit. */
+    toAccountWeight(weight) {
+        return convertWeight(Number(weight), this.sessionUnit(), this.app.settings.weightUnit);
+    }
+
+    /**
+     * Switch the per-session display/entry unit (Item 8). Reads any in-progress
+     * planned-row weight inputs and re-displays them in the new unit so the user
+     * doesn't lose what they typed, then re-renders + persists.
+     */
+    setSessionUnit(unit) {
+        if (!this.currentWorkoutSession) return;
+        if (unit !== 'kg' && unit !== 'lb') return;
+        if (this.sessionUnit() === unit) return;
+
+        const account = this.app.settings.weightUnit;
+        // Read current planned-row weight inputs (in the OLD session unit) and
+        // carry their canonical values onto stickyValues so the re-render
+        // repopulates them converted into the new unit.
+        const oldUnit = this.sessionUnit();
+        this.currentWorkoutSession.exercises.forEach((exercise, eIdx) => {
+            const list = document.querySelectorAll(`#exercise-${eIdx} .set-row-planned`);
+            list.forEach(row => {
+                const slot = Number(row.dataset.slot);
+                const input = row.querySelector('.set-weight');
+                if (!input || input.value === '') return;
+                const canonical = convertWeight(Number(input.value), oldUnit, account);
+                if (!exercise.stickyValues) exercise.stickyValues = {};
+                const reps = row.querySelector('.set-reps');
+                exercise.stickyValues[slot] = {
+                    weight: canonical,
+                    reps: reps && reps.value !== '' ? Number(reps.value) : (exercise.stickyValues[slot]?.reps ?? ''),
+                    duration: exercise.stickyValues[slot]?.duration ?? 0,
+                };
+            });
+        });
+
+        this.currentWorkoutSession.sessionUnit = unit === account ? null : unit;
+        storageService.saveActiveWorkout(this.currentWorkoutSession.toJSON());
+        this.syncSessionUnitToggle();
+        this.renderActiveWorkout();
+    }
+
+    /** Reflect the active session unit in the header toggle button states. */
+    syncSessionUnitToggle() {
+        const unit = this.sessionUnit();
+        document.querySelectorAll('#workout-unit-toggle .workout-unit-btn').forEach(btn => {
+            const on = btn.dataset.unit === unit;
+            btn.classList.toggle('is-active', on);
+            btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        });
     }
 
     setupNavigationGuard() {
-        // Intercept browser back button and page unload
+        // Refresh / tab close: arm the native confirmation whenever a workout
+        // is active, regardless of whether any sets are committed yet (Item 5).
+        // The native dialog is the only "are you sure" UI browsers allow here.
         window.addEventListener('beforeunload', (e) => {
-            if (this.currentWorkoutSession && !this.currentWorkoutSession.completed) {
-                // Check if any sets were added
-                const hasAnySets = this.currentWorkoutSession.exercises.some(ex =>
-                    ex.sets && ex.sets.length > 0
-                );
-
-                if (hasAnySets) {
-                    // Save workout state before leaving
-                    this.pauseAndSaveWorkout();
-                    // Show browser's native confirmation
-                    e.preventDefault();
-                    e.returnValue = '';
-                    return '';
-                }
+            if (this.hasActiveWorkout()) {
+                e.preventDefault();
+                e.returnValue = '';
+                return '';
             }
+        });
+
+        // Browser BACK trap (Item 5): a sentinel history entry is pushed when
+        // the workout screen opens. On popstate while a workout is active we
+        // immediately re-push the sentinel and show the in-app leave modal.
+        window.addEventListener('popstate', () => {
+            if (!this.hasActiveWorkout() || !this._backSentinelArmed) return;
+            // Re-push so the user stays on the workout screen until they choose.
+            this._pushBackSentinel();
+            this.showBackLeaveModal();
         });
 
         // Intercept in-app navigation
         this.interceptNavigation();
+    }
+
+    /** Push a history sentinel so the next browser BACK lands on popstate
+     *  while keeping the user on the workout screen. Idempotent-ish: callers
+     *  guard with _backSentinelArmed. */
+    _pushBackSentinel() {
+        try {
+            history.pushState({ gtWorkoutSentinel: true }, '', window.location.href);
+        } catch { /* history unavailable (tests / sandbox) */ }
+    }
+
+    /** Arm the back-navigation trap when the active-workout screen opens. */
+    armBackGuard() {
+        if (this._backSentinelArmed) return;
+        this._backSentinelArmed = true;
+        this._pushBackSentinel();
+    }
+
+    /** Disarm the trap on finish/discard/pause so back navigates normally. */
+    disarmBackGuard() {
+        this._backSentinelArmed = false;
+    }
+
+    /**
+     * In-app "Leave workout?" modal for the back-navigation trap. "Stay" keeps
+     * the workout untouched; "Pause and leave" pauses+saves then navigates home.
+     */
+    showBackLeaveModal() {
+        const modal = document.getElementById('leave-workout-modal');
+        if (!modal) return;
+        if (modal.classList.contains('active')) return;
+
+        const stayBtn = document.getElementById('leave-workout-stay');
+        const leaveBtn = document.getElementById('leave-workout-pause-leave');
+
+        const cleanup = () => {
+            // R3-6: drop focus off the clicked button before hiding so no
+            // focused descendant sits inside a closing/aria-hidden dialog.
+            if (modal.contains(document.activeElement)) document.activeElement.blur();
+            modal.classList.remove('active');
+            stayBtn.removeEventListener('click', onStay);
+            leaveBtn.removeEventListener('click', onLeave);
+        };
+        const onStay = () => { cleanup(); };
+        const onLeave = () => {
+            cleanup();
+            this.disarmBackGuard();
+            this.pauseAndSaveWorkout();
+            this.app.showView('home');
+        };
+
+        stayBtn.addEventListener('click', onStay);
+        leaveBtn.addEventListener('click', onLeave);
+        modal.classList.add('active');
+        trapModalFocus(modal);
     }
 
     interceptNavigation() {
@@ -244,7 +395,6 @@ class WorkoutView {
                     } else if (result === 'pause') {
                         // Pause and save, then navigate
                         this.pauseAndSaveWorkout();
-                        showToast('Workout paused. You can resume later.', 'info');
                     } else if (result === 'discard') {
                         // Discard workout
                         this.discardWorkout();
@@ -341,6 +491,8 @@ class WorkoutView {
 
         debugLog('Workout paused and saved', this.currentWorkoutSession.toJSON());
 
+        this.disarmBackGuard();
+
         // Reset UI state so the paused banner shows when returning
         document.getElementById('active-workout').classList.remove('active');
         document.getElementById('workout-selection').classList.add('active');
@@ -363,13 +515,37 @@ class WorkoutView {
         }
 
         this.pauseAndSaveWorkout();
-        showToast('Workout paused. You can resume later.', 'info');
         this.app.showView('home');
+    }
+
+    /**
+     * Item 3: pause the workout (no confirmation) and jump straight into the
+     * program editor for the program this workout was started from. Records
+     * that the editor was entered from workout mode so the editor shows a
+     * "Return to workout" button (Item 4).
+     */
+    editProgramFromWorkout() {
+        if (!this.hasActiveWorkout()) return;
+        const programId = this.currentWorkoutSession.programId;
+
+        // Pause + save silently (same effect as the pause flow, no dialog).
+        this.skipRest();
+        this.pauseAndSaveWorkout();
+
+        const programsCtrl = this.app.viewControllers.programs;
+        if (programsCtrl) programsCtrl.enteredFromWorkout = true;
+
+        this.app.showView('programs');
+        // Open the modal once the programs view is rendered.
+        setTimeout(() => {
+            programsCtrl?.openProgramModal(programId);
+        }, 100);
     }
 
     discardWorkout() {
         timerService.stopWorkoutTimer();
         this.skipRest();
+        this.disarmBackGuard();
         storageService.clearActiveWorkout();
         document.getElementById('active-workout').classList.remove('active');
         document.getElementById('workout-selection').classList.add('active');
@@ -381,10 +557,22 @@ class WorkoutView {
     }
 
     render() {
-        this.renderProgramSelection();
+        // If a workout is live in memory, returning to the workout view must
+        // land on the active session, not the program picker. Otherwise show
+        // the picker as usual (paused/persisted workouts surface their resume
+        // banner from renderProgramSelection).
+        if (this.hasActiveWorkout()) {
+            document.getElementById('workout-selection').classList.remove('active');
+            document.getElementById('active-workout').classList.add('active');
+            this.renderActiveWorkout();
+        } else {
+            document.getElementById('active-workout').classList.remove('active');
+            document.getElementById('workout-selection').classList.add('active');
+            this.renderProgramSelection();
+        }
     }
 
-    async resumeWorkout() {
+    async resumeWorkout(opts = {}) {
         const pausedWorkout = storageService.getActiveWorkout();
         if (!pausedWorkout) {
             showToast('No paused workout found', 'error');
@@ -395,13 +583,26 @@ class WorkoutView {
         this.currentWorkoutSession = WorkoutSession.fromJSON(pausedWorkout);
         this.currentWorkoutSession.resumeWorkout();
 
+        // Item 4: re-sync the session plan with an edited program when the user
+        // returned from the in-workout program editor.
+        if (opts.resyncProgramId != null) {
+            this.resyncSessionWithProgram(opts.resyncProgramId);
+        }
+
         // Reset per-session state, then seed collapse for completed exercises.
-        this.sessionPrCount = 0;
+        // Item R2-10: rebuild PR badges from the persisted committed sets so the
+        // superseded state survives pause/resume (only the best set per exercise
+        // keeps its badge).
         this.sessionPrSlots = {};
+        this.rebuildSessionPrSlots();
         this.collapsedExercises = {};
-        this.exerciseRestOverrides = {};
         this._prevCompleteState = {};
         this._activeRestType = null;
+        this._feelModalShown = {};
+        // Item R3-4: don't re-pop the feel modal on resume for exercises that
+        // already satisfy the all-sets-at-max condition. The modal only fires on
+        // the commit transition; mark satisfied exercises as already shown.
+        this._seedFeelModalShownFromSession();
         this._seedCollapseStateFromSession();
 
         // Start timer with saved elapsed time
@@ -415,8 +616,36 @@ class WorkoutView {
 
         // Render workout
         this.renderActiveWorkout();
+        this.armBackGuard();
+        this.app.updateGlobalFab();
+    }
 
-        showToast('Workout resumed!', 'success');
+    /**
+     * Item 4: reconcile the live (paused) session with the edited program.
+     * Delegates to the pure mergeSessionWithProgram helper, then rehydrates
+     * the merged plain objects into WorkoutExercise instances and persists.
+     */
+    resyncSessionWithProgram(programId) {
+        const program = this.app.getProgramById(programId);
+        if (!program || !this.currentWorkoutSession) return;
+
+        const sessionJson = this.currentWorkoutSession.exercises.map(e => e.toJSON());
+        const merged = mergeSessionWithProgram(
+            sessionJson,
+            program.exercises,
+            (progEx) => ({
+                exerciseId: progEx.exerciseId,
+                exerciseName: progEx.exerciseName,
+                sets: [],
+                targetSets: progEx.targetSets,
+                targetReps: progEx.targetReps,
+                restSeconds: progEx.restSeconds,
+                restAfterSeconds: progEx.restAfterSeconds,
+                groupId: progEx.groupId || null,
+            }),
+        );
+        this.currentWorkoutSession.exercises = merged.map(e => WorkoutExercise.fromJSON(e));
+        storageService.saveActiveWorkout(this.currentWorkoutSession.toJSON());
     }
 
     /**
@@ -454,6 +683,45 @@ class WorkoutView {
         }
     }
 
+    /**
+     * Item R2-6: a calendar-like week strip at the top of the workout selection
+     * screen. Shown only when the program-schedule toggle is on and at least one
+     * program is scheduled. Seven day cells ordered per the firstDayOfWeek
+     * preference, today highlighted, each listing the scheduled program name(s).
+     * Today's scheduled entry is emphasized; tapping a program entry starts that
+     * workout immediately (Item R3-1). Returns '' when nothing should render.
+     */
+    _renderWeekStripHTML(programs) {
+        const showSchedule = this.app.settings?.showProgramSchedule !== false;
+        if (!showSchedule || !programs || programs.length === 0) return '';
+        const anyScheduled = programs.some(p => Array.isArray(p.scheduleDays) && p.scheduleDays.length > 0);
+        if (!anyScheduled) return '';
+
+        const firstDay = this.app.settings?.firstDayOfWeek === 1 ? 1 : 0;
+        const labels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        const fullLabels = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+        const cells = weekStrip(programs, firstDay).map(cell => {
+            const entries = cell.programs.map(p => `
+                <button type="button" class="week-strip-program" data-action="start-workout" data-program-id="${p.id}" title="Start ${escapeHtml(p.name)}">
+                    <span class="week-strip-dot" aria-hidden="true"></span>
+                    <span class="week-strip-program-name">${escapeHtml(p.name)}</span>
+                </button>`).join('');
+            const classes = ['week-strip-day'];
+            if (cell.isToday) classes.push('is-today');
+            if (cell.programs.length > 0) classes.push('has-program');
+            return `
+                <div class="${classes.join(' ')}" aria-label="${fullLabels[cell.weekday]}${cell.isToday ? ', today' : ''}">
+                    <span class="week-strip-label">${labels[cell.weekday]}</span>
+                    <div class="week-strip-entries">${entries || '<span class="week-strip-empty" aria-hidden="true">&middot;</span>'}</div>
+                </div>`;
+        }).join('');
+
+        return `
+            <section class="week-strip" aria-label="This week's scheduled programs">
+                <div class="week-strip-grid">${cells}</div>
+            </section>`;
+    }
+
     renderProgramSelection() {
         const container = document.getElementById('workout-program-list');
         // Same ordering source-of-truth as Home + Programs: the user's chosen
@@ -483,6 +751,8 @@ class WorkoutView {
             return;
         }
 
+        html += this._renderWeekStripHTML(programs);
+
         html += `
             <h2>Select a Program</h2>
             <p class="subtitle">Choose which program you want to do today</p>
@@ -491,7 +761,7 @@ class WorkoutView {
                     const lastSession = this._lastSessionForProgram(program.id);
                     const lastDoneHTML = this._renderLastDoneInfo(lastSession);
                     return `
-                    <div class="program-card">
+                    <div class="program-card" data-program-card="${program.id}">
                         <div class="program-header">
                             <h3>${escapeHtml(program.name)}</h3>
                         </div>
@@ -516,6 +786,9 @@ class WorkoutView {
         `;
 
         container.innerHTML = html;
+
+        // Item R3-1: week-strip program entries use data-action="start-workout",
+        // wired by the delegated click handler in wireWorkoutActions.
 
         const banner = container.querySelector('.paused-workout-banner');
         if (banner) {
@@ -558,12 +831,11 @@ class WorkoutView {
         this.currentWorkoutSession.startWorkout();
 
         // Reset per-session state.
-        this.sessionPrCount = 0;
         this.sessionPrSlots = {};
         this.collapsedExercises = {};
-        this.exerciseRestOverrides = {};
         this._prevCompleteState = {};
         this._activeRestType = null;
+        this._feelModalShown = {};
 
         // Start workout timer
         timerService.startWorkoutTimer((elapsed) => {
@@ -576,6 +848,8 @@ class WorkoutView {
 
         // Render workout
         this.renderActiveWorkout();
+        this.armBackGuard();
+        this.app.updateGlobalFab();
     }
 
     adjustWorkoutTitleSize() {
@@ -608,6 +882,7 @@ class WorkoutView {
         document.getElementById('workout-title').textContent = this.currentWorkoutSession.workoutDayName;
         this.adjustWorkoutTitleSize();
         this.syncPlateHintsButton();
+        this.syncSessionUnitToggle();
 
         const container = document.getElementById('workout-exercises-list');
 
@@ -676,7 +951,9 @@ class WorkoutView {
         const exerciseData = this.app.getExerciseById(exercise.exerciseId);
         const isDuration = !!(exerciseData && exerciseData.exerciseType === 'duration');
         const previousSets = this.getPreviousExerciseData(exercise.exerciseId) || [];
-        const unit = this.app.settings.weightUnit;
+        // Item 8: display + entry use the per-session unit; canonical storage
+        // stays in the account unit.
+        const unit = this.sessionUnit();
 
         // Task 6: rep-range labels from the program exercise's sets[].
         // Fall back gracefully for old sessions/programs that lack sets[].
@@ -755,53 +1032,38 @@ class WorkoutView {
             }
         }
 
-        // Per-exercise rest adjusters — two separate values:
-        //   restSeconds:      between sets of THIS exercise (always per-exercise)
-        //   restAfterSeconds: between exercises; per-exercise in custom mode,
-        //                     uniform value when restMode === 'uniform'
-        const isUniform = program?.restMode === 'uniform';
+        // Item R3-4: the chosen feel for THIS session (set via the modal) shows
+        // on the exercise header and toggles good -> none on tap. The inline
+        // prompt row is gone; the picker is the modal (see commitPlannedSet).
+        const sessionFeelHTML = !isDuration ? this.renderFeelToggleIcon(index, exercise.feel) : '';
 
-        // Between-set rest: always per-exercise; override stored in exerciseRestOverrides
+        // Item 7: last feel marking for this exercise across prior sessions,
+        // shown next to the name to inform progression (history, unchanged). Only
+        // when there is no session feel chosen yet so the two icons don't stack.
+        const lastFeel = (!isDuration && exercise.feel !== 'good')
+            ? latestFeelForExercise(this.app.workoutSessions, exercise.exerciseId, s => s.sortTimestamp)
+            : null;
+        const lastFeelHTML = lastFeel ? this.renderFeelHistoryIcon(lastFeel) : '';
+
+        // Item R2-3: the between-set rest is shown as a single in-place chip.
+        // Idle, it renders the duration as a static GRAY number; when a set is
+        // completed the same element becomes the live colored countdown, then
+        // reverts to gray. No "Between sets"/"After exercise" pills.
         const progEx2 = program?.exercises.find(e => e.exerciseId === exercise.exerciseId);
-        const betweenSetBase = progEx2?.restSeconds ?? exercise.restSeconds ?? 90;
-        const betweenSetActive = this.exerciseRestOverrides[index]?.set ?? betweenSetBase;
-        const betweenSetMinus = Math.max(5, betweenSetActive - 5);
-        const betweenSetPlus = betweenSetActive + 5;
-
-        // Between-exercise rest: program-derived, display-only (not adjustable mid-workout)
-        const betweenExActive = isUniform
-            ? (program.uniformRestSeconds ?? 90)
-            : (progEx2?.restAfterSeconds ?? exercise.restAfterSeconds ?? 90);
-
-        const restPillsHTML = `
-            <div class="rest-adjuster" aria-label="Rest between sets of this exercise">
-                <span class="rest-adj-label">Between sets</span>
-                <button type="button" class="rest-adj-btn"
-                    data-action="set-rest-override"
-                    data-rest-kind="set"
-                    data-exercise-index="${index}"
-                    data-seconds="${betweenSetMinus}"
-                    aria-label="Decrease between-set rest by 5 seconds">-5</button>
-                <span class="rest-adj-value">${this.formatRest(betweenSetActive)}</span>
-                <button type="button" class="rest-adj-btn"
-                    data-action="set-rest-override"
-                    data-rest-kind="set"
-                    data-exercise-index="${index}"
-                    data-seconds="${betweenSetPlus}"
-                    aria-label="Increase between-set rest by 5 seconds">+5</button>
-            </div>
-            ${isUniform ? '' : `
-            <div class="rest-adjuster rest-adjuster--display-only" aria-label="Rest after last set of this exercise">
-                <span class="rest-adj-label">After exercise</span>
-                <span class="rest-adj-value">${this.formatRest(betweenExActive)}</span>
-            </div>
-            `}
+        const betweenSetActive = progEx2?.restSeconds ?? exercise.restSeconds ?? 90;
+        const isRestingHere = this.activeRestExerciseIndex === index && this._activeRestType === 'set';
+        const restChipHTML = `
+            <div class="rest-countdown-chip${isRestingHere ? '' : ' rest-countdown-chip--idle'}"
+                 data-rest-idle="${betweenSetActive}" aria-live="off"
+                 title="Rest between sets">${this.formatRest(betweenSetActive)}</div>
         `;
 
         // Per-exercise plate-hints toggle.
         // Global OFF overrides everything: hints hidden for ALL exercises.
         // Global ON: per-exercise preference applies (defaults to ON).
-        const globalHints = this.app.settings?.plateHintsEnabled !== false;
+        // Item 8: plate config is in account units, so hide the toggle and
+        // hints entirely while the session unit differs from the account unit.
+        const globalHints = this.app.settings?.plateHintsEnabled !== false && !this.unitsDiffer();
         const perExHints = this.app.settings?.exercisePlateHints?.[exercise.exerciseId];
         const hintsOnForExercise = globalHints && (perExHints !== undefined ? perExHints : true);
         // Per-exercise toggle is only meaningful when global hints are ON.
@@ -828,7 +1090,7 @@ class WorkoutView {
                         <i class="fas fa-chevron-${isCollapsed ? 'down' : 'up'}" aria-hidden="true"></i>
                     </button>
                     <h3>
-                        <span class="exercise-name-main">${escapeHtml(exercise.exerciseName)}</span>${muscle ? `
+                        <span class="exercise-name-main">${escapeHtml(exercise.exerciseName)}</span>${sessionFeelHTML}${lastFeelHTML}${muscle ? `
                         <span class="exercise-name-sub">(${escapeHtml(muscle)})</span>` : ''}${allSameRepRange ? `
                         <span class="exercise-rep-target" aria-label="Target: ${sharedRepLabel}">${sharedRepLabel}</span>` : ''}
                     </h3>
@@ -839,8 +1101,8 @@ class WorkoutView {
                 </div>
 
                 <div class="exercise-body">
-                    <div class="rest-row${this.activeRestExerciseIndex === index && this._activeRestType === 'set' ? ' rest-row--resting' : ''}">
-                        ${restPillsHTML}
+                    <div class="rest-row${isRestingHere ? ' rest-row--resting' : ''}">
+                        ${restChipHTML}
                         ${plateToggleHTML}
                     </div>
 
@@ -900,12 +1162,17 @@ class WorkoutView {
             `;
         }
 
-        const weight = prior ? prior.weight : '';
+        // Prior weights are canonical (account-unit); convert into the session
+        // display unit for prefill (Item 8). One decimal via convertWeight.
+        const weight = prior && prior.weight !== '' && prior.weight != null
+            ? this.toSessionWeight(prior.weight)
+            : '';
         const reps = prior ? prior.reps : (targetReps || '');
-        // Per-exercise plate hints: global OFF overrides everything.
+        // Per-exercise plate hints: global OFF overrides everything; also off
+        // while the session unit differs from the account unit (Item 8).
         const sessionExercise = this.currentWorkoutSession?.exercises[exerciseIndex];
         const exerciseId = sessionExercise?.exerciseId;
-        const globalHintsOn = this.app.settings?.plateHintsEnabled !== false;
+        const globalHintsOn = this.app.settings?.plateHintsEnabled !== false && !this.unitsDiffer();
         const perExHintsVal = exerciseId !== undefined
             ? this.app.settings?.exercisePlateHints?.[exerciseId]
             : undefined;
@@ -930,6 +1197,139 @@ class WorkoutView {
                 ${plateHintHTML ? `<div class="plate-hint" id="plate-hint-${exerciseIndex}-${slot}">${plateHintHTML}</div>` : ''}
             </li>
         `;
+    }
+
+    /**
+     * Item R3-4: the chosen-feel icon shown on the exercise header for THIS
+     * session. Rendered ONLY when feel === 'good' (green smiley). Tapping it
+     * toggles good -> none (removes the mark); see cycleExerciseFeel. Returns ''
+     * for any other value, so the history icon (if any) shows instead.
+     */
+    renderFeelToggleIcon(exerciseIndex, feel) {
+        if (feel !== 'good') return '';
+        const label = 'Felt good. Tap to remove.';
+        return `
+            <button type="button" class="feel-toggle feel-toggle-good"
+                data-action="cycle-feel" data-exercise-index="${exerciseIndex}"
+                aria-label="${label}" title="${label}">
+                <i class="fas fa-face-smile" aria-hidden="true"></i>
+            </button>
+        `;
+    }
+
+    /**
+     * Item 7: the last-feel icon shown next to the exercise name. Rendered ONLY
+     * when feel === 'good' (green smiley); returns '' otherwise, so legacy
+     * sessions marked 'bad' show no icon.
+     */
+    renderFeelHistoryIcon(feel) {
+        if (feel !== 'good') return '';
+        const label = 'Last time this felt good (you marked it for more weight)';
+        return `<span class="feel-history feel-history-good" role="img" aria-label="${label}" title="${label}"><i class="fas fa-face-smile" aria-hidden="true"></i></span>`;
+    }
+
+    /**
+     * Item R3-4: set the feel marking on a session exercise to an explicit value
+     * (or null). Persisted to the active session so it survives pause/resume.
+     */
+    setExerciseFeel(exerciseIndex, feel) {
+        const exercise = this.currentWorkoutSession?.exercises[exerciseIndex];
+        if (!exercise) return;
+        exercise.feel = feel === 'good' ? 'good' : null;
+        if (this.app.settings?.vibrationAlerts !== false) vibrate(20);
+        storageService.saveActiveWorkout(this.currentWorkoutSession.toJSON());
+        this.rerenderExercise(exerciseIndex);
+    }
+
+    /**
+     * Item R3-4: toggle the header feel icon good -> none. Preserves the
+     * round-1 "change before saving" affordance without an inline prompt row.
+     */
+    cycleExerciseFeel(exerciseIndex) {
+        const exercise = this.currentWorkoutSession?.exercises[exerciseIndex];
+        if (!exercise) return;
+        this.setExerciseFeel(exerciseIndex, nextFeel(exercise.feel));
+    }
+
+    /**
+     * Item R3-4: whether the exercise newly satisfies the all-sets-at-max
+     * condition (every target set completed at the max of its rep range).
+     * Duration exercises never qualify. Shared by the render path and the
+     * commit/resume feel-modal triggers.
+     */
+    _exerciseReachesMax(exercise) {
+        if (!exercise) return false;
+        const exerciseData = this.app.getExerciseById(exercise.exerciseId);
+        if (exerciseData && exerciseData.exerciseType === 'duration') return false;
+        const program = this.app.getProgramById(this.currentWorkoutSession?.programId);
+        const progEx = program?.exercises.find(e => e.exerciseId === exercise.exerciseId);
+        const progSets = (progEx?.sets && progEx.sets.length > 0) ? progEx.sets : null;
+        const targetSets = Math.max(1, exercise.targetSets || 3);
+        return allSetsReachMax(
+            exercise.sets,
+            targetSets,
+            (set, arrIdx) => {
+                const slot = set.slot != null ? set.slot : arrIdx;
+                return (progSets && slot < progSets.length)
+                    ? progSets[slot].repsMax
+                    : exercise.targetReps;
+            },
+        );
+    }
+
+    /**
+     * Item R3-4: on resume, mark exercises that already satisfy the
+     * all-sets-at-max condition as "modal already shown" so the picker does not
+     * re-pop for them (it only fires on the commit transition).
+     */
+    _seedFeelModalShownFromSession() {
+        const exercises = this.currentWorkoutSession?.exercises || [];
+        exercises.forEach((exercise, i) => {
+            if (this._exerciseReachesMax(exercise)) this._feelModalShown[i] = true;
+        });
+    }
+
+    /**
+     * Item R3-4: show the feel picker modal for `exerciseIndex` the FIRST time
+     * the exercise satisfies the all-sets-at-max condition this session. The
+     * modal's green "Felt good" smiley is the only choice: picking it records the
+     * feel, closes the modal and collapses the exercise. "Not yet" (and the X)
+     * closes without recording (the exercise still auto-collapses because it is
+     * complete).
+     */
+    maybeShowFeelModal(exerciseIndex) {
+        const exercise = this.currentWorkoutSession?.exercises[exerciseIndex];
+        if (!exercise) return;
+        const reaches = this._exerciseReachesMax(exercise);
+        if (!shouldShowFeelModal(this._feelModalShown, exerciseIndex, reaches)) return;
+        const modal = document.getElementById('feel-intro-modal');
+        if (!modal) return;
+
+        this._feelModalShown[exerciseIndex] = true;
+
+        modal.classList.add('active');
+        trapModalFocus(modal);
+
+        const close = () => {
+            // R3-6: blur the clicked choice before hiding (no focused descendant
+            // under a closing dialog).
+            if (modal.contains(document.activeElement)) document.activeElement.blur();
+            modal.classList.remove('active');
+            goodBtn?.removeEventListener('click', onGood);
+            skipX?.removeEventListener('click', close);
+            skipBtn?.removeEventListener('click', close);
+        };
+        const onGood = () => {
+            this.setExerciseFeel(exerciseIndex, 'good');
+            close();
+        };
+
+        const goodBtn = document.getElementById('feel-modal-good');
+        const skipX = document.getElementById('feel-modal-skip');
+        const skipBtn = document.getElementById('feel-modal-skip-btn');
+        goodBtn?.addEventListener('click', onGood);
+        skipX?.addEventListener('click', close);
+        skipBtn?.addEventListener('click', close);
     }
 
     /** Format a rep range for display: "8 reps" or "8-10 reps". */
@@ -967,6 +1367,7 @@ class WorkoutView {
     refreshPlateHint(exerciseIndex, slot, weight) {
         const hintEl = document.getElementById(`plate-hint-${exerciseIndex}-${slot}`);
         if (!hintEl) return;
+        if (this.unitsDiffer()) return;
         const unit = this.app.settings.weightUnit;
         const sessionExercise = this.currentWorkoutSession?.exercises[exerciseIndex];
         const exerciseId = sessionExercise?.exerciseId;
@@ -1015,7 +1416,9 @@ class WorkoutView {
             const secs = set.duration % 60;
             details = `<span class="duration-value">${mins}:${secs.toString().padStart(2, '0')}</span>`;
         } else {
-            details = `${set.weight.toLocaleString()}${unit} × ${set.reps}`;
+            // set.weight is canonical (account unit); display in session unit.
+            const shown = this.toSessionWeight(set.weight);
+            details = `${shown.toLocaleString()}${unit} × ${set.reps}`;
         }
 
         const toggle = this.renderSetToggle(true, 'unmark-set', exerciseIndex, slot, 'Unmark set');
@@ -1109,37 +1512,6 @@ class WorkoutView {
             }
         }
         this.rerenderExercise(exerciseIndex);
-    }
-
-    /**
-     * Override the between-set rest timer for one exercise in this session.
-     * Updates the rest adjuster in-place to avoid remounting completed-set pills.
-     */
-    setRestOverride(exerciseIndex, seconds) {
-        if (!this.exerciseRestOverrides[exerciseIndex]) {
-            this.exerciseRestOverrides[exerciseIndex] = {};
-        }
-        this.exerciseRestOverrides[exerciseIndex].set = seconds;
-
-        const host = document.getElementById(`exercise-${exerciseIndex}`);
-        if (!host) { this.rerenderExercise(exerciseIndex); return; }
-
-        const newMinus = Math.max(5, seconds - 5);
-        const newPlus = seconds + 5;
-
-        const [minusBtn, plusBtn] = host.querySelectorAll(
-            '[data-action="set-rest-override"][data-rest-kind="set"]'
-        );
-        const valueEl = host.querySelector(
-            '.rest-adjuster:not(.rest-adjuster--display-only) .rest-adj-value'
-        );
-
-        if (!minusBtn || !plusBtn || !valueEl) { this.rerenderExercise(exerciseIndex); return; }
-
-        minusBtn.dataset.seconds = String(newMinus);
-        minusBtn.setAttribute('aria-label', 'Decrease between-set rest by 5 seconds');
-        plusBtn.dataset.seconds = String(newPlus);
-        valueEl.textContent = this.formatRest(seconds);
     }
 
     /** Toggle per-exercise plate hints for the exercise at `exerciseIndex`.
@@ -1309,12 +1681,14 @@ class WorkoutView {
         } else {
             const weightInput = document.getElementById(`weight-${exerciseIndex}-${slot}`);
             const repsInput = document.getElementById(`reps-${exerciseIndex}-${slot}`);
-            const weight = parseFloat(weightInput?.value);
+            const entered = parseFloat(weightInput?.value);
             const reps = parseInt(repsInput?.value, 10);
-            if (isNaN(weight) || weight < 0 || !reps) {
+            if (isNaN(entered) || entered < 0 || !reps) {
                 showToast('Please enter weight and reps', 'error');
                 return;
             }
+            // The input is in the session unit; store canonical (account unit).
+            const weight = this.toAccountWeight(entered);
             set = new Set({ weight, reps, completed: true, slot });
         }
 
@@ -1322,16 +1696,24 @@ class WorkoutView {
         // not by array index, so order-of-insertion doesn't matter.
         exercise.sets.push(set);
 
+        // Item R2-8: a logged set dismisses the finish-modal "no sets" message.
+        const finishMsg = document.getElementById('finish-inline-message');
+        if (finishMsg) finishMsg.hidden = true;
+
         if (this.app.settings?.vibrationAlerts !== false) vibrate(30);
 
         // PR check — compare the just-logged set against all prior sets of
-        // this exercise (from completed sessions, not the in-progress one).
-        const pr = AnalyticsService.isSetPR(exercise.exerciseId, set, this.app.workoutSessions);
+        // this exercise: completed sessions PLUS earlier committed sets of the
+        // current session, so a repeat at the same new max isn't re-celebrated.
+        const priorSessionSets = exercise.sets.filter(s => s !== set);
+        const pr = AnalyticsService.isSetPR(exercise.exerciseId, set, this.app.workoutSessions, priorSessionSets);
         if (pr) {
-            this.sessionPrCount += 1;
-            // Store the PR payload so the row can render a badge showing
-            // the improvement amount (e.g. "PR +40 lb").
-            this.sessionPrSlots[`${exerciseIndex}:${slot}`] = pr;
+            // Item R2-10: record the PR and supersede any earlier badge for the
+            // same exercise this session — only the best set keeps the badge.
+            // The toast still fires (live celebration). rerenderExercise below
+            // is per-exercise, so an earlier set in the SAME exercise drops its
+            // badge on this rerender; cross-exercise badges are untouched.
+            recordPrSupersede(this.sessionPrSlots, `${exerciseIndex}:${slot}`, pr);
             this.announcePR(pr);
         }
 
@@ -1340,17 +1722,29 @@ class WorkoutView {
         const targetSets = Math.max(1, exercise.targetSets || 3);
         const isNowComplete = exercise.sets.length >= targetSets;
         if (isNowComplete) {
-            // Only auto-collapse if the user hasn't explicitly expanded it
-            // after a prior auto-collapse (collapsedExercises[i] === false means
-            // the user manually opened it).
-            if (this.collapsedExercises[exerciseIndex] !== false) {
-                this.collapsedExercises[exerciseIndex] = true;
-            }
+            // #23: committing a set is a deliberate action, so re-arm auto-collapse
+            // even if the user had manually expanded a previously-complete exercise
+            // (collapsedExercises[i] === false). The manual-expand suppression is
+            // only meant to survive passive re-renders, not a fresh set commit.
+            this.collapsedExercises[exerciseIndex] = true;
         }
         // Track complete state for deleteSet's re-trigger logic.
         this._prevCompleteState[exerciseIndex] = isNowComplete;
 
         this.rerenderExercise(exerciseIndex);
+
+        // Item R3-4: if this commit just made the exercise satisfy the
+        // all-sets-at-max condition, show the feel picker modal (once per
+        // exercise per session). Picking collapses the exercise.
+        this.maybeShowFeelModal(exerciseIndex);
+
+        // Final set of the LAST exercise -> workout complete: no rest of any
+        // kind, and jump to the top where the Finish button lives.
+        if (isWorkoutComplete(this.currentWorkoutSession?.exercises || [])) {
+            this.skipRest();
+            this.scrollWorkoutToTop();
+            return;
+        }
 
         // Determine rest type: last set of exercise -> between-exercise (bottom bar);
         // any earlier set -> between-set (inline chip only).
@@ -1368,8 +1762,7 @@ class WorkoutView {
                 this.startRest(betweenExSecs, exerciseIndex, 'exercise');
             } else {
                 // Between-set rest -> inline chip only
-                const betweenSetBase = progEx?.restSeconds ?? exercise.restSeconds ?? 90;
-                const betweenSetSecs = this.exerciseRestOverrides[exerciseIndex]?.set ?? betweenSetBase;
+                const betweenSetSecs = progEx?.restSeconds ?? exercise.restSeconds ?? 90;
                 this.startRest(betweenSetSecs, exerciseIndex, 'set');
             }
         } else {
@@ -1397,13 +1790,74 @@ class WorkoutView {
         return true;
     }
 
+    /** Smooth-scroll the page to the top (workout header / Finish button). */
+    scrollWorkoutToTop() {
+        if (typeof window === 'undefined' || typeof window.scrollTo !== 'function') return;
+        try {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        } catch {
+            window.scrollTo(0, 0);
+        }
+    }
+
+    /** Index of the first incomplete exercise, or -1 if every one is complete. */
+    firstIncompleteExerciseIndex() {
+        const exercises = this.currentWorkoutSession?.exercises;
+        if (!exercises) return -1;
+        for (let i = 0; i < exercises.length; i++) {
+            const targetSets = Math.max(1, exercises[i].targetSets || 3);
+            if ((exercises[i].sets?.length || 0) < targetSets) return i;
+        }
+        return -1;
+    }
+
+    /**
+     * Jump to the exercise the user is actually lifting: the first incomplete
+     * one (lowest index whose sets < target). Lands the block's top just below
+     * the sticky workout header. If the exercise is collapsed, expand it first.
+     * If every exercise is complete, fall back to the top (Finish + timer).
+     */
+    scrollToCurrentExercise() {
+        if (typeof window === 'undefined' || typeof window.scrollTo !== 'function') return;
+        const index = this.firstIncompleteExerciseIndex();
+        if (index < 0) {
+            this.scrollWorkoutToTop();
+            return;
+        }
+
+        // Be safe: an incomplete exercise is normally expanded, but if a stored
+        // collapse flag is suppressing its sets, clear it and rerender so the
+        // target block is fully visible before we measure and scroll.
+        if (this.collapsedExercises[index]) {
+            delete this.collapsedExercises[index];
+            this.rerenderExercise(index);
+        }
+
+        const el = document.getElementById(`exercise-${index}`);
+        if (!el) return;
+
+        // The page (window) is the scroll container; the workout header is
+        // position: sticky, so its on-screen bottom edge is the floor the
+        // target must clear. Use that bottom plus a small gap as the offset.
+        const header = document.querySelector('#active-workout .workout-header');
+        const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
+        const gap = 8;
+        const target = el.getBoundingClientRect().top + window.scrollY - headerBottom - gap;
+        const top = Math.max(0, target);
+        try {
+            window.scrollTo({ top, behavior: 'smooth' });
+        } catch {
+            window.scrollTo(0, top);
+        }
+    }
+
     /**
      * Show a celebratory toast for the given PR + play the chime cue.
      * Respects the user's restAlerts preference for audio (always vibrates
      * and always shows the toast — the toast is the actual info).
      */
     announcePR(pr) {
-        const unit = this.app.settings.weightUnit;
+        const unit = this.sessionUnit();
         const label = `🏆 New PR  ${this.formatPrDelta(pr, unit)}`;
         showToast(label, 'success', 4000);
         if (this.app.settings?.vibrationAlerts !== false) vibrate([40, 60, 120]);
@@ -1420,7 +1874,9 @@ class WorkoutView {
             const secs = pr.delta % 60;
             return `+${mins}:${String(secs).padStart(2, '0')}`;
         }
-        return `+${Math.round(pr.delta)} ${unit}`;
+        // pr.delta is in the account unit; convert to the display unit (Item 8).
+        const delta = convertWeight(pr.delta, this.app.settings.weightUnit, unit);
+        return `+${Math.round(delta)} ${unit}`;
     }
 
     /**
@@ -1459,10 +1915,11 @@ class WorkoutView {
                 </div>
             `;
         } else {
+            const editWeight = this.toSessionWeight(set.weight);
             editFormHTML = `
                 <div class="set-row-inputs">
                     <input type="number" class="set-edit-input"
-                        id="edit-weight-${exerciseIndex}-${slot}" value="${set.weight}" step="0.5" min="0" placeholder="Weight" aria-label="Weight">
+                        id="edit-weight-${exerciseIndex}-${slot}" value="${editWeight}" step="0.5" min="0" placeholder="Weight" aria-label="Weight">
                     <span class="set-row-x">×</span>
                     <input type="number" class="set-edit-input"
                         id="edit-reps-${exerciseIndex}-${slot}" value="${set.reps}" min="1" placeholder="Reps" aria-label="Reps">
@@ -1495,6 +1952,52 @@ class WorkoutView {
         }
     }
 
+    /**
+     * Item R2-4 / #18: after a set is edited or deleted, the per-exercise derived
+     * state (auto-collapse, _prevCompleteState, _feelModalShown) must equal a
+     * fresh evaluation — the commit path keeps these in sync, the edit/delete
+     * paths historically did not. Mirrors commitPlannedSet's bookkeeping:
+     *   - re-evaluate complete/collapse (respecting the user-explicit-expand
+     *     invariant collapsedExercises[i] === false, and clearing that
+     *     suppression on a complete->incomplete transition so auto-collapse can
+     *     fire again);
+     *   - clear _feelModalShown when the exercise no longer reaches max, so
+     *     bringing it back to max re-shows the modal (left as-is if it still
+     *     reaches max, since the modal already fired).
+     * Returns the freshly computed `isNowComplete` so callers can decide whether
+     * to (re)trigger the feel modal.
+     *
+     * `armCollapse` (#23): set true for a DELIBERATE set action (committing a set,
+     * saving a set edit). On such actions a now-complete exercise auto-collapses
+     * even if the user had manually expanded it (collapsedExercises[i] === false).
+     * Passive re-renders / deletes pass false so "opened just to look" stays open.
+     */
+    _recomputeExerciseDerivedState(exerciseIndex, armCollapse = false) {
+        const exercise = this.currentWorkoutSession?.exercises[exerciseIndex];
+        if (!exercise) return false;
+
+        const targetSets = Math.max(1, exercise.targetSets || 3);
+        const isNowComplete = exercise.sets.length >= targetSets;
+        const wasComplete = this._prevCompleteState[exerciseIndex] === true;
+
+        if (isNowComplete) {
+            if (armCollapse || this.collapsedExercises[exerciseIndex] !== false) {
+                this.collapsedExercises[exerciseIndex] = true;
+            }
+        } else if (wasComplete) {
+            // complete -> incomplete: clear the manual-expand suppression so the
+            // next time it completes, auto-collapse fires again.
+            delete this.collapsedExercises[exerciseIndex];
+        }
+        this._prevCompleteState[exerciseIndex] = isNowComplete;
+
+        if (!this._exerciseReachesMax(exercise)) {
+            this._feelModalShown[exerciseIndex] = false;
+        }
+
+        return isNowComplete;
+    }
+
     saveSetEdit(exerciseIndex, slot) {
         if (!this.currentWorkoutSession) return;
 
@@ -1517,65 +2020,56 @@ class WorkoutView {
         } else {
             const weightInput = document.getElementById(`edit-weight-${exerciseIndex}-${slot}`);
             const repsInput = document.getElementById(`edit-reps-${exerciseIndex}-${slot}`);
-            const weight = parseFloat(weightInput.value);
+            const entered = parseFloat(weightInput.value);
             const reps = parseInt(repsInput.value, 10);
-            if (isNaN(weight) || weight < 0 || !reps) {
+            if (isNaN(entered) || entered < 0 || !reps) {
                 showToast('Please enter valid weight and reps', 'error');
                 return;
             }
-            set.weight = weight;
+            // Input is in the session unit; store canonical (account unit).
+            set.weight = this.toAccountWeight(entered);
             set.reps = reps;
         }
 
-        // Edits can turn a set into a PR, out of a PR, or just update the
-        // delta on an already-PR row. Re-evaluate once here instead of
-        // forcing users to toggle off/on.
-        const prTransition = this.reevaluatePrForSlot(exerciseIndex, slot, set, exercise);
+        // Item R3-7: derived PR state must equal a fresh recomputation after
+        // any edit. Recompute the whole session PR map from scratch (so editing
+        // away a superseding set restores an earlier set's badge), then announce
+        // only when THIS slot newly became a PR.
+        const prKey = `${exerciseIndex}:${slot}`;
+        const hadPr = !!(this.sessionPrSlots && this.sessionPrSlots[prKey]);
+        this.rebuildSessionPrSlots();
+        const pr = this.sessionPrSlots[prKey];
+        if (pr && !hadPr) this.announcePR(pr);
+
+        // #18: keep the per-exercise derived state (collapse / complete /
+        // feel-modal) consistent with the edited reps, then mirror the commit
+        // path by (re)showing the feel modal if the edit newly satisfies the
+        // all-sets-at-max condition. maybeShowFeelModal self-guards via
+        // shouldShowFeelModal, so it won't double-show or fire when incomplete.
+        // #23: a save IS a deliberate set action, so re-arm auto-collapse on a
+        // still-complete exercise even if the user had manually expanded it.
+        this._recomputeExerciseDerivedState(exerciseIndex, true);
 
         this.rerenderExercise(exerciseIndex);
 
-        // Suppress the generic "Set updated" toast when a new PR fires —
-        // the PR toast already communicates that the save happened, and
-        // stacking two toasts drowns the celebration.
-        if (prTransition !== 'new') {
-            showToast('Set updated', 'success');
-        }
+        this.maybeShowFeelModal(exerciseIndex);
     }
 
     /**
-     * Recompute PR status for a single set and update the session record
-     * accordingly. Called after any mutation to a committed set's values.
-     *
-     * Returns one of:
-     *   'new'    — wasn't a PR before, is now (fires toast + sound + haptic)
-     *   'update' — was a PR, still is; badge delta refreshed silently
-     *   'lost'   — was a PR, no longer is; badge + count cleared
-     *   'none'   — wasn't a PR, still isn't
-     *
-     * Never re-announces a PR that was already celebrated — "still PR" is
-     * silent so the user isn't chimed at every tiny edit.
+     * Item R2-10 / R3-7: recompute sessionPrSlots from the current session's
+     * committed sets, from scratch. Each exercise's sets are evaluated in slot
+     * order against completed sessions plus earlier sets of the same exercise,
+     * so a later higher set supersedes earlier badges and only the best set per
+     * exercise survives. Called on resume and after EVERY set edit/delete so the
+     * derived PR state always equals a fresh recomputation.
      */
-    reevaluatePrForSlot(exerciseIndex, slot, set, exercise) {
-        const prKey = `${exerciseIndex}:${slot}`;
-        const hadPr = !!(this.sessionPrSlots && this.sessionPrSlots[prKey]);
-        const pr = AnalyticsService.isSetPR(exercise.exerciseId, set, this.app.workoutSessions);
-
-        if (pr && !hadPr) {
-            this.sessionPrCount += 1;
-            this.sessionPrSlots[prKey] = pr;
-            this.announcePR(pr);
-            return 'new';
-        }
-        if (pr && hadPr) {
-            this.sessionPrSlots[prKey] = pr;
-            return 'update';
-        }
-        if (!pr && hadPr) {
-            delete this.sessionPrSlots[prKey];
-            this.sessionPrCount = Math.max(0, this.sessionPrCount - 1);
-            return 'lost';
-        }
-        return 'none';
+    rebuildSessionPrSlots() {
+        const exercises = this.currentWorkoutSession?.exercises || [];
+        this.sessionPrSlots = recomputePrSlots(
+            exercises,
+            (exerciseId, set, priorSessionSets) =>
+                AnalyticsService.isSetPR(exerciseId, set, this.app.workoutSessions, priorSessionSets),
+        );
     }
 
     cancelSetEdit(exerciseIndex) {
@@ -1584,10 +2078,9 @@ class WorkoutView {
     }
 
     /**
-     * Remove a committed set from an exercise. `opts.silent` suppresses the
-     * "Set deleted" toast — used by the pill-toggle un-check flow, where
-     * the knob animation already gives clear visual confirmation and a
-     * duplicate toast would be noise.
+     * Remove a committed set from an exercise. The visible row + knob animation
+     * already confirm the action, so no toast fires (Item R2-8). `opts` is kept
+     * for caller compatibility (pill-toggle un-check passes { silent: true }).
      */
     deleteSet(exerciseIndex, slot, opts = {}) {
         if (!this.currentWorkoutSession) return;
@@ -1616,25 +2109,17 @@ class WorkoutView {
             duration: removed.duration,
         };
 
-        // If this set held a PR for the current session, clear the badge
-        // and decrement the counter. Re-committing recomputes PR fresh.
-        const prKey = `${exerciseIndex}:${slot}`;
-        if (this.sessionPrSlots && this.sessionPrSlots[prKey]) {
-            delete this.sessionPrSlots[prKey];
-            this.sessionPrCount = Math.max(0, this.sessionPrCount - 1);
-        }
+        // Item R3-7: recompute the whole session PR map from scratch after the
+        // delete. Removing a set that had SUPERSEDED an earlier PR must restore
+        // the earlier set's badge, so patching a single slot is not enough.
+        this.rebuildSessionPrSlots();
 
-        // Auto-collapse re-trigger fix: if the exercise was complete before this
-        // delete and is no longer complete, clear the manual-expand suppression
-        // (collapsedExercises[i] === false). The next time it becomes complete,
-        // auto-collapse will fire again.
-        const targetSets = Math.max(1, exercise.targetSets || 3);
-        const wasComplete = this._prevCompleteState[exerciseIndex] === true;
-        const isStillComplete = exercise.sets.length >= targetSets;
-        if (wasComplete && !isStillComplete) {
-            delete this.collapsedExercises[exerciseIndex];
-        }
-        this._prevCompleteState[exerciseIndex] = isStillComplete;
+        // #18: keep collapse / complete / feel-modal derived state consistent
+        // with the post-delete sets. This clears the manual-expand suppression on
+        // a complete->incomplete transition (so auto-collapse re-fires later) and
+        // resets _feelModalShown when the exercise no longer reaches max (so
+        // re-reaching max re-shows the modal).
+        this._recomputeExerciseDerivedState(exerciseIndex);
 
         // Bugs B+C: unmarking a set cancels any active rest timer that was
         // started for this exercise (between-set chip or between-exercise bottom
@@ -1645,7 +2130,6 @@ class WorkoutView {
         }
 
         this.rerenderExercise(exerciseIndex);
-        if (!opts.silent) showToast('Set deleted', 'info');
     }
 
     updateWorkoutTimer(elapsed) {
@@ -1717,6 +2201,8 @@ class WorkoutView {
         const bar = document.getElementById('rest-timer-bar');
         if (!bar) return;
         bar.hidden = false;
+        // Lift the sitewide back-to-top arrow above the rest bar (item 10).
+        document.body.classList.add('gt-rest-bar-visible');
         bar.classList.remove('rest-timer-done', 'rest-timer-urgent');
         const valueEl = document.getElementById('rest-timer-value');
         const fill = document.getElementById('rest-timer-progress-fill');
@@ -1738,38 +2224,44 @@ class WorkoutView {
             bar.hidden = true;
             bar.classList.remove('rest-timer-done', 'rest-timer-urgent');
         }
+        document.body.classList.remove('gt-rest-bar-visible');
         this.activeRestExerciseIndex = -1;
         this.lastPingedRestSecond = -1;
     }
 
-    /** Render (or refresh) the compact countdown chip inside the exercise card. */
+    /**
+     * Item R2-3: switch the persistent in-card chip into the live countdown
+     * state (colored, ticking). The chip element always exists; we never
+     * create or remove it, only toggle its state classes and text.
+     */
     showRestChip(exerciseIndex, remaining) {
         if (exerciseIndex < 0) return;
         const header = document.querySelector(`#exercise-${exerciseIndex} .rest-row`);
         if (!header) return;
+        const chip = header.querySelector('.rest-countdown-chip');
+        if (!chip) return;
         header.classList.add('rest-row--resting');
-        let chip = header.querySelector('.rest-countdown-chip');
-        if (!chip) {
-            chip = document.createElement('div');
-            chip.className = 'rest-countdown-chip';
-            chip.setAttribute('aria-live', 'off');
-            header.appendChild(chip);
-        }
-        const urgent = remaining <= 5 && remaining > 0;
+        const countdown = this.app.settings?.timerCountdownSeconds ?? 5;
+        const urgent = remaining <= countdown && remaining > 0;
         chip.className = 'rest-countdown-chip' + (urgent ? ' rest-countdown-chip--urgent' : '');
         chip.textContent = this.formatRest(remaining);
     }
 
-    /** Remove the in-card countdown chip from any exercise. */
+    /**
+     * Item R2-3: revert the in-card chip to its idle gray state showing the
+     * static between-set rest duration. The chip is never removed.
+     */
     clearRestChip() {
         const idx = this.activeRestExerciseIndex;
         if (idx < 0) return;
         const row = document.querySelector(`#exercise-${idx} .rest-row`);
-        if (row) {
-            row.classList.remove('rest-row--resting');
-            const chip = row.querySelector('.rest-countdown-chip');
-            if (chip) chip.remove();
-        }
+        if (!row) return;
+        row.classList.remove('rest-row--resting');
+        const chip = row.querySelector('.rest-countdown-chip');
+        if (!chip) return;
+        const idle = parseInt(chip.dataset.restIdle, 10) || 0;
+        chip.className = 'rest-countdown-chip rest-countdown-chip--idle';
+        chip.textContent = this.formatRest(idle);
     }
 
     onRestTick(remaining) {
@@ -1788,9 +2280,22 @@ class WorkoutView {
             this.showRestChip(this.activeRestExerciseIndex, remaining);
         }
 
-        // Final 5-second urgent state.
+        const firstWarning = this.app.settings?.timerFirstWarningSeconds ?? 10;
+        const countdown = this.app.settings?.timerCountdownSeconds ?? 5;
+        const { warn, urgent } = restTickCues(remaining, firstWarning, countdown);
+
+        // Single early heads-up tone (distinct from the per-second pip).
+        if (warn && remaining !== this.lastPingedRestSecond) {
+            this.lastPingedRestSecond = remaining;
+            if (this.app.settings?.soundAlerts !== false) playSound('timer-warn');
+            if (this.app.settings?.vibrationAlerts !== false && typeof navigator.vibrate === 'function') {
+                navigator.vibrate(60);
+            }
+        }
+
+        // Final-countdown urgent state — per-second pip + urgent styling.
         const bar = document.getElementById('rest-timer-bar');
-        if (remaining <= 5 && remaining > 0) {
+        if (urgent) {
             if (isExercise && bar) bar.classList.add('rest-timer-urgent');
             // One ping per second — guard with lastPingedRestSecond.
             if (remaining !== this.lastPingedRestSecond) {
@@ -1836,15 +2341,23 @@ class WorkoutView {
     openFinishWorkoutModal() {
         if (!this.currentWorkoutSession) return;
 
+        const finishModal = document.getElementById('finish-workout-modal');
+
         // Check if any sets were completed
         const hasCompletedSets = this.currentWorkoutSession.exercises.some(ex =>
             ex.sets && ex.sets.length > 0 && ex.sets.some(set => set.completed)
         );
 
+        // Item R2-8: no floating toast. With zero sets, open the modal and show
+        // an inline message instead; it dismisses as soon as the user logs a set.
+        const msg = document.getElementById('finish-inline-message');
         if (!hasCompletedSets) {
-            showToast('Cannot finish workout - no sets completed', 'error');
+            if (msg) msg.hidden = false;
+            finishModal.classList.add('active');
+            trapModalFocus(finishModal);
             return;
         }
+        if (msg) msg.hidden = true;
 
         // Update summary
         const duration = timerService.getWorkoutElapsed();
@@ -1872,7 +2385,6 @@ class WorkoutView {
             prsValue.textContent = `${this.sessionPrCount}`;
         }
 
-        const finishModal = document.getElementById('finish-workout-modal');
         finishModal.classList.add('active');
         trapModalFocus(finishModal);
     }
@@ -1886,8 +2398,8 @@ class WorkoutView {
         );
 
         if (!hasCompletedSets) {
-            showToast('Cannot save workout - no sets completed', 'error');
-            document.getElementById('finish-workout-modal').classList.remove('active');
+            const msg = document.getElementById('finish-inline-message');
+            if (msg) msg.hidden = false;
             return;
         }
 
@@ -1918,9 +2430,13 @@ class WorkoutView {
         // Stop timer + rest bar
         timerService.stopWorkoutTimer();
         this.skipRest();
+        this.disarmBackGuard();
 
-        // Close modal and reset
-        document.getElementById('finish-workout-modal').classList.remove('active');
+        // Close modal and reset (R3-6: blur before hide so the confirm button
+        // doesn't retain focus inside the closing dialog).
+        const finishModalEl = document.getElementById('finish-workout-modal');
+        if (finishModalEl.contains(document.activeElement)) document.activeElement.blur();
+        finishModalEl.classList.remove('active');
         document.getElementById('active-workout').classList.remove('active');
         document.getElementById('workout-selection').classList.add('active');
 
@@ -1929,6 +2445,7 @@ class WorkoutView {
 
         this.showCompletionBurst(completedSession);
         this.render();
+        this.app.updateGlobalFab();
     }
 
     /**
@@ -1993,7 +2510,7 @@ class WorkoutView {
      */
     _lastSessionForProgram(programId) {
         const sessions = (this.app.workoutSessions || [])
-            .filter(s => s.programId === programId && s.completed)
+            .filter(s => sameId(s.programId, programId) && s.completed)
             .sort((a, b) => new Date(b.sortTimestamp) - new Date(a.sortTimestamp));
         return sessions[0] || null;
     }
@@ -2079,6 +2596,7 @@ class WorkoutView {
         if (confirmed) {
             timerService.stopWorkoutTimer();
             this.skipRest();
+            this.disarmBackGuard();
             storageService.clearActiveWorkout();
             document.getElementById('active-workout').classList.remove('active');
             document.getElementById('workout-selection').classList.add('active');

--- a/apps/gym-tracker/sw.js
+++ b/apps/gym-tracker/sw.js
@@ -16,7 +16,7 @@
  * Old caches are pruned automatically on activate.
  */
 
-const CACHE_VERSION = '1.5.2';
+const CACHE_VERSION = '1.7.4';
 const PRECACHE = `gym-precache-${CACHE_VERSION}`;
 const RUNTIME = `gym-runtime-${CACHE_VERSION}`;
 
@@ -43,10 +43,16 @@ const PRECACHE_URLS = [
   './js/utils/dark-calendar.js',
   './js/utils/dark-select.js',
   './js/utils/event-bus.js',
+  './js/utils/exercise-feel.js',
   './js/utils/helpers.js',
+  './js/utils/id-utils.js',
   './js/utils/modal-focus.js',
   './js/utils/plate-calculator.js',
+  './js/utils/pr-session.js',
   './js/utils/program-order.js',
+  './js/utils/program-schedule.js',
+  './js/utils/rest-cues.js',
+  './js/utils/session-merge.js',
   './js/utils/paginator.js',
   './js/utils/sync-status.js',
   './js/views/achievements-view.js',

--- a/apps/gym-tracker/tests/analytics.test.mjs
+++ b/apps/gym-tracker/tests/analytics.test.mjs
@@ -87,6 +87,39 @@ test('isSetPR: heavier weight at fewer reps below volume is NOT a PR', () => {
     assert.equal(result, null);
 });
 
+// Item 11: a PR must beat both completed sessions AND earlier committed sets
+// of the current session, so a repeat at the same new max isn't re-celebrated.
+test('isSetPR: second set at same new max is NOT a PR (in-session dedupe)', () => {
+    const sessions = [makeSession({ date: '2026-04-01', sets: [{ weight: 90, reps: 5 }] })];
+    // Set 1 at 100x5 beats history (450 -> 500) -> PR.
+    const set1 = { weight: 100, reps: 5 };
+    const pr1 = AnalyticsService.isSetPR(100, set1, sessions, []);
+    assert.equal(pr1.kind, 'volume');
+    // Set 2 at 100x5 ties set 1's session volume -> NOT a PR.
+    const pr2 = AnalyticsService.isSetPR(100, { weight: 100, reps: 5 }, sessions, [set1]);
+    assert.equal(pr2, null);
+    // Set 3 at 105x5 beats both -> PR again.
+    const pr3 = AnalyticsService.isSetPR(100, { weight: 105, reps: 5 }, sessions, [set1, { weight: 100, reps: 5 }]);
+    assert.equal(pr3.kind, 'volume');
+});
+
+test('isSetPR: equal-weight-more-reps still PRs across in-session sets', () => {
+    const sessions = [makeSession({ date: '2026-04-01', sets: [{ weight: 90, reps: 8 }] })];
+    const set1 = { weight: 100, reps: 8 }; // 800 vs 720 -> PR
+    assert.ok(AnalyticsService.isSetPR(100, set1, sessions, []));
+    const set2 = { weight: 100, reps: 10 }; // 1000 > 800 -> PR
+    assert.ok(AnalyticsService.isSetPR(100, set2, sessions, [set1]));
+    const set3 = { weight: 100, reps: 10 }; // ties set2 -> not a PR
+    assert.equal(AnalyticsService.isSetPR(100, set3, sessions, [set1, set2]), null);
+});
+
+test('isSetPR: empty currentSessionPriorSets matches the legacy 3-arg behavior', () => {
+    const sessions = [makeSession({ date: '2026-04-01', sets: [{ weight: 100, reps: 5 }] })];
+    const a = AnalyticsService.isSetPR(100, { weight: 100, reps: 6 }, sessions);
+    const b = AnalyticsService.isSetPR(100, { weight: 100, reps: 6 }, sessions, []);
+    assert.deepEqual(a, b);
+});
+
 test('getCurrentStreak: zero when no sessions', () => {
     assert.equal(AnalyticsService.getCurrentStreak([]), 0);
 });

--- a/apps/gym-tracker/tests/exercise-feel.test.mjs
+++ b/apps/gym-tracker/tests/exercise-feel.test.mjs
@@ -1,0 +1,177 @@
+// Tests for Item 7: "how did it feel" marking.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WorkoutExercise } from '../js/models/WorkoutExercise.js';
+import { setReachesMaxReps, allSetsReachMax, latestFeelForExercise, nextFeel, shouldShowFeelModal } from '../js/utils/exercise-feel.js';
+
+// -------------------------------------------------------
+// WorkoutExercise.feel round-trip
+// -------------------------------------------------------
+
+test('WorkoutExercise: feel defaults to null', () => {
+    const ex = new WorkoutExercise({ exerciseId: 'e1' });
+    assert.equal(ex.feel, null);
+});
+
+test('WorkoutExercise: feel round-trips through toJSON/fromJSON', () => {
+    // 'good' is the only value produced now, but legacy 'bad' must survive a
+    // round-trip so existing saved sessions are not corrupted on load.
+    for (const feel of ['good', 'bad']) {
+        const ex = new WorkoutExercise({ exerciseId: 'e1', feel });
+        const back = WorkoutExercise.fromJSON(ex.toJSON());
+        assert.equal(back.feel, feel);
+    }
+});
+
+test('WorkoutExercise: invalid feel coerces to null', () => {
+    const ex = new WorkoutExercise({ exerciseId: 'e1', feel: 'meh' });
+    assert.equal(ex.feel, null);
+});
+
+// -------------------------------------------------------
+// setReachesMaxReps
+// -------------------------------------------------------
+
+test('setReachesMaxReps: true at or above the slot max', () => {
+    assert.equal(setReachesMaxReps({ reps: 10 }, 10), true);
+    assert.equal(setReachesMaxReps({ reps: 12 }, 10), true);
+});
+
+test('setReachesMaxReps: false below the slot max', () => {
+    assert.equal(setReachesMaxReps({ reps: 8 }, 10), false);
+});
+
+test('setReachesMaxReps: duration sets are skipped', () => {
+    assert.equal(setReachesMaxReps({ reps: 0, duration: 60 }, 10), false);
+});
+
+// -------------------------------------------------------
+// allSetsReachMax — strict gating (Item R2-4)
+// -------------------------------------------------------
+
+// A rep range 8-12 across 3 sets: max per slot is 12.
+const max12 = () => 12;
+
+test('allSetsReachMax: 12/12/12 over 3 sets qualifies', () => {
+    const sets = [{ reps: 12 }, { reps: 12 }, { reps: 12 }];
+    assert.equal(allSetsReachMax(sets, 3, max12), true);
+});
+
+test('allSetsReachMax: 12/12/11 over 3 sets does NOT qualify (one below max)', () => {
+    const sets = [{ reps: 12 }, { reps: 12 }, { reps: 11 }];
+    assert.equal(allSetsReachMax(sets, 3, max12), false);
+});
+
+test('allSetsReachMax: fewer than target sets does not qualify', () => {
+    const sets = [{ reps: 12 }, { reps: 12 }];
+    assert.equal(allSetsReachMax(sets, 3, max12), false);
+});
+
+test('allSetsReachMax: above max still qualifies (>= max)', () => {
+    const sets = [{ reps: 13 }, { reps: 12 }, { reps: 14 }];
+    assert.equal(allSetsReachMax(sets, 3, max12), true);
+});
+
+test('allSetsReachMax: singular target 5/5/5 qualifies, 5/5/4 does not', () => {
+    const max5 = () => 5;
+    assert.equal(allSetsReachMax([{ reps: 5 }, { reps: 5 }, { reps: 5 }], 3, max5), true);
+    assert.equal(allSetsReachMax([{ reps: 5 }, { reps: 5 }, { reps: 4 }], 3, max5), false);
+});
+
+test('allSetsReachMax: any duration set disqualifies the whole exercise', () => {
+    const sets = [{ reps: 12 }, { reps: 12 }, { reps: 0, duration: 60 }];
+    assert.equal(allSetsReachMax(sets, 3, max12), false);
+});
+
+test('allSetsReachMax: per-slot max resolved independently per set', () => {
+    // Slot 0 max 10, slots 1+ max 12.
+    const slotMax = (set, i) => (i === 0 ? 10 : 12);
+    assert.equal(allSetsReachMax([{ reps: 10 }, { reps: 12 }, { reps: 12 }], 3, slotMax), true);
+    assert.equal(allSetsReachMax([{ reps: 9 }, { reps: 12 }, { reps: 12 }], 3, slotMax), false);
+});
+
+test('allSetsReachMax: targetSets defaults to >= 1', () => {
+    assert.equal(allSetsReachMax([{ reps: 12 }], 1, max12), true);
+    assert.equal(allSetsReachMax([], 1, max12), false);
+});
+
+// -------------------------------------------------------
+// latestFeelForExercise
+// -------------------------------------------------------
+
+test('latestFeelForExercise: returns most recent non-null feel', () => {
+    const sessions = [
+        {
+            completed: true,
+            sortTimestamp: '2026-01-01T10:00:00Z',
+            exercises: [{ exerciseId: 'e1', feel: 'bad' }],
+        },
+        {
+            completed: true,
+            sortTimestamp: '2026-03-01T10:00:00Z',
+            exercises: [{ exerciseId: 'e1', feel: 'good' }],
+        },
+        {
+            completed: true,
+            sortTimestamp: '2026-02-01T10:00:00Z',
+            exercises: [{ exerciseId: 'e1', feel: 'bad' }],
+        },
+    ];
+    assert.equal(latestFeelForExercise(sessions, 'e1', s => s.sortTimestamp), 'good');
+});
+
+test('latestFeelForExercise: null when no marking exists', () => {
+    const sessions = [
+        { completed: true, sortTimestamp: '2026-01-01', exercises: [{ exerciseId: 'e1', feel: null }] },
+        { completed: true, sortTimestamp: '2026-02-01', exercises: [{ exerciseId: 'e2', feel: 'good' }] },
+    ];
+    assert.equal(latestFeelForExercise(sessions, 'e1', s => s.sortTimestamp), null);
+});
+
+test('latestFeelForExercise: ignores sessions without the exercise', () => {
+    const sessions = [
+        { completed: true, sortTimestamp: '2026-02-01', exercises: [{ exerciseId: 'e9', feel: 'good' }] },
+    ];
+    assert.equal(latestFeelForExercise(sessions, 'e1', s => s.sortTimestamp), null);
+});
+
+test('latestFeelForExercise: legacy bad-only history yields null (no gray icon)', () => {
+    const sessions = [
+        { completed: true, sortTimestamp: '2026-01-01', exercises: [{ exerciseId: 'e1', feel: 'bad' }] },
+        { completed: true, sortTimestamp: '2026-02-01', exercises: [{ exerciseId: 'e1', feel: 'bad' }] },
+    ];
+    assert.equal(latestFeelForExercise(sessions, 'e1', s => s.sortTimestamp), null);
+});
+
+test('latestFeelForExercise: a newer bad does not override an older good', () => {
+    const sessions = [
+        { completed: true, sortTimestamp: '2026-01-01', exercises: [{ exerciseId: 'e1', feel: 'good' }] },
+        { completed: true, sortTimestamp: '2026-03-01', exercises: [{ exerciseId: 'e1', feel: 'bad' }] },
+    ];
+    assert.equal(latestFeelForExercise(sessions, 'e1', s => s.sortTimestamp), 'good');
+});
+
+// -------------------------------------------------------
+// Item R3-4: feel cycle (header icon) + once-per-session modal bookkeeping
+// -------------------------------------------------------
+
+test('nextFeel: toggles good <-> none (never bad)', () => {
+    assert.equal(nextFeel('good'), null);
+    assert.equal(nextFeel(null), 'good');
+    assert.equal(nextFeel(undefined), 'good');
+    // Legacy 'bad' is treated as "not good", so toggling it marks 'good'.
+    assert.equal(nextFeel('bad'), 'good');
+});
+
+test('shouldShowFeelModal: only when reaches-max and not already shown', () => {
+    const shown = {};
+    // Not reaching max: never show.
+    assert.equal(shouldShowFeelModal(shown, 0, false), false);
+    // Reaches max, not yet shown: show.
+    assert.equal(shouldShowFeelModal(shown, 0, true), true);
+    // Caller marks it shown; second satisfaction must NOT re-show.
+    shown[0] = true;
+    assert.equal(shouldShowFeelModal(shown, 0, true), false);
+    // A different exercise index is independent.
+    assert.equal(shouldShowFeelModal(shown, 1, true), true);
+});

--- a/apps/gym-tracker/tests/id-utils.test.mjs
+++ b/apps/gym-tracker/tests/id-utils.test.mjs
@@ -1,0 +1,40 @@
+// Tests for sameId: type-insensitive id comparison.
+//
+// Why this matters: Program ids are generated numerically, but ids that come
+// back from the DOM (dataset.programId, drag payloads) are always strings.
+// getProgramById-style lookups must match a numeric id when queried by its
+// string form, or "Start Workout" / Edit / Delete silently no-op on real
+// programs. These tests reproduce that exact mismatch.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sameId } from '../js/utils/id-utils.js';
+
+test('sameId: numeric id matches its string form (the dataset case)', () => {
+    assert.equal(sameId(1717000000000, '1717000000000'), true);
+    assert.equal(sameId('1717000000000', 1717000000000), true);
+});
+
+test('sameId: string ids (imported/legacy data) match', () => {
+    assert.equal(sameId('g-abc', 'g-abc'), true);
+    assert.equal(sameId('g-abc', 'g-xyz'), false);
+});
+
+test('sameId: distinct numeric ids do not match', () => {
+    assert.equal(sameId(1, 2), false);
+});
+
+test('getProgramById-style lookup finds a numeric id by its string form', () => {
+    const programs = [
+        { id: 1717000000001, name: 'Push' },
+        { id: 1717000000002, name: 'Pull' },
+    ];
+    // The id arrives from dataset.* as a string.
+    const found = programs.find(p => sameId(p.id, '1717000000002'));
+    assert.equal(found?.name, 'Pull');
+});
+
+test('getProgramById-style lookup also works for imported string ids', () => {
+    const programs = [{ id: 'legacy-1', name: 'Legacy' }];
+    const found = programs.find(p => sameId(p.id, 'legacy-1'));
+    assert.equal(found?.name, 'Legacy');
+});

--- a/apps/gym-tracker/tests/play-sound.test.mjs
+++ b/apps/gym-tracker/tests/play-sound.test.mjs
@@ -1,0 +1,117 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// A minimal fake Web Audio graph that records what was built and started,
+// so we can assert a tone actually got scheduled on a given context.
+function makeFakeAudioContext(initialState = 'running') {
+    const started = [];
+    const ctx = {
+        state: initialState,
+        currentTime: 0,
+        resumeCalls: 0,
+        createOscillator() {
+            const osc = {
+                type: 'sine',
+                frequency: { value: 0 },
+                connect: () => osc,
+                start: (when) => started.push({ when }),
+                stop: () => {},
+            };
+            return osc;
+        },
+        createGain() {
+            const node = {
+                gain: { setValueAtTime() {}, linearRampToValueAtTime() {} },
+                connect: () => node,
+            };
+            return node;
+        },
+        createBiquadFilter() {
+            const node = { type: 'lowpass', frequency: { value: 0 }, connect: () => node };
+            return node;
+        },
+        destination: {},
+        resume() {
+            this.resumeCalls += 1;
+            if (this.state !== 'closed') this.state = 'running';
+            return Promise.resolve();
+        },
+    };
+    ctx.started = started;
+    return ctx;
+}
+
+// Stub the global `window` AudioContext factory before importing helpers.
+// `playSound` caches a module-level context; `nextCtx` controls what the next
+// `new Ctx()` returns. `created` records every context constructed.
+let nextCtx = null;
+const created = [];
+globalThis.window = {
+    AudioContext: function AudioContext() {
+        const c = nextCtx || makeFakeAudioContext('running');
+        created.push(c);
+        nextCtx = null;
+        return c;
+    },
+};
+
+const { playSound } = await import('../js/utils/helpers.js');
+
+// Force the cached module context to be discarded before a test that needs a
+// known-fresh one: closing it makes getAudioContext() recreate from nextCtx.
+function discardCachedContext() {
+    if (created.length) created[created.length - 1].state = 'closed';
+}
+
+test('playSound: running context schedules a tone immediately', () => {
+    nextCtx = makeFakeAudioContext('running');
+    playSound('rest-done');
+    const ctx = created[created.length - 1];
+    assert.ok(ctx.started.length >= 1, 'expected at least one oscillator started');
+});
+
+test('playSound: a closed context is discarded and replaced; sound plays on the new one', () => {
+    // Seed a context, then close it to simulate an iOS/Android teardown.
+    discardCachedContext();
+    nextCtx = makeFakeAudioContext('running');
+    playSound('timer-low');
+    const closedCtx = created[created.length - 1];
+    closedCtx.state = 'closed';
+
+    const before = created.length;
+    nextCtx = makeFakeAudioContext('running');
+    playSound('timer-low');
+    assert.equal(created.length, before + 1, 'expected a fresh AudioContext to be created');
+    const fresh = created[created.length - 1];
+    assert.notEqual(fresh, closedCtx);
+    assert.ok(fresh.started.length >= 1, 'tone should play on the replacement context');
+});
+
+test('playSound: a suspended context is resumed and the tone is scheduled after resume', async () => {
+    discardCachedContext();
+    const suspended = makeFakeAudioContext('suspended');
+    nextCtx = suspended;
+    playSound('pr');
+    assert.equal(suspended.resumeCalls, 1, 'resume() should be called on a suspended context');
+    // resume() resolves on the microtask queue; let it flush.
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.ok(suspended.started.length >= 1, 'tone should be scheduled after resume resolves');
+});
+
+test('playSound: timer-warn produces a distinct tone', () => {
+    discardCachedContext();
+    nextCtx = makeFakeAudioContext('running');
+    playSound('timer-warn');
+    const ctx = created[created.length - 1];
+    assert.ok(ctx.started.length >= 1);
+});
+
+test('playSound: no AudioContext available is a safe no-op', () => {
+    discardCachedContext();
+    const saved = globalThis.window.AudioContext;
+    globalThis.window.AudioContext = undefined;
+    globalThis.window.webkitAudioContext = undefined;
+    assert.doesNotThrow(() => playSound('rest-done'));
+    globalThis.window.AudioContext = saved;
+});

--- a/apps/gym-tracker/tests/pr-session.test.mjs
+++ b/apps/gym-tracker/tests/pr-session.test.mjs
@@ -1,0 +1,141 @@
+// Tests for Item R2-10: in-session PR supersede bookkeeping.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    exerciseKeyOf,
+    recordPrSupersede,
+    uniquePrChainCount,
+    recomputePrSlots,
+} from '../js/utils/pr-session.js';
+
+const pr = (delta) => ({ kind: 'volume', delta });
+
+// A volume-based PR predicate over history baseline + earlier same-exercise
+// session sets, mirroring AnalyticsService.isSetPR's volume rule. `baseline`
+// is the prior-best volume from completed sessions for the exercise.
+const makeIsPr = (baseline) => (exerciseId, set, priorSessionSets) => {
+    const vol = (s) => (s.weight || 0) * (s.reps || 0);
+    const prevMax = priorSessionSets.reduce((m, s) => Math.max(m, vol(s)), baseline);
+    const v = vol(set);
+    return v > prevMax ? pr(v - prevMax) : null;
+};
+
+test('exerciseKeyOf: returns the index portion before the first colon', () => {
+    assert.equal(exerciseKeyOf('0:0'), '0');
+    assert.equal(exerciseKeyOf('3:11'), '3');
+    assert.equal(exerciseKeyOf('lone'), 'lone');
+});
+
+test('recordPrSupersede: a higher set replaces the earlier badge for the same exercise', () => {
+    const slots = {};
+    recordPrSupersede(slots, '0:0', pr(100)); // Set1 100x10
+    assert.deepEqual(Object.keys(slots), ['0:0']);
+
+    recordPrSupersede(slots, '0:1', pr(200)); // Set2 100x12 supersedes
+    assert.deepEqual(Object.keys(slots), ['0:1']);
+    assert.equal(slots['0:0'], undefined);
+    assert.equal(uniquePrChainCount(slots), 1);
+});
+
+test('recordPrSupersede: a 100 -> 110 -> 120 chain counts once and keeps only the last', () => {
+    const slots = {};
+    recordPrSupersede(slots, '0:0', pr(100));
+    recordPrSupersede(slots, '0:1', pr(110));
+    recordPrSupersede(slots, '0:2', pr(120));
+    assert.deepEqual(Object.keys(slots), ['0:2']);
+    assert.equal(uniquePrChainCount(slots), 1);
+});
+
+test('recordPrSupersede: different exercises keep independent badges', () => {
+    const slots = {};
+    recordPrSupersede(slots, '0:0', pr(100));
+    recordPrSupersede(slots, '1:0', pr(50));
+    assert.deepEqual(Object.keys(slots).sort(), ['0:0', '1:0']);
+    assert.equal(uniquePrChainCount(slots), 2);
+
+    // A supersede on exercise 0 must not touch exercise 1.
+    recordPrSupersede(slots, '0:1', pr(200));
+    assert.deepEqual(Object.keys(slots).sort(), ['0:1', '1:0']);
+    assert.equal(uniquePrChainCount(slots), 2);
+});
+
+test('uniquePrChainCount: empty map is 0', () => {
+    assert.equal(uniquePrChainCount({}), 0);
+});
+
+test('uniquePrChainCount: counts distinct exercises, not slots', () => {
+    // Defensive: even if two slots of one exercise lingered, count is per-exercise.
+    const slots = { '0:0': pr(1), '0:1': pr(2), '2:0': pr(3) };
+    assert.equal(uniquePrChainCount(slots), 2);
+});
+
+// --- Item R3-7: full recompute restores superseded badges after edits. ---
+
+test('recomputePrSlots: editing away a superseding set restores the earlier badge', () => {
+    // Prior best volume 900. Set1 100x10 (1000) -> PR. Set2 100x12 (1200) ->
+    // badge moves to set2, count stays 1 (single chain).
+    const isPr = makeIsPr(900);
+    const before = recomputePrSlots(
+        [{ exerciseId: 'sq', sets: [
+            { slot: 0, weight: 100, reps: 10 },
+            { slot: 1, weight: 100, reps: 12 },
+        ] }], isPr);
+    assert.deepEqual(Object.keys(before), ['0:1']);
+    assert.equal(uniquePrChainCount(before), 1);
+
+    // Edit set2 down to 80x8 (640) -> no longer a PR. Set1's badge returns.
+    const after = recomputePrSlots(
+        [{ exerciseId: 'sq', sets: [
+            { slot: 0, weight: 100, reps: 10 },
+            { slot: 1, weight: 80, reps: 8 },
+        ] }], isPr);
+    assert.deepEqual(Object.keys(after), ['0:0']);
+    assert.equal(uniquePrChainCount(after), 1);
+});
+
+test('recomputePrSlots: deleting the superseding set restores the earlier badge', () => {
+    const isPr = makeIsPr(900);
+    const after = recomputePrSlots(
+        [{ exerciseId: 'sq', sets: [
+            { slot: 0, weight: 100, reps: 10 },
+        ] }], isPr);
+    assert.deepEqual(Object.keys(after), ['0:0']);
+    assert.equal(uniquePrChainCount(after), 1);
+});
+
+test('recomputePrSlots: order-based on slots, not insertion time (mid-list resequence)', () => {
+    // Sets recorded out of slot order in the array; recompute must evaluate by
+    // slot. Slot0=1000, slot1=900 (not PR vs slot0), slot2=1200 (PR, supersedes).
+    const isPr = makeIsPr(800);
+    const slots = recomputePrSlots(
+        [{ exerciseId: 'bp', sets: [
+            { slot: 2, weight: 100, reps: 12 },  // inserted first, but slot 2
+            { slot: 0, weight: 100, reps: 10 },
+            { slot: 1, weight: 90, reps: 10 },
+        ] }], isPr);
+    // slot0 PR vs baseline, slot1 not a PR, slot2 supersedes -> only slot2 survives.
+    assert.deepEqual(Object.keys(slots), ['0:2']);
+    assert.equal(uniquePrChainCount(slots), 1);
+});
+
+test('recomputePrSlots: a newly-larger mid-list edit keeps the best slot', () => {
+    // slot0 1000 (PR), slot1 edited up to 100x15 (1500, supersedes). Best is slot1.
+    const isPr = makeIsPr(900);
+    const slots = recomputePrSlots(
+        [{ exerciseId: 'dl', sets: [
+            { slot: 0, weight: 100, reps: 10 },
+            { slot: 1, weight: 100, reps: 15 },
+        ] }], isPr);
+    assert.deepEqual(Object.keys(slots), ['0:1']);
+});
+
+test('recomputePrSlots: independent exercises keep independent badges', () => {
+    const isPr = makeIsPr(0);
+    const slots = recomputePrSlots(
+        [
+            { exerciseId: 'a', sets: [{ slot: 0, weight: 50, reps: 5 }] },
+            { exerciseId: 'b', sets: [{ slot: 0, weight: 60, reps: 5 }] },
+        ], isPr);
+    assert.deepEqual(Object.keys(slots).sort(), ['0:0', '1:0']);
+    assert.equal(uniquePrChainCount(slots), 2);
+});

--- a/apps/gym-tracker/tests/program-clone.test.mjs
+++ b/apps/gym-tracker/tests/program-clone.test.mjs
@@ -1,0 +1,56 @@
+// R3-3: Program.clone stages editor edits so Cancel/X discard them.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Program } from '../js/models/Program.js';
+
+function sample() {
+    return new Program({
+        name: 'Push Day',
+        description: 'chest + shoulders',
+        scheduleDays: [1, 4],
+        restMode: 'uniform',
+        uniformRestSeconds: 120,
+        exercises: [
+            { exerciseId: 'bench', exerciseName: 'Bench', targetSets: 3, targetReps: 8 },
+            { exerciseId: 'ohp', exerciseName: 'OHP', targetSets: 3, targetReps: 10 },
+        ],
+    });
+}
+
+test('clone keeps the same id', () => {
+    const p = sample();
+    assert.equal(Program.clone(p).id, p.id);
+});
+
+test('clone is a deep, independent copy', () => {
+    const original = sample();
+    const staged = Program.clone(original);
+
+    // Mutate every field the editor can touch.
+    staged.name = 'Edited';
+    staged.scheduleDays = [2, 3, 5];
+    staged.uniformRestSeconds = 30;
+    staged.addExercise('row', 'Row', 4, 12);
+    staged.updateExercise(0, { exerciseName: 'Incline Bench' });
+
+    // Original is untouched (Cancel path).
+    assert.equal(original.name, 'Push Day');
+    assert.deepEqual(original.scheduleDays, [1, 4]);
+    assert.equal(original.uniformRestSeconds, 120);
+    assert.equal(original.exercises.length, 2);
+    assert.equal(original.exercises[0].exerciseName, 'Bench');
+    assert.equal(staged.exercises[0].exerciseName, 'Incline Bench');
+});
+
+test('committing the clone back by id reflects all edits (Save path)', () => {
+    const stored = [sample()];
+    const staged = Program.clone(stored[0]);
+    staged.name = 'Committed';
+    staged.addExercise('row', 'Row', 4, 12);
+
+    const idx = stored.findIndex(p => p.id === staged.id);
+    stored[idx] = staged;
+
+    assert.equal(stored[0].name, 'Committed');
+    assert.equal(stored[0].exercises.length, 3);
+});

--- a/apps/gym-tracker/tests/program-schedule.test.mjs
+++ b/apps/gym-tracker/tests/program-schedule.test.mjs
@@ -1,0 +1,149 @@
+// Tests for Item 9: program day-of-week schedule.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Program } from '../js/models/Program.js';
+import { Settings } from '../js/models/Settings.js';
+import { programsScheduledOnWeekday, weekdayOrder, weekStrip } from '../js/utils/program-schedule.js';
+
+// -------------------------------------------------------
+// Program.scheduleDays model
+// -------------------------------------------------------
+
+test('Program: scheduleDays defaults to [] for legacy data', () => {
+    const p = new Program({ name: 'Legacy' });
+    assert.deepEqual(p.scheduleDays, []);
+});
+
+test('Program: scheduleDays round-trips and is deduped/sorted', () => {
+    const p = new Program({ name: 'Split', scheduleDays: [4, 1, 1, 4] });
+    assert.deepEqual(p.scheduleDays, [1, 4]);
+    const back = Program.fromJSON(p.toJSON());
+    assert.deepEqual(back.scheduleDays, [1, 4]);
+});
+
+test('Program: invalid scheduleDays entries are dropped', () => {
+    const p = new Program({ name: 'Bad', scheduleDays: [0, 7, -1, 'x', 6] });
+    assert.deepEqual(p.scheduleDays, [0, 6]);
+});
+
+test('Program: non-array scheduleDays becomes []', () => {
+    const p = new Program({ name: 'X', scheduleDays: 'mon' });
+    assert.deepEqual(p.scheduleDays, []);
+});
+
+// -------------------------------------------------------
+// Settings.showProgramSchedule
+// -------------------------------------------------------
+
+test('Settings: showProgramSchedule defaults to true', () => {
+    assert.equal(Settings.getDefault().showProgramSchedule, true);
+});
+
+test('Settings: showProgramSchedule false round-trips', () => {
+    const s = new Settings({ showProgramSchedule: false });
+    assert.equal(s.showProgramSchedule, false);
+    assert.equal(Settings.fromJSON(s.toJSON()).showProgramSchedule, false);
+});
+
+test('Settings: legacy data without the key defaults on', () => {
+    const s = Settings.fromJSON({ weightUnit: 'kg' });
+    assert.equal(s.showProgramSchedule, true);
+});
+
+// -------------------------------------------------------
+// programsScheduledOnWeekday
+// -------------------------------------------------------
+
+test('programsScheduledOnWeekday: matches programs on the weekday', () => {
+    const programs = [
+        { name: 'Push', scheduleDays: [1, 4] },
+        { name: 'Legs', scheduleDays: [2, 5] },
+        { name: 'Unscheduled', scheduleDays: [] },
+    ];
+    assert.deepEqual(programsScheduledOnWeekday(programs, 1).map(p => p.name), ['Push']);
+    assert.deepEqual(programsScheduledOnWeekday(programs, 2).map(p => p.name), ['Legs']);
+    assert.deepEqual(programsScheduledOnWeekday(programs, 3).map(p => p.name), []);
+});
+
+test('programsScheduledOnWeekday: programs without scheduleDays never match', () => {
+    const programs = [{ name: 'X' }];
+    assert.deepEqual(programsScheduledOnWeekday(programs, 0), []);
+});
+
+// -------------------------------------------------------
+// weekdayOrder
+// -------------------------------------------------------
+
+test('weekdayOrder: Monday-first', () => {
+    assert.deepEqual(weekdayOrder(1), [1, 2, 3, 4, 5, 6, 0]);
+});
+
+test('weekdayOrder: Sunday-first', () => {
+    assert.deepEqual(weekdayOrder(0), [0, 1, 2, 3, 4, 5, 6]);
+});
+
+// -------------------------------------------------------
+// Item R2-5: Settings.firstDayOfWeek user-facing setting
+// -------------------------------------------------------
+
+test('R2-5: firstDayOfWeek defaults to 0 (Sunday)', () => {
+    assert.equal(Settings.getDefault().firstDayOfWeek, 0);
+});
+
+test('R2-5: firstDayOfWeek = 1 (Monday) round-trips', () => {
+    const s = new Settings({ firstDayOfWeek: 1 });
+    assert.equal(s.firstDayOfWeek, 1);
+    assert.equal(Settings.fromJSON(s.toJSON()).firstDayOfWeek, 1);
+});
+
+test('R2-5: legacy data without firstDayOfWeek defaults to Sunday', () => {
+    assert.equal(Settings.fromJSON({ weightUnit: 'kg' }).firstDayOfWeek, 0);
+});
+
+// Calendar grid leading-blank offset is a pure formula shared by both column
+// orders: how far the month's first weekday sits from the configured first
+// column. Encodes WHY: blanks before day 1 must align day 1 under its header.
+test('R2-5: calendar leading-blank offset honors firstDayOfWeek', () => {
+    const offset = (firstDayOfMonth, firstDay) => (firstDayOfMonth - firstDay + 7) % 7;
+    // Month starting on a Wednesday (3).
+    assert.equal(offset(3, 0), 3); // Sunday-first: Sun,Mon,Tue blank -> 3
+    assert.equal(offset(3, 1), 2); // Monday-first: Mon,Tue blank -> 2
+    // Month starting on a Sunday (0).
+    assert.equal(offset(0, 0), 0); // Sunday-first: no blanks
+    assert.equal(offset(0, 1), 6); // Monday-first: six blanks before Sunday
+});
+
+// -------------------------------------------------------
+// Item R2-6: weekStrip for the workout selection screen
+// -------------------------------------------------------
+
+test('R2-6: weekStrip returns 7 cells ordered per firstDayOfWeek', () => {
+    const programs = [{ name: 'Push', scheduleDays: [1, 4] }];
+    const sun = weekStrip(programs, 0, new Date(2026, 5, 7)); // a Sunday
+    assert.deepEqual(sun.map(c => c.weekday), [0, 1, 2, 3, 4, 5, 6]);
+    const mon = weekStrip(programs, 1, new Date(2026, 5, 7));
+    assert.deepEqual(mon.map(c => c.weekday), [1, 2, 3, 4, 5, 6, 0]);
+});
+
+test('R2-6: weekStrip flags today and attaches scheduled programs per weekday', () => {
+    const programs = [
+        { id: 'a', name: 'Push', scheduleDays: [1, 4] },
+        { id: 'b', name: 'Legs', scheduleDays: [3] },
+    ];
+    // 2026-06-08 is a Monday (weekday 1).
+    const strip = weekStrip(programs, 0, new Date(2026, 5, 8));
+    const monday = strip.find(c => c.weekday === 1);
+    assert.equal(monday.isToday, true);
+    assert.deepEqual(monday.programs.map(p => p.name), ['Push']);
+    const wednesday = strip.find(c => c.weekday === 3);
+    assert.equal(wednesday.isToday, false);
+    assert.deepEqual(wednesday.programs.map(p => p.name), ['Legs']);
+    const tuesday = strip.find(c => c.weekday === 2);
+    assert.deepEqual(tuesday.programs, []);
+});
+
+test('R2-6: weekStrip with no scheduled programs yields empty program lists', () => {
+    const strip = weekStrip([{ name: 'X', scheduleDays: [] }], 0, new Date(2026, 5, 7));
+    assert.equal(strip.length, 7);
+    assert.ok(strip.every(c => c.programs.length === 0));
+});

--- a/apps/gym-tracker/tests/rest-cues.test.mjs
+++ b/apps/gym-tracker/tests/rest-cues.test.mjs
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { restTickCues, isWorkoutComplete } from '../js/utils/rest-cues.js';
+
+// --- restTickCues (Item 2) -------------------------------------------------
+
+test('restTickCues: with 10/5, warning fires only at 10s', () => {
+    // Above the warning second: nothing.
+    assert.deepEqual(restTickCues(12, 10, 5), { warn: false, urgent: false });
+    // Exactly the warning second: warn, not yet urgent.
+    assert.deepEqual(restTickCues(10, 10, 5), { warn: true, urgent: false });
+    // Between warning and countdown: nothing.
+    assert.deepEqual(restTickCues(7, 10, 5), { warn: false, urgent: false });
+});
+
+test('restTickCues: with 10/5, urgent (pips) begins at 5s and warn stays off', () => {
+    assert.deepEqual(restTickCues(5, 10, 5), { warn: false, urgent: true });
+    assert.deepEqual(restTickCues(1, 10, 5), { warn: false, urgent: true });
+    // Zero is not urgent (rest is over).
+    assert.deepEqual(restTickCues(0, 10, 5), { warn: false, urgent: false });
+});
+
+test('restTickCues: countdown start of 10 makes pips begin at 10s', () => {
+    assert.equal(restTickCues(10, 10, 10).urgent, true);
+    assert.equal(restTickCues(11, 10, 10).urgent, false);
+});
+
+test('restTickCues: first warning Off (0) never warns', () => {
+    for (let r = 1; r <= 30; r++) {
+        assert.equal(restTickCues(r, 0, 5).warn, false, `r=${r}`);
+    }
+});
+
+test('restTickCues: warning at or inside the countdown window is suppressed', () => {
+    // First warning 5 with countdown 5 -> warning would overlap pips, so off.
+    assert.equal(restTickCues(5, 5, 5).warn, false);
+    // First warning 3 with countdown 5 -> warning <= countdown, off.
+    assert.equal(restTickCues(3, 3, 5).warn, false);
+});
+
+// --- isWorkoutComplete (Item 12) -------------------------------------------
+
+const ex = (targetSets, count) => ({ targetSets, sets: Array.from({ length: count }) });
+
+test('isWorkoutComplete: false until the last exercise has all its sets', () => {
+    assert.equal(isWorkoutComplete([ex(3, 3), ex(3, 2)]), false);
+    assert.equal(isWorkoutComplete([ex(3, 3), ex(3, 3)]), true);
+});
+
+test('isWorkoutComplete: empty session is not complete', () => {
+    assert.equal(isWorkoutComplete([]), false);
+});
+
+test('isWorkoutComplete: superset arrangement completes only when both groups full', () => {
+    // Two supersetted exercises (3 sets each) interleaved with a solo lift.
+    const a = { groupId: 'g1', targetSets: 3, sets: Array.from({ length: 3 }) };
+    const b = { groupId: 'g1', targetSets: 3, sets: Array.from({ length: 2 }) };
+    const solo = ex(4, 4);
+    assert.equal(isWorkoutComplete([a, b, solo]), false);
+    b.sets = Array.from({ length: 3 });
+    assert.equal(isWorkoutComplete([a, b, solo]), true);
+});
+
+test('isWorkoutComplete: defaults targetSets to 3 when missing', () => {
+    assert.equal(isWorkoutComplete([{ sets: Array.from({ length: 3 }) }]), true);
+    assert.equal(isWorkoutComplete([{ sets: Array.from({ length: 2 }) }]), false);
+});

--- a/apps/gym-tracker/tests/session-merge.test.mjs
+++ b/apps/gym-tracker/tests/session-merge.test.mjs
@@ -1,0 +1,93 @@
+// Tests for Item 4: re-syncing a paused session with an edited program.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mergeSessionWithProgram } from '../js/utils/session-merge.js';
+
+const makeSessionExercise = (p) => ({
+    exerciseId: p.exerciseId,
+    exerciseName: p.exerciseName,
+    sets: [],
+    targetSets: p.targetSets,
+    targetReps: p.targetReps,
+    restSeconds: p.restSeconds,
+    restAfterSeconds: p.restAfterSeconds,
+    groupId: p.groupId || null,
+});
+
+test('merge: exercise with committed sets is kept untouched', () => {
+    const session = [
+        { exerciseId: 'a', exerciseName: 'Squat', sets: [{ slot: 0, weight: 100, reps: 5 }], targetSets: 3, targetReps: 5 },
+    ];
+    const program = [
+        { exerciseId: 'a', exerciseName: 'Squat (renamed)', targetSets: 5, targetReps: 8, restSeconds: 120, restAfterSeconds: 120 },
+    ];
+    const out = mergeSessionWithProgram(session, program, makeSessionExercise);
+    assert.equal(out.length, 1);
+    assert.deepEqual(out[0].sets, [{ slot: 0, weight: 100, reps: 5 }]);
+    assert.equal(out[0].exerciseName, 'Squat'); // untouched
+    assert.equal(out[0].targetSets, 3);
+});
+
+test('merge: target updates apply to exercises without committed sets', () => {
+    const session = [
+        { exerciseId: 'a', exerciseName: 'Bench', sets: [], targetSets: 3, targetReps: 10, restSeconds: 90, restAfterSeconds: 90 },
+    ];
+    const program = [
+        { exerciseId: 'a', exerciseName: 'Bench Press', targetSets: 5, targetReps: 6, restSeconds: 150, restAfterSeconds: 150 },
+    ];
+    const out = mergeSessionWithProgram(session, program, makeSessionExercise);
+    assert.equal(out[0].targetSets, 5);
+    assert.equal(out[0].targetReps, 6);
+    assert.equal(out[0].restSeconds, 150);
+    assert.equal(out[0].exerciseName, 'Bench Press');
+});
+
+test('merge: program-added exercise is appended', () => {
+    const session = [
+        { exerciseId: 'a', exerciseName: 'Bench', sets: [], targetSets: 3, targetReps: 10 },
+    ];
+    const program = [
+        { exerciseId: 'a', exerciseName: 'Bench', targetSets: 3, targetReps: 10, restSeconds: 90, restAfterSeconds: 90 },
+        { exerciseId: 'b', exerciseName: 'Row', targetSets: 4, targetReps: 12, restSeconds: 60, restAfterSeconds: 60 },
+    ];
+    const out = mergeSessionWithProgram(session, program, makeSessionExercise);
+    assert.equal(out.length, 2);
+    assert.equal(out[1].exerciseId, 'b');
+    assert.deepEqual(out[1].sets, []);
+});
+
+test('merge: removed exercise without committed sets is dropped', () => {
+    const session = [
+        { exerciseId: 'a', exerciseName: 'Bench', sets: [], targetSets: 3, targetReps: 10 },
+        { exerciseId: 'b', exerciseName: 'Row', sets: [], targetSets: 3, targetReps: 10 },
+    ];
+    const program = [
+        { exerciseId: 'a', exerciseName: 'Bench', targetSets: 3, targetReps: 10, restSeconds: 90, restAfterSeconds: 90 },
+    ];
+    const out = mergeSessionWithProgram(session, program, makeSessionExercise);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].exerciseId, 'a');
+});
+
+test('merge: removed exercise WITH committed sets survives', () => {
+    const session = [
+        { exerciseId: 'b', exerciseName: 'Row', sets: [{ slot: 0, weight: 50, reps: 12 }], targetSets: 3, targetReps: 10 },
+    ];
+    const program = [
+        { exerciseId: 'a', exerciseName: 'Bench', targetSets: 3, targetReps: 10, restSeconds: 90, restAfterSeconds: 90 },
+    ];
+    const out = mergeSessionWithProgram(session, program, makeSessionExercise);
+    // b survives (has sets) + a is appended.
+    const ids = out.map(e => e.exerciseId).sort();
+    assert.deepEqual(ids, ['a', 'b']);
+    const b = out.find(e => e.exerciseId === 'b');
+    assert.equal(b.sets.length, 1);
+});
+
+test('merge: does not mutate inputs', () => {
+    const session = [{ exerciseId: 'a', exerciseName: 'Bench', sets: [], targetSets: 3, targetReps: 10 }];
+    const program = [{ exerciseId: 'a', exerciseName: 'Bench Press', targetSets: 5, targetReps: 6, restSeconds: 150, restAfterSeconds: 150 }];
+    const sessionCopy = JSON.parse(JSON.stringify(session));
+    mergeSessionWithProgram(session, program, makeSessionExercise);
+    assert.deepEqual(session, sessionCopy);
+});

--- a/apps/gym-tracker/tests/session-unit.test.mjs
+++ b/apps/gym-tracker/tests/session-unit.test.mjs
@@ -1,0 +1,44 @@
+// Tests for Item 8: temporary per-session kg/lbs switch.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WorkoutSession } from '../js/models/WorkoutSession.js';
+import { convertWeight } from '../js/utils/helpers.js';
+
+test('WorkoutSession: sessionUnit defaults to null (follow account unit)', () => {
+    const s = new WorkoutSession({});
+    assert.equal(s.sessionUnit, null);
+});
+
+test('WorkoutSession: sessionUnit round-trips through toJSON/fromJSON', () => {
+    const s = new WorkoutSession({ sessionUnit: 'lb' });
+    assert.equal(s.sessionUnit, 'lb');
+    const back = WorkoutSession.fromJSON(s.toJSON());
+    assert.equal(back.sessionUnit, 'lb');
+});
+
+test('WorkoutSession: invalid sessionUnit coerces to null', () => {
+    const s = new WorkoutSession({ sessionUnit: 'stone' });
+    assert.equal(s.sessionUnit, null);
+});
+
+test('entry conversion: 100 lb entered with a kg account stores ~45.4 kg', () => {
+    // The view converts the entered (session-unit) value into the account unit
+    // before storing it on the Set. Verify the underlying conversion.
+    const stored = convertWeight(100, 'lb', 'kg');
+    assert.ok(Math.abs(stored - 45.4) < 0.1, `expected ~45.4, got ${stored}`);
+});
+
+test('entry conversion round-trip: display matches what was entered', () => {
+    // Account unit kg, session unit lb. Enter 135 lb -> store kg -> show back lb.
+    const account = 'kg';
+    const session = 'lb';
+    const entered = 135;
+    const canonical = convertWeight(entered, session, account);
+    const shownBack = convertWeight(canonical, account, session);
+    // Round-trip should land within 1 unit (rounding to 1 decimal each way).
+    assert.ok(Math.abs(shownBack - entered) < 1, `round-trip drifted: ${shownBack} vs ${entered}`);
+});
+
+test('same-unit conversion is a no-op', () => {
+    assert.equal(convertWeight(60, 'kg', 'kg'), 60);
+});

--- a/apps/gym-tracker/tests/settings-timer-markers.test.mjs
+++ b/apps/gym-tracker/tests/settings-timer-markers.test.mjs
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Settings } from '../js/models/Settings.js';
+
+test('Settings: timer marker defaults are 10 (first warning) / 5 (countdown)', () => {
+    const s = Settings.getDefault();
+    assert.equal(s.timerFirstWarningSeconds, 10);
+    assert.equal(s.timerCountdownSeconds, 5);
+});
+
+test('Settings: legacy data without timer keys loads with the defaults', () => {
+    // Simulate a previously-saved settings blob from before this feature.
+    const legacy = { weightUnit: 'lb', soundAlerts: true, vibrationAlerts: false };
+    const s = Settings.fromJSON(legacy);
+    assert.equal(s.timerFirstWarningSeconds, 10);
+    assert.equal(s.timerCountdownSeconds, 5);
+});
+
+test('Settings: timer markers round-trip through toJSON/fromJSON', () => {
+    const s = new Settings({ timerFirstWarningSeconds: 20, timerCountdownSeconds: 10 });
+    const json = s.toJSON();
+    assert.equal(json.timerFirstWarningSeconds, 20);
+    assert.equal(json.timerCountdownSeconds, 10);
+    const back = Settings.fromJSON(json);
+    assert.equal(back.timerFirstWarningSeconds, 20);
+    assert.equal(back.timerCountdownSeconds, 10);
+});
+
+test('Settings: first warning accepts Off (0) and the old fixed options unchanged', () => {
+    for (const v of [0, 10, 15, 20, 30]) {
+        assert.equal(new Settings({ timerFirstWarningSeconds: v }).timerFirstWarningSeconds, v);
+    }
+    for (const v of [3, 5, 10]) {
+        assert.equal(new Settings({ timerCountdownSeconds: v }).timerCountdownSeconds, v);
+    }
+});
+
+// Item R2-1: markers are now free numeric inputs, not a fixed option list.
+test('R2-1: arbitrary in-range integers are accepted (no snap to fixed options)', () => {
+    assert.equal(new Settings({ timerFirstWarningSeconds: 7 }).timerFirstWarningSeconds, 7);
+    assert.equal(new Settings({ timerFirstWarningSeconds: 25 }).timerFirstWarningSeconds, 25);
+    assert.equal(new Settings({ timerCountdownSeconds: 4 }).timerCountdownSeconds, 4);
+    assert.equal(new Settings({ timerCountdownSeconds: 8 }).timerCountdownSeconds, 8);
+});
+
+test('R2-1: invalid / empty timer values fall back to defaults', () => {
+    assert.equal(new Settings({ timerFirstWarningSeconds: 'nope' }).timerFirstWarningSeconds, 10);
+    assert.equal(new Settings({ timerFirstWarningSeconds: '' }).timerFirstWarningSeconds, 10);
+    assert.equal(new Settings({ timerFirstWarningSeconds: -3 }).timerFirstWarningSeconds, 10);
+    assert.equal(new Settings({ timerCountdownSeconds: null }).timerCountdownSeconds, 5);
+    assert.equal(new Settings({ timerCountdownSeconds: 0 }).timerCountdownSeconds, 5);
+    assert.equal(new Settings({ timerCountdownSeconds: -1 }).timerCountdownSeconds, 5);
+});
+
+test('R2-1: countdown start minimum is 1, first warning 0 stays off (disabled)', () => {
+    assert.equal(new Settings({ timerCountdownSeconds: 1 }).timerCountdownSeconds, 1);
+    assert.equal(new Settings({ timerFirstWarningSeconds: 0 }).timerFirstWarningSeconds, 0);
+});
+
+test('R2-1: values are clamped to their caps (120 / 60) and rounded to integers', () => {
+    assert.equal(new Settings({ timerFirstWarningSeconds: 999 }).timerFirstWarningSeconds, 120);
+    assert.equal(new Settings({ timerCountdownSeconds: 999 }).timerCountdownSeconds, 60);
+    assert.equal(new Settings({ timerFirstWarningSeconds: 12.7 }).timerFirstWarningSeconds, 13);
+    assert.equal(new Settings({ timerCountdownSeconds: 6.4 }).timerCountdownSeconds, 6);
+});
+
+test('R2-1: string inputs (number-field values are strings) are accepted', () => {
+    assert.equal(new Settings({ timerFirstWarningSeconds: '25' }).timerFirstWarningSeconds, 25);
+    assert.equal(new Settings({ timerCountdownSeconds: '8' }).timerCountdownSeconds, 8);
+    assert.equal(Settings.normalizeFirstWarningSeconds('0'), 0);
+    assert.equal(Settings.normalizeCountdownSeconds('1'), 1);
+});
+
+test('R2-1: legacy normalizeTimerSeconds option helper still works for explicit lists', () => {
+    assert.equal(Settings.normalizeTimerSeconds('20', [0, 10, 15, 20, 30], 10), 20);
+    assert.equal(Settings.normalizeTimerSeconds('0', [0, 10, 15, 20, 30], 10), 0);
+    assert.equal(Settings.normalizeTimerSeconds('3', [3, 5, 10], 5), 3);
+});

--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -45,9 +45,20 @@
 (function() {
   'use strict';
 
-  var THRESHOLD = 400;
+  // Show/hide use SEPARATE thresholds (hysteresis): the button appears once
+  // scrolled past SHOW_THRESHOLD and only disappears below the lower
+  // HIDE_THRESHOLD. A single threshold made the button flicker (toggle every
+  // frame) when a momentum scroll or URL-bar resize hovered right at the line.
+  var SHOW_THRESHOLD = 400;
+  var HIDE_THRESHOLD = 320;
   var EDGE_GAP = 16;       // px gap between the button and the modal rect edge
   var MODAL_Z_INDEX = 11001; // above apps' modal panels (z up to 11000)
+  // While a finger/pointer is pressing the button (and briefly after release,
+  // covering the synthesized click), the hide path is suppressed so a scroll
+  // event firing mid-gesture cannot set the button display:none and make the
+  // tap fall through to whatever is behind it. ~400ms covers the touch->click
+  // delay on slow devices.
+  var GESTURE_HOLD_MS = 400;
 
   function prefersReducedMotion() {
     return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
@@ -79,6 +90,12 @@
 
     // The container currently driving modal mode, or null for window mode.
     var modalContainer = null;
+
+    // True while the button is being pressed (and for GESTURE_HOLD_MS after
+    // release). Suppresses hide() so a scroll event firing between touchstart
+    // and the synthesized click cannot remove the button from under the finger.
+    var gestureActive = false;
+    var gestureReleaseTimer = null;
 
     // Pick the visible opted-in container that should own modal mode, or
     // null if none are visible (window mode). Greatest scrollTop wins; ties
@@ -115,6 +132,12 @@
     }
 
     function hide() {
+      // Never yank the button out from under an in-progress tap: a scroll
+      // crossing the threshold mid-gesture would otherwise set display:none
+      // and the click would retarget to the element behind.
+      if (gestureActive) {
+        return;
+      }
       if (!button.hidden) {
         button.classList.remove('back-to-top--visible');
         button.hidden = true;
@@ -160,19 +183,26 @@
 
       if (modalContainer) {
         // Modal mode: visibility and position track the container only.
-        if (modalContainer.scrollTop > THRESHOLD) {
+        // Hysteresis: show past SHOW_THRESHOLD, hide only below HIDE_THRESHOLD;
+        // in the band between, keep the current state (no flicker).
+        var mTop = modalContainer.scrollTop;
+        if (mTop > SHOW_THRESHOLD) {
           positionInModal(modalContainer);
           show();
-        } else {
+        } else if (mTop < HIDE_THRESHOLD) {
           hide();
           clearModalPosition();
+        } else if (!button.hidden) {
+          // Stay visible inside the band; keep the anchor fresh.
+          positionInModal(modalContainer);
         }
       } else {
-        // Window mode: today's behavior.
+        // Window mode: today's behavior, with the same hysteresis band.
         clearModalPosition();
-        if (windowScrolled() > THRESHOLD) {
+        var wTop = windowScrolled();
+        if (wTop > SHOW_THRESHOLD) {
           show();
-        } else {
+        } else if (wTop < HIDE_THRESHOLD) {
           hide();
         }
       }
@@ -193,17 +223,15 @@
     function swallow(e) {
       e.stopPropagation();
     }
-    button.addEventListener('pointerdown', swallow);
-    button.addEventListener('mousedown', swallow);
-    button.addEventListener('touchstart', swallow, { passive: true });
 
-    button.addEventListener('click', function(e) {
-      e.stopPropagation();
+    // The scroll-to-top action, shared by the touch/pointer activation and the
+    // mouse click path.
+    function scrollToTop() {
       var behavior = prefersReducedMotion() ? 'auto' : 'smooth';
-      // Recompute the context at click time rather than trusting the cached
-      // modalContainer: closing a modal fires no scroll event, so the cache
-      // can point at a now-hidden container and the click would "scroll" an
-      // invisible element while the page stays put.
+      // Recompute the context at activation time rather than trusting the
+      // cached modalContainer: closing a modal fires no scroll event, so the
+      // cache can point at a now-hidden container and the action would "scroll"
+      // an invisible element while the page stays put.
       var target = findModalContainer();
       if (target) {
         if (typeof target.scrollTo === 'function') {
@@ -218,7 +246,7 @@
         // its desktop sidebar open: body.sidebar-open { overflow:hidden } turns
         // the body into the scroll context). window.scrollTo cannot move a
         // scrolled body/documentElement in those states, so the button would
-        // SHOW (from body.scrollTop) yet the click would do nothing. Scroll
+        // SHOW (from body.scrollTop) yet the action would do nothing. Scroll
         // whatever actually holds the offset back to the top as well.
         if (document.body.scrollTop > 0) {
           if (typeof document.body.scrollTo === 'function') {
@@ -235,9 +263,89 @@
           }
         }
       }
-      // Re-sync visibility shortly after: if the click was a no-op (stale
+      // Re-sync visibility shortly after: if the action was a no-op (stale
       // context, page already at top), the button should still hide.
       window.setTimeout(update, 300);
+    }
+
+    // Touch/pen position tracking so we only activate on a TAP (finger came
+    // down and up on the button without a scrolling drag), not on a scroll
+    // gesture that happened to start on the button.
+    var SCROLL_TOLERANCE = 10; // px of movement still counted as a tap
+    var startX = 0, startY = 0, moved = false;
+
+    // Mark a gesture as in-progress on press, so a scroll event firing before
+    // activation cannot hide the button (see hide()). Release is deferred by
+    // GESTURE_HOLD_MS so the button stays put through the touch->click delay;
+    // the next update() after that re-evaluates visibility normally.
+    function beginGesture(e) {
+      e.stopPropagation();
+      gestureActive = true;
+      moved = false;
+      var pt = (e.touches && e.touches[0]) ? e.touches[0] : e;
+      startX = pt.clientX || 0;
+      startY = pt.clientY || 0;
+      if (gestureReleaseTimer) {
+        window.clearTimeout(gestureReleaseTimer);
+        gestureReleaseTimer = null;
+      }
+    }
+    function trackMove(e) {
+      var pt = (e.touches && e.touches[0]) ? e.touches[0] : e;
+      if (Math.abs((pt.clientX || 0) - startX) > SCROLL_TOLERANCE ||
+          Math.abs((pt.clientY || 0) - startY) > SCROLL_TOLERANCE) {
+        moved = true;
+      }
+    }
+    function scheduleRelease() {
+      if (gestureReleaseTimer) {
+        window.clearTimeout(gestureReleaseTimer);
+      }
+      gestureReleaseTimer = window.setTimeout(function() {
+        gestureActive = false;
+        gestureReleaseTimer = null;
+        onScroll();
+      }, GESTURE_HOLD_MS);
+    }
+    button.addEventListener('pointerdown', beginGesture);
+    button.addEventListener('mousedown', swallow);
+    button.addEventListener('touchstart', beginGesture, { passive: true });
+    button.addEventListener('pointermove', trackMove, { passive: true });
+    button.addEventListener('touchmove', trackMove, { passive: true });
+    button.addEventListener('pointercancel', function(e) { e.stopPropagation(); scheduleRelease(); });
+
+    // Touch is the authoritative activation path on phones. We act on touchend
+    // and call preventDefault() so the browser does NOT synthesize the trailing
+    // ~300ms-delayed `click`. That delayed click is the bug: by the time it
+    // fires, a scroll event may have hidden the button (display:none) and the
+    // click retargets to whatever is behind it. Acting on touchend and killing
+    // the synthesized click makes the tap land deterministically and removes
+    // any possibility of fall-through. The listener is non-passive so
+    // preventDefault is honored.
+    button.addEventListener('touchend', function(e) {
+      e.stopPropagation();
+      if (!moved) {
+        e.preventDefault(); // cancels the synthesized click -> no fall-through
+        scrollToTop();
+      }
+      scheduleRelease();
+    }, { passive: false });
+    button.addEventListener('touchcancel', function() { scheduleRelease(); });
+
+    // Pen: Pointer Events provide a clean up event with no synthesized-click
+    // delay quirk; activate here. Mouse falls through to the click handler so
+    // desktop behavior is byte-for-byte the prior behavior.
+    button.addEventListener('pointerup', function(e) {
+      e.stopPropagation();
+      if (e.pointerType === 'pen' && !moved) {
+        scrollToTop();
+      }
+      scheduleRelease();
+    });
+
+    button.addEventListener('click', function(e) {
+      e.stopPropagation();
+      scrollToTop();
     });
 
     // Capture phase so scroll events from opt-in containers (which do not


### PR DESCRIPTION
## Summary

A large gym-tracker round delivered as one branch: it bundles the previously-uncommitted R1-R3 feature work plus this session's UX additions and fixes, plus one sitewide change to the shared back-to-top button. 37 files (+2922 / -548). `npm test`: **993 pass / 0 fail**.

> Note on the branch base: the branch's HEAD is the merge-base with `master`, so this PR shows exactly this work; `master`'s later football-h2h / rising-seasons commits touch different apps and do not appear here.

## Changes by area

### Programs (`js/views/programs-view.js` +224, `index.html`, `css/gym-tracker.css`)
- **Weekday schedule on tiles**: a program's assigned `scheduleDays` now render as "Mon, Wed, Fri" (or "Every day") on each program tile, ordered by the first-day-of-week setting; nothing shows when unscheduled.
- **Sticky Save/Cancel header**: in normal create/edit mode the program modal's Save Program + Cancel buttons move into a sticky `.program-modal-header` (mirroring the R2-7 workout-mode pattern); the bottom action row is hidden; Save keeps submitting via `form="program-form"`; colors pinned against the sitewide red.
- **Opens at top**: `openProgramModal` resets the scroll container so the modal never opens mid-scroll (fixes seeing the bottom of the modal mid-workout).
- **Range-mode TAB order**: `setRepValue` no longer full-re-renders on a value edit; it updates the model and writes only a clamped sibling input in place, so the input node is never rebuilt and TAB moves min -> max instead of jumping.
- Plus prior-round program work: rep ranges per set, uniform vs per-exercise rest modes, exercise reordering, day-of-week scheduling UI, mid-workout program editing.

### Dashboard / navigation (`js/app.js` +169, `js/views/home-view.js` +82, `index.html`, `css`)
- **Tile cursor**: dashboard "Your Programs" tiles were keyed on `[onclick]` (never matched, since they use `data-action`); re-keyed to `[data-action]` so the pointer cursor + hover work, matching Recent Workouts.
- **Desktop FAB on all views**: the "Start workout" FAB was relocated out of the dashboard DOM to app level; show/hide/label logic moved into `app.js` (`wireGlobalFab` / `updateGlobalFab` / `handleGlobalFabClick`, refreshed on every `onViewChange`); visible on every desktop view, hidden on the active-workout screen; mobile behavior unchanged (still no floating FAB).
- **Workout tab routing**: tapping Workout when already on the active workout used to be a no-op; it now re-asserts the active screen and, mid-workout, **jumps to the current (first incomplete) exercise** under the sticky header (distinct from the back-to-top arrow, which still scrolls to the very top); falls back to top when all exercises are complete.

### Onboarding welcome tour (`index.html` +317, `js/app.js`, `css`)
- Replaced the thin 3-step modal with one richer **single scrollable** tour: 5 grouped sections / ~13 items / exactly 4 deep-link CTAs (Programs / Workout / Calendar / Settings). All copy verified against the real code; no em dashes.
- CTAs close through the shared `closeModalSafely` (blurs focus before `aria-hidden`, fixing the "Blocked aria-hidden ... retained focus" console error) and re-assert **scroll-to-top on the destination view** after the modal's scroll-lock restore.

### Workout screen (`js/views/workout-view.js` +980, `css`)
- **Slim mobile rest timer**: the between-exercise rest bar was redesigned compact (~45px), sits just above the tab bar, adds bottom padding so it never hides the last set / Add-set row, and stays left-anchored to leave a right-corner pocket for the back-to-top arrow.
- **Single-tap feel**: the "how did it feel" prompt is now one green "Felt good" + a plain "Not yet" dismiss; the gray "Keep the weight" / `'bad'` path is removed from all UI (`nextFeel` is good<->none; `latestFeelForExercise` ignores `'bad'`); legacy `feel:'bad'` is preserved in storage but renders no icon; feel icons now render in color (good green, the override was the sitewide `button { color:#555 !important }`).
- **Re-collapse after edit**: a completed exercise that you expand and then edit (commit or save a set edit) auto-collapses again; just opening it to look stays open (`_recomputeExerciseDerivedState(armCollapse)`).
- Plus prior-round workout work: in-card rest chip with +/-5s, PR badges with in-session supersede, auto-collapse across pause/resume, final-5-seconds pulse + audio/haptics, plate-calculator hints.

### Models / services / utils
- `js/models/Settings.js` (+54): first-day-of-week, configurable timer sound markers; removed the now-orphaned `feelIntroSeen` field (single-tap feel made it dead).
- `js/models/Program.js` (+33): `scheduleDays`. `WorkoutExercise.js` / `WorkoutSession.js`: feel field + pause/resume plumbing (legacy `'bad'` preserved on `fromJSON`).
- `js/services/AnalyticsService.js`, `StorageService.js`: small supporting changes for PR/session state.
- `js/utils/helpers.js` (+164): audio/sound helpers; `resumeAudioContext` now only resumes an existing context (never creates one outside a gesture, killing the autoplay warning). `js/utils/modal-focus.js` (+34): the `closeModalSafely` helper used above.
- **New DOM-free helper modules** (extracted from the views so they can be unit-tested): `exercise-feel.js`, `id-utils.js`, `pr-session.js`, `program-schedule.js`, `rest-cues.js`, `session-merge.js`.
- `js/views/calendar-view.js` (+55): scheduled-program markers + first-day-of-week. `js/views/settings-view.js` (+127): sticky save header, week-start + timer-marker controls.
- `sw.js`: cache-version bump so the CSS/JS changes serve fresh.

### Sitewide
- `assets/js/back-to-top.js` (+142): mobile reliability for the shared arrow (gesture-hold + hysteresis to stop flicker/fall-through). The gym-tracker-specific low-tuck position + arrow pocket live in `css/gym-tracker.css`.

### Docs
- `README.md`: documented program scheduling, the welcome tour, and the desktop quick-start FAB; corrected "week starts Monday" to the configurable first-day setting; removed roadmap items that are already shipped (plate calculator, body measurements, superset grouping, rest-timer auto-start).

## Bugfixes found along the way
- Stale `.feel-history-*` color rules (missing `!important`) were being overridden by `main.css` to flat `#555` gray.
- The onboarding modal regressed the existing `closeModalSafely` ("R3-6") fix and re-introduced the aria-hidden focus console error.
- The modal scroll-lock restore (a MutationObserver microtask) was clobbering the post-navigation scroll-to-top.

## Explicitly untouched (deliberate)
- `assets/css/main.css` and other apps were not modified; gym-tracker pins its own colors against main.css rather than changing it.
- Legacy `feel:'bad'` data is preserved in storage (no migration that mutates saved sessions); it just never renders.
- The back-to-top arrow's scroll-to-top behavior was intentionally left as-is so it stays distinct from the Workout-tab jump.

## Judgment calls
- "Not yet" / X close the feel modal without recording anything (replacing the old gray choice); single green smiley is the only positive signal.
- Workout-tab mid-workout jumps to the *current* exercise (owner-chosen over plain scroll-to-top).
- Mobile rest-bar clearance is intentionally tight (~9px) to keep the arrow pocket; arrow nav-gap is ~16px (close-to-nav per the owner's request).
- `feelIntroSeen` removed rather than retained (migration-safe: old saved values are ignored and drop on next save).

## Testing
- `npm test`: **993 pass / 0 fail**.
- Acceptance plan (local, gitignored): latest run over the feel/workout-tab sections 32 pass / 0 fail / 3 unverified (interaction-only); the prior full pass over the new-feature sections 68 pass / 0 fail. Headless verification used the DevTools protocol (computed styles, console capture, scroll/geometry, state transitions).
