### PR TITLE
fix(rising-seasons): finder collections order by release, sort to top

### DIFF
--- a/apps/rising-seasons/exports/kometa/finder-consistently-great.yml
+++ b/apps/rising-seasons/exports/kometa/finder-consistently-great.yml
@@ -10,8 +10,8 @@ collections:
   "Consistently Great":
     template: {name: rs_consistently_great}
     summary: "Highly-rated live-action shows whose seasons never wavered - from the Rising Seasons Show Finder."
-    sort_title: "!rsf_consistently-great"
-    collection_order: alpha
+    sort_title: "!000_rsf_consistently-great"
+    collection_order: release
     sync_mode: sync
     tmdb_show:
       - 1438

--- a/apps/rising-seasons/exports/kometa/finder-marathon-material.yml
+++ b/apps/rising-seasons/exports/kometa/finder-marathon-material.yml
@@ -10,8 +10,8 @@ collections:
   "Marathon Material":
     template: {name: rs_marathon_material}
     summary: "100+ episodes and still rated 7.5 or better - shows you can live in for months. From the Rising Seasons Show Finder."
-    sort_title: "!rsf_marathon-material"
-    collection_order: alpha
+    sort_title: "!000_rsf_marathon-material"
+    collection_order: release
     sync_mode: sync
     tmdb_show:
       - 2734

--- a/apps/rising-seasons/exports/kometa/finder-modern-prestige.yml
+++ b/apps/rising-seasons/exports/kometa/finder-modern-prestige.yml
@@ -10,8 +10,8 @@ collections:
   "Modern Prestige":
     template: {name: rs_modern_prestige}
     summary: "The defining shows of the last few years - 2018 onward, huge audiences, top-shelf ratings. From the Rising Seasons Show Finder."
-    sort_title: "!rsf_modern-prestige"
-    collection_order: alpha
+    sort_title: "!000_rsf_modern-prestige"
+    collection_order: release
     sync_mode: sync
     tmdb_show:
       - 250307

--- a/apps/rising-seasons/exports/kometa/finder-outshines-reputation.yml
+++ b/apps/rising-seasons/exports/kometa/finder-outshines-reputation.yml
@@ -10,8 +10,8 @@ collections:
   "Better Than You Heard":
     template: {name: rs_outshines_reputation}
     summary: "Shows whose episodes rate well above the show's own IMDb score - the audience that stayed loved what it found. From the Rising Seasons Show Finder."
-    sort_title: "!rsf_outshines-reputation"
-    collection_order: alpha
+    sort_title: "!000_rsf_outshines-reputation"
+    collection_order: release
     sync_mode: sync
     tmdb_show:
       - 44606

--- a/apps/rising-seasons/exports/kometa/finder-went-out-on-top.yml
+++ b/apps/rising-seasons/exports/kometa/finder-went-out-on-top.yml
@@ -10,8 +10,8 @@ collections:
   "Went Out On Top":
     template: {name: rs_went_out_on_top}
     summary: "Shows that saved their best season for last - no limp endings here. From the Rising Seasons Show Finder."
-    sort_title: "!rsf_went-out-on-top"
-    collection_order: alpha
+    sort_title: "!000_rsf_went-out-on-top"
+    collection_order: release
     sync_mode: sync
     tmdb_show:
       - 1396

--- a/apps/rising-seasons/scripts/integrations-lib.js
+++ b/apps/rising-seasons/scripts/integrations-lib.js
@@ -269,11 +269,15 @@ function buildFinderCollection(preset, rows, info = {}) {
     lines.push(`    template: {name: ${tpl.name}}`);
   }
   if (preset.summary) lines.push(`    summary: ${yamlString(preset.summary)}`);
-  lines.push(`    sort_title: ${yamlString(preset.sort_title || `!rsf_${preset.slug}`)}`);
+  // `!000_` prefix sorts these ahead of everything else in the Plex library
+  // collection list (punctuation/zero beats the consuming instance's own
+  // `!001_`+ sort titles and all unprefixed collections).
+  lines.push(`    sort_title: ${yamlString(preset.sort_title || `!000_rsf_${preset.slug}`)}`);
   // A tmdb_show/tvdb_show/imdb_id LIST expands to one builder per ID, so
   // `collection_order: custom` (single-builder only) makes Kometa reject the
