### PR TITLE
feat(gym-tracker): logging improvements + active-workout, rest-timer & editor redesign

### DIFF
--- a/apps/gym-tracker/README.md
+++ b/apps/gym-tracker/README.md
@@ -8,17 +8,17 @@ A comprehensive, mobile-first workout tracking application built with vanilla Ja
 
 - **Program Builder**: Create workout programs with custom exercises and reorderable exercise lists; each set row has a labeled toggle for a single rep target or a rep range (e.g. set 1: 11-12, set 2: 8-10); a program-level rest mode (one uniform between-exercises duration set with an M:SS stepper, or custom per-exercise rest); the exercise picker adds your picks as simple rows you then refine per set; removing an exercise asks for confirmation
 - **Supersets**: Link consecutive exercises into a superset so they are grouped together in both the program builder and the workout view
-- **Workout Execution**: Mobile-optimized interface for tracking sets, reps, and weight during workouts; per-set rep range labels (shown once per exercise when all sets match); between-set rest shows an in-card countdown chip with a +30s extend button and a Skip control, while between-exercise rest shows in the bottom bar and, for uniform programs, in the sticky workout header; after-exercise rest is read-only during a workout (it is set in the program); auto-collapsing completed exercises that re-collapse after un-marking and stay collapsed across a pause/resume; a final-5-seconds red pulse countdown with audio pings and haptics; and a plate calculator for all plate-loaded equipment (barbell, trap-bar, and plate-loaded machines such as the leg press) with per-exercise and global toggles whose state persists once a workout is saved
+- **Workout Execution**: Mobile-optimized interface for tracking sets, reps, and weight during workouts; per-set rep range labels (shown once per exercise when all sets match); rest is shown by a compact floating circular timer dial, color-coded (green between sets, blue between exercises), with the countdown centered and +30s / Skip controls inside it, and for uniform programs the between-exercise rest also shows in the sticky workout header; after-exercise rest is read-only during a workout (it is set in the program); a pencil button on each exercise opens an inline notes field saved as you type, and a "same as last time" chip restores the previous session's weight and reps on a row; auto-collapsing completed exercises that re-collapse after un-marking and stay collapsed across a pause/resume (the edit and plate-hint buttons hide while a card is collapsed); a final-5-seconds red pulse countdown with audio pings and haptics; the finish summary shows total volume with a percentage delta versus your previous session of the same program; and a plate calculator for all plate-loaded equipment (barbell, trap-bar, and plate-loaded machines such as the leg press) with per-exercise and global toggles whose state persists once a workout is saved
 - **Exercise Database**: 500+ exercises categorized by muscle group and equipment, with persistent sorting (name, most recently used, most logged), numbered pagination, and the ability to remove a specific exercise's logged history
 - **Back to top**: A floating button appears on long pages and tall modals, and on the public exercise directory pages, to jump back to the top
 - **Custom Exercises**: Create and manage your own custom exercises
-- **Workout History**: Complete history of all workouts with detailed stats, numbered pagination, and clickable workout details
+- **Workout History**: Complete history of all workouts with detailed stats, numbered pagination, and clickable workout details; each exercise in the session detail shows a small inline strength-trend chart of its top-set weight over recent sessions, plus any per-exercise notes you logged
 - **Progress Tracking**: View previous workout data (all sets) during current workout for progression
 - **Calendar View**: Visual representation of workout days with progress indicators (first day of week is configurable, Sunday or Monday)
-- **Program Scheduling**: Assign weekdays to a program; the days show on the program tiles, as markers on the calendar, and as a week strip at the top of the workout screen
+- **Program Scheduling**: Assign weekdays to a program; the days show on the program tiles, as markers on the calendar, and as a compact day-pill week strip at the top of the workout screen where tapping a day shows that day's scheduled workout below the pills and highlights the matching program card
 - **Welcome Tour**: A single scrollable onboarding modal that explains the core features, with quick links into Programs, Workout, Calendar, and Settings; replayable any time from Settings
 - **Quick Start**: A floating "Start workout" button on desktop (visible across views; hidden on the active-workout screen) that starts or resumes a workout from anywhere
-- **Achievements**: Unlock achievements for reaching milestones (daily, weekly, monthly, lifetime)
+- **Achievements**: Unlock achievements for reaching milestones (daily, weekly, monthly, lifetime), plus per-exercise personal-record achievements shown in a dedicated "Strength PRs" section when you beat your all-time best on an exercise
 
 ### 📊 Analytics & Stats
 
@@ -261,6 +261,10 @@ Users can create custom exercises with:
 - Exercise variety goals
 - Workout streaks
 - Personal records
+
+### Strength PRs
+- Per-exercise personal-record achievements, awarded when a finished session's top set beats your all-time best for that exercise (requires 2+ prior sessions with that exercise; reps-based exercises only)
+- Shown in a dedicated "Strength PRs" section on the Achievements screen with the exercise name, PR weight, and date
 
 ## Browser Compatibility
 

--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -1577,93 +1577,6 @@ body.modal-open {
 /* Unified sizing for every header control — creates one visual system.
    Minimum 44px tap target (WCAG 2.2 AA) so sweaty mid-workout fingers
    can't accidentally trigger Discard instead of Pause/Finish. */
-.workout-header .btn-icon {
-    width: 44px !important;
-    height: 44px !important;
-    padding: 0 !important;
-    border-radius: var(--radius-md);
-    font-size: 0.95rem !important;
-    line-height: 1 !important;
-    font-family: inherit !important;
-    font-weight: 500 !important;
-    border: 1px solid var(--border-color);
-    background: var(--bg-elevated);
-    color: var(--text-secondary) !important;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition-base), border-color var(--transition-base),
-                color var(--transition-base), box-shadow var(--transition-base),
-                transform var(--transition-base);
-}
-
-.workout-header .btn-icon i {
-    color: inherit;
-    font-size: inherit;
-}
-
-.workout-header .btn-icon:hover {
-    border-color: var(--border-light);
-    background: var(--bg-hover);
-    color: var(--text-primary) !important;
-}
-
-/* End/Close — most subtle. Muted outline, reads as "cancel/exit" */
-.workout-header .btn-icon-end {
-    background: transparent !important;
-    border-color: var(--border-color) !important;
-    color: var(--text-muted) !important;
-}
-
-.workout-header .btn-icon-end:hover {
-    background: rgba(239, 68, 68, 0.1) !important;
-    border-color: rgba(239, 68, 68, 0.45) !important;
-    color: #ef4444 !important;
-}
-
-/* Pause — neutral/secondary. Softer amber so it doesn't fight with Finish */
-.workout-header .btn-icon-pause {
-    background: rgba(251, 191, 36, 0.08) !important;
-    border-color: rgba(251, 191, 36, 0.28) !important;
-    color: #f0b429 !important;
-}
-
-.workout-header .btn-icon-pause:hover {
-    background: rgba(251, 191, 36, 0.18) !important;
-    border-color: rgba(251, 191, 36, 0.5) !important;
-    color: #fbbf24 !important;
-}
-
-/* Finish — primary action. Filled green gradient so it reads as the CTA */
-.workout-header .btn-icon-finish {
-    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%) !important;
-    border-color: transparent !important;
-    color: #ffffff !important;
-    box-shadow: 0 3px 10px rgba(34, 197, 94, 0.35) !important;
-}
-
-.workout-header .btn-icon-finish:hover {
-    border-color: transparent !important;
-    color: #ffffff !important;
-    box-shadow: 0 5px 14px rgba(34, 197, 94, 0.5) !important;
-    transform: translateY(-1px);
-    filter: brightness(1.06);
-}
-
-.workout-header .btn-icon-finish:active {
-    transform: translateY(0);
-    filter: brightness(0.95);
-}
-
-.workout-header .btn-icon:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.35);
-}
-
-.workout-header .btn-icon-finish:focus-visible {
-    box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.4),
-                0 3px 10px rgba(34, 197, 94, 0.35) !important;
-}
 
 /* Two-row workout header on narrow screens.
    At full width the six header controls (end + unit toggle + plate/edit/pause/
@@ -1789,280 +1702,211 @@ body.gym-tracker #active-workout .superset-block {
     }
 }
 
-/* Rest timer — persistent floating pill above the bottom nav.
-   Sits well clear of the nav (20px gap + drop shadow) so it always reads
-   as an elevated, separate layer. Uses a contained palette that matches
-   the app's purple/green language without overwhelming the workout content. */
+/* ==========================================================================
+   Rest timer: a large FLOATING circular dial (countdown is the focus inside a
+   glowing progress ring) with a separate round Skip button beside it.
+   Color-coded by rest type: GREEN between sets, BLUE between exercises.
+   Floats above the bottom nav; soft shadow; minimal borders.
+   ========================================================================== */
 .rest-timer-bar {
     position: fixed;
     left: 50%;
+    /* Self-contained dial: centered over the Workout tab (viewport center). */
     transform: translateX(-50%);
-    bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 20px);
-    width: calc(100% - 1rem);
-    max-width: 520px;
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0) 40%),
-        linear-gradient(135deg, rgba(40, 32, 95, 0.92) 0%, rgba(30, 24, 75, 0.92) 100%);
-    border: 1px solid rgba(91, 155, 255, 0.45);
-    border-radius: 18px;
-    backdrop-filter: blur(14px) saturate(140%);
-    -webkit-backdrop-filter: blur(14px) saturate(140%);
-    box-shadow:
-        0 1px 0 rgba(255, 255, 255, 0.08) inset,
-        0 12px 32px rgba(0, 0, 0, 0.55),
-        0 0 0 1px rgba(91, 155, 255, 0.08);
+    bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 10px);
     z-index: 90;
-    animation: rest-bar-in 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
-    overflow: hidden;
+    display: inline-flex;
+    /* Accent for the active rest type; overridden by the type classes below. */
+    --rest-accent: var(--accent-primary);
+    --rest-glow: rgba(91, 155, 255, 0.45);
+    animation: rest-bar-in 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .rest-timer-bar[hidden] { display: none; }
 
 @keyframes rest-bar-in {
-    from { opacity: 0; transform: translate(-50%, 16px) scale(0.97); }
+    from { opacity: 0; transform: translate(-50%, 14px) scale(0.96); }
     to   { opacity: 1; transform: translate(-50%, 0) scale(1); }
 }
 
-/* On mobile the rest bar anchors LEFT and stops its right edge clear of the
-   back-to-top arrow (44px circle at right: 1.25rem), leaving a corner pocket so
-   the arrow can sit low beside it instead of being pushed above it. The right
-   inset = arrow right-offset (1.25rem) + arrow width (44px) + a gap (0.75rem),
-   so the bar never touches the arrow circle. The default rest-bar-in keyframe
-   translates by -50% and would yank this now-left-anchored bar off-screen, so
-   the mobile rule uses rest-bar-in-mobile (no translateX) instead. */
-@media (max-width: 767px) {
-    body.gym-tracker .rest-timer-bar {
-        left: 0.5rem;
-        right: calc(1.25rem + 44px + 0.75rem + env(safe-area-inset-right, 0px));
-        transform: none;
-        width: auto;
-        max-width: none;
-        animation-name: rest-bar-in-mobile;
-        /* #17: slim strip just above the nav. Slimmer bar -> tighter gap.
-           Right inset (arrow pocket) is intentionally unchanged. */
-        bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 12px);
-        border-radius: 12px;
-        box-shadow:
-            0 1px 0 rgba(255, 255, 255, 0.06) inset,
-            0 6px 18px rgba(0, 0, 0, 0.5);
-    }
-
-    /* #17: condense the inner layout into a slim strip. */
-    body.gym-tracker .rest-timer-bar-inner {
-        gap: 0.55rem;
-        padding: 0.4rem 0.55rem 0.5rem;
-    }
-    body.gym-tracker .rest-timer-info {
-        gap: 0.4rem;
-        font-size: 0.8rem;
-    }
-    body.gym-tracker .rest-timer-info i {
-        width: 18px;
-        height: 18px;
-        font-size: 0.8rem;
-    }
-    body.gym-tracker .rest-timer-label {
-        font-size: 0.58rem;
-    }
-    body.gym-tracker .rest-timer-value {
-        font-size: 1.1rem;
-        padding-left: 0.2rem;
-    }
-    body.gym-tracker .rest-timer-actions {
-        gap: 0.3rem;
-    }
-    body.gym-tracker .rest-timer-action-btn {
-        height: 30px;
-        min-width: 44px;
-        padding: 0 0.6rem;
-        font-size: 0.74rem;
-    }
-    body.gym-tracker .rest-timer-progress {
-        height: 3px;
-    }
+/* Color coding by rest type. */
+.rest-timer-bar.rest-timer--set {
+    --rest-accent: var(--accent-success);
+    --rest-glow: rgba(52, 211, 153, 0.45);
+}
+.rest-timer-bar.rest-timer--exercise {
+    --rest-accent: var(--accent-primary);
+    --rest-glow: rgba(91, 155, 255, 0.45);
 }
 
-@keyframes rest-bar-in-mobile {
-    from { opacity: 0; transform: translateY(16px) scale(0.97); }
-    to   { opacity: 1; transform: none; }
-}
-
-.rest-timer-bar.rest-timer-done {
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0) 40%),
-        linear-gradient(135deg, rgba(20, 83, 45, 0.92) 0%, rgba(15, 60, 35, 0.92) 100%);
-    border-color: rgba(34, 197, 94, 0.6);
-    box-shadow:
-        0 1px 0 rgba(255, 255, 255, 0.08) inset,
-        0 12px 32px rgba(0, 0, 0, 0.55),
-        0 0 0 1px rgba(34, 197, 94, 0.18),
-        0 0 24px rgba(34, 197, 94, 0.25);
-}
-
-.rest-timer-bar-inner {
+/* The circular dial. */
+.rest-timer-dial {
     position: relative;
-    display: grid;
-    grid-template-columns: 1fr auto;
-    align-items: center;
-    gap: 0.8rem;
-    padding: 0.7rem 0.9rem 0.85rem;
-}
-
-.rest-timer-info {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    color: var(--text-primary);
-    font-weight: 600;
-    font-size: 0.92rem;
-    min-width: 0;
-}
-
-.rest-timer-info i {
-    color: var(--accent-primary);
-    font-size: 0.95rem;
-    width: 22px;
-    height: 22px;
+    width: 146px;
+    height: 146px;
+    flex-shrink: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background: rgba(91, 155, 255, 0.18);
     border-radius: 50%;
-    flex-shrink: 0;
+    background:
+        radial-gradient(circle at 50% 40%, rgba(255, 255, 255, 0.04), rgba(0, 0, 0, 0) 70%),
+        var(--bg-secondary);
+    box-shadow:
+        0 10px 34px rgba(0, 0, 0, 0.5),
+        0 0 0 1px rgba(255, 255, 255, 0.03),
+        0 0 26px var(--rest-glow);
 }
 
-.rest-timer-bar.rest-timer-done .rest-timer-info i {
-    color: #4ade80;
-    background: rgba(34, 197, 94, 0.22);
+.rest-timer-ring {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    transform: rotate(-90deg);
+}
+
+.rest-timer-ring-track {
+    fill: none;
+    stroke: rgba(255, 255, 255, 0.08);
+    stroke-width: 6;
+}
+
+.rest-timer-ring-fill {
+    fill: none;
+    stroke: var(--rest-accent);
+    stroke-width: 6;
+    stroke-linecap: round;
+    filter: drop-shadow(0 0 5px var(--rest-glow));
+    transition: stroke-dashoffset 1s linear, stroke var(--transition-base);
+}
+
+.rest-timer-dial-content {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.05rem;
+    line-height: 1;
+}
+
+.rest-timer-icon {
+    color: var(--rest-accent);
+    font-size: 0.72rem;
 }
 
 .rest-timer-label {
-    color: var(--text-muted);
+    color: var(--rest-accent);
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    font-size: 0.64rem;
+    letter-spacing: 0.14em;
+    font-size: 0.55rem;
     font-weight: 700;
-    line-height: 1;
+    margin-bottom: 0.02rem;
 }
 
 .rest-timer-value {
     font-variant-numeric: tabular-nums;
-    font-size: 1.3rem;
-    font-weight: 700;
-    color: #ffffff;
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--text-primary);
     letter-spacing: -0.02em;
-    line-height: 1;
-    margin-left: auto;
-    padding-left: 0.3rem;
 }
 
-.rest-timer-bar.rest-timer-done .rest-timer-value {
-    color: #4ade80;
+.rest-timer-caption {
+    color: var(--text-muted);
+    font-size: 0.58rem;
+    font-weight: 500;
 }
 
+/* Action row: +30s and Skip as two equal pills, centered inside the dial so
+   the timer is a single self-contained control (no detached button). */
 .rest-timer-actions {
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    gap: 0.4rem;
-    flex-shrink: 0;
+    justify-content: center;
+    gap: 0.3rem;
+    margin-top: 0.32rem;
 }
 
-/* Uniform 38px pills. +30s uses an accent tint to hint "add time," while
-   Skip stays quiet so "end rest early" doesn't feel like the primary CTA.
-   !important on `color` is required because assets/css/main.css applies
-   `button { color: #555555 !important; }` globally with higher priority. */
-.rest-timer-action-btn {
-    background: rgba(255, 255, 255, 0.08);
-    color: #ffffff !important;
-    border: 1px solid rgba(255, 255, 255, 0.14);
+.rest-timer-btn,
+.rest-timer-btn:hover,
+.rest-timer-btn:focus-visible {
+    box-sizing: border-box;
+    height: 24px;
+    min-width: 46px;
+    padding: 0 0.55rem;
     border-radius: 999px;
-    padding: 0 0.95rem;
-    font-weight: 700;
-    font-size: 0.82rem;
-    letter-spacing: 0.01em;
-    cursor: pointer;
-    height: 38px;
-    min-width: 52px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 0.22rem;
     font-family: inherit;
+    font-weight: 700;
+    font-size: 0.64rem;
+    line-height: 1;
     font-variant-numeric: tabular-nums;
-    transition: background var(--transition-fast), border-color var(--transition-fast),
-                transform var(--transition-fast), color var(--transition-fast);
+    cursor: pointer;
+    box-shadow: none !important;
     -webkit-tap-highlight-color: transparent;
+    transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
-.rest-timer-action-btn:hover {
-    background: rgba(91, 155, 255, 0.3);
-    border-color: rgba(91, 155, 255, 0.6);
-    color: #ffffff !important;
-}
-
-.rest-timer-action-btn:active { transform: scale(0.96); }
-
-.rest-timer-action-btn:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.45);
-}
-
-.rest-timer-action-btn.rest-timer-skip {
+/* +30s — accent-outlined (primary of the pair). */
+.rest-timer-add,
+.rest-timer-add:hover,
+.rest-timer-add:focus-visible {
+    border: 1.5px solid color-mix(in srgb, var(--rest-accent) 50%, transparent);
     background: transparent;
-    color: #e5e7eb !important;
-    border-color: rgba(255, 255, 255, 0.18);
+    color: var(--rest-accent) !important;
+}
+.rest-timer-add:hover {
+    background: color-mix(in srgb, var(--rest-accent) 16%, transparent);
 }
 
-.rest-timer-action-btn.rest-timer-skip:hover {
+/* Skip — neutral filled (visually secondary, still easy to tap). */
+.rest-timer-skip,
+.rest-timer-skip:hover,
+.rest-timer-skip:focus-visible {
+    border: 1.5px solid rgba(255, 255, 255, 0.12);
     background: rgba(255, 255, 255, 0.06);
-    color: #ffffff !important;
-    border-color: rgba(255, 255, 255, 0.3);
+    color: var(--text-secondary) !important;
+}
+.rest-timer-skip:hover {
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--text-primary) !important;
+}
+.rest-timer-skip i { font-size: 0.6rem; }
+
+.rest-timer-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--rest-glow) !important;
 }
 
-.rest-timer-bar.rest-timer-done .rest-timer-action-btn {
-    border-color: rgba(34, 197, 94, 0.35);
+/* Done: ring + countdown go green (completion), then auto-hide. */
+.rest-timer-bar.rest-timer-done {
+    --rest-accent: var(--accent-success);
+    --rest-glow: rgba(52, 211, 153, 0.5);
+}
+.rest-timer-bar.rest-timer-done .rest-timer-value { color: var(--accent-success); }
+
+/* Urgent (final seconds): ring + value turn red (value via the shared rule). */
+.rest-timer-bar.rest-timer-urgent {
+    --rest-accent: var(--accent-error);
+    --rest-glow: rgba(248, 113, 113, 0.5);
 }
 
-.rest-timer-bar.rest-timer-done .rest-timer-action-btn:hover {
-    background: rgba(34, 197, 94, 0.25);
-    border-color: rgba(34, 197, 94, 0.65);
-}
-
-/* Thicker, unbroken progress line anchored to the bar's bottom edge so it
-   reads as part of the pill itself — not a floating extra element. */
-.rest-timer-progress {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 4px;
-    background: rgba(255, 255, 255, 0.08);
-    overflow: hidden;
-}
-
-.rest-timer-progress-fill {
-    display: block;
-    height: 100%;
-    width: 100%;
-    background: linear-gradient(90deg, var(--accent-primary) 0%, #5b9bff 70%, #93b8ff 100%);
-    transform-origin: left center;
-    transition: transform 1s linear;
-    box-shadow: 0 0 12px rgba(91, 155, 255, 0.55);
-}
-
-.rest-timer-bar.rest-timer-done .rest-timer-progress-fill {
-    background: linear-gradient(90deg, #22c55e 0%, #4ade80 100%);
-    box-shadow: 0 0 12px rgba(74, 222, 128, 0.6);
-}
-
+/* Desktop has no bottom nav, so sit just above the viewport bottom. */
 @media (min-width: 768px) {
-    .rest-timer-bar {
-        bottom: 20px;
-    }
+    .rest-timer-bar { bottom: 24px; }
 }
+
+/* During rest the dial owns the bottom-center; hide the scroll-to-top arrow
+   so the two never collide. */
+body.gt-rest-bar-visible .back-to-top { display: none !important; }
 
 @media (prefers-reduced-motion: reduce) {
     .rest-timer-bar { animation: none; }
-    .rest-timer-progress-fill { transition: none; }
+    .rest-timer-ring-fill { transition: stroke var(--transition-base); }
 }
 
 /* Final-5-seconds urgent state: bar + chip turn red and pulse. */
@@ -2086,26 +1930,33 @@ body.gym-tracker #active-workout .superset-block {
 /* In-card rest countdown chip — dominant timer element in the rest row.
    Item R2-3: one element, two states. Active (default below) is the live
    colored countdown; --idle is the static gray between-set duration. */
+/* Pass 2 #2: integrated into the subtitle row as a small neutral chip.
+   Idle = quiet meta; only the live countdown picks up the azure accent. */
 .rest-countdown-chip {
     display: inline-flex;
     align-items: center;
-    font-size: 1.15rem;
-    font-weight: 700;
+    gap: 0.3rem;
+    font-size: 0.78rem;
+    font-weight: 600;
     font-variant-numeric: tabular-nums;
-    color: rgba(255, 255, 255, 0.85);
-    background: rgba(91, 155, 255, 0.15);
-    border: 1px solid rgba(91, 155, 255, 0.3);
-    border-radius: 999px;
-    padding: 0.3rem 0.9rem;
-    line-height: 1.4;
+    color: var(--accent-primary);
+    background: transparent;
+    border: 1px solid var(--accent-primary);
+    border-radius: var(--radius-sm);
+    padding: 0.15rem 0.5rem;
+    line-height: 1.3;
 }
+.rest-countdown-chip i { font-size: 0.7rem; }
 
-/* Idle: static gray duration, same size/position as the active countdown. */
+/* Idle: static neutral duration, same size/position as the active countdown. */
 body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
-    color: var(--gt-muted);
-    background: rgba(255, 255, 255, 0.05);
-    border-color: rgba(255, 255, 255, 0.12);
+    color: var(--text-secondary);
+    background: transparent;
+    border-color: var(--border-color);
     animation: none;
+}
+body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle i {
+    color: var(--text-muted);
 }
 
 /* Plate-hints toggle button — same sizing as other header btn-icons. */
@@ -2169,14 +2020,16 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 }
 
 /* Exercise Entry Card (Mobile-Optimized) */
+/* Pass 2 #2: the card is the only large container — one border, one radius,
+   no inset/stacked shadows. */
 .exercise-entry {
     background: var(--bg-card);
     border-radius: var(--radius-lg);
-    padding: 0.95rem 0.95rem 0.85rem;
+    padding: 0.85rem 0.9rem;
     margin-bottom: 0.85rem;
     border: 1px solid var(--border-color);
-    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset, var(--shadow-sm);
-    transition: border-color var(--transition-base), box-shadow var(--transition-base);
+    box-shadow: none;
+    transition: border-color var(--transition-base);
 }
 
 .exercise-entry-header {
@@ -2184,7 +2037,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     justify-content: space-between;
     align-items: flex-start;
     gap: 0.6rem;
-    margin-bottom: 0.6rem;
+    margin-bottom: 0.75rem;
 }
 
 .exercise-entry-header h3 {
@@ -2199,7 +2052,6 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     gap: 0.45rem;
     line-height: 1.25;
     min-width: 0;
-    flex: 1;
 }
 
 .exercise-name-main {
@@ -2207,12 +2059,20 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     font-weight: 700;
 }
 
+/* Pass 2 #2: subtitle row under the name — progress pill, muscle, rep range,
+   rest chip all on one calm meta line. */
+.exercise-subtitle {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+}
+
 .exercise-name-sub {
-    color: var(--text-muted);
-    font-size: 0.74rem;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
     font-weight: 500;
     white-space: nowrap;
-    opacity: 0.7;
     letter-spacing: 0.005em;
 }
 
@@ -2758,6 +2618,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
    Each exercise renders an <ol> of rows where `i < sets.length` is a
    committed set (locked, edit/delete) and later rows are planned inputs
    with a tap-to-complete button. */
+/* Pass 2 #2: progress badge sits in the subtitle row beside the name. */
 .exercise-progress {
     flex-shrink: 0;
     font-size: 0.72rem;
@@ -2766,22 +2627,22 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     font-variant-numeric: tabular-nums;
     background: var(--bg-elevated);
     border: 1px solid var(--border-color);
-    border-radius: 999px;
-    padding: 0.25rem 0.7rem;
+    border-radius: var(--radius-sm);
+    padding: 0.15rem 0.5rem;
     letter-spacing: 0.04em;
     text-transform: uppercase;
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
-    line-height: 1;
+    gap: 0.3rem;
+    line-height: 1.3;
     transition: background var(--transition-base), border-color var(--transition-base),
                 color var(--transition-base);
 }
 
 .exercise-progress.is-complete {
-    background: rgba(34, 197, 94, 0.16);
-    border-color: rgba(34, 197, 94, 0.5);
-    color: #4ade80;
+    background: rgba(52, 211, 153, 0.14);
+    border-color: var(--accent-success);
+    color: var(--accent-success);
 }
 
 .exercise-progress.is-complete i {
@@ -2789,9 +2650,8 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 }
 
 .exercise-entry.exercise-complete {
-    border-color: rgba(34, 197, 94, 0.38);
-    box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.2) inset,
-                0 6px 16px rgba(34, 197, 94, 0.1);
+    border-color: var(--accent-success);
+    box-shadow: none;
 }
 
 .set-row-list {
@@ -2800,62 +2660,58 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4rem;
 }
 
 /* Horizontal three-zone layout: [ num ] [ content ] [ actions + check ].
    Flex with align-items:center gives bulletproof vertical centering so the
    set number, the "55lb × 8" text, and the right-side icons always share
    the same baseline — no matter how tall the row grows. */
+/* Pass 2 #3/#4: clean, quiet, consistent rows. One border style (solid 1px),
+   tighter padding/height, no dashed borders. The active cue is a single
+   left accent border applied on focus-within only. */
 .set-row {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 0.6rem;
-    padding: 0.7rem 0.6rem 0.7rem 0.6rem;
-    background: rgba(255, 255, 255, 0.02);
+    gap: 0.5rem;
+    padding: 0.5rem 0.55rem;
+    background: var(--bg-tertiary);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    min-height: 60px;
-    transition: background var(--transition-fast), border-color var(--transition-fast),
-                box-shadow var(--transition-fast);
+    border-left: 3px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    min-height: 48px;
+    transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .set-row-planned {
-    background: rgba(255, 255, 255, 0.02);
-    border-style: dashed;
-    border-color: rgba(74, 74, 117, 0.7);
+    background: var(--bg-tertiary);
+    border-color: var(--border-color);
 }
 
+/* Active cue: a single left accent border (no glow, no fill, no outline). */
 .set-row-planned:focus-within {
-    background: var(--bg-card);
-    border-style: solid;
-    border-color: rgba(91, 155, 255, 0.5);
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.12);
+    border-left-color: var(--accent-primary);
 }
 
 .set-row-complete {
-    background: rgba(34, 197, 94, 0.08);
-    border-color: rgba(34, 197, 94, 0.3);
-    border-left: 3px solid rgba(34, 197, 94, 0.7);
-    /* Border-left adds 2px — compensate so text alignment with planned rows stays flush. */
-    padding-left: calc(0.6rem - 2px);
+    background: rgba(52, 211, 153, 0.07);
+    border-color: var(--border-color);
+    border-left-color: var(--accent-success);
 }
 
 .set-row-editing {
-    background: var(--bg-card);
-    border-color: var(--accent-primary);
-    box-shadow: 0 0 0 2px rgba(91, 155, 255, 0.2);
+    border-left-color: var(--accent-primary);
 }
 
 .set-row-num {
     flex-shrink: 0;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    background: rgba(91, 155, 255, 0.12);
-    border: 1px solid rgba(91, 155, 255, 0.28);
-    color: var(--accent-primary);
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-light);
+    color: var(--text-secondary);
     font-weight: 700;
     font-size: 0.76rem;
     display: inline-flex;
@@ -2867,16 +2723,10 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
                 color var(--transition-base);
 }
 
