### PR TITLE
copy(marketing): clarify Legacy wording on home and about pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -102,7 +102,7 @@
           </div>
           <div class="skill-row">
             <h3>Full stack web</h3>
-            <p>Vanilla JavaScript, server-rendered legacy stacks when they are unavoidable, backend-for-frontend services, static frontends, and progressive web apps.</p>
+            <p>Vanilla JavaScript, server-rendered stacks when a project still relies on them, backend-for-frontend services, static frontends, and progressive web apps.</p>
           </div>
           <div class="skill-row">
             <h3>Data and integration</h3>

--- a/home.html
+++ b/home.html
@@ -191,7 +191,7 @@
         </article>
         <article class="capability">
           <span class="icon fa-database" aria-hidden="true"></span>
-          <h3>Databases and Legacy Integration</h3>
+          <h3>Databases and System Integration</h3>
           <p>Oracle, PostgreSQL, mainframe interop, Firestore. We have spent a lot of time on the seam between a modern Spring Boot service and a system that has been around for decades.</p>
           <ul class="stack"><li>Oracle</li><li>PostgreSQL</li><li>Mainframe</li><li>Liquibase</li><li>Firestore</li></ul>
         </article>


### PR DESCRIPTION
## Summary

Two small marketing-copy tweaks around the word "Legacy", from a review of how the term reads on the public pages. Both are wording-only; no layout, structure, or behavior changes.

## Changes by file

- **`home.html`** — capability section heading **"Databases and Legacy Integration" → "Databases and System Integration"**. As a capitalized service name, "Legacy Integration" was slightly clunky and ambiguous (it can read as "integrating legacy [things]"). The card body already leads with Oracle / PostgreSQL / mainframe, so "System Integration" is clearer and still accurate.
- **`about.html`** — Full-stack-web line: **"server-rendered legacy stacks when they are unavoidable" → "server-rendered stacks when a project still relies on them"**. Removes the faintly reluctant "unavoidable" framing (which undercut the confident tone of the surrounding copy) and trims one of several repeated uses of "legacy".

## Deliberate non-changes (explicitly untouched)
- The other ~10 uses of "legacy" across `about.html`, `home.html`, and `work.html` were left as-is — each is technically accurate (legacy JSP, mainframe/Tomcat interop, legacy storefronts) and a legitimate selling point for the firm. Only the two spots above were stylistic outliers worth changing.
- No CSS, structure, or stack-list changes.

## Testing
- `npm test` → 1049 / 0 fail.
- Screenshot-verified both pages on desktop (1280) and mobile (390): both edited strings render cleanly with no clipping, overflow, or layout shift; the heading wraps consistently with the sibling cards.
