### PR TITLE
fix(maptap-rivals): sync games from MapTap's iOS rounds shape

### DIFF
--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -146,7 +146,7 @@
   const {
     N_LOCS, WEIGHTS, MAX_RAW,
     weightedTotal, predTotalFromScores, hasLocs, iPlayed, theyPlayed, bothPlayed, arrEq,
-    getMyTotal, getTheirTotal, parseMapTapScore,
+    getMyTotal, getTheirTotal, parseMapTapScore, mapTapHistoryToRounds,
     resultOf, resultLoc, stdDev, average, streaks, linearTrend, projectNext,
     rivalryScoreFromGames,
   } = window.MapTapStats;
@@ -4973,24 +4973,8 @@
     return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
   }
 
-  // Convert profile.gameHistory into { "YYYY-MM-DD": { scores: number[5], cities: {lat,lng,name}[5] } }.
-  // Rejects entries missing a clean 5-round breakdown so we never store
-  // partial data — those days just won't pair.
-  function mapTapHistoryToRounds(gameHistory) {
-    const out = {};
-    for (const [date, entry] of Object.entries(gameHistory || {})) {
-      if (!entry || !Array.isArray(entry.roundData) || entry.roundData.length !== 5) continue;
-      const scores = entry.roundData.map(r => Number(r.score));
-      if (!scores.every(s => Number.isFinite(s) && s >= 0 && s <= 100)) continue;
-      const cities = entry.roundData.map(r => ({
-        lat: Number(r.cityLat),
-        lng: Number(r.cityLng),
-        name: typeof r.cityName === 'string' ? r.cityName : '',
-      }));
-      out[date] = { scores, cities };
-    }
-    return out;
-  }
+  // mapTapHistoryToRounds lives in stats.js (bound at the top of this IIFE) so
+  // the profile-history → per-day-rounds conversion can be unit-tested in node.
 
   // Geographic continent from (lat, lng). Order matters — overlapping
   // bounding boxes are resolved by the first matching rule (Africa

--- a/apps/maptap-rivals/js/stats.js
+++ b/apps/maptap-rivals/js/stats.js
@@ -125,6 +125,65 @@
     return { rounds, finalScore, computedTotal, date, totalMismatch };
   }
 