-.set-row-planned .set-row-num {
-    background: transparent;
-    border-color: var(--border-color);
-    color: var(--text-muted);
-}
-
 .set-row-complete .set-row-num {
-    background: rgba(34, 197, 94, 0.2);
-    border-color: rgba(34, 197, 94, 0.55);
-    color: #4ade80;
+    background: rgba(52, 211, 153, 0.16);
+    border-color: var(--accent-success);
+    color: var(--accent-success);
 }
 
 .set-row-inputs {
@@ -2889,24 +2739,23 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 }
 
 .set-row-inputs input {
-    width: 76px;
-    padding: 0.5rem 0.55rem;
-    background: var(--bg-tertiary);
+    width: 68px;
+    height: 40px;
+    padding: 0.4rem 0.5rem;
+    background: var(--bg-card);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-sm);
     color: var(--text-primary);
-    font-size: 1rem;
+    font-size: 0.95rem;
     font-weight: 700;
     text-align: center;
     font-variant-numeric: tabular-nums;
     letter-spacing: -0.01em;
-    transition: border-color var(--transition-fast), background var(--transition-fast),
-                box-shadow var(--transition-fast);
+    transition: border-color var(--transition-fast);
 }
 
 .set-row-inputs input::placeholder {
     color: var(--text-muted);
-    opacity: 0.5;
     font-weight: 500;
 }
 
@@ -2915,16 +2764,14 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 .set-row-inputs input:focus {
     outline: none;
     border-color: var(--accent-primary);
-    background: var(--bg-hover);
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.16);
+    box-shadow: none;
 }
 
 .set-row-x,
 .set-row-inputs .duration-separator {
     color: var(--text-muted);
-    font-weight: 700;
-    font-size: 0.9rem;
-    opacity: 0.8;
+    font-weight: 600;
+    font-size: 0.8rem;
 }
 
 .set-row-details {
@@ -2943,9 +2790,12 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
    slides from left (incomplete) to right (completed). The knob's checkmark
    fades in as it lands, and a soft green glow confirms the ON state.
    Driven purely by `aria-pressed` so the DOM stays identical between states. */
+/* Pass 2 #3: smaller resting footprint, neutral off, green only when ON.
+   A transparent 40px tap padding keeps the touch target while the visible
+   track stays compact. One emphasis cue per state (no stacked glows). */
 .set-toggle {
-    --toggle-width: 54px;
-    --toggle-height: 30px;
+    --toggle-width: 40px;
+    --toggle-height: 22px;
     --toggle-pad: 3px;
     --toggle-knob: calc(var(--toggle-height) - (var(--toggle-pad) * 2));
     --toggle-travel: calc(var(--toggle-width) - var(--toggle-knob) - (var(--toggle-pad) * 2));
@@ -2955,14 +2805,16 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     width: var(--toggle-width);
     height: var(--toggle-height);
     padding: 0;
+    box-sizing: content-box;
+    /* Transparent border supplies a >=40px tap target without inflating the
+       visible track (the green fill paints to padding-box only). */
+    border: 9px solid transparent;
     border-radius: 999px;
-    border: 1px solid var(--border-light);
-    background: var(--bg-tertiary);
+    background: var(--bg-elevated) padding-box;
     cursor: pointer;
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
+    box-shadow: none;
     transition: background 220ms cubic-bezier(0.2, 0.8, 0.2, 1),
-                border-color 220ms ease,
-                box-shadow 220ms ease;
+                border-color 220ms ease;
     -webkit-tap-highlight-color: transparent;
     font-family: inherit;
 }
@@ -2974,12 +2826,11 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     width: var(--toggle-knob);
     height: var(--toggle-knob);
     border-radius: 50%;
-    background: linear-gradient(180deg, #c7c7d8 0%, #8a8aa6 100%);
+    background: var(--text-muted);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.45),
-                0 0 0 1px rgba(0, 0, 0, 0.1);
+    box-shadow: none;
     transition: transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
                 background 200ms ease;
     will-change: transform;
@@ -2987,7 +2838,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 
 .set-toggle-knob i {
     color: #ffffff !important;
-    font-size: 0.62rem;
+    font-size: 0.58rem;
     font-weight: 900;
     opacity: 0;
     transform: scale(0.7);
@@ -2995,24 +2846,18 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     line-height: 1;
 }
 
-/* ---- ON state: completed ---- */
+/* ---- ON state: completed (green = completion semantics) ---- */
 .set-toggle[aria-pressed="true"] {
-    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
-    border-color: rgba(34, 197, 94, 0.85);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18),
-                0 0 0 1px rgba(34, 197, 94, 0.3),
-                0 2px 10px rgba(34, 197, 94, 0.35);
+    background: var(--accent-success) padding-box;
 }
 
 .set-toggle[aria-pressed="true"] .set-toggle-knob {
     transform: translateX(var(--toggle-travel));
-    background: linear-gradient(180deg, #ffffff 0%, #e8eae7 100%);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35),
-                0 0 0 1px rgba(0, 0, 0, 0.08);
+    background: #ffffff;
+    box-shadow: none;
 }
 
 .set-toggle[aria-pressed="true"] .set-toggle-knob i {
-    /* Dark green check reads cleanly on the white knob. */
     color: #15803d !important;
     opacity: 1;
     transform: scale(1);
@@ -3021,13 +2866,10 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 /* ---- Affordances on pointer devices ---- */
 @media (hover: hover) {
     .set-toggle:hover {
-        border-color: var(--text-muted);
+        background: var(--bg-hover) padding-box;
     }
     .set-toggle[aria-pressed="true"]:hover {
         filter: brightness(1.06);
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2),
-                    0 0 0 1px rgba(34, 197, 94, 0.4),
-                    0 4px 14px rgba(34, 197, 94, 0.5);
     }
 }
 
@@ -3042,27 +2884,17 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 
 .set-toggle:focus-visible {
     outline: none;
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35),
-                0 0 0 3px rgba(91, 155, 255, 0.45);
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.45);
 }
 
 .set-toggle[aria-pressed="true"]:focus-visible {
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18),
-                0 0 0 3px rgba(34, 197, 94, 0.45),
-                0 2px 10px rgba(34, 197, 94, 0.35);
+    box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.45);
 }
 
-/* Highlight the toggle when the user is entering weight/reps — subtle hint
-   about what to do next, without switching state. */
-.set-row-planned:focus-within .set-toggle:not([aria-pressed="true"]) {
-    border-color: rgba(34, 197, 94, 0.55);
-    background: rgba(34, 197, 94, 0.1);
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25),
-                0 0 0 3px rgba(34, 197, 94, 0.12);
-}
-
+/* Hint the toggle while the user is entering weight/reps — single neutral
+   nudge (the knob brightens slightly), no competing fill/glow. */
 .set-row-planned:focus-within .set-toggle:not([aria-pressed="true"]) .set-toggle-knob {
-    background: linear-gradient(180deg, #e5e7eb 0%, #9ca3af 100%);
+    background: var(--text-secondary);
 }
 
 /* Celebratory pulse when a row transitions to the completed state. Triggers
@@ -3145,11 +2977,13 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 
 /* Row of add/remove controls under the set list. Remove is a compact square
    icon button that only renders when there's an uncommitted row to drop. */
+/* Pass 2 #5: compact set-management row — minus (neutral, red-on-hover) sits
+   tight beside an azure-affordance Add-set. One border style, no dashed. */
 .set-row-footer {
-    margin-top: 0.6rem;
+    margin-top: 0.55rem;
     display: flex;
     align-items: stretch;
-    gap: 0.5rem;
+    gap: 0.4rem;
 }
 
 .set-row-footer .btn-add-set--extra {
@@ -3159,13 +2993,14 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 
 .btn-remove-set {
     flex: 0 0 auto;
-    width: 44px;
-    min-height: 44px;
+    width: 40px;
+    height: 40px;
+    min-height: 40px;
     padding: 0;
-    background: rgba(239, 68, 68, 0.07);
-    border: 1px dashed rgba(239, 68, 68, 0.4);
-    border-radius: var(--radius-md);
-    color: #fca5a5 !important;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary) !important;
     font-family: inherit;
     font-size: 0.85rem;
     font-weight: 700;
@@ -3174,8 +3009,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     align-items: center;
     justify-content: center;
     transition: background var(--transition-fast), color var(--transition-fast),
-                border-color var(--transition-fast), transform var(--transition-fast),
-                box-shadow var(--transition-fast);
+                border-color var(--transition-fast);
     -webkit-tap-highlight-color: transparent;
 }
 
@@ -3185,79 +3019,65 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 }
 
 .btn-remove-set:hover {
-    background: rgba(239, 68, 68, 0.18);
-    color: #ffffff !important;
-    border-color: rgba(239, 68, 68, 0.7);
-    border-style: solid;
-    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.12);
+    background: var(--bg-elevated);
+    color: var(--accent-error) !important;
+    border-color: var(--accent-error);
 }
 
 .btn-remove-set:active {
-    transform: translateY(1px);
-    background: rgba(239, 68, 68, 0.28);
-    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+    background: var(--bg-hover);
 }
 
 .btn-remove-set:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.4);
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4);
 }
 
-/* Secondary CTA — reads as clearly clickable at rest (primary-text color,
-   visible tinted surface). Hover ramps brightness + border solidifies so the
-   affordance upgrade feels tactile.
-   !important on `color` is required because assets/css/main.css applies
-   `button { color: #555555 !important; }` globally with higher cascade
-   priority than our variable reference. */
+/* Add-set: the primary action of the row — quiet neutral surface with an
+   azure label + "+" icon. One solid border, no dashed.
+   !important on `color` defeats main.css `button { color:#555 !important }`. */
 .btn-add-set--extra {
-    margin-top: 0.6rem;
+    margin-top: 0.55rem;
     width: 100%;
-    min-height: 44px;
-    padding: 0.7rem 1rem;
-    background: rgba(91, 155, 255, 0.12);
-    border: 1px dashed rgba(91, 155, 255, 0.55);
-    border-radius: var(--radius-md);
-    color: #ffffff !important;
+    height: 40px;
+    min-height: 40px;
+    padding: 0 1rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    color: var(--accent-primary) !important;
     font-family: inherit;
-    font-size: 0.9rem;
-    font-weight: 700;
+    font-size: 0.85rem;
+    font-weight: 600;
     letter-spacing: 0.01em;
     line-height: 1;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
-    transition: background var(--transition-fast), color var(--transition-fast),
-                border-color var(--transition-fast), transform var(--transition-fast),
-                box-shadow var(--transition-fast);
+    gap: 0.45rem;
+    transition: background var(--transition-fast), border-color var(--transition-fast);
     -webkit-tap-highlight-color: transparent;
 }
 
 .btn-add-set--extra i {
-    font-size: 0.8rem;
+    font-size: 0.78rem;
     color: var(--accent-primary) !important;
-    transition: transform var(--transition-fast), color var(--transition-fast);
 }
 
 .btn-add-set--extra:hover {
-    background: rgba(91, 155, 255, 0.22);
-    color: #ffffff !important;
+    background: var(--bg-hover);
+    color: var(--accent-primary) !important;
     border-color: var(--accent-primary);
-    border-style: solid;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.15), 0 4px 12px rgba(91, 155, 255, 0.2);
 }
 
 .btn-add-set--extra:hover i {
-    transform: scale(1.15);
-    color: #ffffff !important;
+    color: var(--accent-primary) !important;
 }
 
 .btn-add-set--extra:active {
-    transform: translateY(1px);
-    background: rgba(91, 155, 255, 0.3);
-    color: #ffffff !important;
-    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+    background: var(--bg-hover);
+    color: var(--accent-primary) !important;
 }
 
 .btn-add-set--extra:focus-visible {
@@ -3267,15 +3087,12 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 
 @media (max-width: 480px) {
     .set-row {
-        gap: 0.5rem;
-        padding: 0.7rem 0.5rem 0.7rem 0.55rem;
-    }
-    .set-row-complete {
-        padding-left: calc(0.55rem - 2px);
+        gap: 0.45rem;
+        padding: 0.5rem 0.5rem;
     }
     /* Slightly smaller input width so the planned-row [weight × reps] line
        doesn't wrap on narrow phones. */
-    .set-row-inputs input { width: 70px; }
+    .set-row-inputs input { width: 62px; }
     /* Tighter action spacing on phones to keep the right cluster compact. */
     .set-row-actions { gap: 0.25rem; }
 }
@@ -4544,10 +4361,10 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 
 #program-form .form-group label {
     margin-bottom: 0.4rem;
-    font-size: 0.74rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--text-secondary);
 }
 
@@ -4613,16 +4430,16 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 }
 
 .program-exercises-heading i {
-    color: var(--accent-primary);
-    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-size: 0.8rem;
 }
 
 .program-exercises-count {
     font-size: 0.75rem;
     color: var(--text-muted);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
 }
 
 .program-exercises-count:empty { display: none; }
@@ -4642,7 +4459,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     padding: 1.4rem 1rem;
     background: var(--bg-card);
     border: 1px dashed var(--border-color);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-lg);
     text-align: center;
 }
 
@@ -4682,7 +4499,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     padding: 0.55rem 0.7rem;
     background: var(--bg-card);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-lg);
     box-shadow: var(--shadow-sm);
     transition: transform var(--transition-fast), background var(--transition-fast),
                 border-color var(--transition-fast), box-shadow var(--transition-fast);