-  // whole collection. Use alpha - the same order the shape collections use.
-  lines.push(`    collection_order: alpha`);
+  // whole collection. release is the only date/rank-ish order Plex collections
+  // support besides alpha; custom would need a single ordered builder.
+  lines.push(`    collection_order: release`);
   lines.push(`    sync_mode: ${preset.sync_mode || 'sync'}`);
   if (tmdbIds.length) {
     lines.push(`    tmdb_show:`);

--- a/apps/rising-seasons/tests/finder-lib.test.js
+++ b/apps/rising-seasons/tests/finder-lib.test.js
@@ -190,12 +190,13 @@ test('buildFinderCollection renders YAML with ID fallbacks', () => {
   const y = col.contents;
   assert.match(y, /^ {2}"Demo: List":$/m);
   assert.match(y, /^ {4}summary: "A \\"demo\\" list"$/m);
-  assert.match(y, /^ {4}sort_title: "!rsf_demo"$/m);
+  // `!000_` prefix floats finder collections ahead of everything in Plex.
+  assert.match(y, /^ {4}sort_title: "!000_rsf_demo"$/m);
   assert.match(y, /^ {4}sync_mode: sync$/m);
   // A multi-ID builder list = one builder per ID, so `custom` (single-builder
-  // only) would make Kometa reject the collection. Must be alpha.
-  assert.match(y, /^ {4}collection_order: alpha$/m);
-  assert.doesNotMatch(y, /collection_order: custom/);
+  // only) would make Kometa reject the collection. release is the safe order.
+  assert.match(y, /^ {4}collection_order: release$/m);
+  assert.doesNotMatch(y, /collection_order: (custom|alpha)/);
   assert.match(y, /^ {4}tmdb_show:\n {6}- 101$/m);
   assert.match(y, /^ {4}tvdb_show:\n {6}- 202$/m);
   assert.match(y, /^ {4}imdb_id:\n {6}- tt3$/m);


### PR DESCRIPTION
## Why

Two presentation tweaks to the generated Rising Seasons `finder-*.yml` presets,
requested after the collections started building (PR #179):

1. **Item order:** they were `alpha` (A-Z). Switch to `release` so each
   collection lists its shows by release date. Plex collections support only
   `release`, `alpha`, and `custom`; `custom` would need a single ordered
   builder, which a multi-ID `tmdb_show` list is not, so `release` is the
   only alternative to alpha.
2. **Library position:** the collections sorted under `!rsf_`, which lands
   *after* the consuming Kometa instance's hand-made `!001_`-`!006_`
   collections. Change the prefix to `!000_rsf_` so they sort ahead of
   everything (a Plex view sorted by Title is still required for sort titles
   to take effect at all).

## Changes

**Generator**
- `apps/rising-seasons/scripts/integrations-lib.js` - in `buildFinderCollection()`:
  `collection_order: alpha` -> `release`; `sort_title` fallback `!rsf_${slug}`
  -> `!000_rsf_${slug}`.

**Regenerated exports** (`npm run export:rising-seasons`; only the `sort_title`
and `collection_order` lines changed - show lists byte-identical)
- `finder-consistently-great.yml`, `finder-went-out-on-top.yml`,
  `finder-outshines-reputation.yml`, `finder-marathon-material.yml`,
  `finder-modern-prestige.yml`

**Test**
- `apps/rising-seasons/tests/finder-lib.test.js` - updated the
  `buildFinderCollection` render assertions: `sort_title: "!000_rsf_demo"`,
  `collection_order: release`, and forbid both `custom` and `alpha`.

## Explicitly untouched

- `finder-presets.json` (no preset overrides `sort_title`, so the generator
  fallback is the single source), `data.json`, the shape collections, and the
  README export.

## Testing

`npm run test:rising-seasons` - 207 passing, 0 failing.