+  // ---------- MapTap profile history → per-day rounds ----------
+  // Convert profile.gameHistory into { "YYYY-MM-DD": { scores: number[5], cities: {lat,lng,name}[5] } }.
+  //
+  // Prefers `roundData` — the web/legacy shape that carries answer-city
+  // coordinates (cityLat/cityLng/cityName) so the continent breakdown can light
+  // up. MapTap's newer iOS client (v4.04+) stops writing `roundData` and emits
+  // only `rounds`, which still has the per-round score and the answer-city NAME
+  // (targetCity) but no coordinates. We fall back to `rounds` ONLY when a clean
+  // `roundData` array is absent, so those games still pair on score — their
+  // cities are left coordinate-less, which classifyContinent already tolerates
+  // (it buckets them as 'Unknown', same as any pre-cities game today).
+  //
+  // Either source must yield a clean 5-round score breakdown; entries that
+  // don't are rejected so we never store partial data — those days just won't
+  // pair.
+  function mapTapHistoryToRounds(gameHistory) {
+    const out = {};
+    for (const [date, entry] of Object.entries(gameHistory || {})) {
+      if (!entry) continue;
+      const parsed = roundsFromRoundData(entry.roundData) || roundsFromRounds(entry.rounds);
+      if (parsed) out[date] = parsed;
+    }
+    return out;
+  }
+
+  // Validate a 5-element score array against MapTap's 0-100 raw range.
+  function validRawScores(scores) {
+    return scores.length === N_LOCS
+      && scores.every(s => Number.isFinite(s) && s >= 0 && s <= MAX_RAW);
+  }
+
+  // Web/legacy shape: roundData[] carrying answer-city coordinates.
+  function roundsFromRoundData(roundData) {
+    if (!Array.isArray(roundData) || roundData.length !== N_LOCS) return null;
+    const scores = roundData.map(r => Number(r.score));
+    if (!validRawScores(scores)) return null;
+    const cities = roundData.map(r => ({
+      lat: Number(r.cityLat),
+      lng: Number(r.cityLng),
+      name: typeof r.cityName === 'string' ? r.cityName : '',
+    }));
+    return { scores, cities };
+  }
+
+  // iOS 4.04+ shape: rounds[] with score + answer-city NAME (targetCity) but no
+  // coordinates. Used only when roundData is absent. Cities keep the name and
+  // get NaN coords, so continent classification falls back to 'Unknown'.
+  function roundsFromRounds(rounds) {
+    if (!Array.isArray(rounds) || rounds.length !== N_LOCS) return null;
+    const scores = rounds.map(r => Number(r.score));
+    if (!validRawScores(scores)) return null;
+    const cities = rounds.map(r => ({
+      lat: NaN,
+      lng: NaN,
+      name: typeof r.targetCity === 'string' ? r.targetCity : '',
+    }));
+    return { scores, cities };
+  }
+
   // ---------- results ----------
   function resultOf(g) {
     // Rival-only (or me-only) days have no W/L semantics — neither side beat
@@ -239,7 +298,7 @@
     weightedTotal, predTotalFromScores, hasLocs, iPlayed, theyPlayed, bothPlayed, arrEq,
     getMyTotal, getTheirTotal,
     // parsing
-    parseMapTapScore,
+    parseMapTapScore, mapTapHistoryToRounds,
     // results / aggregates
     resultOf, resultLoc, stdDev, average, streaks, linearTrend, projectNext,
     rivalryScoreFromGames,

--- a/apps/maptap-rivals/js/stats.js
+++ b/apps/maptap-rivals/js/stats.js
@@ -132,10 +132,16 @@
   // coordinates (cityLat/cityLng/cityName) so the continent breakdown can light
   // up. MapTap's newer iOS client (v4.04+) stops writing `roundData` and emits
   // only `rounds`, which still has the per-round score and the answer-city NAME
-  // (targetCity) but no coordinates. We fall back to `rounds` ONLY when a clean
-  // `roundData` array is absent, so those games still pair on score — their
-  // cities are left coordinate-less, which classifyContinent already tolerates
-  // (it buckets them as 'Unknown', same as any pre-cities game today).
+  // (targetCity) but no coordinates.
+  //
+  // The `rounds` fallback is consulted ONLY when `roundData` is entirely absent
+  // from the entry. Any entry that carries a `roundData` field at all — which
+  // the web/legacy client always does — is handled exactly as before, including
+  // being dropped when malformed. That makes this byte-for-byte unchanged for
+  // non-iOS players; only entries that omit roundData (iOS) take the fallback.
+  // Fallback games still pair on score; their cities are left coordinate-less,
+  // which classifyContinent already tolerates (it buckets them as 'Unknown',
+  // same as any pre-cities game today).
   //
   // Either source must yield a clean 5-round score breakdown; entries that
   // don't are rejected so we never store partial data — those days just won't
@@ -144,7 +150,9 @@
     const out = {};
     for (const [date, entry] of Object.entries(gameHistory || {})) {
       if (!entry) continue;
-      const parsed = roundsFromRoundData(entry.roundData) || roundsFromRounds(entry.rounds);
+      const parsed = entry.roundData != null
+        ? roundsFromRoundData(entry.roundData)
+        : roundsFromRounds(entry.rounds);
       if (parsed) out[date] = parsed;
     }
     return out;

--- a/apps/maptap-rivals/tests/stats.test.js
+++ b/apps/maptap-rivals/tests/stats.test.js
@@ -10,7 +10,7 @@ const assert = require('node:assert/strict');
 const {
   N_LOCS, WEIGHTS, MAX_RAW, MONTHS,
   weightedTotal, predTotalFromScores, hasLocs, iPlayed, theyPlayed, bothPlayed, arrEq,
-  getMyTotal, getTheirTotal, parseMapTapScore,
+  getMyTotal, getTheirTotal, parseMapTapScore, mapTapHistoryToRounds,
   resultOf, resultLoc, stdDev, average, streaks, linearTrend, projectNext,
   rivalryScoreFromGames,
 } = require('../js/stats.js');
@@ -167,6 +167,79 @@ test('parseMapTapScore: empty / blank / junk input returns null', () => {
   assert.equal(parseMapTapScore('   \n  '), null);
   assert.equal(parseMapTapScore('hello world'), null);
   assert.equal(parseMapTapScore(null), null);
+});
+
+// --- mapTapHistoryToRounds -------------------------------------------------
+
+// Web/legacy day: roundData[] carrying answer-city coordinates.
+const roundDataDay = {
+  date: '2026-06-14', finalScore: 920,
+  roundData: [
+    { round: 1, score: 95, cityLat: 35.96, cityLng: -83.92, cityName: 'Knoxville, Tennessee' },
+    { round: 2, score: 80, cityLat: 46.84, cityLng: 0.91,   cityName: 'Châtellerault, France' },
+    { round: 3, score: 70, cityLat: 54.51, cityLng: 9.69,   cityName: 'Schleswig, Germany' },
+    { round: 4, score: 90, cityLat: 49.92, cityLng: 7.74,   cityName: 'Bingen, Germany' },
+    { round: 5, score: 60, cityLat: 57.36, cityLng: 33.66,  cityName: 'Ostashkov, Russia' },
+  ],
+};
+// iOS 4.04+ day: rounds[] only — score + targetCity name, no coordinates.
+const iosRoundsDay = {
+  date: '2026-06-14', finalScore: 957, clientPlatform: 'ios', clientVersion: '4.04 (4)',
+  rounds: [
+    { roundNumber: 1, targetCity: 'Knoxville, Tennessee', userLat: 37.9, userLng: -87.7, score: 95, timeSpent: 4457 },
+    { roundNumber: 2, targetCity: 'Châtellerault, France', userLat: 46.0, userLng: 0.0,  score: 95, timeSpent: 3000 },
+    { roundNumber: 3, targetCity: 'Schleswig, Germany',    userLat: 54.0, userLng: 9.0,  score: 94, timeSpent: 3000 },
+    { roundNumber: 4, targetCity: 'Bingen, Germany',       userLat: 49.0, userLng: 7.0,  score: 98, timeSpent: 3000 },
+    { roundNumber: 5, targetCity: 'Ostashkov, Russia',     userLat: 57.0, userLng: 33.0, score: 95, timeSpent: 3000 },
+  ],
+};
+
+test('mapTapHistoryToRounds: parses the web/legacy roundData shape with city coords', () => {
+  const out = mapTapHistoryToRounds({ '2026-06-14': roundDataDay });
+  assert.deepEqual(out['2026-06-14'].scores, [95, 80, 70, 90, 60]);
+  assert.deepEqual(out['2026-06-14'].cities[0], { lat: 35.96, lng: -83.92, name: 'Knoxville, Tennessee' });
+});
+
+test('mapTapHistoryToRounds: falls back to the iOS 4.04 rounds shape when roundData is absent', () => {
+  const out = mapTapHistoryToRounds({ '2026-06-14': iosRoundsDay });
+  // Scores still pair, which is the whole point of the fallback.
+  assert.deepEqual(out['2026-06-14'].scores, [95, 95, 94, 98, 95]);
+  // City name is kept (from targetCity); coordinates are unavailable → NaN.
+  assert.equal(out['2026-06-14'].cities[0].name, 'Knoxville, Tennessee');
+  assert.ok(Number.isNaN(out['2026-06-14'].cities[0].lat));
+  assert.ok(Number.isNaN(out['2026-06-14'].cities[0].lng));
+});
+
+test('mapTapHistoryToRounds: prefers roundData when an entry has BOTH (web shape)', () => {
+  // The web client writes both keys; we must keep the coordinate-rich one.
+  const both = { ...roundDataDay, rounds: iosRoundsDay.rounds };
+  const out = mapTapHistoryToRounds({ '2026-06-14': both });
+  assert.deepEqual(out['2026-06-14'].scores, [95, 80, 70, 90, 60]); // roundData scores
+  assert.equal(out['2026-06-14'].cities[0].lat, 35.96);            // roundData coords
+});
+
+test('mapTapHistoryToRounds: keeps each day in its own correct format', () => {
+  const out = mapTapHistoryToRounds({ '2026-06-13': roundDataDay, '2026-06-14': iosRoundsDay });
+  assert.equal(Object.keys(out).length, 2);
+  assert.equal(out['2026-06-13'].cities[0].lat, 35.96);
+  assert.ok(Number.isNaN(out['2026-06-14'].cities[0].lat));
+});
+
+test('mapTapHistoryToRounds: rejects entries with neither a clean roundData nor rounds array', () => {
+  assert.deepEqual(mapTapHistoryToRounds({}), {});
+  assert.deepEqual(mapTapHistoryToRounds(null), {});
+  assert.deepEqual(mapTapHistoryToRounds({ d: null }), {});
+  assert.deepEqual(mapTapHistoryToRounds({ d: { finalScore: 500 } }), {}); // no rounds at all
+  // Wrong length is rejected on both paths.
+  assert.deepEqual(mapTapHistoryToRounds({ d: { roundData: roundDataDay.roundData.slice(0, 4) } }), {});
+  assert.deepEqual(mapTapHistoryToRounds({ d: { rounds: iosRoundsDay.rounds.slice(0, 4) } }), {});
+});
+
+test('mapTapHistoryToRounds: rejects out-of-range or non-numeric scores on either path', () => {
+  const badRoundData = { roundData: roundDataDay.roundData.map((r, i) => i === 0 ? { ...r, score: 101 } : r) };
+  const badRounds = { rounds: iosRoundsDay.rounds.map((r, i) => i === 0 ? { ...r, score: 'NaN' } : r) };
+  assert.deepEqual(mapTapHistoryToRounds({ d: badRoundData }), {});
+  assert.deepEqual(mapTapHistoryToRounds({ d: badRounds }), {});
 });
 
 // --- results ---------------------------------------------------------------

--- a/apps/maptap-rivals/tests/stats.test.js
+++ b/apps/maptap-rivals/tests/stats.test.js
@@ -242,6 +242,18 @@ test('mapTapHistoryToRounds: rejects out-of-range or non-numeric scores on eithe
   assert.deepEqual(mapTapHistoryToRounds({ d: badRounds }), {});
 });
 
