### PR TITLE
feat(site): focus rings, 404 recovery, sitemap freshness, a11y labels, Person schema

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,7 +6,7 @@
     <meta name="color-scheme" content="light" />
     <meta name="theme-color" content="#ffffff" />
     <title>404 – Page Not Found | Shevato</title>
-    <meta name="description" content="The page you requested could not be found on shevato.com. You will be redirected to the home page." />
+    <meta name="description" content="The page you requested could not be found on shevato.com. Use the links to head to the home, work, or apps pages." />
     <meta name="robots" content="noindex, follow" />
 
     <!-- Resource hints -->
@@ -38,24 +38,23 @@
 
 <main id="main-content" class="wrapper wrapper-inherit-padding">
     <div class="inner">
-        <header class="special">
-            <h2>
-                <img src="/images/full-logo.svg" alt="Shevato – Expert Software Engineering Services Logo" width="250" height="219" fetchpriority="high" decoding="async">
-            </h2>
-            <p>Sorry, we couldn’t find that page.</p>
+        <div class="hero">
             <p>
-                Redirecting to our <a href="/">home page</a> in
-                <strong><span id="redirect-countdown" aria-live="polite" aria-atomic="true">5</span> seconds</strong>.
+                <img class="hero-logo" src="/images/full-logo.svg" alt="Shevato, Expert Software Engineering Services Logo" width="250" height="219" fetchpriority="high" decoding="async">
             </p>
-        </header>
+            <h1>Page not found</h1>
+            <p class="lede">Sorry, we could not find that page. Try one of these instead.</p>
+            <div class="cta-row">
+                <a href="/home.html" class="button primary">Home</a>
+                <a href="/work.html" class="button ghost">Work</a>
+                <a href="/apps.html" class="button ghost">Apps</a>
+            </div>
+        </div>
     </div>
 </main>
 
 <!-- footer include -->
 <div data-include="footer"></div>
-
-<!-- countdown + redirect script -->
-<script defer src="/assets/js/redirect-countdown.js"></script>
 
 <!-- Scripts: deferred so they run in document order after parse, before DOMContentLoaded. -->
 <script defer src="/assets/js/passive-events-fix.js"></script>

--- a/about.html
+++ b/about.html
@@ -66,6 +66,17 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Nikita Soifer",
+    "jobTitle": "Software Engineer",
+    "url": "https://www.linkedin.com/in/nikita-soifer/",
+    "worksFor": { "@id": "https://shevato.com/#organization" }
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
       { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },

--- a/apps.html
+++ b/apps.html
@@ -196,7 +196,7 @@
             </header>
             <p>An installable PWA for logging workouts, building programs, and watching your numbers move. Works offline once installed.</p>
             <ul class="actions special">
-              <li><a href="apps/gym-tracker/" class="button">Start Tracking</a></li>
+              <li><a href="apps/gym-tracker/" class="button" aria-label="Start Tracking, Gym Tracker">Start Tracking</a></li>
             </ul>
           </div>
         </section>
@@ -208,7 +208,7 @@
             </header>
             <p>Real-time multiplayer hub for private rooms with friends. Create a room, share an invite link, and play across a growing collection of games: Globe Drop geography (pin cities on a 3D globe), head-to-head Trivia, and more on the way.</p>
             <ul class="actions special">
-              <li><a href="apps/arena/" class="button">Open Arena</a></li>
+              <li><a href="apps/arena/" class="button" aria-label="Open Arena, Arena">Open Arena</a></li>
             </ul>
           </div>
         </section>
@@ -220,7 +220,7 @@
             </header>
             <p>Head-to-head football match recorder. Scores, penalty shootouts, team selections, and a player comparison table for the long-running rivalry at home.</p>
             <ul class="actions special">
-              <li><a href="apps/football-h2h/" class="button">View League</a></li>
+              <li><a href="apps/football-h2h/" class="button" aria-label="View League, Football H2H League">View League</a></li>
             </ul>
           </div>
         </section>
