### PR TITLE
feat(rising-seasons): finder summaries show filters + a Finder link

### DIFF
--- a/apps/rising-seasons/exports/kometa/finder-consistently-great.yml
+++ b/apps/rising-seasons/exports/kometa/finder-consistently-great.yml
@@ -9,7 +9,7 @@ external_templates:
 collections:
   "Consistently Great":
     template: {name: rs_consistently_great}
-    summary: "Highly-rated live-action shows whose seasons never wavered - from the Rising Seasons Show Finder."
+    summary: "Highly-rated live-action shows whose seasons never wavered - from the Rising Seasons Show Finder.\nFilters: 12+ episodes · 25,000+ votes · show IMDb 7.5+ · since 1980 · shape: Consistent · sorted by show rating\nExplore on Rising Seasons: https://shevato.com/apps/rising-seasons/#view=finder&fSort=showRating&fMinEps=12&fMinVotes=25000&fMinShow=7.5&fMinYear=1980&fxg=Animation%2CBiography%2CDocumentary%2CGame-Show%2CReality-TV%2CNews%2CMusical%2CTalk-Show&fl=en&fShape=consistent"
     sort_title: "!000_rsf_consistently-great"
     collection_order: release
     sync_mode: sync

--- a/apps/rising-seasons/exports/kometa/finder-marathon-material.yml
+++ b/apps/rising-seasons/exports/kometa/finder-marathon-material.yml
@@ -9,7 +9,7 @@ external_templates:
 collections:
   "Marathon Material":
     template: {name: rs_marathon_material}
-    summary: "100+ episodes and still rated 7.5 or better - shows you can live in for months. From the Rising Seasons Show Finder."
+    summary: "100+ episodes and still rated 7.5 or better - shows you can live in for months. From the Rising Seasons Show Finder.\nFilters: 100+ episodes · 25,000+ votes · show IMDb 7.5+ · since 1980 · sorted by episode count\nExplore on Rising Seasons: https://shevato.com/apps/rising-seasons/#view=finder&fSort=episodes&fMinEps=100&fMinVotes=25000&fMinShow=7.5&fMinYear=1980&fxg=Animation%2CBiography%2CDocumentary%2CGame-Show%2CReality-TV%2CNews%2CMusical%2CTalk-Show&fl=en"
     sort_title: "!000_rsf_marathon-material"
     collection_order: release
     sync_mode: sync

--- a/apps/rising-seasons/exports/kometa/finder-modern-prestige.yml
+++ b/apps/rising-seasons/exports/kometa/finder-modern-prestige.yml
@@ -9,7 +9,7 @@ external_templates:
 collections:
   "Modern Prestige":
     template: {name: rs_modern_prestige}
-    summary: "The defining shows of the last few years - 2018 onward, huge audiences, top-shelf ratings. From the Rising Seasons Show Finder."
+    summary: "The defining shows of the last few years - 2018 onward, huge audiences, top-shelf ratings. From the Rising Seasons Show Finder.\nFilters: 12+ episodes · 100,000+ votes · show IMDb 8+ · since 2018 · sorted by show rating\nExplore on Rising Seasons: https://shevato.com/apps/rising-seasons/#view=finder&fSort=showRating&fMinEps=12&fMinVotes=100000&fMinShow=8&fMinYear=2018&fxg=Animation%2CBiography%2CDocumentary%2CGame-Show%2CReality-TV%2CNews%2CMusical%2CTalk-Show&fl=en"
     sort_title: "!000_rsf_modern-prestige"
     collection_order: release
     sync_mode: sync

--- a/apps/rising-seasons/exports/kometa/finder-outshines-reputation.yml
+++ b/apps/rising-seasons/exports/kometa/finder-outshines-reputation.yml
@@ -9,7 +9,7 @@ external_templates:
 collections:
   "Better Than You Heard":
     template: {name: rs_outshines_reputation}
-    summary: "Shows whose episodes rate well above the show's own IMDb score - the audience that stayed loved what it found. From the Rising Seasons Show Finder."
+    summary: "Shows whose episodes rate well above the show's own IMDb score - the audience that stayed loved what it found. From the Rising Seasons Show Finder.\nFilters: 12+ episodes · 25,000+ votes · show IMDb 7+ · episode avg 8+ · episodes beat the show by 0.3+ · since 1980 · sorted by gap size\nExplore on Rising Seasons: https://shevato.com/apps/rising-seasons/#view=finder&fSort=gap&fMinEps=12&fMinVotes=25000&fMinShow=7&fMinAvg=8&fMinYear=1980&fGapDir=up&fMinGap=0.3&fxg=Animation%2CBiography%2CDocumentary%2CGame-Show%2CReality-TV%2CNews%2CMusical%2CTalk-Show&fl=en"
     sort_title: "!000_rsf_outshines-reputation"
     collection_order: release
     sync_mode: sync