+test('mapTapHistoryToRounds: a present-but-malformed roundData is dropped, NOT recovered via rounds', () => {
+  // Web-safety guarantee: the rounds fallback fires only when roundData is
+  // entirely ABSENT. Any entry that carries roundData (the web shape always
+  // does) behaves exactly as it did before — including being dropped when
+  // malformed — even if a valid `rounds` sits alongside it. This keeps non-iOS
+  // players byte-for-byte unchanged.
+  const wrongLen  = { roundData: roundDataDay.roundData.slice(0, 4), rounds: iosRoundsDay.rounds };
+  const outOfRange = { roundData: roundDataDay.roundData.map((r, i) => i === 0 ? { ...r, score: 101 } : r), rounds: iosRoundsDay.rounds };
+  assert.deepEqual(mapTapHistoryToRounds({ d: wrongLen }), {});
+  assert.deepEqual(mapTapHistoryToRounds({ d: outOfRange }), {});
+});
+
 // --- results ---------------------------------------------------------------
 
 test('resultOf: W / L / T from totals', () => {


### PR DESCRIPTION
## Problem

A rival's recent games would not appear after syncing, even though the rival had clearly played. Investigation against the live MapTap public-profile API showed the cause: MapTap's newer **iOS client (v4.04+)** stores a game's per-round breakdown under a `rounds` key, while the older/web client uses `roundData`. The sync parser only read `roundData`, so any day logged from the iOS client was silently dropped.

The web client writes **both** keys, which is why rivals who play on web synced fine and only iOS players were affected.

Field shapes observed live:
- `roundData[]` (web/legacy): `{round, score, cityLat, cityLng, cityName, ...}` - carries answer-city coordinates.
- `rounds[]` (iOS 4.04+): `{roundNumber, score, targetCity, userLat, userLng, timeSpent}` - carries the score and the answer-city **name**, but no answer-city coordinates (`userLat/userLng` is the player's guess, not the city). iOS entries omit the `roundData` key entirely.

## Changes

### `apps/maptap-rivals/js/stats.js`
- Added `mapTapHistoryToRounds` here (moved out of `app.js`) so the profile-history -> per-day-rounds conversion is unit-testable in node, and exported it on the `MapTapStats` api object.
- The `roundData` path is the original logic verbatim (length-5 guard, `Number(r.score)` with 0-100 validation, city objects from `cityLat/cityLng/cityName`).
- Added a `rounds` fallback that is consulted **only when `roundData` is entirely absent** from the entry. The fallback recovers per-round scores and the city name (`targetCity`); coordinates are unavailable in that shape, so cities get `NaN` lat/lng, which `classifyContinent` already maps to the existing 'Unknown' bucket (same as any pre-cities game).
- Added a shared `validRawScores` helper so the 0-100, length-5 rejection (never store partial data) is enforced identically on both paths.

### `apps/maptap-rivals/js/app.js`
- Removed the inline `mapTapHistoryToRounds` definition and now bind it from `window.MapTapStats` alongside the other stats helpers. The two call sites in `syncMapTapForRival` are unchanged.

### `apps/maptap-rivals/tests/stats.test.js`
- Imported `mapTapHistoryToRounds` and added 7 tests: web `roundData` shape, iOS `rounds` fallback, an entry with both keys prefers `roundData`, mixed-format days, rejection of missing/wrong-length arrays, rejection of out-of-range/non-numeric scores, and the web-safety guarantee that a present-but-malformed `roundData` is dropped (never recovered via `rounds`).

## Web-safety guarantee (no change for non-iOS players)

Because the `rounds` fallback fires **only when `roundData` is absent**, every entry that carries a `roundData` field - which the web/legacy client always does - is handled byte-for-byte as before, including being dropped when malformed. This was verified by diffing the old vs new implementation across web-shape inputs (both-keys-valid, multiple days, roundData-only, malformed roundData, malformed roundData with a valid `rounds` alongside, and junk/empty/null): **zero divergence**. Only entries that omit `roundData` (iOS) take the new path.

## Deliberate non-changes
- The backfill / update logic in `syncMapTapForRival` is untouched; cities-less iOS games behave like existing cities-less games.
- No `gameType` filtering: the app never filtered on it, the iOS client does not provide it, and the `gameHistory` map is keyed by calendar date (daily-only by construction).
- No CSS, UI, or storage-schema changes.

## Testing
- Full suite: `npm test` -> **1124 passing, 0 failing**.
- `node --check` passes for both `app.js` and `stats.js`.
- Old-vs-new equivalence harness over web-shape inputs: zero divergence.