### PR TITLE
fix(theme): pin app button styles defeated by main.css, restore gym-tracker backdrop

### DIFF
--- a/apps/arena/css/styles.css
+++ b/apps/arena/css/styles.css
@@ -350,6 +350,9 @@ body.brain-arena-app button {
   border-radius: 999px;
   background: transparent;
   color: var(--muted-2) !important;
+  /* Pin off main.css's global `button` gray ring (inset 0 0 0 1px #555);
+     an inactive pill is borderless. The .is-active variant sets its own. */
+  box-shadow: none !important;
   font-size: 0.9rem;
   font-weight: 500;
   letter-spacing: 0.015em;
@@ -361,6 +364,7 @@ body.brain-arena-app button {
   background: rgba(34, 211, 238, 0.05);
   border-color: rgba(34, 211, 238, 0.20);
   color: var(--text) !important;
+  box-shadow: none !important;
 }
 .view-tab.is-active,
 .view-tab.is-active:hover {
@@ -979,6 +983,9 @@ select option { background: var(--surface); color: var(--text); }
      dim against the recessed track; bumped up to a soft white so
      the option clearly looks clickable. */
   color: #d1d5db !important;
+  /* Pin off main.css's global `button` gray ring (inset 0 0 0 1px #555);
+     an inactive segment is borderless. The .is-active variant sets its own. */
+  box-shadow: none !important;
   font: inherit;
   font-size: 0.9rem;
   font-weight: 600;
@@ -993,6 +1000,7 @@ select option { background: var(--surface); color: var(--text); }
 .game-type-btn:hover {
   color: #ffffff !important;
   background: rgba(255, 255, 255, 0.04);
+  box-shadow: none !important;
 }
 .game-type-btn.is-active,
 .game-type-btn.is-active:hover {

--- a/apps/football-h2h/css/football-h2h.css
+++ b/apps/football-h2h/css/football-h2h.css
@@ -649,8 +649,10 @@
     border-radius: 0.5rem;
     background: #374151;
     /* color pinned !important across inactive/hover/active so the sitewide
-       theme trap can't gray the tabs or turn them red on hover. */
+       theme trap can't gray the tabs or turn them red on hover. box-shadow
+       pinned to kill the trap's inset #555 ring (these tabs are borderless). */
     color: #e2e8f0 !important;
+    box-shadow: none !important;
     cursor: pointer;
     transition: all 0.3s ease;
     font-weight: 500;
@@ -1662,7 +1664,11 @@
     background: rgba(255, 255, 255, 0.1);
     border: none;
     font-size: 1.75rem;
-    color: white;
+    /* color + box-shadow pinned !important across base/hover/active so the
+       sitewide theme trap can't gray the white close glyph, paint it red on
+       hover, or add its inset #555 ring (this button is borderless). */
+    color: #ffffff !important;
+    box-shadow: none !important;
     cursor: pointer;
     line-height: 1;
     padding: 0;
@@ -1675,8 +1681,11 @@
     transition: all 0.2s ease;
 }
 
-.modal-close:hover {
+.modal-close:hover,
+.modal-close:hover:active {
     background: rgba(255, 255, 255, 0.25);
+    color: #ffffff !important;
+    box-shadow: none !important;
     transform: scale(1.05);
 }
 

--- a/apps/football-h2h/css/refresh.css
+++ b/apps/football-h2h/css/refresh.css
@@ -487,6 +487,9 @@ body.football-h2h-tracker .sidebar-header-clear {
     background: rgba(255, 255, 255, 0.03) !important;
     border: 1px solid var(--fh-border) !important;
     color: var(--fh-muted) !important;
+    /* Kill the sitewide theme trap's inset #555 ring (main.css
+       button{box-shadow: inset 0 0 0 1px #555}); this chip is border-only. */
+    box-shadow: none !important;
     border-radius: 8px !important;
     transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
@@ -750,6 +753,9 @@ body.football-h2h-tracker.theme .sidebar-date-today-btn:hover {
 body.football-h2h-tracker .sidebar-toggle,
 body.football-h2h-tracker.theme .sidebar-toggle {
     background: linear-gradient(135deg, var(--fh-accent), var(--fh-accent-strong)) !important;
+    /* Pin white so the sitewide theme trap (main.css button{color:#555!important})
+       can't gray the hamburger icon's currentColor. */
+    color: #ffffff !important;
     box-shadow: 0 6px 20px rgba(99, 102, 241, 0.35) !important;
     border: 1px solid rgba(255, 255, 255, 0.08) !important;
 }

--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -170,6 +170,17 @@ body.gym-tracker #footer {
     -webkit-tap-highlight-color: transparent;
 }
 
+/* main.css paints inset 0 0 0 1px #555 (gray) / #ce1b28 (red hover) on every
+   <button>; the bottom-nav items are borderless so it leaks as a ring. Pin it
+   off across base/hover/active (the active tab uses a background pill, not a
+   ring). Caught on the 390px mobile bottom-nav. */
+.bottom-nav .nav-item,
+.bottom-nav .nav-item:hover,
+.bottom-nav .nav-item:hover:active,
+.bottom-nav .nav-item.active {
+    box-shadow: none !important;
+}
+
 .bottom-nav .nav-item:hover:not(.active) {
     color: #ffffff !important;
     background: rgba(255, 255, 255, 0.04);

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -55,14 +55,10 @@ body.gym-tracker {
     color-scheme: dark;
 }
 
-/* The shared marketing-site backdrop (body::before = a fixed bg.jpg gym photo)
-   bleeds through the app's transparent content areas, making sparse views look
-   busy and unprofessional. Replace it with the app's own dark azure gradient so
-   every view sits on one clean, opaque canvas. */
-body.gym-tracker::before {
-    background-image: var(--gt-bg-grad) !important;
-    background-color: var(--gt-bg) !important;
-}
+/* Keep the shared marketing-site backdrop (main.css `body::before` = a fixed
+   bg.jpg photo at 5% opacity) so Gym Tracker carries the same faint site
+   texture as the other apps, layered over the app's own dark azure body
+   gradient. */
 
 /* ---------- Typography ---------- */
 
@@ -142,6 +138,15 @@ body.gym-tracker .section {
         -webkit-text-fill-color: transparent;
     }
 
+    body.gym-tracker .side-nav .nav-link,
+    body.gym-tracker .side-nav .nav-link:hover,
+    body.gym-tracker .side-nav .nav-link:hover:active {
+        /* main.css paints inset 0 0 0 1px #555 (gray) / #ce1b28 (red hover)
+           on every <button>; nav links are borderless so it shows as a ring.
+           Pin box-shadow off; .active re-asserts its accent marker below. */
+        box-shadow: none !important;
+    }
+
     body.gym-tracker .side-nav .nav-link {
         font-size: 0.9rem;
         font-weight: 500;
@@ -168,10 +173,11 @@ body.gym-tracker .section {
     body.gym-tracker .side-nav .nav-link:hover i,
     body.gym-tracker .side-nav .nav-link:hover span { color: var(--gt-text); }
 
-    body.gym-tracker .side-nav .nav-link.active {
+    body.gym-tracker .side-nav .nav-link.active,
+    body.gym-tracker .side-nav .nav-link.active:hover {
         background: var(--gt-accent-soft);
         color: var(--gt-text) !important;
-        box-shadow: inset 2px 0 0 var(--gt-accent);
+        box-shadow: inset 2px 0 0 var(--gt-accent) !important;
     }
     body.gym-tracker .side-nav .nav-link.active i,
     body.gym-tracker .side-nav .nav-link.active span {
@@ -364,6 +370,7 @@ body.gym-tracker .btn-text:hover,
 body.gym-tracker .btn-text:hover:active {
     background: transparent;
     border-color: transparent;
+    box-shadow: none !important;
     font-weight: 500;
 }
 body.gym-tracker .btn-text { color: var(--gt-muted) !important; }
@@ -494,6 +501,13 @@ body.gym-tracker .modal-close {
     border-radius: 50%;
     font-size: 1rem;
     transition: background 0.15s ease, border-color 0.15s ease;
+}
+/* main.css's inset 1px #555/#ce1b28 ring paints a square inside this circle;
+   pin it off across base/hover/active (focus-visible ring untouched). */
+body.gym-tracker .modal-close,
+body.gym-tracker .modal-close:hover,
+body.gym-tracker .modal-close:hover:active {
+    box-shadow: none !important;
 }
 body.gym-tracker .modal-close:hover {
     background: var(--gt-surface-2);

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -3431,7 +3431,8 @@ body.maptap-rivals-app select option {
    current icon, with a floating grid flyout that mirrors the rival
    icon-swatch palette but at a slightly tighter density. */
 .my-icon-wrap { position: relative; display: inline-flex; }
-.my-icon-btn {
+.my-icon-btn,
+.my-icon-btn:hover {
   width: 28px;
   height: 28px;
   border-radius: 7px;
@@ -3444,6 +3445,8 @@ body.maptap-rivals-app select option {
   padding: 0;
   font-size: 1.02rem;
   line-height: 1;
+  color: var(--text) !important;
+  box-shadow: none !important;
   transition: background 0.15s ease, border-color 0.15s ease;
 }
 .my-icon-btn:hover { background: var(--surface-3); border-color: var(--border-strong); }

--- a/apps/mario-kart/css/refresh.css
+++ b/apps/mario-kart/css/refresh.css
@@ -655,6 +655,17 @@ body.mario-kart-app .sidebar-date-today-btn:hover {
 
 /* Sidebar toggle button (the hamburger floating outside the sidebar) */
 body.mario-kart-app .sidebar-toggle,
+body.mario-kart-app.theme .sidebar-toggle,
+body.mario-kart-app .sidebar-toggle:hover,
+body.mario-kart-app.theme .sidebar-toggle:hover,
+body.mario-kart-app .sidebar-toggle:hover:active,
+body.mario-kart-app.theme .sidebar-toggle:hover:active {
+    /* color pinned to beat global `button{color:#555!important}` /
+       `button:hover{color:#ce1b28!important}` from assets/css/main.css */
+    color: #fff !important;
+}
+
+body.mario-kart-app .sidebar-toggle,
 body.mario-kart-app.theme .sidebar-toggle {
     background: linear-gradient(135deg, var(--mk-accent), var(--mk-accent-strong)) !important;
     box-shadow: 0 6px 20px rgba(99, 102, 241, 0.35) !important;

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -4652,6 +4652,8 @@ body.advanced-drawer-open {
   background: rgba(245, 197, 24, 0.06);
   border-color: rgba(245, 197, 24, 0.32);
   color: #FFFFFF !important;
+  /* Pin to defeat global main.css button:hover red ring (#ce1b28). */
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset !important;
   transform: translateY(-1px);
 }
 .sticky-shape-chip.is-active,

--- a/assets/css/moadon-alef-theme.css
+++ b/assets/css/moadon-alef-theme.css
@@ -35,7 +35,12 @@
   padding: 12px 24px;
   border: 2px solid var(--medical-blue);
   background: white;
-  color: var(--medical-blue);
+  /* main.css paints `button{color:#555!important; box-shadow: inset 0 0 0 1px
+     #555}` and `button:hover{color:#ce1b28!important}` on every <button>; pin
+     color + ring across base/hover/active so the brand blue/white wins and no
+     gray ring or red hover text leaks onto the green pill. */
+  color: var(--medical-blue) !important;
+  box-shadow: none !important;
   border-radius: 25px;
   cursor: pointer;
   font-weight: 600;
@@ -47,7 +52,8 @@
 
 .lang-btn:hover {
   background: #28a745;
-  color: white;
+  color: white !important;
+  box-shadow: none !important;
   border-color: #28a745;
   transform: translateY(-2px);
 }
@@ -55,7 +61,8 @@
 
 .lang-btn.active {
   background: #28a745;
-  color: white;
+  color: white !important;
+  box-shadow: none !important;
   border-color: #28a745;
 }
 


### PR DESCRIPTION
## Summary

Sitewide theme-collision audit. `assets/css/main.css` applies global `!important`
rules to every `<button>` — gray `#555` text + inset gray ring at rest, red
`#ce1b28` text/ring on hover, and a red `rgba(206,27,40,0.25)` wash when pressed —
that silently defeat app button styles regardless of specificity. Every app and
root page that links `main.css` was probed in **rendered** form
(`getComputedStyle` in headless Chrome) across base / hover / pressed states at
desktop 1280 and mobile 390. Each true collision was fixed by pinning the
intended color/ring with `!important` across base/`:hover`/`:hover:active` (the
established idiom). `assets/css/main.css` was deliberately left untouched.

Also bundled: restoring the shared site backdrop on Gym Tracker (visual
consistency, not a collision — see below).

## Changed files

**`apps/arena/css/styles.css`** — `.view-tab` (Lobby/Globe Drop/Trivia pills) and
`.game-type-btn` segments were leaking main.css's inset `#555` ring; both are
intentionally borderless, so pinned `box-shadow: none !important` on base +
`:hover`. `.is-active` variants (which set their own ring) left untouched.

**`apps/football-h2h/css/football-h2h.css`** — `.category-btn` icon-picker tabs:
added `box-shadow: none !important` (borderless tabs, gray ring leaked; text was
already pinned). `.modal-close`: pinned `color: #ffffff !important` +
`box-shadow: none !important` across base and a new combined
`:hover, :hover:active` rule (glyph was grayed at rest and would go red on hover).

**`apps/football-h2h/css/refresh.css`** — `.sidebar-toggle`: pinned
`color: #ffffff !important` (icon `currentColor` was grayed).
`.sidebar-close-btn` / `.sidebar-header-clear`: `box-shadow: none !important`
(border-only chips; inset `#555` ring leaked).

**`apps/gym-tracker/css/refresh.css`** — two changes:
(1) `.side-nav .nav-link` (+ `:hover`/`:hover:active`): `box-shadow: none
!important`, with `.nav-link.active`/`.active:hover` re-asserting its accent
marker as `!important`; `.btn-text` and `.modal-close` rings pinned off too.
(2) **Backdrop restore** — removed the `body.gym-tracker::before` override that
had replaced main.css's shared `bg.jpg` overlay (fixed, 5% opacity) with the
app's gradient, so Gym Tracker now carries the same faint site texture as every
other app. Owner-approved after eyeballing desktop + mobile.

**`apps/gym-tracker/css/gym-tracker.css`** — `.bottom-nav .nav-item`
(+ `:hover`/`:hover:active`/`.active`): added `box-shadow: none !important`. The
mobile bottom-nav items are borderless and never declared a box-shadow, so
main.css's gray ring leaked around every tab on the 390px viewport. Caught on
mobile; desktop probes had missed it.

**`apps/maptap-rivals/css/styles.css`** — `.my-icon-btn` (+ `:hover`): pinned
`color: var(--text) !important` + `box-shadow: none !important` (button rendered
gray with a gray ring).

**`apps/mario-kart/css/refresh.css`** — `.sidebar-toggle` (+ `.theme` variant,
base/hover/pressed): pinned `color: #fff !important`. The floating hamburger
glyph rendered gray; its indigo glow ring was already correct and kept.

**`apps/rising-seasons/css/styles.css`** — `.sticky-shape-chip:hover`: pinned a
subtle inset `box-shadow ... !important` so the chip keeps its gold accent
instead of inheriting main.css's red hover ring.

**`assets/css/moadon-alef-theme.css`** — `.lang-btn` base/`:hover`/`.active`:
pinned `color` (`var(--medical-blue)` inactive, `white` active+hover) +
`box-shadow: none !important`. The language buttons rendered with gray
low-contrast text (worst on the green active "English" pill) and would flash red
text on hover.

## Deliberate non-changes

- **`assets/css/main.css`** — explicitly untouched; it is the shared marketing
  theme and the fixes live in each app's own CSS by design.
- **apps.html** — its filter pills and card CTAs render as the marketing site's
  native gray-outline → red-hover Phantom theme with no competing custom CSS;
  that is the intended brand styling, not an app-vs-theme collision, so left
  as-is.
- **home / about / work / contact / 404** — probed clean, no changes.

## Judgment calls

- Gym Tracker bottom-nav, MapTap my-icon, Mario Kart toggle, etc. were pinned to
  values read from each app's own tokens/siblings (white icons on accent
  backgrounds, brand blue/white on language pills, `var(--text)`/`var(--mk-text)`
  where applicable) — no colors were guessed.
- The Gym Tracker backdrop restore is a visual-consistency call the owner
  approved this round; it is the one non-collision change in the diff.

## Testing

- `npm test` → **1112 pass, 0 fail**.
- Detection + re-verification via rendered `getComputedStyle` probes across
  base/hover/pressed × desktop 1280 / mobile 390 for all 6 apps
  (rising-seasons ×2 pages) and all 7 root pages linking main.css; every fix
  re-probed to `COLLISIONS=0`.
