### PR TITLE
fix(arena): remove non-functional leaderboard category dropdown

### DIFF
--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -827,17 +827,6 @@
               <option value="week">Last 7 days</option>
             </select>
           </label>
-          <label class="lobby-field">
-            <span>Category</span>
-            <select id="leaderboard-category">
-              <option value="all">All categories</option>
-              <option value="geography">Geography</option>
-              <option value="science">Science</option>
-              <option value="history">History</option>
-              <option value="pop-culture">Pop culture</option>
-              <option value="sports">Sports</option>
-            </select>
-          </label>
         </div>
       </header>
 

--- a/apps/arena/js/app.js
+++ b/apps/arena/js/app.js
@@ -6465,7 +6465,6 @@ function wireH2H() {
 
 function wireLeaderboard() {
     $('#leaderboard-period').addEventListener('change', renderLeaderboardEntries);
-    $('#leaderboard-category').addEventListener('change', renderLeaderboardEntries);
     bindLeaderboardSortHandlers();
     // Admin: delete-row clicks. Delegated to the leaderboard body so we
     // don't have to re-bind on every render.


### PR DESCRIPTION
## Summary

Removes the non-functional **Category** dropdown from Arena's Global leaderboard.

The dropdown (All categories / Geography / Science / History / Pop culture /
Sports) had a wired change-listener (`#leaderboard-category` →
`renderLeaderboardEntries`), but the render function never read its value: it
only filters by time period. The leaderboard is a single per-player **lifetime
aggregate** (`xp`, `wins`, `gamesPlayed`, `lifetimeBullseyes`, `bestRoundScore`,
`lastPlayedAt`) - confirmed in the write path `writeEndOfGameStats` and the
`startLeaderboardListener` snapshot - with **no category dimension** stored
anywhere. So the control could never filter anything; it silently did nothing
and misrepresented what the board can do.

Per the owner's call, the dead control was removed rather than building
per-category leaderboard tracking (which would require a schema change to record
per-category aggregates at write time, a new filter/rank path, and would leave
existing players with no category history - a feature, not a bug fix).

## Changed files

**`apps/arena/index.html`** - removed the Category `<label>`/`<select>` block
(6 options) from the leaderboard filter header. The Time-period filter is left
in place.

**`apps/arena/js/app.js`** - removed the dead
`$('#leaderboard-category').addEventListener('change', renderLeaderboardEntries)`
line in `wireLeaderboard()`. No other code referenced the element.

## Deliberate non-changes

- **`renderLeaderboardEntries` filter logic** - untouched; the Time-period
  filter and sortable columns already work and were not modified.
- **Leaderboard data model / write path** - untouched; no per-category schema
  was added (explicitly out of scope per the owner decision).
- **arena README** - already accurate after the prior docs round ("Global score
  leaderboard (filterable by time period) plus a separate Daily challenge
  board"); it never claimed category filtering, so no edit was needed.

## Verification

- DOM-verified the rendered leaderboard filter bar now contains only
  `#leaderboard-period` and no `#leaderboard-category` (labels: ["Time period"]).
- `grep` confirms zero remaining `leaderboard-category` references in `apps/arena`.
- `npm test` → **1112 pass, 0 fail**.
- The leaderboard view is Firebase/auth-gated, so live in-app confirmation is
  routed to the Arena human test plan (new section 33).
