### PR TITLE
fix(rising-seasons): finder collections use collection_order alpha, not custom

### DIFF
--- a/apps/rising-seasons/exports/kometa/finder-consistently-great.yml
+++ b/apps/rising-seasons/exports/kometa/finder-consistently-great.yml
@@ -11,7 +11,7 @@ collections:
     template: {name: rs_consistently_great}
     summary: "Highly-rated live-action shows whose seasons never wavered - from the Rising Seasons Show Finder."
     sort_title: "!rsf_consistently-great"
-    collection_order: custom
+    collection_order: alpha
     sync_mode: sync
     tmdb_show:
       - 1438

--- a/apps/rising-seasons/exports/kometa/finder-marathon-material.yml
+++ b/apps/rising-seasons/exports/kometa/finder-marathon-material.yml
@@ -11,7 +11,7 @@ collections:
     template: {name: rs_marathon_material}
     summary: "100+ episodes and still rated 7.5 or better - shows you can live in for months. From the Rising Seasons Show Finder."
     sort_title: "!rsf_marathon-material"
-    collection_order: custom
+    collection_order: alpha
     sync_mode: sync
     tmdb_show:
       - 2734

--- a/apps/rising-seasons/exports/kometa/finder-modern-prestige.yml
+++ b/apps/rising-seasons/exports/kometa/finder-modern-prestige.yml
@@ -11,7 +11,7 @@ collections:
     template: {name: rs_modern_prestige}
     summary: "The defining shows of the last few years - 2018 onward, huge audiences, top-shelf ratings. From the Rising Seasons Show Finder."
     sort_title: "!rsf_modern-prestige"
-    collection_order: custom
+    collection_order: alpha
     sync_mode: sync
     tmdb_show:
       - 250307

--- a/apps/rising-seasons/exports/kometa/finder-outshines-reputation.yml
+++ b/apps/rising-seasons/exports/kometa/finder-outshines-reputation.yml
@@ -11,7 +11,7 @@ collections:
     template: {name: rs_outshines_reputation}
     summary: "Shows whose episodes rate well above the show's own IMDb score - the audience that stayed loved what it found. From the Rising Seasons Show Finder."
     sort_title: "!rsf_outshines-reputation"
-    collection_order: custom
+    collection_order: alpha
     sync_mode: sync
     tmdb_show:
       - 44606

--- a/apps/rising-seasons/exports/kometa/finder-went-out-on-top.yml
+++ b/apps/rising-seasons/exports/kometa/finder-went-out-on-top.yml
@@ -11,7 +11,7 @@ collections:
     template: {name: rs_went_out_on_top}
     summary: "Shows that saved their best season for last - no limp endings here. From the Rising Seasons Show Finder."
     sort_title: "!rsf_went-out-on-top"
-    collection_order: custom
+    collection_order: alpha
     sync_mode: sync
     tmdb_show:
       - 1396

--- a/apps/rising-seasons/scripts/integrations-lib.js
+++ b/apps/rising-seasons/scripts/integrations-lib.js
@@ -270,8 +270,10 @@ function buildFinderCollection(preset, rows, info = {}) {
   }
   if (preset.summary) lines.push(`    summary: ${yamlString(preset.summary)}`);
   lines.push(`    sort_title: ${yamlString(preset.sort_title || `!rsf_${preset.slug}`)}`);
-  // custom keeps the preset query's sort order (Kometa preserves builder order).
-  lines.push(`    collection_order: custom`);
+  // A tmdb_show/tvdb_show/imdb_id LIST expands to one builder per ID, so
+  // `collection_order: custom` (single-builder only) makes Kometa reject the
+  // whole collection. Use alpha - the same order the shape collections use.
+  lines.push(`    collection_order: alpha`);
   lines.push(`    sync_mode: ${preset.sync_mode || 'sync'}`);
   if (tmdbIds.length) {
     lines.push(`    tmdb_show:`);

--- a/apps/rising-seasons/tests/finder-lib.test.js
+++ b/apps/rising-seasons/tests/finder-lib.test.js
@@ -192,6 +192,10 @@ test('buildFinderCollection renders YAML with ID fallbacks', () => {
   assert.match(y, /^ {4}summary: "A \\"demo\\" list"$/m);
   assert.match(y, /^ {4}sort_title: "!rsf_demo"$/m);
   assert.match(y, /^ {4}sync_mode: sync$/m);
+  // A multi-ID builder list = one builder per ID, so `custom` (single-builder
+  // only) would make Kometa reject the collection. Must be alpha.
+  assert.match(y, /^ {4}collection_order: alpha$/m);
+  assert.doesNotMatch(y, /collection_order: custom/);
   assert.match(y, /^ {4}tmdb_show:\n {6}- 101$/m);
   assert.match(y, /^ {4}tvdb_show:\n {6}- 202$/m);
   assert.match(y, /^ {4}imdb_id:\n {6}- tt3$/m);


### PR DESCRIPTION
## Why

Kometa rejected every one of the five Rising Seasons "finder" collections at
build time:

```
Collection Error: collection_order: custom can only be used with a single
builder per collection
```

The finder-preset generator emitted `collection_order: custom`, but each preset
feeds a 25-ID `tmdb_show` list. Kometa expands a multi-ID `tmdb_show` /
`tvdb_show` / `imdb_id` list into one builder per ID, and `custom` is only legal
with a single builder. So all five collections built nothing on the consuming
Kometa instance. (Observed in a kometa run that pulls these files via raw URL.)

Ranked order is not achievable from a raw ID list in Kometa anyway, so this
switches to `alpha`, the same order the shape collections already use.

## Changes

**Generator**
- `apps/rising-seasons/scripts/integrations-lib.js` - in `buildFinderCollection()`,
  `collection_order: custom` -> `collection_order: alpha`, with a comment
  explaining why custom is invalid for a multi-ID builder list.

**Regenerated exports** (via `npm run export:rising-seasons`; only the
`collection_order` line changed in each - the show lists are byte-identical, so
`data.json` did not drift)
- `apps/rising-seasons/exports/kometa/finder-consistently-great.yml`
- `apps/rising-seasons/exports/kometa/finder-went-out-on-top.yml`
- `apps/rising-seasons/exports/kometa/finder-outshines-reputation.yml`
- `apps/rising-seasons/exports/kometa/finder-marathon-material.yml`
- `apps/rising-seasons/exports/kometa/finder-modern-prestige.yml`

**Test**
- `apps/rising-seasons/tests/finder-lib.test.js` - added a regression assertion
  to the existing `buildFinderCollection` render test: requires
  `collection_order: alpha` and forbids `collection_order: custom`.

## Explicitly untouched

- The shape collections (`rising.yml`, `big-finale.yml`, etc.) already use
  `alpha` and were not regenerated or changed.
- `finder-presets.json`, `data.json`, and the README export are unchanged.

## Trade-off

`alpha` orders collections alphabetically in Plex, not by the finder's rating
rank. Preserving rank would require emitting a single ordered builder (e.g. a
trakt/mdblist list) instead of a raw ID list - out of scope here.

## Testing

`npm run test:rising-seasons` - 207 passing, 0 failing.