@@ -4741,8 +4558,8 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     .program-exercise-row .pex-name-main { font-size: 1.05rem; }
 
     .program-exercise-row .pex-name-sub {
-        font-size: 0.78rem;
-        opacity: 0.75;
+        font-size: 0.8rem;
+        opacity: 1;
     }
 
     /* Controls row: sets-block takes the majority of space; rest stepper
@@ -4784,9 +4601,8 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     }
 
     .program-exercise-row .pex-stepper-label {
-        font-size: 0.68rem;
-        letter-spacing: 0.08em;
-        opacity: 0.8;
+        font-size: 0.76rem;
+        letter-spacing: 0;
         padding-left: 0.1rem;
     }
 
@@ -4798,7 +4614,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
         padding: 0.4rem 0.65rem;
         background: var(--bg-elevated);
         border: 1px solid var(--border-color);
-        border-radius: var(--radius-md);
+        border-radius: var(--radius-sm);
         min-width: 0;
         box-sizing: border-box;
     }
@@ -4826,9 +4642,9 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
         font-size: 0.9rem;
     }
     .program-exercise-row .pex-position {
-        width: 24px;
-        height: 24px;
-        font-size: 0.7rem;
+        width: 22px;
+        height: 22px;
+        font-size: 0.8rem;
     }
 
     /* Delete stays tertiary at rest; aligned to the identity row's right edge. */
@@ -4857,7 +4673,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     gap: 0.5rem;
     background: var(--bg-elevated);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-sm);
     padding: 0.15rem 0.35rem;
     font-size: 0.78rem;
     min-width: 0;
@@ -4867,10 +4683,10 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 .pex-stepper-label {
     flex-shrink: 0;
     font-weight: 600;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    font-size: 0.65rem;
+    color: var(--text-secondary);
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 0.78rem;
     white-space: nowrap;
 }
 
@@ -4938,19 +4754,19 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     box-shadow: var(--shadow-md);
 }
 
+/* Neutral, low-emphasis index marker (not a bold blue circle). */
 .pex-position {
-    width: 22px;
-    height: 22px;
+    width: 20px;
+    height: 20px;
     flex-shrink: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background: rgba(91, 155, 255, 0.12);
-    border: 1px solid rgba(91, 155, 255, 0.25);
-    border-radius: 50%;
-    color: var(--accent-primary);
-    font-size: 0.68rem;
-    font-weight: 700;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    font-weight: 600;
     font-variant-numeric: tabular-nums;
 }
 
@@ -4960,12 +4776,12 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 18px;
-    height: 24px;
+    width: 20px;
+    height: 26px;
     color: var(--text-muted);
-    opacity: 0.5;
+    opacity: 0.85;
     cursor: grab;
-    font-size: 0.85rem;
+    font-size: 0.95rem;
     transition: color var(--transition-fast), opacity var(--transition-fast);
     flex-shrink: 0;
 }
@@ -5029,9 +4845,9 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 
 .pex-name-sub {
     font-weight: 500;
-    color: var(--text-muted);
-    font-size: 0.72rem;
-    opacity: 0.7;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    opacity: 1;
     white-space: nowrap;
 }
 
@@ -5066,17 +4882,19 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 
 .pex-delete:hover,
 .pex-delete:focus-visible {
-    color: #ffffff !important;
-    background: rgba(239, 68, 68, 0.85);
-    border-color: rgba(239, 68, 68, 0.9) !important;
+    color: var(--accent-error) !important;
+    background: var(--bg-elevated);
+    border-color: var(--accent-error) !important;
     opacity: 1;
     outline: none;
-    transform: scale(1.05);
+}
+
+.pex-delete:focus-visible {
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
 }
 
 .pex-delete:active {
-    transform: scale(0.94);
-    background: #dc2626;
+    transform: scale(0.96);
 }
 
 /* Add Exercise — full-width secondary action. Subtle tinted surface at rest,
@@ -5090,11 +4908,11 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     margin: 0;
     height: auto !important;
     min-height: 0 !important;
-    padding: 0.55rem 1rem !important;
-    background: rgba(91, 155, 255, 0.1) !important;
-    border: 1px dashed rgba(91, 155, 255, 0.4) !important;
-    border-radius: var(--radius-md);
-    color: #ffffff !important;
+    padding: 0.6rem 1rem !important;
+    background: var(--bg-elevated) !important;
+    border: 1px dashed var(--border-light) !important;
+    border-radius: var(--radius-lg);
+    color: var(--text-secondary) !important;
     font-family: inherit !important;
     font-weight: 600 !important;
     font-size: 0.85rem !important;
@@ -5102,31 +4920,35 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
     cursor: pointer;
     box-shadow: none !important;
     transition: background var(--transition-base), border-color var(--transition-base),
-                transform var(--transition-base), box-shadow var(--transition-base);
+                color var(--transition-base), box-shadow var(--transition-base);
 }
 
 .btn-add-exercise:hover {
-    background: rgba(91, 155, 255, 0.2) !important;
-    border-color: var(--accent-primary) !important;
-    border-style: solid !important;
-    transform: translateY(-1px);
-    box-shadow: 0 3px 10px rgba(91, 155, 255, 0.22) !important;
+    background: var(--bg-hover) !important;
+    border-color: var(--border-light) !important;
+    color: var(--text-primary) !important;
+    box-shadow: none !important;
 }
 
 .btn-add-exercise:active {
-    transform: translateY(0);
-    background: rgba(91, 155, 255, 0.28) !important;
+    background: var(--bg-hover) !important;
     box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.25) !important;
+}
+
+.btn-add-exercise:focus-visible {
+    outline: none;
+    color: var(--text-primary) !important;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
 }
 
 .btn-add-exercise i {
     font-size: 0.78rem;
-    color: var(--accent-primary) !important;
+    color: inherit !important;
     transition: color var(--transition-base);
 }
 
 .btn-add-exercise:hover i {
-    color: #ffffff !important;
+    color: inherit !important;
 }
 
 /* Bottom action row — anchored footer with clear Cancel/Save hierarchy. */
@@ -5184,34 +5006,36 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle {
 }
 
 /* Save — primary CTA. Strong gradient + glow so it's the obvious action. */
+/* Calmer azure primary: flat fill, standard height, no glow/heavy shadow. */
 .btn-save-program {
-    background: var(--gradient-primary) !important;
+    background: var(--accent-primary) !important;
     border: 1px solid transparent !important;
     color: #ffffff !important;
-    box-shadow: 0 4px 14px rgba(91, 155, 255, 0.4) !important;
+    box-shadow: none !important;
+    padding: 0.5rem 1rem !important;
+    height: auto !important;
+    min-height: 0 !important;
+    font-size: 0.85rem !important;
 }
 
 .btn-save-program i {
     color: #ffffff !important;
-    font-size: 0.85rem;
+    font-size: 0.82rem;
 }
 
 .btn-save-program:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 8px 20px rgba(91, 155, 255, 0.5) !important;
-    filter: brightness(1.06);
+    filter: brightness(1.08);
+    box-shadow: none !important;
 }
 
 .btn-save-program:active {
-    transform: translateY(0);
     filter: brightness(0.95);
-    box-shadow: 0 1px 3px rgba(91, 155, 255, 0.25) !important;
+    box-shadow: none !important;
 }
 
 .btn-save-program:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4),