@@ -232,7 +232,7 @@
             </header>
             <p>Log daily MapTap.gg head-to-head scores against named friends. Win streaks, averages, per-rival dashboards, time-boxed rivalry seasons, and a calendar heatmap of daily activity.</p>
             <ul class="actions special">
-              <li><a href="apps/maptap-rivals/" class="button">Track Rivals</a></li>
+              <li><a href="apps/maptap-rivals/" class="button" aria-label="Track Rivals, MapTap Rivals">Track Rivals</a></li>
             </ul>
           </div>
         </section>
@@ -244,7 +244,7 @@
             </header>
             <p>Log Mario Kart races, track player stats over time, and dig into performance with charts and achievements.</p>
             <ul class="actions special">
-              <li><a href="apps/mario-kart/" class="button">Track Races</a></li>
+              <li><a href="apps/mario-kart/" class="button" aria-label="Track Races, Mario Kart Tracker">Track Races</a></li>
             </ul>
           </div>
         </section>
@@ -256,7 +256,7 @@
             </header>
             <p>Find TV shows by the shape of their episode ratings. Rising, consistent, slow-burn, big-finale, or rebound seasons across thousands of shows.</p>
             <ul class="actions special">
-              <li><a href="apps/rising-seasons/" class="button">Browse Seasons</a></li>
+              <li><a href="apps/rising-seasons/" class="button" aria-label="Browse Seasons, Rising Seasons">Browse Seasons</a></li>
             </ul>
           </div>
         </section>

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -581,6 +581,22 @@ body {
   box-shadow: none;
 }
 