--- a/apps/rising-seasons/exports/kometa/finder-went-out-on-top.yml
+++ b/apps/rising-seasons/exports/kometa/finder-went-out-on-top.yml
@@ -9,7 +9,7 @@ external_templates:
 collections:
   "Went Out On Top":
     template: {name: rs_went_out_on_top}
-    summary: "Shows that saved their best season for last - no limp endings here. From the Rising Seasons Show Finder."
+    summary: "Shows that saved their best season for last - no limp endings here. From the Rising Seasons Show Finder.\nFilters: 12+ episodes · 25,000+ votes · show IMDb 7.5+ · since 1980 · shape: Big finale · sorted by show rating\nExplore on Rising Seasons: https://shevato.com/apps/rising-seasons/#view=finder&fSort=showRating&fMinEps=12&fMinVotes=25000&fMinShow=7.5&fMinYear=1980&fxg=Animation%2CBiography%2CDocumentary%2CGame-Show%2CReality-TV%2CNews%2CMusical%2CTalk-Show&fl=en&fShape=big-finale"
     sort_title: "!000_rsf_went-out-on-top"
     collection_order: release
     sync_mode: sync

--- a/apps/rising-seasons/scripts/integrations-lib.js
+++ b/apps/rising-seasons/scripts/integrations-lib.js
@@ -79,10 +79,12 @@ function bestConfidenceForShape(matches, shape) {
 // contain characters with YAML meaning (`:` `'` `#` `&` etc.) need quoting.
 function yamlString(s) {
   if (typeof s !== 'string') return JSON.stringify(s);
-  // Always double-quote and escape backslash + double-quote. That covers
-  // every special character we care about (titles, summaries, etc.) without
-  // having to maintain a special-character allowlist.
-  return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+  // Always double-quote and escape backslash + double-quote + newline. That
+  // covers every special character we care about (titles, summaries, etc.)
+  // without having to maintain a special-character allowlist. Newlines become
+  // a literal \n escape so multi-line summaries survive as real line breaks
+  // (an unescaped newline in a double-quoted scalar folds to a space).
+  return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n') + '"';
 }
 
 // Per-shape Kometa collection YAML.
@@ -227,6 +229,62 @@ function buildSeasonOverlays(matches, opts = {}) {
   return { contents: lines.join('\n') + '\n', shapesEmitted: emitted };
 }
 
+// Human-readable labels for the Show Finder sort + shape params, mirroring the
+// browser UI (index.html sort <option>s and js/app.js SHAPE_LABELS) so the Plex
+// summary speaks the same language as the site.
+const FINDER_SORT_LABELS = {
+  gap: 'gap size',
+  showRating: 'show rating',
+  avgEpisode: 'avg episode rating',
+  episodes: 'episode count',
+  votes: 'votes',
+};
+const FINDER_SHAPE_LABELS = {
+  rising: 'Rising', consistent: 'Consistent', 'slow-burn': 'Slow burn',
+  'big-finale': 'Big finale', 'saved-best-for-last': 'Saved best for last',
+  rebound: 'Rebound', 'front-loaded': 'Front-loaded', declining: 'Declining',
+  'bad-finale': 'Bad finale', rollercoaster: 'Rollercoaster', 'mid-peak': 'Mid-peak',
+  'u-shaped': 'U-shaped',
+};
+
+// Public Show Finder URL with this preset's filters pre-applied. The preset
+// `query` IS the page's URL hash (see finder-presets.json), so the link drops
+// a viewer straight into the same filtered Finder view.
+const FINDER_BASE_URL = 'https://shevato.com/apps/rising-seasons/';
+function finderShareUrl(query) {
+  return `${FINDER_BASE_URL}#${String(query || '').replace(/^#/, '')}`;
+}
+
+// One-line, human-readable digest of a preset's Finder filters for the Plex
+// summary. Deliberately omits genre (fxg) and language (fl) - noise for a Plex
+// browser. Returns '' when nothing notable is set.
+function describeFinderFilters(query) {
+  const p = new URLSearchParams(String(query || '').replace(/^#/, ''));
+  const pos = (k) => { const v = parseFloat(p.get(k)); return Number.isFinite(v) && v > 0 ? v : null; };
+  const n = (v) => v.toLocaleString('en-US');
+  const parts = [];
+  const eps = pos('fMinEps'); if (eps) parts.push(`${n(eps)}+ episodes`);
+  const votes = pos('fMinVotes'); if (votes) parts.push(`${n(votes)}+ votes`);
+  const show = pos('fMinShow'); if (show) parts.push(`show IMDb ${show}+`);
+  const avg = pos('fMinAvg'); if (avg) parts.push(`episode avg ${avg}+`);
+  const gap = pos('fMinGap');
+  const gapDir = p.get('fGapDir');
+  if (gap && gapDir === 'up') parts.push(`episodes beat the show by ${gap}+`);
+  else if (gap && gapDir === 'down') parts.push(`episodes trail the show by ${gap}+`);
+  else if (gap) parts.push(`episode/show gap ${gap}+`);
+  const minYear = parseInt(p.get('fMinYear'), 10) || null;
+  const maxYear = parseInt(p.get('fMaxYear'), 10) || null;
+  if (minYear && maxYear) parts.push(`${minYear}-${maxYear}`);
+  else if (minYear) parts.push(`since ${minYear}`);
+  else if (maxYear) parts.push(`through ${maxYear}`);
+  const shapes = (p.get('fShape') || '').split(',').filter(Boolean)
+    .map((s) => FINDER_SHAPE_LABELS[s] || s);
+  if (shapes.length) parts.push(`shape: ${shapes.join(' / ')}`);
+  const sort = p.get('fSort');
+  if (sort && FINDER_SORT_LABELS[sort]) parts.push(`sorted by ${FINDER_SORT_LABELS[sort]}`);
+  return parts.join(' · ');
+}
+
 // Kometa collection YAML for one Show Finder preset (finder-presets.json).
 // `rows` are show-agg rows already filtered/sorted/limited by the caller -
 // scripts/finder-lib.js owns the selection (one source of truth with the
@@ -268,7 +326,15 @@ function buildFinderCollection(preset, rows, info = {}) {
   if (tpl && tpl.name && tplSource) {
     lines.push(`    template: {name: ${tpl.name}}`);
   }
-  if (preset.summary) lines.push(`    summary: ${yamlString(preset.summary)}`);
+  // Summary shown in Plex: the curated blurb, then the actual filter thresholds
+  // (so the collection is self-documenting), then a link back into the Finder
+  // with those filters live. yamlString turns the \n joins into real line breaks.
+  const summaryParts = [];
+  if (preset.summary) summaryParts.push(preset.summary);
+  const filters = describeFinderFilters(preset.query);
+  if (filters) summaryParts.push(`Filters: ${filters}`);
+  summaryParts.push(`Explore on Rising Seasons: ${finderShareUrl(preset.query)}`);
+  lines.push(`    summary: ${yamlString(summaryParts.join('\n'))}`);
   // `!000_` prefix sorts these ahead of everything else in the Plex library
   // collection list (punctuation/zero beats the consuming instance's own
   // `!001_`+ sort titles and all unprefixed collections).
@@ -336,6 +402,8 @@ const API = {
   // Exposed for tests:
   yamlString,
   bestConfidenceForShape,
+  describeFinderFilters,
+  finderShareUrl,
 };
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/apps/rising-seasons/tests/finder-lib.test.js
+++ b/apps/rising-seasons/tests/finder-lib.test.js
@@ -11,7 +11,11 @@ const {
   finderComparator,
   filterAndSortRows,
 } = require('../scripts/finder-lib.js');
-const { buildFinderCollection } = require('../scripts/integrations-lib.js');
+const {
+  buildFinderCollection,
+  describeFinderFilters,
+  finderShareUrl,
+} = require('../scripts/integrations-lib.js');
 
 // Deterministic stand-in for match.js detectShapes: a curve is "rising" when
 // every point meets or exceeds the previous one. Enough to verify the wiring
@@ -189,7 +193,11 @@ test('buildFinderCollection renders YAML with ID fallbacks', () => {
   assert.equal(col.seriesCount, 3);
   const y = col.contents;
   assert.match(y, /^ {2}"Demo: List":$/m);
-  assert.match(y, /^ {4}summary: "A \\"demo\\" list"$/m);
+  // Summary = curated blurb, then the filter digest, then a Finder link, joined
+  // by \n escapes (yamlString renders real newlines as a literal \n).
+  assert.match(y, /^ {4}summary: "A \\"demo\\" list\\nFilters: /m);
+  assert.match(y, /\\nFilters: 1,000\+ votes\\n/);
+  assert.match(y, /\\nExplore on Rising Seasons: https:\/\/shevato\.com\/apps\/rising-seasons\/#fMinVotes=1000"$/m);
   // `!000_` prefix floats finder collections ahead of everything in Plex.
   assert.match(y, /^ {4}sort_title: "!000_rsf_demo"$/m);
   assert.match(y, /^ {4}sync_mode: sync$/m);
@@ -204,6 +212,37 @@ test('buildFinderCollection renders YAML with ID fallbacks', () => {
   // No template declared → no external reference emitted.
   assert.doesNotMatch(y, /external_templates/);
   assert.doesNotMatch(y, /^ {4}template:/m);
+});
+
+test('describeFinderFilters renders thresholds and omits genre + language', () => {
+  // genre (fxg) and language (fl) are present in the query but must NOT appear.
+  const q = 'view=finder&fSort=showRating&fMinEps=12&fMinVotes=25000'
+    + '&fMinShow=7.5&fMinYear=1980&fxg=Animation%2CNews&fl=en&fShape=consistent';
+  assert.equal(
+    describeFinderFilters(q),
+    '12+ episodes · 25,000+ votes · show IMDb 7.5+ · since 1980 · shape: Consistent · sorted by show rating',
+  );
+});
+
+test('describeFinderFilters handles gap direction, episode avg, and a year range', () => {
+  const q = 'fSort=gap&fMinAvg=8&fGapDir=up&fMinGap=0.3&fMinYear=2000&fMaxYear=2010';
+  assert.equal(
+    describeFinderFilters(q),
+    'episode avg 8+ · episodes beat the show by 0.3+ · 2000-2010 · sorted by gap size',
+  );
+});
+
+test('describeFinderFilters is empty when only genre/language (or nothing) is set', () => {
+  assert.equal(describeFinderFilters(''), '');
+  assert.equal(describeFinderFilters('fxg=Animation&fl=en'), '');
+});
+
+test('finderShareUrl builds a Finder hash link and tolerates a leading #', () => {
+  assert.equal(
+    finderShareUrl('view=finder&fShape=consistent'),
+    'https://shevato.com/apps/rising-seasons/#view=finder&fShape=consistent',
+  );
+  assert.equal(finderShareUrl('#view=finder'), 'https://shevato.com/apps/rising-seasons/#view=finder');
 });
 
 test('buildFinderCollection emits the local template hook when declared', () => {


### PR DESCRIPTION
## Why

The generated Rising Seasons finder collections showed only a curated blurb in
Plex. This surfaces the *actual* filters behind each collection and a link back
into the Show Finder with those filters live, so a Plex browser can see why a
show qualified and go tweak the query themselves.

## What changed in the Plex summary

Each `finder-*.yml` summary is now three lines: the existing blurb, a filter
digest, and an Explore link. Example (`consistently-great`):

```
Highly-rated live-action shows whose seasons never wavered - from the Rising Seasons Show Finder.
Filters: 12+ episodes · 25,000+ votes · show IMDb 7.5+ · since 1980 · shape: Consistent · sorted by show rating
Explore on Rising Seasons: https://shevato.com/apps/rising-seasons/#view=finder&fSort=showRating&...
```

Genre (`fxg`) and language (`fl`) are intentionally omitted - noise for a Plex
browser. The link is the preset query verbatim as the page URL hash, so it
drops the viewer into the identical filtered Finder view.

## Changes

**Generator** - `apps/rising-seasons/scripts/integrations-lib.js`
- New `describeFinderFilters(query)`: human-readable digest of the thresholds
  (episodes, votes, show IMDb, episode avg, gap direction + size, year / year
  range, shape, sort), using the same sort/shape labels as the browser UI.
- New `finderShareUrl(query)`: builds the `https://shevato.com/apps/rising-seasons/#<hash>`
  link (tolerates a leading `#`).
- `buildFinderCollection()` appends both to the summary.
- `yamlString()` now also escapes newlines (`\n`), so a multi-line summary
  renders as real line breaks instead of folding to a space. Harmless for all
  existing single-line callers.
- Both helpers exported for tests.

**Regenerated exports** - the five `finder-*.yml` files (only the `summary`
line changed; ID lists are byte-identical).

**Tests** - `apps/rising-seasons/tests/finder-lib.test.js`
- Four new tests: filter digest (incl. genre/language omission), gap + avg +
  year-range path, empty-when-nothing-set, and the share-URL builder.
- Updated the `buildFinderCollection` render assertions for the new summary.

## Untouched

- `finder-presets.json` (the blurbs and queries are unchanged), `data.json`,
  the shape collections, the README export.

## Caveat

Plex renders collection summaries as plain text, so the link is copyable but not
clickable in most Plex clients.

## Testing

`npm run test:rising-seasons` - 211 passing, 0 failing. Also verified the output
parses under PyYAML (what Kometa uses) into a clean 3-line summary.