-                0 3px 10px rgba(91, 155, 255, 0.3) !important;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
 }
 
 @media (max-width: 520px) {
@@ -8802,14 +8626,14 @@ button.calendar-day {
     position: absolute;
     top: -8px;
     left: 12px;
-    padding: 1px 6px;
-    background: var(--bg-card);
-    border: 1px solid rgba(91, 155, 255, 0.55);
-    border-radius: 4px;
-    color: var(--accent-primary);
-    font-size: 0.6rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    padding: 1px 7px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-size: 0.65rem;
+    font-weight: 600;
+    letter-spacing: 0;
 }
 .program-exercise-row { position: relative; }
 
@@ -9106,7 +8930,7 @@ button.calendar-day {
     padding: 0.55rem 0.75rem;
     background: var(--bg-elevated);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-lg);
 }
 
 .rest-mode-label {
@@ -9121,7 +8945,7 @@ button.calendar-day {
 }
 
 .rest-mode-label i {
-    color: var(--accent-primary);
+    color: var(--text-muted);
     font-size: 0.9rem;
 }
 
@@ -9135,9 +8959,9 @@ button.calendar-day {
 .rest-mode-uniform-label {
     font-size: 0.78rem;
     font-weight: 600;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+    text-transform: none;
+    letter-spacing: 0;
 }
 
 .rest-mode-uniform-input {
@@ -9183,36 +9007,46 @@ button.calendar-day {
     gap: 0.5rem;
 }
 
-/* Reuse the existing .pex-stepper-label for the "Sets / Reps" heading */
+/* Reuse the existing .pex-stepper-label for the "Sets / Reps" heading.
+   Reduced emphasis: smaller, lighter, Title Case. */
 .pex-sets-header .pex-stepper-label {
-    font-size: 0.65rem;
-    letter-spacing: 0.08em;
-    font-weight: 700;
-    text-transform: uppercase;
-    color: var(--text-muted);
+    font-size: 0.76rem;
+    letter-spacing: 0;
+    font-weight: 600;
+    text-transform: none;
+    color: var(--text-secondary);
 }
 
+/* Add set: a quiet neutral chip that reads as part of the sets block.
+   Clearly clickable (filled elevated surface) without a blue border. */
 .pex-add-set-btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
-    padding: 0.15rem 0.5rem;
-    background: transparent;
-    border: 1px solid rgba(91, 155, 255, 0.35);
+    gap: 0.3rem;
+    padding: 0.25rem 0.6rem;
+    background: var(--bg-elevated) !important;
+    border: 1px solid transparent !important;
     border-radius: var(--radius-sm);
-    color: var(--accent-primary);
-    font-size: 0.7rem;
+    color: var(--text-secondary) !important;
+    font-size: 0.72rem;
     font-weight: 600;
     cursor: pointer;
-    transition: background 120ms ease, border-color 120ms ease;
+    transition: background 120ms ease, color 120ms ease;
     white-space: nowrap;
 }
 
-.pex-add-set-btn:hover,
-.pex-add-set-btn:focus-visible {
-    background: rgba(91, 155, 255, 0.12);
-    border-color: rgba(91, 155, 255, 0.6);
+.pex-add-set-btn i { color: inherit !important; }
+
+.pex-add-set-btn:hover {
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
     outline: none;
+}
+
+.pex-add-set-btn:focus-visible {
+    color: var(--text-primary) !important;
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
 }
 
 .pex-set-rows {
@@ -9230,11 +9064,11 @@ button.calendar-day {
 
 .pex-set-label {
     flex: 0 0 auto;
-    font-size: 0.7rem;
+    font-size: 0.78rem;
     font-weight: 600;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+    text-transform: none;
+    letter-spacing: 0;
     min-width: 3.2rem;
 }
 
@@ -9282,54 +9116,58 @@ button.calendar-day {
     display: none;
 }
 
-/* Toggle that shows/hides the rep range max input */
+/* Single/Range selector: a quiet neutral segmented-style toggle, not a
+   bordered blue button. Borderless quiet fill at rest; subtle elevated fill
+   when on. */
 .pex-range-toggle {
     flex: 0 0 auto;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.25rem;
-    min-width: 60px;
+    gap: 0.3rem;
+    min-width: 64px;
     height: 32px;
-    padding: 0 0.45rem;
-    background: transparent !important;
-    border: 1px solid rgba(255, 255, 255, 0.12) !important;
-    border-radius: 4px;
-    color: rgba(255, 255, 255, 0.7) !important;
+    padding: 0 0.55rem;
+    background: var(--bg-elevated) !important;
+    border: 1px solid transparent !important;
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary) !important;
     cursor: pointer;
-    font-size: 0.65rem;
+    font-size: 0.7rem;
     transition: background 100ms ease, color 100ms ease, border-color 100ms ease;
 }
 
-.pex-range-toggle:hover,
+.pex-range-toggle:hover {
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
+}
+
 .pex-range-toggle:focus-visible {
-    background: rgba(91, 155, 255, 0.14) !important;
-    border-color: rgba(91, 155, 255, 0.5) !important;
-    color: #fff !important;
+    color: var(--text-primary) !important;
+    border-color: transparent !important;
     outline: none;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
 }
 
 .pex-range-toggle:hover:active {
-    background: rgba(91, 155, 255, 0.25) !important;
-    color: #fff !important;
+    background: var(--bg-hover) !important;
 }
 
 .pex-range-toggle.is-on {
-    background: rgba(91, 155, 255, 0.2) !important;
-    border-color: rgba(91, 155, 255, 0.6) !important;
-    color: var(--accent-primary) !important;
+    background: var(--bg-hover) !important;
+    border-color: transparent !important;
+    color: var(--text-primary) !important;
 }
 
-.pex-range-toggle.is-on:hover,
-.pex-range-toggle.is-on:focus-visible {
-    background: rgba(91, 155, 255, 0.3) !important;
-    color: #fff !important;
+.pex-range-toggle.is-on:hover {
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
 }
 
 .pex-range-toggle-label {
-    font-size: 0.68rem;
+    font-size: 0.72rem;
     font-weight: 600;
-    letter-spacing: 0.03em;
+    letter-spacing: 0;
     line-height: 1;
     color: inherit;
 }
@@ -9362,18 +9200,23 @@ button.calendar-day {
     justify-content: center;
     background: transparent;
     border: none;
-    border-radius: 4px;
-    color: rgba(255, 255, 255, 0.3);
+    border-radius: var(--radius-sm);
+    color: var(--text-disabled);
     cursor: pointer;
     font-size: 0.72rem;
     transition: color 100ms ease, background 100ms ease;
 }
 
-.pex-set-remove:hover:not(:disabled),
-.pex-set-remove:focus-visible:not(:disabled) {
-    color: var(--color-danger, #ff6b6b);
-    background: rgba(255, 107, 107, 0.1);
+.pex-set-remove:hover:not(:disabled) {
+    color: var(--accent-error);
+    background: var(--bg-elevated);
     outline: none;
+}
+
+.pex-set-remove:focus-visible:not(:disabled) {
+    color: var(--accent-error);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4);
 }
 
 .pex-set-remove:disabled {
@@ -9400,13 +9243,14 @@ button.calendar-day {
     max-height: 90vh;
 }
 
-/* Hero banner: workout name + live duration */
+/* Hero banner: workout name + live duration. Calmer: single subtle azure
+   tint, consistent padding with the body, one bottom border (no glow). */
 .finish-modal-hero {
-    background: linear-gradient(135deg, rgba(91, 155, 255, 0.18) 0%, rgba(91, 155, 255, 0.10) 100%);
-    border-bottom: 1px solid rgba(91, 155, 255, 0.25);
-    padding: var(--spacing-lg) var(--spacing-lg) var(--spacing-md);
+    background: rgba(91, 155, 255, 0.08);
+    border-bottom: 1px solid var(--border-color);
+    padding: var(--spacing-md) var(--spacing-lg);
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: space-between;
     gap: var(--spacing-md);
 }
@@ -9432,7 +9276,7 @@ button.calendar-day {
 }
 
 .finish-modal-duration-hero {
-    font-size: 2rem;
+    font-size: 1.6rem;
     font-weight: 800;
     letter-spacing: -0.03em;
     color: var(--accent-primary);
@@ -9440,9 +9284,23 @@ button.calendar-day {
     font-variant-numeric: tabular-nums;
 }
 
-.finish-modal-close {
+/* Small neutral close button matching .gt-iconbtn (decision #8 modal system). */
+.finish-modal-close,
+.feel-intro-modal-content .modal-close {
     flex-shrink: 0;
-    margin-top: 0.15rem;
+    margin-top: 0;
+    width: 26px;
+    height: 26px;
+    font-size: 1.02rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid transparent;
+    background: var(--bg-elevated) !important;
+    color: var(--text-muted) !important;
+}
+.finish-modal-close:hover,
+.feel-intro-modal-content .modal-close:hover {
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
 }
 
 /* Summary stat grid */
@@ -9632,46 +9490,63 @@ button.calendar-day {
 }
 
 /* Action row */
+/* #7 Complete / Cancel — calm green primary + tight neutral secondary that
+   read as one action group (decision #2). No heavy glow, standard height. */
 .finish-workout-actions {
+    /* Complete Workout on top (primary focus); Cancel as a plain centered
+       text link directly below it, tight gap. */
     display: flex;
-    gap: var(--spacing-md);
+    flex-direction: column-reverse;
+    gap: 0.3rem;
     align-items: center;
     margin-top: var(--spacing-lg);
 }
 
-.finish-workout-submit {
-    flex: 1;
-    background: var(--gradient-primary) !important;
-    border: none !important;
+.finish-workout-submit,
+.finish-workout-submit:hover,
+.finish-workout-submit:focus-visible {
+    width: 100%;
+    background: var(--accent-success) !important;
+    border: 1px solid transparent !important;
+    border-radius: var(--radius-lg);
+    color: #07140d !important;
     font-weight: 700;
     letter-spacing: 0.01em;
-    min-height: 52px;
+    min-height: 48px;
     font-size: 1rem;
+    box-shadow: none !important;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+}
+.finish-workout-submit i { color: inherit !important; }
+.finish-workout-submit:hover { filter: brightness(1.06); }
+.finish-workout-submit:focus-visible {
+    box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.45) !important;
 }
 
-.finish-workout-submit:hover {
-    opacity: 0.92;
-    transform: translateY(-1px);
-    box-shadow: 0 6px 20px rgba(91, 155, 255, 0.38) !important;
+/* Cancel: a plain centered text button (no pill, no border/fill), muted. */
+.finish-workout-cancel,
+.finish-workout-cancel:hover,
+.finish-workout-cancel:focus-visible {
+    flex: 0 0 auto;
+    min-width: 0;
+    min-height: 0;
+    padding: 0.5rem 1rem;
+    border: none !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted) !important;
+    font-weight: 500;
+    text-align: center;
 }
-
-.finish-workout-cancel {
-    min-width: 88px;
+.finish-workout-cancel:hover {
     color: var(--text-secondary) !important;
-    min-height: 52px;
 }
 
-/* Mobile: stack cancel below submit, full width */
 @media (max-width: 480px) {
-    .finish-workout-actions {
-        flex-direction: column-reverse;
-        gap: var(--spacing-sm);
-    }
-
-    .finish-workout-actions .btn {
-        width: 100%;
-    }
-
     .workout-summary {
         grid-template-columns: repeat(3, 1fr);
     }
@@ -9948,64 +9823,110 @@ button.calendar-day {
 
 /* Item R3-4: the feel picker modal. The intro copy + the single "Felt good"
    icon button (the only choice) + "Not yet". */
+/* #8 Feel modal: shorter, consistent padding, calm rewarding green primary
+   + neutral secondary as one action group. One accent, no stacked glow. */
+.feel-modal-header {
+    padding: var(--spacing-md) var(--spacing-xl);
+    border-bottom: none;
+}
+.feel-modal-header h2 {
+    font-size: 1.15rem;
+}
+.feel-modal-body {
+    /* Roomier: clear top gap below the header, generous side padding, and a
+       comfortable bottom so the actions are not cramped. */
+    padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-xl);
+}
 .feel-intro-lead {
-    margin: 0 0 var(--spacing-md);
+    margin: 0 0 var(--spacing-lg);
     color: var(--text-secondary);
-    text-align: center;
+    text-align: left;
+    font-size: 0.9rem;
+    line-height: 1.5;
 }
-.feel-modal-choices {
+.feel-modal-actions {
     display: flex;
-    gap: 1rem;
-    justify-content: center;
+    align-items: stretch;
+    gap: var(--spacing-md);
 }
-/* Pinned colors with !important to defeat the sitewide button color/hover. */
+/* "Felt good" — primary. Calm green: solid-tinted, content-hugging row, one
+   border (no glow). Pinned !important to defeat sitewide button color/hover. */
 .feel-modal-btn {
     appearance: none;
-    flex: 1 1 0;
-    max-width: 160px;
-    display: flex;
-    flex-direction: column;
+    flex: 0 1 auto;
+    display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.5rem;
-    padding: 1rem 0.75rem;
+    padding: 0.6rem 1.35rem;
+    min-height: 46px;
     border-radius: var(--radius-lg);
-    border: 1.5px solid transparent;
+    border: 1px solid transparent;
     cursor: pointer;
-    font-size: 2.2rem;
+    /* Smaller icon so the smiley reads friendly, not heavy. */
+    font-size: 1.05rem;
     box-shadow: none !important;
-    transition: background var(--transition-base), border-color var(--transition-base),
-                color var(--transition-base), transform var(--transition-base);
+    transition: filter var(--transition-base), box-shadow var(--transition-base);
 }
 .feel-modal-btn-label {
-    font-size: 0.85rem;
-    font-weight: 600;
+    font-size: 0.92rem;
+    font-weight: 700;
 }
 .feel-modal-btn-good {
-    background: rgba(34, 197, 94, 0.12);
-    border-color: rgba(34, 197, 94, 0.5);
-    color: #22c55e !important;
+    background: var(--accent-success) !important;
+    border-color: transparent;
+    color: #0a3a26 !important;
 }
-.feel-modal-btn-good i { color: #22c55e !important; }
+/* Premium two-tone smiley: a filled darker-green face with the button's green
+   showing through the eyes/smile, so it reads as an intentional crafted mark
+   (not a default emoji). Sized slightly larger than the label for presence and
+   vertically centered with the text. */
+.feel-modal-smiley {
+    width: 1.5em;
+    height: 1.5em;
+    flex-shrink: 0;
+    display: block;
+}
 .feel-modal-btn-good:hover,
 .feel-modal-btn-good:focus-visible {
-    background: rgba(34, 197, 94, 0.22);
-    border-color: rgba(34, 197, 94, 0.8);
-    color: #16a34a !important;
-    transform: translateY(-2px);
+    filter: brightness(1.06);
+    color: #0a3a26 !important;
 }
-.feel-modal-btn-good:hover i,
-.feel-modal-btn-good:focus-visible i { color: #16a34a !important; }
-.feel-modal-btn:focus-visible { outline: none; }
+.feel-modal-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.45) !important;
+}
+/* "Not yet" — clear secondary (neutral ghost), matched height + roomy padding. */
+.feel-modal-skip-secondary,
+.feel-modal-skip-secondary:hover,
+.feel-modal-skip-secondary:focus-visible {
+    flex: 0 0 auto;
+    min-width: 96px;
+    min-height: 46px;
+    padding: 0.6rem 1.35rem;
+    color: var(--text-secondary) !important;
+    border-radius: var(--radius-lg);
+}
 
 /* Item 9: weekday chips in the program editor. */
 .program-schedule-days {
     display: flex;
-    flex-wrap: wrap;
     gap: 0.4rem;
     margin-top: 0.35rem;
 }
 .schedule-day-chip {
     appearance: none;
+    /* Every day is an identical cell: equal width (flex share) + fixed height,
+       border-box so the 1px border never shifts size. Selection changes ONLY
+       background/border/text color, never the box dimensions. */
+    flex: 1 1 0;
+    min-width: 0;
+    box-sizing: border-box;
+    height: 40px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: 1px solid var(--border-light);
     background: var(--bg-elevated);
     /* Pin colour !important across states: these chips are <button>s, so the
@@ -10015,7 +9936,6 @@ button.calendar-day {
     font: inherit;
     font-size: 0.82rem;
     font-weight: 600;
-    padding: 0.4rem 0.7rem;
     border-radius: var(--radius-md);
     cursor: pointer;
     transition: background var(--transition-base), border-color var(--transition-base),
@@ -10089,90 +10009,152 @@ button.calendar-day {
    ============================================================ */
 
 /* Item R2-6: week strip on the workout selection screen. */
+/* ==========================================================================
+   Workout-selection week schedule (mobile-first): a row of compact day pills
+   (label + a dot when that day has a workout) and a detail panel below that
+   shows the SELECTED day's full workout name(s). The selected day also
+   highlights the matching program card(s) further down. Tapping a pill selects
+   a day; it does not start a workout.
+   ========================================================================== */
 .week-strip {
     margin: 0 0 1.25rem;
-    padding: 0.85rem;
+    padding: 0.75rem;
     background: var(--bg-card);
     border: 1px solid var(--border-color);
     border-radius: var(--radius-lg);
 }
-.week-strip-grid {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    gap: 0.4rem;
+.week-strip-pills {
+    display: flex;
+    gap: 0.3rem;
 }
-.week-strip-day {
+.week-day-pill {
+    flex: 1 1 0;
+    min-width: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.35rem;
-    min-width: 0;
-    padding: 0.4rem 0.25rem;
-    border-radius: var(--radius-md);
-    background: rgba(255, 255, 255, 0.02);
+    justify-content: center;
+    gap: 0.32rem;
+    min-height: 48px;
+    padding: 0.4rem 0.15rem;
+    border-radius: var(--radius-sm);
     border: 1px solid transparent;
+    background: var(--bg-elevated) !important;
+    color: var(--text-secondary) !important;
+    cursor: pointer;
+    font-family: inherit;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+    transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
 }
-.week-strip-day.is-today {
-    background: rgba(91, 155, 255, 0.12);
+.week-day-pill-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+}
+.week-day-pill-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: transparent;
+}
+/* Empty days stay quiet (no dot); only workout days show the accent dot. */
+.week-day-pill.has-workout .week-day-pill-dot { background: var(--accent-primary); }
+.week-day-pill:hover {
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
+}
+/* Today: subtle accent ring (when not the selected day). */
+.week-day-pill.is-today {
+    color: var(--text-primary) !important;
     border-color: rgba(91, 155, 255, 0.45);
 }
-.week-strip-label {
-    font-size: 0.7rem;
+/* Selected day: strong filled state. */
+.week-day-pill.is-selected,
+.week-day-pill.is-selected:hover {
+    background: var(--accent-primary) !important;
+    color: #0a1020 !important;
+    border-color: transparent;
+}
+.week-day-pill.is-selected .week-day-pill-dot,
+.week-day-pill.is-selected.has-workout .week-day-pill-dot { background: #0a1020; }
+.week-day-pill:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.45) !important;
+}
+
+/* Selected-day detail: full workout name(s) with room to breathe. */
+.week-strip-detail { margin-top: 0.75rem; }
+.week-detail-day {
+    margin: 0 0 0.45rem;
+    font-size: 0.74rem;
     font-weight: 700;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
     color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
 }
-.week-strip-day.is-today .week-strip-label { color: #b3adff; }
-.week-strip-entries {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    width: 100%;
-    align-items: center;
-    min-height: 1.1rem;
-}
-.week-strip-empty { color: var(--text-muted, #666); font-size: 0.85rem; }
-.week-strip-program {
+.week-detail-empty { margin: 0; color: var(--text-secondary); font-size: 0.9rem; }
+.week-detail-list { display: flex; flex-direction: column; gap: 0.45rem; }
+.week-detail-item {
     display: flex;
     align-items: center;
-    gap: 0.25rem;
-    max-width: 100%;
-    padding: 0.2rem 0.3rem;
+    justify-content: space-between;
+    gap: 0.6rem;
+    padding: 0.55rem 0.7rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+}
+.week-detail-name {
+    font-weight: 700;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    line-height: 1.3;
+}
+.week-detail-start,
+.week-detail-start:hover,
+.week-detail-start:focus-visible {
+    flex-shrink: 0;
+    background: var(--accent-primary) !important;
+    color: #0a1020 !important;
     border: none;
-    border-radius: var(--radius-sm, 6px);
-    background: rgba(91, 155, 255, 0.10) !important;
-    color: var(--text-primary) !important;
+    border-radius: 999px;
+    padding: 0.4rem 0.95rem;
+    font-weight: 700;
+    font-size: 0.82rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    box-shadow: none !important;
     cursor: pointer;
-    font-size: 0.66rem;
-    line-height: 1.1;
-    transition: background var(--transition-fast);
 }
-.week-strip-program:hover {
-    background: rgba(91, 155, 255, 0.22) !important;
-    color: var(--text-primary) !important;
+.week-detail-start:hover { filter: brightness(1.06); }
+.week-detail-start:focus-visible { box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.45) !important; }
+
+/* Selected day highlights the matching program card(s) below. */
+.program-selection-grid .program-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
 }
-.week-strip-program:focus-visible {
-    outline: 2px solid var(--accent-primary);
-    outline-offset: 1px;
+.program-card--scheduled {
+    border-color: var(--accent-primary) !important;
+    box-shadow: 0 0 0 1px var(--accent-primary);
 }
-.week-strip-day.is-today .week-strip-program {
-    background: rgba(91, 155, 255, 0.28) !important;
-    font-weight: 600;
-}
-.week-strip-day.is-today .week-strip-program:hover {
-    background: rgba(91, 155, 255, 0.4) !important;
-}
-.week-strip-dot {
-    flex: 0 0 auto;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #8b85ff;
-}
-.week-strip-program-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
+.program-sched-chip {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--accent-primary);
+    background: rgba(91, 155, 255, 0.14);
+    border-radius: 999px;
+    padding: 0.18rem 0.5rem;
     white-space: nowrap;
 }
 
@@ -10268,7 +10250,7 @@ button.calendar-day {
     z-index: 5;
     background: var(--bg-secondary);
     border-bottom: 1px solid var(--border-color);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    box-shadow: none;
 }
 #program-modal.program-editor-workout-mode .modal-close {
     display: none;
@@ -10305,15 +10287,45 @@ button.calendar-day {
 .program-modal-normal-actions .btn { white-space: nowrap; }
 
 /* Pin the header in normal mode too (the R2-7 rule only stickies workout mode).
-   Both modes now use the header for actions, so the header is always sticky. */
+   Both modes now use the header for actions, so the header is always sticky.
+   Reads as a flat navigation bar: title left, actions right, a single bottom
+   border (no card elevation / drop shadow). */
 #program-modal .program-modal-header {
     position: sticky;
     top: 0;
     z-index: 5;
     background: var(--bg-secondary);
     border-bottom: 1px solid var(--border-color);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    box-shadow: none;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.85rem var(--spacing-lg);
 }
+
+/* Title is the focal point of the bar: larger + stronger than the generic
+   modal-header h2. Stays on one line; actions (Cancel + Save) sit on the right. */
+#program-modal-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: 1.15;
+    white-space: nowrap;
+    margin: 0;
+    margin-right: auto;
+}
+
+/* Cancel: a plain muted text button (no border/fill), pairs with the blue Save. */
+#program-modal .program-modal-cancel,
+#program-modal .program-modal-cancel:hover,
+#program-modal .program-modal-cancel:focus-visible {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    color: var(--text-secondary) !important;
+    padding: 0.5rem 0.6rem;
+    font-weight: 600;
+}
+#program-modal .program-modal-cancel:hover { color: var(--text-primary) !important; }
 
 /* The bottom form actions are now redundant in both modes — the header carries
    Save + Cancel. Hide the footer cluster for this modal entirely. */
@@ -10327,6 +10339,34 @@ button.calendar-day {
 .program-modal-normal-actions .btn-save-program,
 .program-modal-normal-actions .btn-save-program:hover,
 .program-modal-normal-actions .btn-save-program:focus {
-    background: var(--gradient-primary) !important;
+    background: var(--accent-primary) !important;
     color: #ffffff !important;
+}
+
+/* Cancel: small, quiet ghost text, not a heavy button. Applies to both the
+   normal and workout header action clusters. */
+.program-modal-normal-actions .btn-ghost,
+.program-modal-workout-actions .btn-ghost {
+    padding: 0.5rem 0.65rem !important;
+    height: auto !important;
+    min-height: 0 !important;
+    font-size: 0.85rem !important;
+    font-weight: 500 !important;
+    background: transparent !important;
+    border: 1px solid transparent !important;
+    color: var(--text-secondary) !important;
+    box-shadow: none !important;
+}
+.program-modal-normal-actions .btn-ghost:hover,
+.program-modal-normal-actions .btn-ghost:focus-visible,
+.program-modal-workout-actions .btn-ghost:hover,
+.program-modal-workout-actions .btn-ghost:focus-visible {
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
+    border-color: transparent !important;
+    outline: none;
+}
+.program-modal-normal-actions .btn-ghost:focus-visible,
+.program-modal-workout-actions .btn-ghost:focus-visible {
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
 }

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -677,26 +677,36 @@ body.gym-tracker #recent-workouts .empty-state {
    ================================================================ */
 
 /* Feature 3: collapsible exercise blocks */
+/* Pass 2 #2: flat header — title block (left, primary) + quiet icon-button
+   controls (right). The whole header stays clickable to collapse. */
 body.gym-tracker .exercise-entry-header {
     display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    align-items: flex-start;
+    gap: 0.6rem;
     cursor: pointer;
 }
 
-body.gym-tracker .exercise-collapse-toggle {
-    background: none;
-    border: none;
-    /* !important defeats the main.css button{color:#555} trap on this chevron. */
-    color: var(--gt-muted) !important;
-    padding: 0.2rem;
-    cursor: pointer;
-    flex-shrink: 0;
-    line-height: 1;
-    transition: color var(--transition-fast), transform var(--transition-fast);
+body.gym-tracker .exercise-title-block {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
 }
-body.gym-tracker .exercise-collapse-toggle:hover {
-    color: var(--gt-accent) !important;
+
+body.gym-tracker .exercise-header-controls {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+/* The chevron + pencil + plate buttons reuse .gt-iconbtn; nothing extra
+   needed beyond keeping them quiet. The collapse chevron pins its color so
+   the sitewide button{color:#555} trap can't grey it. */
+body.gym-tracker .exercise-collapse-toggle,
+body.gym-tracker .exercise-collapse-toggle i {
+    color: var(--text-secondary) !important;
 }
 
 body.gym-tracker .exercise-entry .exercise-body {
@@ -707,58 +717,21 @@ body.gym-tracker .exercise-entry.exercise-collapsed .exercise-body {
     display: none;
 }
 
-/* Item R2-3: between-set rest chip row (idle gray duration / live countdown). */
-body.gym-tracker .rest-row {
-    margin-bottom: 0.5rem;
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    gap: 0.4rem;
+/* When an exercise is collapsed its body (set rows + notes) is hidden, so the
+   notes (edit) and plate-hint header buttons have nothing to act on. Hide them
+   to avoid dead controls; only the collapse chevron stays. They return on
+   expand. */
+body.gym-tracker .exercise-entry.exercise-collapsed .gt-notes-toggle,
+body.gym-tracker .exercise-entry.exercise-collapsed .btn-icon-plates--per-ex {
+    display: none;
 }
 
-body.gym-tracker .rest-row .rest-countdown-chip {
-    grid-column: 2;
-    grid-row: 1;
-}
-
-body.gym-tracker .rest-row .btn-icon-plates--per-ex {
-    grid-column: 3;
-    grid-row: 1;
-    justify-self: end;
-    margin-left: 0;
-}
-
-/* Per-exercise plate-hints toggle (inline in rest-row) */
-body.gym-tracker .btn-icon-plates--per-ex,
-body.gym-tracker .btn-icon-plates--per-ex:hover:active {
-    background: rgba(91, 155, 255, 0.1);
-    border: 1px solid rgba(91, 155, 255, 0.3);
-    border-radius: 999px;
-    /* !important pins defeat the sitewide main.css `button { color:#555 !important }`
-       that otherwise paints this dumbbell icon gray. */
-    color: rgba(91, 155, 255, 0.9) !important;
-    box-shadow: none !important;
-    font-size: 0.75rem;
-    padding: 0.2rem 0.55rem;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    min-width: 40px;
-    min-height: 40px;
-    justify-content: center;
-    transition: background var(--transition-fast), color var(--transition-fast);
-    margin-left: auto;
-}
-body.gym-tracker .btn-icon-plates--per-ex:hover {
-    background: rgba(91, 155, 255, 0.2);
-    color: #5b9bff !important;
-}
+/* Pass 2 #2: per-exercise plate-hints toggle now a neutral .gt-iconbtn.
+   Dimmed-off variant only changes the resting opacity/color, no new fill. */
 body.gym-tracker .btn-icon-plates--per-ex.btn-icon-plates--off,
-body.gym-tracker .btn-icon-plates--per-ex.btn-icon-plates--off:hover {
-    background: transparent;
-    border-color: var(--gt-border);
-    color: var(--gt-muted) !important;
-    opacity: 0.6;
+body.gym-tracker .btn-icon-plates--per-ex.btn-icon-plates--off i {
+    color: var(--text-muted) !important;
+    opacity: 0.65;
 }
 
 /* Uniform rest-between message in sticky workout header */
@@ -921,54 +894,34 @@ body.gym-tracker .save-as-program-btn {
 
 /* Task 6: rep-range labels */
 body.gym-tracker .exercise-rep-target {
-    font-size: 0.72rem;
+    font-size: 0.78rem;
     font-weight: 500;
-    color: var(--gt-muted-2);
-    margin-left: 0.35rem;
+    color: var(--text-secondary);
     white-space: nowrap;
 }
 
 body.gym-tracker .set-rep-target {
-    font-size: 0.72rem;
+    font-size: 0.74rem;
     font-weight: 500;
-    color: var(--gt-muted-2);
+    color: var(--text-secondary);
     white-space: nowrap;
     pointer-events: none;
     user-select: none;
     padding: 0 0.2rem;
 }
 
-/* Task 8: shrink add-set and remove-set buttons */
-body.gym-tracker .btn-add-set--extra {
-    background: transparent !important;
-    border: 1px solid var(--gt-border) !important;
-    color: var(--gt-muted-2) !important;
-    font-size: 0.72rem !important;
-    font-weight: 500 !important;
-    padding: 0.3rem 0.75rem !important;
-    min-height: 40px;
-    box-shadow: none !important;
-}
-body.gym-tracker .btn-add-set--extra:hover {
-    border-color: var(--gt-border-strong) !important;
-    color: var(--gt-muted) !important;
-    background: var(--gt-surface-2) !important;
-}
-
+/* Pass 2 #5: add/remove-set styling is owned by gym-tracker.css now (azure
+   Add-set affordance + neutral red-on-hover minus). These refresh-layer pins
+   only re-assert the box-shadow reset so no stray glow leaks in. */
+body.gym-tracker .btn-add-set--extra,
 body.gym-tracker .btn-remove-set {
-    background: transparent !important;
-    border: 1px solid var(--gt-border) !important;
-    color: var(--gt-muted-2) !important;
-    font-size: 0.72rem !important;
-    padding: 0.3rem 0.55rem !important;
-    min-height: 40px;
-    min-width: 40px;
     box-shadow: none !important;
 }
-body.gym-tracker .btn-remove-set:hover {
-    border-color: var(--gt-border-strong) !important;
-    color: var(--gt-danger) !important;
-    background: transparent !important;
+body.gym-tracker .btn-add-set--extra:focus-visible {
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.45) !important;
+}
+body.gym-tracker .btn-remove-set:focus-visible {
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
 }
 
 /* ================================================================
@@ -1883,12 +1836,12 @@ body.gym-tracker .modal-header h2 {
     letter-spacing: -0.01em;
 }
 
-/* Program form inside modal */
+/* Program form inside modal — Title Case, consistent label sizing. */
 body.gym-tracker #program-form .form-group label {
     color: var(--gt-muted);
-    font-size: 0.72rem;
-    letter-spacing: 0.07em;
-    text-transform: uppercase;
+    font-size: 0.85rem;
+    letter-spacing: 0;
+    text-transform: none;
 }
 
 /* Program exercises section */
@@ -2459,4 +2412,523 @@ body.gym-tracker .program-exercise-row.gt-exercise-added {
     body.gym-tracker .back-to-top {
         bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + 1.25rem);
     }
+}
+
+/* ==========================================================================
+   Strength PR achievements on the Achievements screen.
+   New, uniquely-named rules appended per task brief. Button colors are pinned
+   explicitly so the sitewide main.css `button:hover` red never leaks in.
+   ========================================================================== */
+
+/* --- Strength PRs section on the Achievements screen --- */
+body.gym-tracker .strength-pr-section {
+    margin-bottom: 1.25rem;
+    border: 1px solid var(--gt-accent-ring, rgba(91, 155, 255, 0.38));
+    border-radius: 14px;
+    background:
+        linear-gradient(135deg, rgba(245, 200, 66, 0.10) 0%, rgba(91, 155, 255, 0.06) 100%);
+    overflow: hidden;
+}
+
+body.gym-tracker .strength-pr-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid rgba(245, 200, 66, 0.25);
+}
+
+body.gym-tracker .strength-pr-header-icon {
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+body.gym-tracker .strength-pr-header h2 {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--gt-text, #f1f3f8);
+}
+
+body.gym-tracker .strength-pr-header p {
+    margin: 0.1rem 0 0;
+    font-size: 0.8rem;
+    color: var(--gt-muted, #a4adbd);
+}
+
+body.gym-tracker .strength-pr-count {
+    margin-left: auto;
+    background: #f5c842;
+    color: #1a1a1a;
+    font-weight: 700;
+    font-size: 0.85rem;
+    border-radius: 999px;
+    padding: 0.1rem 0.6rem;
+}
+
+body.gym-tracker .strength-pr-list {
+    display: flex;
+    flex-direction: column;
+}
+
+body.gym-tracker .strength-pr-card {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.7rem 1rem;
+}
+
+body.gym-tracker .strength-pr-card + .strength-pr-card {
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+body.gym-tracker .strength-pr-medal {
+    font-size: 1.35rem;
+    line-height: 1;
+}
+
+body.gym-tracker .strength-pr-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+}
+
+body.gym-tracker .strength-pr-name {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--gt-text, #f1f3f8);
+}
+
+body.gym-tracker .strength-pr-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.82rem;
+}
+
+body.gym-tracker .strength-pr-weight {
+    color: #f5c842;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+body.gym-tracker .strength-pr-date {
+    color: var(--gt-muted, #a4adbd);
+}
+
+/* ==========================================================================
+   Workout-view improvements (workout-view.js owner block)
+   Features 5, 6, 7: restore chip, inline notes, finish-modal volume delta.
+   New, uniquely-named classes only.
+   Colors pinned explicitly so the sitewide button:hover red never leaks in.
+   ========================================================================== */
+
+/* Feature 6: one-tap restore-to-last-time chip. */
+body.gym-tracker .gt-restore-chip {
+    flex: 0 0 100%;
+    margin-top: 0.35rem;
+    padding: 0.25rem 0.5rem;
+    text-align: center;
+    border: 1px solid #3a6df0;
+    border-radius: 999px;
+    background: rgba(58, 109, 240, 0.12);
+    color: #8fb0ff;
+    font-size: 0.72rem;
+    line-height: 1.4;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+body.gym-tracker .gt-restore-chip:hover,
+body.gym-tracker .gt-restore-chip:focus-visible {
+    background: rgba(58, 109, 240, 0.22);
+    color: #b9cdff;
+    border-color: #3a6df0;
+}
+
+/* Pass 2 #2: the notes toggle is now a .gt-iconbtn (sizing/colors inherited).
+   Only the meaningful state variants remain: has-notes = azure (content
+   present), open = pressed look. */
+body.gym-tracker .gt-notes-toggle--has-notes,
+body.gym-tracker .gt-notes-toggle--has-notes i {
+    color: var(--accent-primary) !important;
+    border-color: var(--accent-primary);
+}
+
+body.gym-tracker .gt-notes-toggle--open {
+    background: var(--bg-hover) !important;
+    border-color: var(--border-light);
+    color: var(--text-primary) !important;
+}
+
+/* Pass 2 #6: compact optional notes box inside the card body. */
+body.gym-tracker .gt-exercise-notes {
+    margin: 0 0 0.5rem;
+}
+
+body.gym-tracker .gt-exercise-notes-input {
+    width: 100%;
+    min-height: 2.5rem;
+    padding: 0.45rem 0.55rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    resize: vertical;
+}
+
+body.gym-tracker .gt-exercise-notes-input::placeholder {
+    color: var(--text-secondary);
+}
+
+body.gym-tracker .gt-exercise-notes-input:focus-visible {
+    outline: none;
+    border-color: var(--accent-primary);
+}
+
+/* Feature 7: finish-modal volume delta line. */
+body.gym-tracker .gt-volume-delta {
+    display: block;
+    margin-top: 0.1rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+body.gym-tracker .gt-volume-delta--up {
+    color: #4caf76;
+}
+
+body.gym-tracker .gt-volume-delta--down {
+    color: #e0795a;
+}
+
+/* =====================================================================
+   History session-detail modal additions (Features 2 + 5)
+   - Feature 2: per-exercise inline-SVG strength trend chart
+   - Feature 5: read-only per-exercise notes callout
+   Appended after prior agents' blocks; new class names only.
+   ===================================================================== */
+
+/* Feature 2: per-exercise strength trend chart in the session detail. */
+body.gym-tracker .gt-exercise-trend {
+    margin: 0.5rem 0 0.25rem;
+    padding: 0.4rem 0.55rem 0.5rem;
+    border-radius: 10px;
+    background: rgba(58, 109, 240, 0.06);
+    border: 1px solid rgba(58, 109, 240, 0.18);
+}
+
+body.gym-tracker .gt-exercise-trend-label {
+    display: block;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: #9fb4f5;
+    margin-bottom: 0.3rem;
+}
+
+body.gym-tracker .exercise-trend-chart {
+    display: block;
+    width: 100%;
+    height: 80px;
+    overflow: visible;
+}
+
+body.gym-tracker .gt-exercise-trend-range {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--gt-muted, #a4adbd);
+}
+
+/* Feature 5: read-only per-exercise notes callout in the session detail. */
+body.gym-tracker .gt-detail-exercise-notes {
+    margin: 0.5rem 0 0.25rem;
+    padding: 0.5rem 0.7rem;
+    border-left: 3px solid #f5c842;
+    border-radius: 0 8px 8px 0;
+    background: rgba(245, 200, 66, 0.08);
+}
+
+body.gym-tracker .gt-detail-exercise-notes-label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: #f5c842;
+    margin-bottom: 0.2rem;
+}
+
+body.gym-tracker .gt-detail-exercise-notes-text {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    color: var(--gt-text, #f1f3f8);
+    white-space: pre-wrap;
+}
+
+/* =========================================================================
+   ACTIVE-WORKOUT DESIGN SYSTEM (Pass 1 + Pass 2 shared vocabulary)
+   -------------------------------------------------------------------------
+   Strict semantic palette: azure = the only interactive accent, green =
+   completion only, gold = PR/warning only, everything else neutral. Two
+   radii only (--radius-sm small controls, --radius-lg cards/modals). One
+   border style. At most one of {fill, border, glow} per element.
+
+   Reusable classes (Pass 2 must reuse these verbatim):
+     .gt-iconbtn            square 40x40 neutral icon button
+     .gt-iconbtn--danger    quiet at rest, red-on-hover destructive variant
+     .gt-segment            segmented pill (kg|lb unit toggle)
+     .gt-segment__btn       a segment; .is-active = azure fill
+   All colors pinned for normal/hover/focus-visible to defeat the sitewide
+   main.css `button { color:#555 !important }` + `button:hover` red rules.
+   ========================================================================= */
+body.gym-tracker .gt-iconbtn {
+    appearance: none;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-color);
+    background: var(--bg-elevated) !important;
+    color: var(--text-secondary) !important;
+    font-size: 0.95rem;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: none !important;
+    /* Kill the mobile tap-highlight flash so tapping (e.g. the notes pencil)
+       shows no white/gray flicker. */
+    -webkit-tap-highlight-color: transparent;
+    transition: background var(--transition-base), border-color var(--transition-base),
+                color var(--transition-base);
+}
+body.gym-tracker .gt-iconbtn i { color: inherit !important; font-size: inherit; }
+body.gym-tracker .gt-iconbtn:hover {
+    background: var(--bg-hover) !important;
+    border-color: var(--border-light);
+    color: var(--text-primary) !important;
+}
+body.gym-tracker .gt-iconbtn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
+}
+
+/* Destructive variant: neutral at rest (quiet), only turns red on hover. */
+body.gym-tracker .gt-iconbtn--danger:hover,
+body.gym-tracker .gt-iconbtn--danger:hover i {
+    background: var(--bg-elevated) !important;
+    border-color: var(--accent-error);
+    color: var(--accent-error) !important;
+}
+
+/* Segmented control (kg | lb). Compact pill: inactive = neutral text,
+   active = azure fill + white text. */
+body.gym-tracker .gt-segment {
+    display: inline-flex;
+    align-items: center;
+    height: 40px;
+    padding: 3px;
+    gap: 2px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-color);
+    background: var(--bg-elevated);
+}
+body.gym-tracker .gt-segment__btn {
+    appearance: none;
+    border: 0;
+    background: transparent !important;
+    color: var(--text-secondary) !important;
+    font: inherit;
+    font-weight: 600;
+    font-size: 0.82rem;
+    line-height: 1;
+    padding: 0 0.6rem;
+    height: 100%;
+    min-width: 34px;
+    border-radius: calc(var(--radius-sm) - 2px);
+    cursor: pointer;
+    box-shadow: none !important;
+    transition: background var(--transition-base), color var(--transition-base);
+}
+body.gym-tracker .gt-segment__btn:hover {
+    color: var(--text-primary) !important;
+}
+body.gym-tracker .gt-segment__btn.is-active,
+body.gym-tracker .gt-segment__btn.is-active:hover {
+    background: var(--accent-primary) !important;
+    color: #ffffff !important;
+}
+body.gym-tracker .gt-segment__btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(91, 155, 255, 0.55) inset !important;
+}
+
+/* =========================================================================
+   #1 ACTIVE-WORKOUT HEADER (overflow-menu layout)
+   ========================================================================= */
+body.gym-tracker .workout-header {
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.6rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: var(--radius-lg);
+}
+
+/* Row 1: title (strongest) + elapsed timer to its right, rest line beneath. */
+body.gym-tracker .workout-info {
+    flex: 1 1 100%;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 0.2rem 0.6rem;
+    text-align: left;
+}
+body.gym-tracker .workout-info h2 {
+    flex: 0 1 auto;
+    font-size: 1.15rem;
+    max-width: 100%;
+}
+body.gym-tracker .workout-info .workout-timer {
+    margin-top: 0;
+    margin-right: auto;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+body.gym-tracker .workout-info .workout-rest-between {
+    flex: 1 1 100%;
+    justify-content: flex-start;
+    margin-top: 0;
+    color: var(--text-secondary) !important;
+}
+body.gym-tracker .workout-info .workout-rest-between i { color: var(--accent-primary) !important; }
+body.gym-tracker .workout-info .workout-rest-between strong { color: var(--text-secondary) !important; }
+
+/* Row 2: controls cluster, full width, left-aligned, one spacing token. */
+body.gym-tracker .workout-header-actions {
+    flex: 1 1 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+}
+
+/* The green Finish primary: calm, standard height, no glow. */
+body.gym-tracker .workout-header .gt-finish-btn,
+body.gym-tracker .workout-header .gt-finish-btn:hover,
+body.gym-tracker .workout-header .gt-finish-btn:focus-visible {
+    width: auto;
+    height: 40px;
+    padding: 0 0.95rem;
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid transparent;
+    background: var(--accent-success) !important;
+    color: #07140d !important;
+    font-weight: 700;
+    font-size: 0.9rem;
+    box-shadow: none !important;
+    cursor: pointer;
+    transition: filter var(--transition-base), box-shadow var(--transition-base);
+}
+body.gym-tracker .workout-header .gt-finish-btn i { color: inherit !important; }
+body.gym-tracker .workout-header .gt-finish-btn:hover { filter: brightness(1.06); }
+body.gym-tracker .workout-header .gt-finish-btn:focus-visible {
+    box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.45) !important;
+}
+
+/* Overflow ("...") menu popover. */
+body.gym-tracker .gt-overflow {
+    position: relative;
+    display: inline-flex;
+}
+body.gym-tracker .gt-overflow-menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 120;
+    min-width: 210px;
+    padding: 0.35rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+}
+body.gym-tracker .gt-overflow-menu[hidden] { display: none; }
+body.gym-tracker .gt-overflow-item {
+    appearance: none;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.6rem 0.65rem;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent !important;
+    color: var(--text-secondary) !important;
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 500;
+    text-align: left;
+    cursor: pointer;
+    box-shadow: none !important;
+    transition: background var(--transition-base), color var(--transition-base);
+}
+body.gym-tracker .gt-overflow-item i {
+    width: 1.1rem;
+    text-align: center;
+    color: var(--accent-primary) !important;
+    flex-shrink: 0;
+}
+body.gym-tracker .gt-overflow-item:hover,
+body.gym-tracker .gt-overflow-item:focus-visible {
+    outline: none;
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
+}
+/* Active toggle state (plate hints on) reads as azure. */
+body.gym-tracker .gt-overflow-item[aria-pressed="true"] {
+    color: var(--text-primary) !important;
+}
+body.gym-tracker .gt-overflow-item .gt-overflow-state {
+    margin-left: auto;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-muted) !important;
+}
+body.gym-tracker .gt-overflow-item[aria-pressed="true"] .gt-overflow-state {
+    color: var(--accent-primary) !important;
+}
+/* Divider above the destructive item (last). */
+body.gym-tracker .gt-overflow-divider {
+    height: 1px;
+    margin: 0.3rem 0.2rem;
+    background: var(--border-color);
+}
+body.gym-tracker .gt-overflow-item--danger i { color: var(--text-muted) !important; }
+body.gym-tracker .gt-overflow-item--danger:hover,
+body.gym-tracker .gt-overflow-item--danger:focus-visible {
+    background: rgba(248, 113, 113, 0.12) !important;
+    color: var(--accent-error) !important;
+}
+body.gym-tracker .gt-overflow-item--danger:hover i,
+body.gym-tracker .gt-overflow-item--danger:focus-visible i {
+    color: var(--accent-error) !important;
 }

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -281,19 +281,19 @@
                             <!-- Item R2-7: in workout mode these two actions live in
                                  the sticky header; the footer save/return are hidden. -->
                             <div class="program-modal-workout-actions" id="program-modal-workout-actions" hidden>
-                                <button type="button" class="btn btn-ghost" id="program-modal-cancel-workout">Cancel</button>
+                                <button type="button" class="btn btn-ghost program-modal-cancel" id="program-modal-cancel-workout">Cancel</button>
                                 <button type="button" class="btn btn-primary" id="program-modal-save-resume">
-                                    <i class="fas fa-check"></i> Save and resume workout
+                                    <i class="fas fa-check"></i> Save &amp; resume
                                 </button>
                             </div>
-                            <!-- Feature B: normal create/edit actions, pinned in the sticky header. -->
+                            <!-- Normal create/edit actions, pinned in the sticky header:
+                                 a plain Cancel (dismisses) + a blue Save. No separate X. -->
                             <div class="program-modal-normal-actions" id="program-modal-normal-actions" hidden>
-                                <button type="button" class="btn btn-ghost modal-close">Cancel</button>
+                                <button type="button" class="btn btn-ghost modal-close program-modal-cancel">Cancel</button>
                                 <button type="submit" class="btn btn-primary btn-save-program" form="program-form">
-                                    <i class="fas fa-check"></i> Save Program
+                                    <i class="fas fa-check"></i> Save
                                 </button>
                             </div>
-                            <button class="modal-close" aria-label="Close">&times;</button>
                         </div>
                         <div class="modal-body">
                             <form id="program-form" novalidate>
@@ -468,9 +468,6 @@
                 <!-- Active Workout Screen -->
                 <div id="active-workout" class="workout-screen">
                     <div class="workout-header">
-                        <button class="btn-icon btn-icon-end" id="end-workout-btn" title="Discard Workout" aria-label="Discard workout without saving">
-                            <i class="fas fa-trash-can"></i>
-                        </button>
                         <div class="workout-info">
                             <h2 id="workout-title">Workout</h2>
                             <div class="workout-timer">
@@ -483,22 +480,33 @@
                             </div>
                         </div>
                         <div class="workout-header-actions">
-                            <div class="workout-unit-toggle" id="workout-unit-toggle" role="group" aria-label="Weight unit for this session">
-                                <button type="button" class="workout-unit-btn" id="workout-unit-kg" data-unit="kg" aria-pressed="false">kg</button>
-                                <button type="button" class="workout-unit-btn" id="workout-unit-lb" data-unit="lb" aria-pressed="false">lbs</button>
+                            <div class="gt-segment workout-unit-toggle" id="workout-unit-toggle" role="group" aria-label="Weight unit for this session">
+                                <button type="button" class="gt-segment__btn workout-unit-btn" id="workout-unit-kg" data-unit="kg" aria-pressed="false">kg</button>
+                                <button type="button" class="gt-segment__btn workout-unit-btn" id="workout-unit-lb" data-unit="lb" aria-pressed="false">lbs</button>
                             </div>
-                            <button class="btn-icon btn-icon-plates" id="plate-hints-toggle-btn" title="Set default plate hints on/off for all exercises" aria-label="Toggle default plate calculator hints" aria-pressed="true">
-                                <i class="fas fa-dumbbell"></i>
-                            </button>
-                            <button class="btn-icon btn-icon-edit-program" id="edit-program-btn" title="Edit program" aria-label="Pause and edit this program">
-                                <i class="fas fa-sliders"></i>
-                            </button>
-                            <button class="btn-icon btn-icon-pause" id="pause-workout-btn" title="Pause Workout" aria-label="Pause workout and save progress">
+                            <button class="gt-iconbtn" id="pause-workout-btn" title="Pause Workout" aria-label="Pause workout and save progress">
                                 <i class="fas fa-pause"></i>
                             </button>
-                            <button class="btn-icon btn-icon-finish" id="finish-workout-btn" title="Finish Workout" aria-label="Finish workout and save">
-                                <i class="fas fa-check"></i>
+                            <button class="gt-finish-btn" id="finish-workout-btn" title="Finish Workout" aria-label="Finish workout and save">
+                                <i class="fas fa-check" aria-hidden="true"></i><span>Finish</span>
                             </button>
+                            <div class="gt-overflow">
+                                <button class="gt-iconbtn" id="workout-overflow-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-controls="workout-overflow-menu" title="More options" aria-label="More workout options">
+                                    <i class="fas fa-ellipsis" aria-hidden="true"></i>
+                                </button>
+                                <div class="gt-overflow-menu" id="workout-overflow-menu" role="menu" aria-label="More workout options" hidden>
+                                    <button class="gt-overflow-item" id="edit-program-btn" type="button" role="menuitem" title="Edit program" aria-label="Pause and edit this program">
+                                        <i class="fas fa-sliders" aria-hidden="true"></i><span>Edit program</span>
+                                    </button>
+                                    <button class="gt-overflow-item" id="plate-hints-toggle-btn" type="button" role="menuitem" title="Set default plate hints on/off for all exercises" aria-label="Toggle default plate calculator hints" aria-pressed="true">
+                                        <i class="fas fa-dumbbell" aria-hidden="true"></i><span>Plate hints</span><span class="gt-overflow-state" aria-hidden="true">On</span>
+                                    </button>
+                                    <div class="gt-overflow-divider" role="separator"></div>
+                                    <button class="gt-overflow-item gt-overflow-item--danger" id="end-workout-btn" type="button" role="menuitem" title="Discard Workout" aria-label="Discard workout without saving">
+                                        <i class="fas fa-trash-can" aria-hidden="true"></i><span>Discard workout</span>
+                                    </button>
+                                </div>
+                            </div>
                         </div>
                     </div>
 
@@ -508,24 +516,26 @@
                         </div>
                     </div>
 
-                    <!-- Rest Timer Bar (persistent; appears after a set is logged) -->
+                    <!-- Rest timer: large floating circular dial; color-coded by
+                         rest type (green between sets, blue between exercises). -->
                     <div id="rest-timer-bar" class="rest-timer-bar" role="status" aria-live="polite" hidden>
-                        <div class="rest-timer-bar-inner">
-                            <div class="rest-timer-info">
-                                <i class="fas fa-hourglass-half" aria-hidden="true"></i>
+                        <div class="rest-timer-dial">
+                            <svg class="rest-timer-ring" viewBox="0 0 180 180" aria-hidden="true">
+                                <circle class="rest-timer-ring-track" cx="90" cy="90" r="82"></circle>
+                                <circle id="rest-timer-progress-fill" class="rest-timer-ring-fill" cx="90" cy="90" r="82"></circle>
+                            </svg>
+                            <div class="rest-timer-dial-content">
+                                <i class="fas fa-hourglass-half rest-timer-icon" aria-hidden="true"></i>
                                 <span class="rest-timer-label">Rest</span>
                                 <span id="rest-timer-value" class="rest-timer-value">0:00</span>
-                            </div>
-                            <div class="rest-timer-progress" aria-hidden="true">
-                                <span id="rest-timer-progress-fill" class="rest-timer-progress-fill"></span>
-                            </div>
-                            <div class="rest-timer-actions">
-                                <button type="button" class="rest-timer-action-btn" id="rest-add-btn" aria-label="Add 30 seconds">
-                                    +30s
-                                </button>
-                                <button type="button" class="rest-timer-action-btn rest-timer-skip" id="rest-skip-btn" aria-label="Skip rest">
-                                    Skip
-                                </button>
+                                <span id="rest-timer-caption" class="rest-timer-caption">Next set in</span>
+                                <div class="rest-timer-actions">
+                                    <button type="button" class="rest-timer-btn rest-timer-add" id="rest-add-btn" aria-label="Add 30 seconds">+30s</button>
+                                    <button type="button" class="rest-timer-btn rest-timer-skip" id="rest-skip-btn" aria-label="Skip rest">
+                                        <span class="rest-timer-skip-label">Skip</span>
+                                        <i class="fas fa-forward" aria-hidden="true"></i>
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -556,6 +566,7 @@
                                             <span class="summary-stat-icon"><i class="fas fa-weight-hanging" aria-hidden="true"></i></span>
                                             <span class="value" id="summary-volume" aria-label="Total volume">0 kg</span>
                                             <span class="label">Volume</span>
+                                            <span class="gt-volume-delta" id="summary-volume-delta" hidden></span>
                                         </div>
                                         <div class="summary-stat">
                                             <span class="summary-stat-icon"><i class="fas fa-list-check" aria-hidden="true"></i></span>
@@ -1441,22 +1452,25 @@
          per exercise per session when all sets hit max reps. -->
     <div id="feel-intro-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="feel-intro-title">
         <div class="modal-content small feel-intro-modal-content">
-            <div class="modal-header">
+            <div class="modal-header feel-modal-header">
                 <h2 id="feel-intro-title">All sets at max reps!</h2>
                 <button class="modal-close" id="feel-modal-skip" aria-label="Skip">&times;</button>
             </div>
-            <div class="modal-body">
+            <div class="modal-body feel-modal-body">
                 <p class="feel-intro-lead">Felt strong on every set? Mark it so you know to try more weight next time.</p>
-                <div class="feel-modal-choices" role="group" aria-label="How did this exercise feel">
+                <div class="feel-modal-actions">
                     <button type="button" class="feel-modal-btn feel-modal-btn-good" id="feel-modal-good"
                         aria-label="Felt good, consider more weight next time">
-                        <i class="fas fa-face-smile" aria-hidden="true"></i>
+                        <svg class="feel-modal-smiley" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                            <circle cx="12" cy="12" r="9.3" fill="none" stroke="#0a3a26" stroke-width="2.1"></circle>
+                            <circle cx="9" cy="10" r="1.35" fill="#0a3a26"></circle>
+                            <circle cx="15" cy="10" r="1.35" fill="#0a3a26"></circle>
+                            <path d="M8 14 Q12 17.6 16 14" fill="none" stroke="#0a3a26" stroke-width="2.1" stroke-linecap="round"></path>
+                        </svg>
                         <span class="feel-modal-btn-label">Felt good</span>
                     </button>
+                    <button type="button" class="btn btn-ghost feel-modal-skip-secondary" id="feel-modal-skip-btn">Not yet</button>
                 </div>
-            </div>
-            <div class="modal-footer" style="display:flex;justify-content:center;">
-                <button class="btn btn-ghost" id="feel-modal-skip-btn">Not yet</button>
             </div>
         </div>
     </div>

--- a/apps/gym-tracker/js/app.js
+++ b/apps/gym-tracker/js/app.js
@@ -67,6 +67,13 @@ class GymTrackerApp {
             }
         }
 
+        // Self-heal: if loadAllData filtered out malformed achievement records
+        // (e.g. legacy strength-PR entries missing weight/date), rewrite storage
+        // so the orphaned records do not linger across sessions or sync.
+        if ((storageService.getAchievements() || []).length > this.achievements.length) {
+            this.saveAchievements();
+        }
+
         // Update achievement progress
         this.updateAchievements();
 
@@ -178,7 +185,9 @@ class GymTrackerApp {
 
         this.achievements = this._safeLoad('achievements',
             () => storageService.getAchievements(),
-            (data) => Array.isArray(data) ? data.map(a => Achievement.fromJSON(a)) : [],
+            (data) => Array.isArray(data)
+                ? data.map(a => Achievement.fromJSON(a)).filter(Achievement.isRenderable)
+                : [],
             []
         );
 

--- a/apps/gym-tracker/js/models/Achievement.js
+++ b/apps/gym-tracker/js/models/Achievement.js
@@ -14,6 +14,14 @@ export class Achievement {
         this.unlockedAt = data.unlockedAt || null;
         this.progress = data.progress || 0; // Current progress towards requirement
         this.target = data.target || 100; // Target value for requirement
+
+        // Feature 4: optional strength-PR metadata. Only present on
+        // per-exercise PR achievements (type 'strength-pr'); undefined
+        // otherwise so existing achievements serialize unchanged.
+        this.prWeightKg = data.prWeightKg;       // canonical kilograms
+        this.prUnit = data.prUnit;               // unit to display ('kg' | 'lb')
+        this.prExerciseName = data.prExerciseName;
+        this.prDate = data.prDate;               // YYYY-MM-DD
     }
 
     get progressPercentage() {
@@ -45,11 +53,33 @@ export class Achievement {
             unlocked: this.unlocked,
             unlockedAt: this.unlockedAt,
             progress: this.progress,
-            target: this.target
+            target: this.target,
+            ...(this.prWeightKg !== undefined ? { prWeightKg: this.prWeightKg } : {}),
+            ...(this.prUnit !== undefined ? { prUnit: this.prUnit } : {}),
+            ...(this.prExerciseName !== undefined ? { prExerciseName: this.prExerciseName } : {}),
+            ...(this.prDate !== undefined ? { prDate: this.prDate } : {}),
         };
     }
 
     static fromJSON(json) {
         return new Achievement(json);
+    }
+
+    /**
+     * Whether an achievement carries enough data to render meaningfully.
+     * Strength-PR cards (Feature 4) need a positive canonical weight and a
+     * date; a legacy or partially-synced record missing those would render
+     * as "0 kg" / "Invalid Date", so it is treated as not renderable and
+     * filtered out at load and render time. All other achievement types are
+     * always renderable.
+     */
+    static isRenderable(achievement) {
+        if (!achievement || achievement.requirement?.type !== 'strength-pr') {
+            return true;
+        }
+        return typeof achievement.prWeightKg === 'number'
+            && Number.isFinite(achievement.prWeightKg)
+            && achievement.prWeightKg > 0
+            && !!achievement.prDate;
     }
 }

--- a/apps/gym-tracker/js/services/AchievementService.js
+++ b/apps/gym-tracker/js/services/AchievementService.js
@@ -4,6 +4,8 @@
  */
 import { Achievement } from '../models/Achievement.js';
 import { AnalyticsService } from './AnalyticsService.js';
+import { storageService } from './StorageService.js';
+import { convertWeight } from '../utils/helpers.js';
 
 export class AchievementService {
     /**
@@ -387,6 +389,113 @@ export class AchievementService {
         }
 
         return newlyUnlocked;
+    }
+
+    /**
+     * Feature 4: persistent per-exercise strength-PR achievements.
+     *
+     * Award a PR when the just-finished session's top completed set for an
+     * exercise beats the all-time best weight ever recorded for that exercise
+     * across all PRIOR sessions, AND the lifter has at least 2 prior sessions
+     * that contained the exercise (so a brand-new exercise never fires, and a
+     * single prior baseline session isn't enough either).
+     *
+     * Reps-type only: sets whose top entry is duration-based are skipped.
+     *
+     * Persists newly-awarded PRs via the same achievements storage path the
+     * rest of the app uses, guarding against a duplicate id so finishing the
+     * same session twice (crash-resume) does not double-award. Returns the
+     * array of newly-awarded Achievement objects (possibly empty).
+     *
+     * @param finishedSession the session just saved to history
+     * @param allSessions the full workoutSessions array INCLUDING finishedSession
+     */
+    static checkExercisePRs(finishedSession, allSessions) {
+        if (!finishedSession || !Array.isArray(allSessions)) return [];
+
+        // Display unit comes from current settings; stored set weights are in
+        // that account unit, so the comparison space is consistent and we only
+        // convert to kg for the persisted canonical value.
+        const unit = storageService.getSettings()?.weightUnit === 'lb' ? 'lb' : 'kg';
+
+        const stored = storageService.getAchievements() || [];
+        const existingIds = new Set(stored.map(a => a.id));
+        const date = finishedSession.date;
+
+        // Best completed reps-set weight for an exerciseId within a session.
+        const topWeight = (session, exerciseId) => {
+            let best = null;
+            (session.exercises || []).forEach(ex => {
+                if (ex.exerciseId !== exerciseId) return;
+                (ex.sets || []).forEach(set => {
+                    if (!set.completed) return;
+                    // Duration-type set: skip (not a weighted lift).
+                    if ((set.duration || 0) > 0) return;
+                    const w = set.weight || 0;
+                    if (w <= 0) return;
+                    if (best == null || w > best) best = w;
+                });
+            });
+            return best;
+        };
+
+        const priorSessions = allSessions.filter(s => s.id !== finishedSession.id);
+        const newlyAwarded = [];
+        const seenExerciseIds = new Set();
+
+        for (const ex of (finishedSession.exercises || [])) {
+            const exId = ex.exerciseId;
+            if (!exId || seenExerciseIds.has(exId)) continue;
+            seenExerciseIds.add(exId);
+
+            const sessionTop = topWeight(finishedSession, exId);
+            if (sessionTop == null) continue; // no completed weighted set
+
+            // Prior sessions that actually contained a weighted set for this
+            // exercise, plus the all-time best among them.
+            let priorCount = 0;
+            let priorBest = null;
+            for (const s of priorSessions) {
+                const w = topWeight(s, exId);
+                if (w == null) continue;
+                priorCount += 1;
+                if (priorBest == null || w > priorBest) priorBest = w;
+            }
+
+            if (priorCount < 2) continue;            // needs 2+ prior sessions
+            if (!(sessionTop > priorBest)) continue; // must strictly beat best
+
+            const id = `pr-${exId}-${date}`;
+            if (existingIds.has(id)) continue;       // idempotent by id
+
+            const weightKg = unit === 'lb'
+                ? convertWeight(sessionTop, 'lb', 'kg')
+                : sessionTop;
+
+            const achievement = new Achievement({
+                id,
+                name: `${ex.exerciseName} PR`,
+                description: `New personal record on ${ex.exerciseName}`,
+                type: 'strength-pr',
+                icon: '🏅',
+                requirement: { type: 'strength-pr', exerciseId: exId },
+                target: 1,
+                prWeightKg: Math.round(weightKg * 100) / 100,
+                prUnit: unit,
+                prExerciseName: ex.exerciseName,
+                prDate: date,
+            });
+            achievement.unlock();
+
+            stored.push(achievement.toJSON());
+            existingIds.add(id);
+            newlyAwarded.push(achievement);
+        }
+
+        if (newlyAwarded.length > 0) {
+            storageService.saveAchievements(stored);
+        }
+        return newlyAwarded;
     }
 
     /**

--- a/apps/gym-tracker/js/views/achievements-view.js
+++ b/apps/gym-tracker/js/views/achievements-view.js
@@ -3,9 +3,10 @@
  * Renders achievements as a grouped progression system rather than a flat list.
  */
 import { app } from '../app.js';
+import { Achievement } from '../models/Achievement.js';
 import { AchievementService } from '../services/AchievementService.js';
 import { DarkSelect } from '../utils/dark-select.js';
-import { escapeHtml } from '../utils/helpers.js';
+import { escapeHtml, convertWeight, formatDate } from '../utils/helpers.js';
 
 const VOLUME_TYPES = new Set(['total-volume', 'daily-volume']);
 
@@ -112,21 +113,80 @@ class AchievementsView {
         return text.replace(/kg\b/g, unit);
     }
 
+    /** Feature 4: per-exercise strength-PR achievements, newest first. */
+    get prAchievements() {
+        return (this.app.achievements || [])
+            .filter(a => a.requirement?.type === 'strength-pr')
+            // Defense-in-depth: a legacy or partially-synced PR record missing
+            // its weight/date would render as "0 kg" / "Invalid Date". Skip it.
+            .filter(a => Achievement.isRenderable(a))
+            .sort((a, b) => String(b.prDate || '').localeCompare(String(a.prDate || '')));
+    }
+
+    /**
+     * Render the distinct "Strength PRs" section above the standard
+     * volume/streak categories. Each row shows exercise name, weight + unit,
+     * and date. Weights are stored canonical kg; convert to the row's saved
+     * display unit. Returns the section HTML (empty string when none exist).
+     */
+    renderPRSection() {
+        const prs = this.prAchievements;
+        if (prs.length === 0) return '';
+        const rows = prs.map(a => {
+            const unit = a.prUnit === 'lb' ? 'lb' : 'kg';
+            const weight = unit === 'lb'
+                ? convertWeight(a.prWeightKg || 0, 'kg', 'lb')
+                : (a.prWeightKg || 0);
+            const weightLabel = `${Number(weight).toLocaleString()} ${unit}`;
+            const name = a.prExerciseName || a.name;
+            return `
+                <div class="strength-pr-card">
+                    <span class="strength-pr-medal" aria-hidden="true">${escapeHtml(a.icon || '🏅')}</span>
+                    <div class="strength-pr-info">
+                        <h3 class="strength-pr-name">${escapeHtml(name)}</h3>
+                        <span class="strength-pr-meta">
+                            <span class="strength-pr-weight">${escapeHtml(weightLabel)}</span>
+                            <span class="strength-pr-date">${escapeHtml(formatDate(a.prDate))}</span>
+                        </span>
+                    </div>
+                </div>
+            `;
+        }).join('');
+        return `
+            <section class="strength-pr-section">
+                <header class="strength-pr-header">
+                    <span class="strength-pr-header-icon" aria-hidden="true">🏅</span>
+                    <div>
+                        <h2>Strength PRs</h2>
+                        <p>Personal records: your heaviest set yet on an exercise</p>
+                    </div>
+                    <span class="strength-pr-count">${prs.length}</span>
+                </header>
+                <div class="strength-pr-list">${rows}</div>
+            </section>
+        `;
+    }
+
     render() {
         const container = document.getElementById('achievements-list');
         if (!container) return;
 
-        const all = this.app.achievements;
+        // Strength PRs live outside the standard category groups; render them
+        // in their own visually distinct section and keep them out of the
+        // category/filter machinery below.
+        const all = this.app.achievements.filter(a => a.requirement?.type !== 'strength-pr');
+        const prSectionHtml = this.renderPRSection();
         const sessions = this.app.workoutSessions || [];
 
         // Header counts always reflect the full set
-        document.getElementById('unlocked-count').textContent = all.filter(a => a.unlocked).length;
-        document.getElementById('total-achievements').textContent = all.length;
+        const fullSet = this.app.achievements;
+        document.getElementById('unlocked-count').textContent = fullSet.filter(a => a.unlocked).length;
+        document.getElementById('total-achievements').textContent = fullSet.length;
 
         // Apply status filter
         const filtered = all.filter(a => this.matchesFilter(a));
         if (filtered.length === 0) {
-            container.innerHTML = `
+            container.innerHTML = prSectionHtml + `
                 <div class="empty-state">
                     <i class="fas fa-trophy"></i>
                     <p>No achievements match this filter.</p>
@@ -142,7 +202,7 @@ class AchievementsView {
                 if (a.unlocked !== b.unlocked) return a.unlocked ? 1 : -1;
                 return (b.progressPercentage || 0) - (a.progressPercentage || 0);
             });
-            container.innerHTML = `
+            container.innerHTML = prSectionHtml + `
                 <div class="achievement-chain">
                     ${sorted.map(a => this.renderCard(a, sessions)).join('')}
                 </div>
@@ -156,7 +216,7 @@ class AchievementsView {
                 const bd = b.unlockedAt ? new Date(b.unlockedAt).getTime() : 0;
                 return bd - ad;
             });
-            container.innerHTML = `
+            container.innerHTML = prSectionHtml + `
                 <div class="achievement-chain">
                     ${sorted.map(a => this.renderCard(a, sessions)).join('')}
                 </div>
@@ -180,7 +240,7 @@ class AchievementsView {
             return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
         });
 
-        container.innerHTML = ordered.map(([type, items]) => {
+        container.innerHTML = prSectionHtml + ordered.map(([type, items]) => {
             const meta = CATEGORY_META[type] || { name: type, icon: '🏆', desc: '' };
             const done = items.filter(a => a.unlocked).length;
             const isExpanded = this.expandedCategories.has(type);

--- a/apps/gym-tracker/js/views/history-view.js
+++ b/apps/gym-tracker/js/views/history-view.js
@@ -440,6 +440,24 @@ class HistoryView {
                 html += `
                             </tbody>
                         </table>
+                `;
+
+                // Feature 2: per-exercise strength trend chart (reps-type only).
+                if (!isDuration) {
+                    html += this.buildExerciseTrendChart(exercise.exerciseId, unit);
+                }
+
+                // Feature 5 (display half): read-only per-exercise notes.
+                if (exercise.notes && exercise.notes.trim()) {
+                    html += `
+                        <div class="gt-detail-exercise-notes">
+                            <span class="gt-detail-exercise-notes-label">Notes</span>
+                            <p class="gt-detail-exercise-notes-text">${escapeHtml(exercise.notes)}</p>
+                        </div>
+                    `;
+                }
+
+                html += `
                     </div>
                 `;
             }
@@ -470,6 +488,78 @@ class HistoryView {
 
         modal.classList.add('active');
         trapModalFocus(modal);
+    }
+
+    /**
+     * Feature 2: inline-SVG strength trend for a reps-type exercise.
+     *
+     * Collects every workout session that contains this exercise (matched by
+     * exerciseId), reduces each to its TOP committed set weight, orders them
+     * oldest-first by sortTimestamp, and plots the last 12 as a line chart.
+     * The current session is included so the open detail sits on the line.
+     *
+     * Renders nothing for fewer than 3 data points (no empty-state clutter).
+     * Returns an HTML string (possibly empty).
+     */
+    buildExerciseTrendChart(exerciseId, unit) {
+        if (exerciseId == null) return '';
+
+        const topWeightFor = (ex) => {
+            const committed = (ex.sets || []).filter(s => s.completed && !(s.duration > 0));
+            if (committed.length === 0) return null;
+            return committed.reduce((max, s) => Math.max(max, s.weight || 0), 0);
+        };
+
+        const points = this.app.workoutSessions
+            .map(session => {
+                const ex = (session.exercises || []).find(e => e.exerciseId === exerciseId);
+                if (!ex) return null;
+                const weight = topWeightFor(ex);
+                if (weight == null) return null;
+                return { ts: session.sortTimestamp, weight };
+            })
+            .filter(Boolean)
+            .sort((a, b) => new Date(a.ts) - new Date(b.ts))
+            .slice(-12);
+
+        if (points.length < 3) return '';
+
+        const weights = points.map(p => p.weight);
+        const min = Math.min(...weights);
+        const max = Math.max(...weights);
+        // Y-axis floor sits BELOW the minimum plotted weight so a cluster of
+        // similar weights still spreads across the chart instead of flattening
+        // to the bottom. Use a slice of the spread, with a small absolute
+        // fallback when every weight is identical.
+        const spread = max - min;
+        const floor = Math.max(0, min - (spread > 0 ? spread * 0.15 : Math.max(1, min * 0.05)));
+        const range = Math.max(1e-9, max - floor);
+
+        const W = 240;
+        const H = 80;
+        const pad = 6;
+        const stepX = (W - pad * 2) / (points.length - 1);
+        const coords = points.map((p, i) => {
+            const x = pad + i * stepX;
+            const y = pad + (1 - (p.weight - floor) / range) * (H - pad * 2);
+            return `${x.toFixed(1)},${y.toFixed(1)}`;
+        });
+
+        const dots = coords.map(c => {
+            const [x, y] = c.split(',');
+            return `<circle cx="${x}" cy="${y}" r="2.2" fill="#3a6df0" />`;
+        }).join('');
+
+        return `
+            <div class="gt-exercise-trend">
+                <span class="gt-exercise-trend-label">Exercise trend</span>
+                <svg class="exercise-trend-chart" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" role="img" aria-label="Top set weight across last ${points.length} sessions, in ${unit}">
+                    <polyline points="${coords.join(' ')}" fill="none" stroke="#3a6df0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                    ${dots}
+                </svg>
+                <span class="gt-exercise-trend-range">${min.toLocaleString()}${unit} to ${max.toLocaleString()}${unit}</span>
+            </div>
+        `;
     }
 
     async saveSessionAsProgram(sessionId) {

--- a/apps/gym-tracker/js/views/programs-view.js
+++ b/apps/gym-tracker/js/views/programs-view.js
@@ -656,7 +656,7 @@ class ProgramsView {
 
             return `
             <div class="program-exercise-row ${groupClasses}" draggable="true" data-exercise-index="${index}">
-                ${linkedAbove ? `<span class="pex-superset-tag" aria-hidden="true">SUPERSET</span>` : ''}
+                ${linkedAbove ? `<span class="pex-superset-tag" aria-hidden="true">Superset</span>` : ''}
                 <span class="pex-drag-handle" aria-hidden="true" title="Drag to reorder">
                     <i class="fas fa-grip-vertical"></i>
                 </span>

--- a/apps/gym-tracker/js/views/workout-view.js
+++ b/apps/gym-tracker/js/views/workout-view.js
@@ -14,6 +14,7 @@ import { renderPausedBannerHTML, wirePausedBannerActions } from './paused-banner
 import { orderPrograms } from '../utils/program-order.js';
 import { sameId } from '../utils/id-utils.js';
 import { AnalyticsService } from '../services/AnalyticsService.js';
+import { AchievementService } from '../services/AchievementService.js';
 import { calculatePlates, formatPlateStack } from '../utils/plate-calculator.js';
 import { restTickCues, isWorkoutComplete } from '../utils/rest-cues.js';
 import { allSetsReachMax, latestFeelForExercise, nextFeel, shouldShowFeelModal } from '../utils/exercise-feel.js';
@@ -91,7 +92,25 @@ class WorkoutView {
         // exists on barbell rows.
         view.addEventListener('input', (e) => {
             const t = e.target;
+            // Feature 5: persist per-exercise notes on every keystroke, same
+            // pattern as the stickyValues persistence (save the active workout).
+            if (t instanceof HTMLTextAreaElement && t.classList.contains('gt-exercise-notes-input')) {
+                const eIdx = Number(t.dataset.exerciseIndex);
+                const exercise = this.currentWorkoutSession?.exercises[eIdx];
+                if (exercise) {
+                    exercise.notes = t.value;
+                    storageService.saveActiveWorkout(this.currentWorkoutSession.toJSON());
+                    const toggle = document.querySelector(`.gt-notes-toggle[data-exercise-index="${eIdx}"]`);
+                    if (toggle) toggle.classList.toggle('gt-notes-toggle--has-notes', t.value.trim() !== '');
+                }
+                return;
+            }
             if (!(t instanceof HTMLInputElement)) return;
+            // Feature 6: a weight/reps edit on a planned row may surface (or hide)
+            // the "same as last time" restore chip.
+            if (t.classList.contains('set-weight') || t.classList.contains('set-reps')) {
+                this.maybeToggleRestoreChip(t.closest('.set-row-planned'));
+            }
             const target = t.dataset.plateHintTarget;
             if (!target) return;
             const [eIdx, slot] = target.split('-').map(Number);
@@ -116,6 +135,11 @@ class WorkoutView {
                 case 'start-workout':
                     e.preventDefault();
                     this.startWorkout(target.dataset.programId);
+                    break;
+                case 'select-week-day':
+                    e.preventDefault();
+                    this.selectedWeekday = Number(target.dataset.weekday);
+                    this.renderProgramSelection();
                     break;
                 case 'commit-planned-set':
                     e.preventDefault();
@@ -163,6 +187,14 @@ class WorkoutView {
                 case 'cycle-feel':
                     e.preventDefault();
                     this.cycleExerciseFeel(exerciseIndex);
+                    break;
+                case 'toggle-exercise-notes':
+                    e.preventDefault();
+                    this.toggleExerciseNotes(exerciseIndex);
+                    break;
+                case 'restore-last-time':
+                    e.preventDefault();
+                    this.restoreLastTime(exerciseIndex, slot, target);
                     break;
             }
         });
@@ -213,6 +245,53 @@ class WorkoutView {
         // Session unit toggle (Item 8): kg | lbs for this workout only.
         document.querySelectorAll('#workout-unit-toggle .workout-unit-btn').forEach(btn => {
             btn.addEventListener('click', () => this.setSessionUnit(btn.dataset.unit));
+        });
+
+        // Header overflow ("...") menu: edit program / plate hints / discard.
+        this.setupOverflowMenu();
+    }
+
+    /**
+     * Accessible "..." popover for the low-priority + destructive header
+     * actions. The menu items keep their original IDs and handlers (wired
+     * elsewhere); this only manages open/close + closes the menu after a
+     * menu item fires. Opens on click, closes on outside-click / Escape.
+     */
+    setupOverflowMenu() {
+        const btn = document.getElementById('workout-overflow-btn');
+        const menu = document.getElementById('workout-overflow-menu');
+        if (!btn || !menu) return;
+
+        const close = () => {
+            if (menu.hidden) return;
+            menu.hidden = true;
+            btn.setAttribute('aria-expanded', 'false');
+            document.removeEventListener('click', onOutside, true);
+            document.removeEventListener('keydown', onKey, true);
+        };
+        const open = () => {
+            menu.hidden = false;
+            btn.setAttribute('aria-expanded', 'true');
+            document.addEventListener('click', onOutside, true);
+            document.addEventListener('keydown', onKey, true);
+            const first = menu.querySelector('.gt-overflow-item');
+            if (first) first.focus();
+        };
+        const onOutside = (e) => {
+            if (!menu.contains(e.target) && e.target !== btn) close();
+        };
+        const onKey = (e) => {
+            if (e.key === 'Escape') { close(); btn.focus(); }
+        };
+
+        btn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            menu.hidden ? open() : close();
+        });
+        // Close after any menu item is activated (the item's own handler runs
+        // first; this just dismisses the popover).
+        menu.querySelectorAll('.gt-overflow-item').forEach(item => {
+            item.addEventListener('click', () => close());
         });
     }
 
@@ -700,25 +779,56 @@ class WorkoutView {
         const firstDay = this.app.settings?.firstDayOfWeek === 1 ? 1 : 0;
         const labels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
         const fullLabels = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-        const cells = weekStrip(programs, firstDay).map(cell => {
-            const entries = cell.programs.map(p => `
-                <button type="button" class="week-strip-program" data-action="start-workout" data-program-id="${p.id}" title="Start ${escapeHtml(p.name)}">
-                    <span class="week-strip-dot" aria-hidden="true"></span>
-                    <span class="week-strip-program-name">${escapeHtml(p.name)}</span>
-                </button>`).join('');
-            const classes = ['week-strip-day'];
+        const cells = weekStrip(programs, firstDay);
+        const todayWeekday = cells.find(c => c.isToday)?.weekday ?? new Date().getDay();
+        // Default the selection to today so "today's workout" shows immediately.
+        if (this.selectedWeekday == null) this.selectedWeekday = todayWeekday;
+        const selected = cells.find(c => c.weekday === this.selectedWeekday)
+            || cells.find(c => c.isToday) || cells[0];
+
+        // Compact day pills: label + a dot only when that day has a workout.
+        // Tapping a pill selects the day (it does not start a workout); the
+        // selected day's full workout details appear in the panel below.
+        const pills = cells.map(cell => {
+            const classes = ['week-day-pill'];
             if (cell.isToday) classes.push('is-today');
-            if (cell.programs.length > 0) classes.push('has-program');
+            if (cell.weekday === selected.weekday) classes.push('is-selected');
+            if (cell.programs.length > 0) classes.push('has-workout');
+            const aria = `${fullLabels[cell.weekday]}${cell.isToday ? ', today' : ''}, ${cell.programs.length ? cell.programs.length + ' workout' + (cell.programs.length > 1 ? 's' : '') : 'no workout'}`;
             return `
-                <div class="${classes.join(' ')}" aria-label="${fullLabels[cell.weekday]}${cell.isToday ? ', today' : ''}">
-                    <span class="week-strip-label">${labels[cell.weekday]}</span>
-                    <div class="week-strip-entries">${entries || '<span class="week-strip-empty" aria-hidden="true">&middot;</span>'}</div>
-                </div>`;
+                <button type="button" class="${classes.join(' ')}"
+                    data-action="select-week-day" data-weekday="${cell.weekday}"
+                    aria-pressed="${cell.weekday === selected.weekday ? 'true' : 'false'}"
+                    aria-label="${aria}">
+                    <span class="week-day-pill-label">${labels[cell.weekday]}</span>
+                    <span class="week-day-pill-dot" aria-hidden="true"></span>
+                </button>`;
         }).join('');
 
+        const isSelToday = selected.weekday === todayWeekday;
+        const dayTitle = isSelToday ? `Today, ${fullLabels[selected.weekday]}` : fullLabels[selected.weekday];
+        let detail;
+        if (selected.programs.length === 0) {
+            detail = `
+                <p class="week-detail-day">${dayTitle}</p>
+                <p class="week-detail-empty">No workout scheduled. Pick any program below.</p>`;
+        } else {
+            const items = selected.programs.map(p => `
+                <div class="week-detail-item">
+                    <span class="week-detail-name">${escapeHtml(p.name)}</span>
+                    <button type="button" class="btn btn-primary week-detail-start" data-action="start-workout" data-program-id="${p.id}" title="Start ${escapeHtml(p.name)}">
+                        <i class="fas fa-play" aria-hidden="true"></i> Start
+                    </button>
+                </div>`).join('');
+            detail = `
+                <p class="week-detail-day">${dayTitle}</p>
+                <div class="week-detail-list">${items}</div>`;
+        }
+
         return `
-            <section class="week-strip" aria-label="This week's scheduled programs">
-                <div class="week-strip-grid">${cells}</div>
+            <section class="week-strip" aria-label="Weekly workout schedule">
+                <div class="week-strip-pills" role="group" aria-label="Days of the week">${pills}</div>
+                <div class="week-strip-detail">${detail}</div>
             </section>`;
     }
 
@@ -753,6 +863,12 @@ class WorkoutView {
 
         html += this._renderWeekStripHTML(programs);
 
+        // Connect the selected day (set by the week strip) to the cards below:
+        // the program(s) scheduled on the selected day get a highlight + chip.
+        const selWeekday = this.selectedWeekday;
+        const todayWeekday = new Date().getDay();
+        const fullDayLabels = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
         html += `
             <h2>Select a Program</h2>
             <p class="subtitle">Choose which program you want to do today</p>
@@ -760,10 +876,15 @@ class WorkoutView {
                 ${programs.map(program => {
                     const lastSession = this._lastSessionForProgram(program.id);
                     const lastDoneHTML = this._renderLastDoneInfo(lastSession);
+                    const scheduledSel = selWeekday != null
+                        && Array.isArray(program.scheduleDays)
+                        && program.scheduleDays.includes(selWeekday);
+                    const chipText = selWeekday === todayWeekday ? 'Today' : fullDayLabels[selWeekday];
                     return `
-                    <div class="program-card" data-program-card="${program.id}">
+                    <div class="program-card${scheduledSel ? ' program-card--scheduled' : ''}" data-program-card="${program.id}">
                         <div class="program-header">
                             <h3>${escapeHtml(program.name)}</h3>
+                            ${scheduledSel ? `<span class="program-sched-chip"><i class="fas fa-calendar-check" aria-hidden="true"></i> ${escapeHtml(chipText)}</span>` : ''}
                         </div>
                         ${program.description && program.description.trim() ? `<p>${escapeHtml(program.description)}</p>` : ''}
                         <div class="program-stats">
@@ -1055,7 +1176,7 @@ class WorkoutView {
         const restChipHTML = `
             <div class="rest-countdown-chip${isRestingHere ? '' : ' rest-countdown-chip--idle'}"
                  data-rest-idle="${betweenSetActive}" aria-live="off"
-                 title="Rest between sets">${this.formatRest(betweenSetActive)}</div>
+                 title="Rest between sets"><i class="fas fa-clock" aria-hidden="true"></i> ${this.formatRest(betweenSetActive)}</div>
         `;
 
         // Per-exercise plate-hints toggle.
@@ -1068,7 +1189,7 @@ class WorkoutView {
         const hintsOnForExercise = globalHints && (perExHints !== undefined ? perExHints : true);
         // Per-exercise toggle is only meaningful when global hints are ON.
         const plateToggleHTML = (isPlateLoaded && globalHints) ? `
-            <button type="button" class="btn-icon btn-icon-plates btn-icon-plates--per-ex${hintsOnForExercise ? '' : ' btn-icon-plates--off'}"
+            <button type="button" class="gt-iconbtn btn-icon-plates--per-ex${hintsOnForExercise ? '' : ' btn-icon-plates--off'}"
                 data-action="toggle-exercise-plate-hints"
                 data-exercise-index="${index}"
                 aria-pressed="${hintsOnForExercise ? 'true' : 'false'}"
@@ -1082,28 +1203,44 @@ class WorkoutView {
             <div class="exercise-entry ${isComplete ? 'exercise-complete' : ''} ${isCollapsed ? 'exercise-collapsed' : ''}"
                  id="exercise-${index}" data-exercise-type="${isDuration ? 'duration' : 'reps'}">
                 <div class="exercise-entry-header">
-                    <button type="button" class="exercise-collapse-toggle"
-                        data-action="toggle-exercise-collapse"
-                        data-exercise-index="${index}"
-                        aria-expanded="${isCollapsed ? 'false' : 'true'}"
-                        aria-label="${isCollapsed ? 'Expand' : 'Collapse'} exercise">
-                        <i class="fas fa-chevron-${isCollapsed ? 'down' : 'up'}" aria-hidden="true"></i>
-                    </button>
-                    <h3>
-                        <span class="exercise-name-main">${escapeHtml(exercise.exerciseName)}</span>${sessionFeelHTML}${lastFeelHTML}${muscle ? `
-                        <span class="exercise-name-sub">(${escapeHtml(muscle)})</span>` : ''}${allSameRepRange ? `
-                        <span class="exercise-rep-target" aria-label="Target: ${sharedRepLabel}">${sharedRepLabel}</span>` : ''}
-                    </h3>
-                    <span class="exercise-progress ${isComplete ? 'is-complete' : ''}" aria-label="Sets ${progressLabel}">
-                        ${isComplete ? '<i class="fas fa-check"></i>' : ''}
-                        ${progressLabel}
-                    </span>
+                    <div class="exercise-title-block">
+                        <h3>
+                            <span class="exercise-name-main">${escapeHtml(exercise.exerciseName)}</span>${sessionFeelHTML}${lastFeelHTML}
+                        </h3>
+                        <div class="exercise-subtitle">
+                            <span class="exercise-progress ${isComplete ? 'is-complete' : ''}" aria-label="Sets ${progressLabel}">
+                                ${isComplete ? '<i class="fas fa-check" aria-hidden="true"></i>' : ''}${progressLabel}
+                            </span>${muscle ? `
+                            <span class="exercise-name-sub">${escapeHtml(muscle)}</span>` : ''}${allSameRepRange ? `
+                            <span class="exercise-rep-target" aria-label="Target: ${sharedRepLabel}">${sharedRepLabel}</span>` : ''}
+                            ${restChipHTML}
+                        </div>
+                    </div>
+                    <div class="exercise-header-controls">
+                        <button type="button" class="gt-iconbtn gt-notes-toggle${exercise.notes ? ' gt-notes-toggle--has-notes' : ''}"
+                            data-action="toggle-exercise-notes"
+                            data-exercise-index="${index}"
+                            aria-expanded="false"
+                            aria-label="Notes for this exercise"
+                            title="Notes for this exercise">
+                            <i class="fas fa-pen" aria-hidden="true"></i>
+                        </button>
+                        ${plateToggleHTML}
+                        <button type="button" class="gt-iconbtn exercise-collapse-toggle"
+                            data-action="toggle-exercise-collapse"
+                            data-exercise-index="${index}"
+                            aria-expanded="${isCollapsed ? 'false' : 'true'}"
+                            aria-label="${isCollapsed ? 'Expand' : 'Collapse'} exercise">
+                            <i class="fas fa-chevron-${isCollapsed ? 'down' : 'up'}" aria-hidden="true"></i>
+                        </button>
+                    </div>
                 </div>
 
                 <div class="exercise-body">
-                    <div class="rest-row${isRestingHere ? ' rest-row--resting' : ''}">
-                        ${restChipHTML}
-                        ${plateToggleHTML}
+                    <div class="gt-exercise-notes" id="exercise-notes-${index}" hidden>
+                        <textarea class="gt-exercise-notes-input" data-exercise-index="${index}"
+                            placeholder="Notes for this exercise (form cues, how it felt, etc.)"
+                            aria-label="Exercise notes">${escapeHtml(exercise.notes || '')}</textarea>
                     </div>
 
                     <ol class="set-row-list" id="set-row-list-${index}">
@@ -1179,8 +1316,16 @@ class WorkoutView {
         const hintsOn = globalHintsOn && (perExHintsVal !== undefined ? perExHintsVal : true);
         const plateHintHTML = (isPlateLoaded && hintsOn) ? this.renderPlateHint(weight, unit, usesBarWeight) : '';
 
+        // Feature 6: prior pre-filled values stored on the row so an input that
+        // drifts from them can surface a "same as last time" restore chip. Only
+        // present when prior data exists; the chip itself is created on input
+        // (see maybeToggleRestoreChip), not at render.
+        const restoreData = (prior && weight !== '' && reps !== '' && reps != null)
+            ? `data-prior-weight="${weight}" data-prior-reps="${reps}"`
+            : '';
+
         return `
-            <li class="set-row set-row-planned" data-slot="${slot}">
+            <li class="set-row set-row-planned" data-slot="${slot}" ${restoreData}>
                 <span class="set-row-num">${setLabel}</span>
                 <div class="set-row-inputs">
                     <input type="number" inputmode="decimal" class="set-weight"
@@ -1197,6 +1342,69 @@ class WorkoutView {
                 ${plateHintHTML ? `<div class="plate-hint" id="plate-hint-${exerciseIndex}-${slot}">${plateHintHTML}</div>` : ''}
             </li>
         `;
+    }
+
+    /**
+     * Feature 6: show/hide the "same as last time" restore chip on a planned
+     * row based on whether the current weight/reps differ from the prior
+     * pre-filled values stored on the row.
+     */
+    maybeToggleRestoreChip(row) {
+        if (!row) return;
+        const existing = row.querySelector('.gt-restore-chip');
+        // No prior data on this row -> never show.
+        if (row.dataset.priorWeight === undefined || row.dataset.priorReps === undefined) {
+            if (existing) existing.remove();
+            return;
+        }
+        const priorWeight = Number(row.dataset.priorWeight);
+        const priorReps = Number(row.dataset.priorReps);
+        const weightInput = row.querySelector('.set-weight');
+        const repsInput = row.querySelector('.set-reps');
+        const curWeight = weightInput && weightInput.value !== '' ? Number(weightInput.value) : null;
+        const curReps = repsInput && repsInput.value !== '' ? Number(repsInput.value) : null;
+        const diverged = (curWeight !== null && curWeight !== priorWeight)
+            || (curReps !== null && curReps !== priorReps);
+
+        if (!diverged) {
+            if (existing) existing.remove();
+            return;
+        }
+        if (existing) return;
+
+        const slot = Number(row.dataset.slot);
+        const exerciseIndex = Number(weightInput?.id.split('-')[1]);
+        const unit = this.sessionUnit();
+        const chip = document.createElement('button');
+        chip.type = 'button';
+        chip.className = 'gt-restore-chip';
+        chip.dataset.action = 'restore-last-time';
+        chip.dataset.exerciseIndex = String(exerciseIndex);
+        chip.dataset.slot = String(slot);
+        chip.title = "Restore last session's weight and reps";
+        chip.textContent = `last time: ${priorWeight}${unit} x ${priorReps}`;
+        // Append after the toggle (own full-width line beneath the inputs), the
+        // same placement the Feature 1 bump chip uses.
+        row.appendChild(chip);
+    }
+
+    /**
+     * Feature 6: restore BOTH the weight and reps inputs to the prior pre-filled
+     * values stored on the row, then remove the restore chip.
+     */
+    restoreLastTime(exerciseIndex, slot, chip) {
+        const row = chip.closest('.set-row-planned');
+        if (!row) { chip.remove(); return; }
+        const weightInput = document.getElementById(`weight-${exerciseIndex}-${slot}`);
+        const repsInput = document.getElementById(`reps-${exerciseIndex}-${slot}`);
+        if (weightInput && row.dataset.priorWeight !== undefined) {
+            weightInput.value = row.dataset.priorWeight;
+            this.refreshPlateHint(exerciseIndex, slot, weightInput.value);
+        }
+        if (repsInput && row.dataset.priorReps !== undefined) {
+            repsInput.value = row.dataset.priorReps;
+        }
+        chip.remove();
     }
 
     /**
@@ -1514,6 +1722,60 @@ class WorkoutView {
         this.rerenderExercise(exerciseIndex);
     }
 
+    /**
+     * Feature 5: expand/collapse the per-exercise notes textarea WITHOUT
+     * re-rendering the exercise, so typed-but-unsaved keystrokes are never
+     * lost (the value is also persisted on every input). Expanding focuses the
+     * textarea and arms a one-shot outside-tap listener that collapses it.
+     */
+    toggleExerciseNotes(exerciseIndex) {
+        const region = document.getElementById(`exercise-notes-${exerciseIndex}`);
+        const btn = document.querySelector(`.gt-notes-toggle[data-exercise-index="${exerciseIndex}"]`);
+        if (!region) return;
+        const willOpen = region.hidden;
+        region.hidden = !willOpen;
+        if (btn) btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+        if (btn) btn.classList.toggle('gt-notes-toggle--open', willOpen);
+
+        if (willOpen) {
+            const textarea = region.querySelector('.gt-exercise-notes-input');
+            // preventScroll: focusing must not jump/scroll the page (avoids the
+            // flicker); the only effect of tapping the pencil is the note opening.
+            if (textarea) textarea.focus({ preventScroll: true });
+            // Tap outside the open notes region (and not the toggle) collapses it.
+            const onOutside = (e) => {
+                if (region.contains(e.target) || (btn && btn.contains(e.target))) return;
+                this._collapseExerciseNotes(exerciseIndex);
+                document.removeEventListener('pointerdown', onOutside, true);
+            };
+            this._notesOutsideHandlers = this._notesOutsideHandlers || {};
+            this._notesOutsideHandlers[exerciseIndex] = onOutside;
+            document.addEventListener('pointerdown', onOutside, true);
+        } else {
+            this._removeNotesOutsideHandler(exerciseIndex);
+        }
+    }
+
+    /** Feature 5: collapse the notes region for an exercise (text preserved). */
+    _collapseExerciseNotes(exerciseIndex) {
+        const region = document.getElementById(`exercise-notes-${exerciseIndex}`);
+        const btn = document.querySelector(`.gt-notes-toggle[data-exercise-index="${exerciseIndex}"]`);
+        if (region) region.hidden = true;
+        if (btn) {
+            btn.setAttribute('aria-expanded', 'false');
+            btn.classList.remove('gt-notes-toggle--open');
+        }
+        this._removeNotesOutsideHandler(exerciseIndex);
+    }
+
+    _removeNotesOutsideHandler(exerciseIndex) {
+        const handler = this._notesOutsideHandlers?.[exerciseIndex];
+        if (handler) {
+            document.removeEventListener('pointerdown', handler, true);
+            delete this._notesOutsideHandlers[exerciseIndex];
+        }
+    }
+
     /** Toggle per-exercise plate hints for the exercise at `exerciseIndex`.
      *  Only reachable when global hints are ON (button is hidden otherwise). */
     toggleExercisePlateHints(exerciseIndex) {
@@ -1547,6 +1809,8 @@ class WorkoutView {
         const enabled = this.app.settings.plateHintsEnabled !== false;
         btn.setAttribute('aria-pressed', enabled ? 'true' : 'false');
         btn.classList.toggle('btn-icon-plates--off', !enabled);
+        const state = btn.querySelector('.gt-overflow-state');
+        if (state) state.textContent = enabled ? 'On' : 'Off';
     }
 
     /** Re-render just the given exercise block without touching the others. */
@@ -1880,6 +2144,16 @@ class WorkoutView {
     }
 
     /**
+     * Integration 4: format a persisted PR achievement's weight for its toast.
+     * prWeightKg is canonical kg; show it in the user's current display unit.
+     */
+    _formatPrAchievementWeight(pr) {
+        const unit = this.app.settings.weightUnit;
+        const shown = convertWeight(pr.prWeightKg, 'kg', unit);
+        return `${Math.round(shown * 10) / 10}${unit}`;
+    }
+
+    /**
      * Find a committed set in the exercise by its stable slot. Legacy sets
      * (no `slot` field yet) fall back to their array index so sessions
      * saved before this change still behave correctly.
@@ -2161,15 +2435,9 @@ class WorkoutView {
         this.lastPingedRestSecond = -1;
         this._activeRestType = restType;
 
-        if (restType === 'exercise') {
-            this.showRestBar(duration);
-        } else {
-            // Between-set: keep bar hidden; chip only.
-            // Don't call hideRestBar() — that resets activeRestExerciseIndex.
-            const bar = document.getElementById('rest-timer-bar');
-            if (bar) bar.hidden = true;
-            this.showRestChip(exerciseIndex, duration);
-        }
+        // The floating dial is the single rest display for BOTH rest types,
+        // color-coded by type (green between sets, blue between exercises).
+        this.showRestBar(duration, restType);
 
         this.activeRestTimerId = timerService.startRestTimer(
             duration,
@@ -2197,24 +2465,32 @@ class WorkoutView {
         this.hideRestBar();
     }
 
-    showRestBar(total) {
+    showRestBar(total, restType = 'exercise') {
         const bar = document.getElementById('rest-timer-bar');
         if (!bar) return;
         bar.hidden = false;
-        // Lift the sitewide back-to-top arrow above the rest bar (item 10).
+        // Hide the sitewide back-to-top arrow while the dial owns the bottom.
         document.body.classList.add('gt-rest-bar-visible');
-        bar.classList.remove('rest-timer-done', 'rest-timer-urgent');
+        bar.classList.remove('rest-timer-done', 'rest-timer-urgent', 'rest-timer--set', 'rest-timer--exercise');
+        // Color code: green between sets, blue between exercises.
+        bar.classList.add(restType === 'set' ? 'rest-timer--set' : 'rest-timer--exercise');
+        const captionEl = document.getElementById('rest-timer-caption');
+        if (captionEl) captionEl.textContent = restType === 'set' ? 'Next set in' : 'Next exercise in';
         const valueEl = document.getElementById('rest-timer-value');
         const fill = document.getElementById('rest-timer-progress-fill');
         if (valueEl) valueEl.textContent = this.formatRest(total);
         if (fill) {
-            // Reset transition so the starting frame is 100% width before shrinking.
+            // Circular progress ring: full at start (offset 0), drains to empty
+            // (offset = circumference) as the countdown runs.
+            const len = (typeof fill.getTotalLength === 'function' ? fill.getTotalLength() : 0) || (2 * Math.PI * 24);
+            this._restRingLen = len;
             fill.style.transition = 'none';
-            fill.style.transform = 'scaleX(1)';
-            // Force reflow so the next transform transitions smoothly.
+            fill.style.strokeDasharray = String(len);
+            fill.style.strokeDashoffset = '0';
+            // Force reflow so the next offset change transitions smoothly.
             // eslint-disable-next-line no-unused-expressions
-            fill.offsetHeight;
-            fill.style.transition = 'transform 1s linear';
+            fill.getBoundingClientRect();
+            fill.style.transition = 'stroke-dashoffset 1s linear';
         }
     }
 
@@ -2222,7 +2498,7 @@ class WorkoutView {
         const bar = document.getElementById('rest-timer-bar');
         if (bar) {
             bar.hidden = true;
-            bar.classList.remove('rest-timer-done', 'rest-timer-urgent');
+            bar.classList.remove('rest-timer-done', 'rest-timer-urgent', 'rest-timer--set', 'rest-timer--exercise');
         }
         document.body.classList.remove('gt-rest-bar-visible');
         this.activeRestExerciseIndex = -1;
@@ -2236,15 +2512,12 @@ class WorkoutView {
      */
     showRestChip(exerciseIndex, remaining) {
         if (exerciseIndex < 0) return;
-        const header = document.querySelector(`#exercise-${exerciseIndex} .rest-row`);
-        if (!header) return;
-        const chip = header.querySelector('.rest-countdown-chip');
+        const chip = document.querySelector(`#exercise-${exerciseIndex} .rest-countdown-chip`);
         if (!chip) return;
-        header.classList.add('rest-row--resting');
         const countdown = this.app.settings?.timerCountdownSeconds ?? 5;
         const urgent = remaining <= countdown && remaining > 0;
         chip.className = 'rest-countdown-chip' + (urgent ? ' rest-countdown-chip--urgent' : '');
-        chip.textContent = this.formatRest(remaining);
+        chip.innerHTML = `<i class="fas fa-clock" aria-hidden="true"></i> ${this.formatRest(remaining)}`;
     }
 
     /**
@@ -2254,30 +2527,22 @@ class WorkoutView {
     clearRestChip() {
         const idx = this.activeRestExerciseIndex;
         if (idx < 0) return;
-        const row = document.querySelector(`#exercise-${idx} .rest-row`);
-        if (!row) return;
-        row.classList.remove('rest-row--resting');
-        const chip = row.querySelector('.rest-countdown-chip');
+        const chip = document.querySelector(`#exercise-${idx} .rest-countdown-chip`);
         if (!chip) return;
         const idle = parseInt(chip.dataset.restIdle, 10) || 0;
         chip.className = 'rest-countdown-chip rest-countdown-chip--idle';
-        chip.textContent = this.formatRest(idle);
+        chip.innerHTML = `<i class="fas fa-clock" aria-hidden="true"></i> ${this.formatRest(idle)}`;
     }
 
     onRestTick(remaining) {
-        const isExercise = this._activeRestType === 'exercise';
-
-        if (isExercise) {
-            const valueEl = document.getElementById('rest-timer-value');
-            const fill = document.getElementById('rest-timer-progress-fill');
-            if (valueEl) valueEl.textContent = this.formatRest(remaining);
-            if (fill && this.restTimerDuration > 0) {
-                const ratio = Math.max(0, Math.min(1, remaining / this.restTimerDuration));
-                fill.style.transform = `scaleX(${ratio})`;
-            }
-        } else {
-            // Between-set: update chip only.
-            this.showRestChip(this.activeRestExerciseIndex, remaining);
+        // The floating dial is the live display for both rest types.
+        const valueEl = document.getElementById('rest-timer-value');
+        const fill = document.getElementById('rest-timer-progress-fill');
+        if (valueEl) valueEl.textContent = this.formatRest(remaining);
+        if (fill && this.restTimerDuration > 0) {
+            const ratio = Math.max(0, Math.min(1, remaining / this.restTimerDuration));
+            const len = this._restRingLen || (2 * Math.PI * 82);
+            fill.style.strokeDashoffset = String(len * (1 - ratio));
         }
 
         const firstWarning = this.app.settings?.timerFirstWarningSeconds ?? 10;
@@ -2296,7 +2561,7 @@ class WorkoutView {
         // Final-countdown urgent state — per-second pip + urgent styling.
         const bar = document.getElementById('rest-timer-bar');
         if (urgent) {
-            if (isExercise && bar) bar.classList.add('rest-timer-urgent');
+            if (bar) bar.classList.add('rest-timer-urgent');
             // One ping per second — guard with lastPingedRestSecond.
             if (remaining !== this.lastPingedRestSecond) {
                 this.lastPingedRestSecond = remaining;
@@ -2312,19 +2577,19 @@ class WorkoutView {
 
     onRestComplete() {
         this.activeRestTimerId = null;
-        const isExercise = this._activeRestType === 'exercise';
         this._activeRestType = null;
 
-        if (isExercise) {
-            const bar = document.getElementById('rest-timer-bar');
-            const valueEl = document.getElementById('rest-timer-value');
-            if (bar) bar.classList.add('rest-timer-done');
-            if (bar) bar.classList.remove('rest-timer-urgent');
-            if (valueEl) valueEl.textContent = 'Done';
-            setTimeout(() => this.hideRestBar(), 2500);
-        } else {
-            this.clearRestChip();
+        // Both rest types use the floating dial: flip to the done state, then
+        // auto-hide. Also revert the in-card chip to its idle static state.
+        const bar = document.getElementById('rest-timer-bar');
+        const valueEl = document.getElementById('rest-timer-value');
+        if (bar) {
+            bar.classList.add('rest-timer-done');
+            bar.classList.remove('rest-timer-urgent');
         }
+        if (valueEl) valueEl.textContent = 'Done';
+        this.clearRestChip();
+        setTimeout(() => this.hideRestBar(), 2500);
 
         // Audio and haptic cues — each opt-outable independently in Settings.
         if (this.app.settings?.vibrationAlerts !== false) vibrate([120, 60, 120]);
@@ -2373,10 +2638,29 @@ class WorkoutView {
         const titleEl = document.getElementById('finish-workout-title');
         if (titleEl) titleEl.textContent = this.currentWorkoutSession.workoutDayName || 'Finish Workout';
 
+        const totalVolume = this.currentWorkoutSession.totalVolume;
         document.getElementById('summary-volume').textContent =
-            `${Math.round(this.currentWorkoutSession.totalVolume).toLocaleString()} ${unit}`;
+            `${Math.round(totalVolume).toLocaleString()} ${unit}`;
         document.getElementById('summary-sets').textContent =
             this.currentWorkoutSession.totalSets;
+
+        // Feature 7: volume delta vs the previous session of the SAME program.
+        // First session for a program shows raw totals only (no delta).
+        const deltaEl = document.getElementById('summary-volume-delta');
+        if (deltaEl) {
+            const prev = this._lastSessionForProgram(this.currentWorkoutSession.programId);
+            const prevVolume = prev ? prev.totalVolume : 0;
+            if (prev && prevVolume > 0) {
+                const pct = Math.round(((totalVolume - prevVolume) / prevVolume) * 100);
+                const sign = pct >= 0 ? '+' : '';
+                deltaEl.textContent = `(${sign}${pct}% vs last time)`;
+                deltaEl.classList.toggle('gt-volume-delta--down', pct < 0);
+                deltaEl.classList.toggle('gt-volume-delta--up', pct >= 0);
+                deltaEl.hidden = false;
+            } else {
+                deltaEl.hidden = true;
+            }
+        }
 
         const prsStat = document.getElementById('summary-prs-stat');
         const prsValue = document.getElementById('summary-prs');
@@ -2420,6 +2704,17 @@ class WorkoutView {
         // Save workout session
         this.app.workoutSessions.push(this.currentWorkoutSession);
         this.app.saveWorkoutSessions();
+
+        // Integration 4: persistent per-exercise PR achievements. Fires only for
+        // exercises that beat their all-time best with 2+ prior sessions; the
+        // service persists + is idempotent by id and returns the new awards.
+        const newPRs = AchievementService.checkExercisePRs(this.currentWorkoutSession, this.app.workoutSessions);
+        if (newPRs.length > 0) {
+            this.app.achievements.push(...newPRs);
+            newPRs.forEach((pr) => {
+                showToast(`New PR: ${pr.prExerciseName} ${this._formatPrAchievementWeight(pr)}`, 'success', 4000);
+            });
+        }
 
         // Clear any paused workout from storage since we're finishing
         storageService.clearActiveWorkout();

--- a/apps/gym-tracker/tests/check-exercise-prs.test.mjs
+++ b/apps/gym-tracker/tests/check-exercise-prs.test.mjs
@@ -1,0 +1,149 @@
+// Tests for Feature 4: persistent per-exercise strength-PR achievements
+// (AchievementService.checkExercisePRs) and the Achievement.isRenderable
+// guard that keeps malformed/legacy PR records from rendering.
+process.env.TZ = 'UTC';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// In-memory localStorage shim so the StorageService singleton (imported
+// transitively by AchievementService) runs without a browser.
+globalThis.localStorage = {
+    _store: new Map(),
+    getItem(key) { return this._store.has(key) ? this._store.get(key) : null; },
+    setItem(key, value) { this._store.set(key, String(value)); },
+    removeItem(key) { this._store.delete(key); },
+    clear() { this._store.clear(); },
+};
+
+const { AchievementService } = await import('../js/services/AchievementService.js');
+const { storageService } = await import('../js/services/StorageService.js');
+const { Achievement } = await import('../js/models/Achievement.js');
+
+const reset = (weightUnit = 'kg') => {
+    localStorage.clear();
+    storageService.saveSettings({ weightUnit });
+};
+
+const session = (id, date, weight, opts = {}) => ({
+    id,
+    date,
+    exercises: [{
+        exerciseId: opts.exerciseId || 'incline-bb-bench',
+        exerciseName: opts.exerciseName || 'Incline Barbell Bench Press',
+        sets: [{ completed: true, weight, reps: 8, duration: opts.duration || 0 }],
+    }],
+});
+
+test('checkExercisePRs: awards a PR with weight, unit and date when the all-time best is beaten', () => {
+    reset('kg');
+    const all = [
+        session('s1', '2026-06-01', 60),
+        session('s2', '2026-06-05', 62.5),
+        session('s3', '2026-06-13', 70),
+    ];
+    const awarded = AchievementService.checkExercisePRs(all[2], all);
+    assert.equal(awarded.length, 1);
+    const json = awarded[0].toJSON();
+    assert.equal(json.id, 'pr-incline-bb-bench-2026-06-13');
+    assert.equal(json.requirement.type, 'strength-pr');
+    assert.equal(json.prWeightKg, 70);
+    assert.equal(json.prUnit, 'kg');
+    assert.equal(json.prExerciseName, 'Incline Barbell Bench Press');
+    assert.equal(json.prDate, '2026-06-13');
+    // Persisted to storage as well.
+    assert.equal((storageService.getAchievements() || []).length, 1);
+});
+
+test('checkExercisePRs: never produces a record without a positive weight or a date', () => {
+    reset('kg');
+    const all = [
+        session('s1', '2026-06-01', 80),
+        session('s2', '2026-06-05', 85),
+        session('s3', '2026-06-13', 90),
+    ];
+    const awarded = AchievementService.checkExercisePRs(all[2], all);
+    assert.equal(awarded.length, 1);
+    const json = awarded[0].toJSON();
+    assert.ok(typeof json.prWeightKg === 'number' && json.prWeightKg > 0, 'weight is positive');
+    assert.ok(json.prDate, 'date is present');
+    assert.equal(Achievement.isRenderable(awarded[0]), true);
+});
+
+test('checkExercisePRs: not awarded on the first-ever session for an exercise', () => {
+    reset('kg');
+    const all = [session('s1', '2026-06-13', 100)];
+    assert.equal(AchievementService.checkExercisePRs(all[0], all).length, 0);
+});
+
+test('checkExercisePRs: not awarded with only one prior session (needs 2+)', () => {
+    reset('kg');
+    const all = [
+        session('s1', '2026-06-01', 60),
+        session('s2', '2026-06-13', 70),
+    ];
+    assert.equal(AchievementService.checkExercisePRs(all[1], all).length, 0);
+});
+
+test('checkExercisePRs: not awarded when the top set does not strictly beat the best', () => {
+    reset('kg');
+    const all = [
+        session('s1', '2026-06-01', 70),
+        session('s2', '2026-06-05', 70),
+        session('s3', '2026-06-13', 70), // ties, does not beat
+    ];
+    assert.equal(AchievementService.checkExercisePRs(all[2], all).length, 0);
+});
+
+test('checkExercisePRs: idempotent by id on a repeated finish (no duplicate)', () => {
+    reset('kg');
+    const all = [
+        session('s1', '2026-06-01', 60),
+        session('s2', '2026-06-05', 62.5),
+        session('s3', '2026-06-13', 70),
+    ];
+    assert.equal(AchievementService.checkExercisePRs(all[2], all).length, 1);
+    assert.equal(AchievementService.checkExercisePRs(all[2], all).length, 0);
+    assert.equal((storageService.getAchievements() || []).length, 1);
+});
+
+test('checkExercisePRs: duration-type sets never earn a strength PR', () => {
+    reset('kg');
+    const all = [
+        session('s1', '2026-06-01', 0, { exerciseId: 'plank', exerciseName: 'Plank', duration: 30 }),
+        session('s2', '2026-06-05', 0, { exerciseId: 'plank', exerciseName: 'Plank', duration: 45 }),
+        session('s3', '2026-06-13', 0, { exerciseId: 'plank', exerciseName: 'Plank', duration: 60 }),
+    ];
+    assert.equal(AchievementService.checkExercisePRs(all[2], all).length, 0);
+});
+
+test('checkExercisePRs: in lb mode, stored weight is converted to canonical kg', () => {
+    reset('lb');
+    const all = [
+        session('s1', '2026-06-01', 135),
+        session('s2', '2026-06-05', 145),
+        session('s3', '2026-06-13', 155),
+    ];
+    const awarded = AchievementService.checkExercisePRs(all[2], all);
+    assert.equal(awarded.length, 1);
+    const json = awarded[0].toJSON();
+    assert.equal(json.prUnit, 'lb');
+    // 155 lb -> ~70.31 kg; stored canonical, rounded to 2 decimals.
+    assert.ok(Math.abs(json.prWeightKg - 70.31) < 0.05, `expected ~70.31 kg, got ${json.prWeightKg}`);
+});
+
+test('Achievement.isRenderable: rejects legacy strength-PR records missing weight or date', () => {
+    const noWeight = new Achievement({ id: 'pr-x-2026-06-13', requirement: { type: 'strength-pr' }, prDate: '2026-06-13' });
+    const zeroWeight = new Achievement({ id: 'pr-x-2026-06-13', requirement: { type: 'strength-pr' }, prWeightKg: 0, prDate: '2026-06-13' });
+    const noDate = new Achievement({ id: 'pr-x-2026-06-13', requirement: { type: 'strength-pr' }, prWeightKg: 70 });
+    const good = new Achievement({ id: 'pr-x-2026-06-13', requirement: { type: 'strength-pr' }, prWeightKg: 70, prDate: '2026-06-13' });
+    assert.equal(Achievement.isRenderable(noWeight), false);
+    assert.equal(Achievement.isRenderable(zeroWeight), false);
+    assert.equal(Achievement.isRenderable(noDate), false);
+    assert.equal(Achievement.isRenderable(good), true);
+});
+
+test('Achievement.isRenderable: always true for non strength-PR achievements', () => {
+    const milestone = new Achievement({ id: '5-workouts', requirement: { type: 'total-workouts' }, target: 5 });
+    assert.equal(Achievement.isRenderable(milestone), true);
+});


### PR DESCRIPTION
Round 3 improvements for **gym-tracker** plus a large owner-reviewed visual/UX redesign of the active-workout flow, rest timer, modals, the Edit Program header, and the mobile week calendar. Scope is gym-tracker only; no other app or site area is touched. All work is on this branch; nothing committed on master.

## Features

- **Persistent strength-PR achievements** — finishing a session whose top set beats the all-time best for an exercise (with 2+ prior sessions, reps-based only) awards a per-exercise PR shown in a new "Strength PRs" section on the Achievements screen.
- **Per-exercise strength-trend chart** — the history session detail now shows a small inline SVG trend of each exercise's top-set weight over recent sessions, plus any per-exercise notes.
- **Inline per-exercise notes** — a pencil toggle in each exercise header opens a notes field saved as you type (read-only in history).
- **"Same as last time" restore chip** — restores the previous session's weight/reps on a planned row.
- **Finish-modal volume delta** — total volume with a percentage delta vs the previous session of the same program.
- **Dropped this round** (were never shipped): the visible overload-nudge chip and the configurable Settings progression increment were removed at the owner's request; `_overloadIncrement` is back to the hardcoded 2.5 kg upper / 5 kg lower defaults.

## Bugfix found along the way

- **Malformed strength-PR records rendered "0 kg / Invalid Date".** Added `Achievement.isRenderable()`; the achievements loader filters and self-heals legacy/partial strength-PR records, and the achievements view guards against them at render time.

## Owner-driven redesign (visual + some behavior)

- Active workout: header restructured into an overflow ("...") menu (Edit program / Plate hints / Discard) with an inline kg/lb segment, Pause, and Finish; flattened exercise card, tighter set rows (no dashed borders), slimmer completion toggle, clearer "Add set". Collapsed cards hide the edit + plate-hint buttons; the notes pencil no longer flickers on tap and lights up live when a note exists.
- Rest timer: replaced the full-width banner with a compact floating circular dial used for BOTH rest types, color-coded **green between sets / blue between exercises**, countdown centered, with +30s and Skip as two equal pills inside the dial.
- Finish modal: Complete Workout full-width with Cancel as a centered text link below it. Feel modal: padding/spacing, equal-height buttons, smaller close, outline-SVG smiley.
- Edit Program: header per owner mockup (title + plain Cancel + blue Save, no separate X; "Save & resume" in workout-edit mode); scheduled-day chips are now identical fixed-size cells so selection changes color only.
- Mobile week calendar (workout selection): compact day pills (label + dot on workout days) with a selected-day detail panel and matching program-card highlight; tapping a day selects it (default selection = today).

## Changed files

- **apps/gym-tracker/js/services/AchievementService.js** — new `checkExercisePRs(finishedSession, allSessions)`: awards idempotent `pr-<exerciseId>-<date>` records (2+ prior sessions, reps-only), persists them, returns new awards.
- **apps/gym-tracker/js/models/Achievement.js** — optional PR metadata fields (prWeightKg/prUnit/prExerciseName/prDate) round-tripped in toJSON; new static `isRenderable()` guard.
- **apps/gym-tracker/js/app.js** — achievements loader filters non-renderable records and self-heals storage on load.
- **apps/gym-tracker/js/views/achievements-view.js** — renders the distinct "Strength PRs" section; excludes PR records from the category machinery; applies the isRenderable guard.
- **apps/gym-tracker/js/views/history-view.js** — per-exercise inline strength-trend SVG (reps-type, 3+ prior sessions, y-floor below min) + read-only per-exercise notes block in the session detail.
- **apps/gym-tracker/js/views/workout-view.js** — the bulk: per-exercise notes capture, restore chip, finish-modal volume delta, PR-check call on finish; reverted overload-chip/`_overloadIncrement` integrations; rest-timer rewired to the floating dial for both rest types (showRestBar(restType)/onRestTick/onRestComplete drive the ring + color class + caption); mobile week-calendar `_renderWeekStripHTML` rewrite (day pills + detail) + new `select-week-day` action + scheduled-card highlight.
- **apps/gym-tracker/js/views/programs-view.js** — "SUPERSET" tag → "Superset" (Title Case).
- **apps/gym-tracker/index.html** — header overflow menu; rest-timer dial markup (SVG ring + two pill actions); feel-modal outline-SVG smiley; finish-modal stacked actions; program-modal header (Cancel + Save, no X); per-exercise notes region; volume-delta element.
- **apps/gym-tracker/css/gym-tracker.css** — rest-timer dial + color coding, feel/finish modal polish, set-toggle resize, schedule-day equal cells, program-modal header (plain Cancel), week-strip pills/detail, program-card highlight; removed dead header-button CSS.
- **apps/gym-tracker/css/refresh.css** — active-workout component layer (`.gt-iconbtn`, `.gt-segment`, overflow menu, flattened card, set rows, notes, restore chip, volume delta, strength-PR + trend-chart styles); collapsed-card icon hide; tap-highlight suppression.
- **apps/gym-tracker/tests/check-exercise-prs.test.mjs** — new: 10 tests for `checkExercisePRs` (award/skip cases, idempotency, duration-skip, lb→kg conversion) + `isRenderable`.
- **apps/gym-tracker/README.md** — documents the new features (Strength PRs, history trend chart, inline notes, restore chip, volume delta, floating rest dial, day-pill week strip).

## Explicitly untouched

- No other app or site area, no shared/site files, no Netlify config. Auto-progression prefill behavior is unchanged (only the visible chip + Settings control were removed). The between-set in-card chip remains as the static planned-rest indicator.

## Judgment calls

- Rest-timer color mapping (owner said "up to you"): green between sets, blue between exercises.
- Edit Program field labels kept Title Case and the Single/Range toggle kept as a button (owner chose both when the mockups were ambiguous).

## Testing

- `npm test`: **1112 pass / 0 fail** (root `node --test` across all apps + sync-system), including the new check-exercise-prs suite.
- Living plan pair `.features/gym-tracker-claude.md` + `-human.md` updated (local-only/gitignored): Run 11 covered R3 sections (101 pass / 0 fail / 16 unverified after the failure-loop fix), plus a "Design round (2026-06-13)" report entry and matching manual-check list for this redesign pass.

## Needs manual verification (also in the human plan)

- Rest timer live ring-drain + correct color per real rest type; done/urgent states.
- Mobile week calendar: tapping a day updates the detail + highlights the right card; today auto-selected.
- Modal layouts (finish/feel/edit-program) at 390px; overflow menu open/keyboard/Escape; collapsed-card icons hidden; Strength-PR card after a real PR.