+/* Keyboard focus rings (Item 1) -------------------------------------------- */
+/* main.css sets `outline:0` on inputs and paints buttons gray/red via global
+   `!important`, so keyboard users get no visible focus indicator on the
+   marketing-page CTAs, filter buttons, preview cards, and contact tiles.
+   Pin a single brand-blue ring via :focus-visible (not :focus, so a mouse
+   click leaves no permanent ring). The skip-link keeps its own ring from
+   brand-colors.css and is intentionally not overridden here. */
+.hero .cta-row .button:focus-visible,
+.cta-banner .cta-button:focus-visible,
+.app-filter-bar button:focus-visible,
+.preview-card:focus-visible,
+.contact-methods a:focus-visible {
+  outline: 2px solid var(--brand-blue) !important;
+  outline-offset: 2px !important;
+}
+
 /* NOTE: styles for the SHARED header/footer partials (.header-inline-nav,
    the desktop menu-toggle hide, #menu aria-current, and the footer two-column
    layout) live in main.css instead of here, because the apps load main.css

--- a/sitemap-pages.xml
+++ b/sitemap-pages.xml
@@ -17,7 +17,7 @@
 
   <url>
     <loc>https://shevato.com/about.html</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -31,7 +31,7 @@
 
   <url>
     <loc>https://shevato.com/apps.html</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -49,35 +49,35 @@
 
   <url>
     <loc>https://shevato.com/apps/mario-kart/</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://shevato.com/apps/gym-tracker/</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://shevato.com/apps/gym-tracker/exercises/</loc>
-    <lastmod>2026-05-18</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://shevato.com/apps/football-h2h/</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://shevato.com/apps/rising-seasons/</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -98,14 +98,14 @@
 
   <url>
     <loc>https://shevato.com/apps/maptap-rivals/</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://shevato.com/apps/arena/</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -9,7 +9,7 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>https://shevato.com/sitemap-pages.xml</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-13</lastmod>
   </sitemap>
   <sitemap>
     <loc>https://shevato.com/apps/rising-seasons/sitemap-shows.xml</loc>


### PR DESCRIPTION
## Summary

Five site-level improvements to the Shevato marketing pages (accessibility, SEO,
and the 404 page). All ideated from a `shevato-pm` pass, then narrowed: of the
PM's 10 proposals, three were already implemented in production (verified live),
one was not a real bug, and two were deferred as owner decisions (see below).

## Changed files

**`assets/css/site.css`** - added a `:focus-visible` block (brand-blue
`outline: 2px solid var(--brand-blue)` = `rgb(0,68,204)`, `outline-offset: 2px`,
pinned `!important` to beat the theme's global `outline:0`) covering
`.hero .cta-row .button`, `.cta-banner .cta-button`, `.app-filter-bar button`,
`.preview-card`, `.contact-methods a`. Keyboard users now get a visible focus
indicator on the home CTAs, work CTA banner, apps filter, preview cards, and
contact tiles. Uses `:focus-visible` (not `:focus`), so mouse clicks leave no
ring; the skip-link's existing ring (in `brand-colors.css`) is untouched.

**`apps.html`** - added `aria-label="<visible text>, <App name>"` to all six app
CTA button anchors (e.g. "Start Tracking, Gym Tracker") so screen readers
announce which app each generic-text button opens. Visible text and the icon
links are unchanged.

**`404.html`** - replaced the 5-second auto-redirect-to-home with explicit
recovery: a real text `<h1>Page not found</h1>` (the logo was previously the
sole content of the heading - now moved into its own element with alt/dimensions
kept), an apology line, and three button links (Home primary, Work + Apps ghost,
colors pinned). Removed the countdown paragraph and the
`redirect-countdown.js` script tag (the JS file is left in the repo, just no
longer loaded). Meta description rewritten to drop the "you will be redirected"
language. `robots: noindex, follow` unchanged.

**`about.html`** - added a `Person` JSON-LD node (`name` "Nikita Soifer",
`jobTitle` "Software Engineer", `url` LinkedIn) whose `worksFor` references the
existing Organization by `@id` (`https://shevato.com/#organization`) without
duplicating that node - improves entity disambiguation in Google's knowledge
graph.

**`sitemap-pages.xml`** - refreshed `<lastmod>` to `2026-06-13` for the six app
landing pages (arena, football-h2h, gym-tracker, maptap-rivals, mario-kart,
rising-seasons) + gym-tracker/exercises + about.html + apps.html (the pages with
genuine recent changes), so Google recrawls them. Other entries left at their
real dates.

**`sitemap.xml`** - bumped the `sitemap-pages.xml` index `<lastmod>` to
`2026-06-13`.

## Deliberate non-changes

- **`assets/css/main.css`, `partials/footer.html`** - explicitly untouched
  (reverted to master). A "Built on Netlify." footer line was implemented during
  this round and then removed before ship: a third-party vendor credit in the
  footer is off-brand for a software-engineering firm. The valuable half of that
  proposal (the Person schema) shipped.
- **Performance hints (preconnect / Font Awesome defer) and the `robots` meta
  with `max-image-preview:large`** - PM flagged these as gaps, but all five
  marketing pages already have them in production. No change needed.
- **apps.html CSS load order** - PM flagged it; verified `brand-colors.css`
  already precedes `site.css` on every page, so there is no FOUC/missing-variable
  risk. No change.

## Owner decisions (deferred, NOT changed)

- **Canonical URLs `.html` -> extensionless** - left as-is. Both forms serve 200,
  the current canonical already consolidates on `.html`, internal links and the
  sitemap are consistently `.html`, and netlify.toml documents a prior root
  de-indexing incident. A real migration (canonical + every internal link +
  301s) carries risk for no clear gain; not bundled here.
- **Linking Moadon Alef from the main nav/footer** - left unlinked. It is a
  separately-branded Hebrew medical-service landing for a different audience;
  cross-linking it from the English consulting site is a brand call the owner
  chose to leave as-is.

## Testing

- `npm test` -> **1112 pass, 0 fail**.
- Acceptance plan: `.features/site-claude.md` + `.features/site-human.md`
  sections 25-29; latest run report **51/59 passed, 4 unverified, 1 plan-error
  corrected** (the "fail" was the plan naming the wrong CSS file for the
  unchanged skip-link rule; the 4 unverified are the footer DOM probes, now moot
  after the footer revert).
- Needs a human (in `site-human.md`): real keyboard-Tab `:focus-visible`
  activation across home/work/apps/contact (headless can't dispatch real Tab),
  and the 404 page recovery-link layout at 1280 + 390.
