### PR TITLE
fix(theme): pin app button colors against main.css global bleed

### DIFF
--- a/apps/arena/css/styles.css
+++ b/apps/arena/css/styles.css
@@ -409,19 +409,25 @@ body.brain-arena-app button {
   margin-bottom: 1rem;
 }
 
-.auth-gate .link-btn {
+.link-btn {
   background: none;
   border: none;
-  color: var(--accent);
+  /* `!important` + box-shadow:none pin off main.css's global `button`
+     rules (gray #555 text/ring, red hover). The end-screen sign-up CTA
+     uses .link-btn outside .auth-gate, so target the class directly. */
+  color: var(--accent) !important;
+  box-shadow: none !important;
   text-decoration: underline;
   cursor: pointer;
   font: inherit;
   padding: 0;
 }
-.auth-gate .link-btn:hover,
-.auth-gate .link-btn:focus-visible {
-  color: var(--cyan-2);
+.link-btn:hover,
+.link-btn:focus-visible {
+  color: var(--cyan-2) !important;
+  box-shadow: none !important;
 }
+.link-btn:hover:active { background: none; }
 
 .lobby-grid {
   display: grid;
@@ -776,12 +782,17 @@ select option { background: var(--surface); color: var(--text); }
   color: var(--muted) !important;
   border-radius: 8px;
   cursor: pointer;
+  /* Pin off main.css's global `button` ring (inset 0 0 0 1px #555) + its
+     red hover/active repaint; this is a borderless icon button. */
+  box-shadow: none !important;
   transition: background 0.18s ease, color 0.18s ease, transform 0.05s ease;
 }
 .room-code-copy:hover {
   background: rgba(34, 211, 238, 0.12);
   color: var(--cyan-2) !important;
+  box-shadow: none !important;
 }
+.room-code-copy:hover:active { background: rgba(34, 211, 238, 0.12); }
 .room-code-copy:active { transform: scale(0.94); }
 .room-code-copy svg { width: 14px; height: 14px; }
 
@@ -1936,6 +1947,9 @@ select option { background: var(--surface); color: var(--text); }
     border-radius: 999px;
     background: rgba(8, 11, 22, 0.55);
     color: #e2e8f0 !important;
+    /* Pin off main.css's global `button` ring (inset 0 0 0 1px #555) + its
+       red hover/active repaint; this pill carries its own border. */
+    box-shadow: none !important;
     font: inherit;
     font-size: 0.82rem;
     font-weight: 600;
@@ -1950,6 +1964,10 @@ select option { background: var(--surface); color: var(--text); }
     border-color: rgba(34, 211, 238, 0.55);
     background: rgba(12, 18, 34, 0.7);
     color: #67e8f9 !important;
+    box-shadow: none !important;
+  }
+  .globe-drop-standings-toggle:hover:active {
+    background: rgba(12, 18, 34, 0.7);
   }
   /* Pulse cue (item 2): while the local player has submitted but the
      board is still collapsed, breathe a soft cyan glow + a glowing dot so
@@ -2346,7 +2364,10 @@ select option { background: var(--surface); color: var(--text); }
   background: rgba(255, 255, 255, 0.025);
   border: 1px solid var(--border);
   border-radius: 9px;
-  color: var(--text);
+  /* `!important` + box-shadow:none pin off main.css's global `button`
+     rules (gray #555 text/ring, red hover/active). */
+  color: var(--text) !important;
+  box-shadow: none !important;
   font-size: 1.05rem;
   line-height: 1;
   cursor: pointer;
@@ -2358,9 +2379,11 @@ select option { background: var(--surface); color: var(--text); }
 .room-chat-quick-btn:hover {
   background: rgba(34, 211, 238, 0.08);
   border-color: rgba(34, 211, 238, 0.35);
-  box-shadow: 0 0 12px rgba(34, 211, 238, 0.18);
+  color: var(--text) !important;
+  box-shadow: 0 0 12px rgba(34, 211, 238, 0.18) !important;
   transform: translateY(-1px);
 }
+.room-chat-quick-btn:hover:active { background: rgba(34, 211, 238, 0.08); }
 .room-chat-quick-btn:active { transform: scale(0.92); }
 @media (max-width: 380px) {
   .room-chat-quick { grid-template-columns: repeat(4, 1fr); }
@@ -5001,9 +5024,13 @@ select option { background: var(--surface); color: var(--text); }
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  /* Pin off main.css's global `button` ring (inset 0 0 0 1px #555) + red
+     hover/active repaint; this is a borderless icon button. */
+  box-shadow: none !important;
   transition: background 0.15s, color 0.15s;
 }
-.modal-close:hover { background: rgba(255, 255, 255, 0.06); color: var(--text) !important; }
+.modal-close:hover { background: rgba(255, 255, 255, 0.06); color: var(--text) !important; box-shadow: none !important; }
+.modal-close:hover:active { background: rgba(255, 255, 255, 0.06); }
 .modal-close svg { width: 13px; height: 13px; display: block; }
 
 .modal-actions {

--- a/apps/football-h2h/css/refresh.css
+++ b/apps/football-h2h/css/refresh.css
@@ -520,7 +520,10 @@ body.football-h2h-tracker .sidebar-add-race-btn {
     transition: filter 0.15s ease, transform 0.08s ease, box-shadow 0.15s ease;
 }
 body.football-h2h-tracker .sidebar-player-settings-btn:hover,
-body.football-h2h-tracker .sidebar-add-game-btn:hover {
+body.football-h2h-tracker .sidebar-add-game-btn:hover,
+body.football-h2h-tracker .sidebar-player-settings-btn:hover:active,
+body.football-h2h-tracker .sidebar-add-game-btn:hover:active {
+    background: linear-gradient(135deg, var(--fh-accent), var(--fh-accent-strong)) !important;
     filter: brightness(1.06);
     transform: translateY(-1px);
     box-shadow: 0 8px 22px -6px rgba(99, 102, 241, 0.55) !important;
@@ -1261,6 +1264,7 @@ body.football-h2h-tracker .custom-date-range button {
 }
 body.football-h2h-tracker .custom-date-range button:hover,
 body.football-h2h-tracker .custom-date-range button:hover:active {
+    background: linear-gradient(135deg, var(--fh-accent), var(--fh-accent-strong)) !important;
     color: #ffffff !important;
     filter: brightness(1.06);
     transform: translateY(-1px);

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -2946,3 +2946,67 @@ body.gym-tracker .gt-overflow-item--danger:hover i,
 body.gym-tracker .gt-overflow-item--danger:focus-visible i {
     color: var(--accent-error) !important;
 }
+
+/* ================================================================
+   THEME-COLLISION GUARDS — custom widgets hit by sitewide main.css
+
+   main.css forces on every <button>:
+     button             { color:#555 !important; box-shadow: inset 0 0 0 1px #555 }
+     button:hover       { color:#ce1b28 !important; box-shadow: inset 0 0 0 1px #ce1b28 }
+     button:hover:active{ background: rgba(206,27,40,.25) }
+
+   The custom dark-select / dark-calendar triggers and the achievement /
+   filter-reset buttons set their colors WITHOUT !important, so the gray
+   base / red hover text and the inset gray/red ring bleed through. Pin
+   the intended values !important across base / :hover / :hover:active.
+   The .is-open / .has-value / :focus-visible rings these widgets set
+   themselves are NOT targeted here, so they stay intact.
+   ================================================================ */
+
+/* Custom select trigger: keep light text, kill the inset gray/red ring. */
+body.gym-tracker .dark-select-trigger,
+body.gym-tracker .dark-select-trigger:hover,
+body.gym-tracker .dark-select-trigger:hover:active {
+    color: var(--text-primary) !important;
+    box-shadow: none !important;
+}
+
+/* Date trigger: text is already pinned; only the inset ring bleeds. */
+body.gym-tracker .dark-calendar-trigger,
+body.gym-tracker .dark-calendar-trigger:hover,
+body.gym-tracker .dark-calendar-trigger:hover:active {
+    box-shadow: none !important;
+}
+
+/* Filter-reset (exercise DB): azure idle, white on hover, muted disabled. */
+body.gym-tracker .btn-filter-reset {
+    color: var(--accent-primary) !important;
+    box-shadow: none !important;
+}
+body.gym-tracker .btn-filter-reset:hover {
+    color: #ffffff !important;
+}
+body.gym-tracker .btn-filter-reset:disabled,
+body.gym-tracker .btn-filter-reset[disabled],
+body.gym-tracker .btn-filter-reset:disabled:hover,
+body.gym-tracker .btn-filter-reset[disabled]:hover {
+    color: var(--text-muted) !important;
+    box-shadow: none !important;
+}
+
+/* Achievement category header: keep light text, kill the inset ring. */
+body.gym-tracker .achievement-category-header,
+body.gym-tracker .achievement-category-header:hover:active {
+    color: var(--text-primary) !important;
+}
+body.gym-tracker .achievement-category-header {
+    box-shadow: none !important;
+}
+body.gym-tracker .achievement-category-header:hover {
+    color: var(--text-primary) !important;
+}
+
+/* Achievement bulk button: text already white; kill the idle inset ring. */
+body.gym-tracker .achievement-bulk-btn {
+    box-shadow: none !important;
+}

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -109,6 +109,9 @@ body.maptap-rivals-app select,
 body.maptap-rivals-app textarea,
 body.maptap-rivals-app button {
   font-family: inherit;
+  /* Baseline text colour so main.css's `input,select,textarea { color:#555 }`
+     can't gray out controls we don't otherwise paint (radios, file inputs). */
+  color: var(--text);
 }
 
 /* ---------- Buttons ----------

--- a/apps/mario-kart/css/course-picker.css
+++ b/apps/mario-kart/css/course-picker.css
@@ -29,7 +29,10 @@
     background: var(--mk-surface-2, #181c26);
     border: 1px solid var(--mk-border, #232838);
     border-radius: 9px;
-    color: var(--mk-text, #f1f3f8);
+    /* color pinned !important to beat the global `button{color:#555!important}`
+       trap in assets/css/main.css; child spans set their own colour but the
+       button's own text colour (and the hover/active red traps) need pinning. */
+    color: var(--mk-text, #f1f3f8) !important;
     cursor: pointer;
     text-align: left;
     transition: border-color 0.12s ease, background 0.12s ease;
@@ -39,6 +42,13 @@
 .course-picker .course-picker-trigger[aria-expanded="true"] {
     border-color: var(--mk-accent, #818cf8);
     background: var(--mk-surface-3, #232836);
+    color: var(--mk-text, #f1f3f8) !important;
+}
+/* Pressed: main.css `button:hover:active{background:rgba(206,27,40,.25)}`
+   would flash a red fill on click — pin the intended surface instead. */
+.course-picker .course-picker-trigger:hover:active {
+    background: var(--mk-surface-3, #232836) !important;
+    color: var(--mk-text, #f1f3f8) !important;
 }
 
 .course-picker .cp-icon { font-size: 1.05rem; flex: 0 0 auto; line-height: 1; opacity: 0.9; }
@@ -74,10 +84,22 @@
     position: absolute; right: 32px; top: 50%; transform: translateY(-50%);
     width: 20px; height: 20px; line-height: 18px; padding: 0;
     border: none; border-radius: 50%;
-    background: rgba(148, 163, 184, 0.20); color: var(--mk-text, #f1f3f8);
+    background: rgba(148, 163, 184, 0.20);
+    /* The "x" is direct text on the button, so the global
+       `button{color:#555!important}` trap in main.css renders it gray. Pin
+       across base/hover/active so it stays legible. */
+    color: var(--mk-text, #f1f3f8) !important;
     font-size: 0.9rem; cursor: pointer;
 }
-.course-picker .cp-clear:hover { background: rgba(239, 68, 68, 0.28); }
+.course-picker .cp-clear:hover {
+    background: rgba(239, 68, 68, 0.28);
+    color: var(--mk-text, #f1f3f8) !important;
+}
+/* Pin the pressed state: defeat main.css `button:hover:active` red bg + red text. */
+.course-picker .cp-clear:hover:active {
+    background: rgba(239, 68, 68, 0.40) !important;
+    color: var(--mk-text, #f1f3f8) !important;
+}
 
 /* ---- Open panel: a single unified surface ---- */
 .course-picker .course-picker-panel {

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -2362,7 +2362,10 @@ button.shape-tag.is-clickable:hover {
   border-radius: 999px;
   border: 1px solid var(--accent);
   background: var(--accent);
-  color: #1a1300;
+  /* !important defeats main.css `button { color:#555555 !important }`,
+     which otherwise greys out this dark-on-yellow FAB. Hover/active are
+     pinned too so the site's red `button:hover` colour can't bleed in. */
+  color: #1a1300 !important;
   font-weight: 700;
   font-size: 0.9rem;
   cursor: pointer;
@@ -2372,6 +2375,8 @@ button.shape-tag.is-clickable:hover {
   transition: transform 0.12s var(--ease), box-shadow 0.2s var(--ease);
 }
 .compare-fab[hidden] { display: none; }
+.compare-fab:hover,
+.compare-fab:hover:active { color: #1a1300 !important; background: var(--accent); }
 .compare-fab:hover { transform: translateY(-1px); }
 .compare-fab-icon { font-size: 1.05rem; }
 .compare-fab-count {

--- a/assets/css/moadon-alef-theme.css
+++ b/assets/css/moadon-alef-theme.css
@@ -50,8 +50,13 @@
   gap: 8px;
 }
 
-.lang-btn:hover {
-  background: #28a745;
+.lang-btn:hover,
+/* main.css `button:hover:active{background-color:rgba(206,27,40,0.25)}` has
+   higher specificity (0,2,1) than `.lang-btn:hover` (0,2,0), so without
+   !important a press of a language pill flashes a red tint over the green.
+   Pin the green across hover AND the hover:active press state. */
+.lang-btn:hover:active {
+  background: #28a745 !important;
   color: white !important;
   box-shadow: none !important;
   border-color: #28a745;
@@ -60,7 +65,7 @@
 
 
 .lang-btn.active {
-  background: #28a745;
+  background: #28a745 !important;
   color: white !important;
   box-shadow: none !important;
   border-color: #28a745;


### PR DESCRIPTION
## Summary

Sitewide theme-collision audit. `assets/css/main.css` (the marketing-site theme, linked by every app and page) applies global rules that silently defeat app styles regardless of specificity: `button, .button { color: #555555 !important; box-shadow: inset 0 0 0 1px #555555 }`, `button:hover { color: #ce1b28 !important; box-shadow: inset 0 0 0 1px #ce1b28 }`, and `button:hover:active { background-color: rgba(206,27,40,0.25) }`, plus `input,select,textarea { color: #555555 }`.

Every app + the marketing pages were audited via **rendered computed styles** in headless Chrome (default/hover/pressed at 1280px and 390px). Each unintended collision is pinned back to the app's intended value with `!important` across base + `:hover` + `:hover:active`, in the app's own CSS. **`main.css` itself is untouched.** 18 controls fixed across 7 files.

## Changed files (complete diff vs `master`)

**`apps/arena/css/styles.css`** (+35/-8)
- `.link-btn` (text/link buttons, e.g. the end-screen sign-up CTA): gray `rgb(85,85,85)` text + red hover → `var(--accent)` cyan `!important`, ring off. Selector broadened from `.auth-gate .link-btn` to bare `.link-btn` so the end-screen instance (outside `.auth-gate`) is covered (judgment call — no other `.link-btn` relied on the themed look).
- `.room-code-copy`, `.globe-drop-standings-toggle`, `.room-chat-quick-btn`, `.modal-close`: stray gray `#555` ring and/or red pressed background → `box-shadow: none !important` and pressed-bg pinned to the app surface color.

**`apps/football-h2h/css/refresh.css`** (+5/-1)
- `.sidebar-add-game-btn:hover:active`, `.sidebar-player-settings-btn:hover:active`, `.custom-date-range button:hover:active`: pressed background leaked `rgba(206,27,40,0.25)` → indigo gradient `!important`. Text/hover colors were already pinned; only the pressed background leaked.

**`apps/gym-tracker/css/refresh.css`** (+64)
- `.dark-select-trigger`, `.dark-calendar-trigger`: gray text + gray/red ring → `var(--text-primary) !important`, ring off (preserves the widgets' own `.is-open`/`.has-value`/`:focus-visible` rings).
- `.btn-filter-reset` (`#exercise-db-reset`): gray → `var(--accent-primary) !important` idle, `#ffffff` hover, `var(--text-muted)` disabled.
- `.achievement-category-header`: gray + ring → `var(--text-primary) !important`, ring off. `.achievement-bulk-btn` (`#achievement-expand-all`): idle ring off.

**`apps/maptap-rivals/css/styles.css`** (+3)
- Added `body.maptap-rivals-app input, select, textarea, button { color: var(--text) }` (wins on specificity + order over main.css's non-important `input,select,textarea{color:#555}`). Closes the bleed on the only 5 unpinned controls: `#import-file`, `#wa-import-file` (hidden file inputs) and 3 season-goal radios. Re-probe: 78 controls, 0 flagged.

**`apps/mario-kart/css/course-picker.css`** (+24/-4)
- `.course-picker .course-picker-trigger` and `.cp-clear` (the "×" clear glyph, visibly illegible gray): gray `rgb(85,85,85)` → `var(--mk-text) !important` (`rgb(241,243,248)`); `:hover` pinned and new `:hover:active` pins the app's own background instead of the red trap.

**`apps/rising-seasons/css/styles.css`** (+6/-1)
- `.compare-fab` (dark-on-gold FAB): `color: #1a1300` → `#1a1300 !important`; added `.compare-fab:hover, .compare-fab:hover:active { color: #1a1300 !important; background: var(--accent) }`.

**`assets/css/moadon-alef-theme.css`** (+9/-2)
- `.lang-btn` language pills flashed red on press (green background wasn't `!important`, so main.css's higher-specificity `button:hover:active` won) → green pinned `!important` across base/hover/active. The only unintended collision on the marketing pages.

## Bugfixes found along the way

- Mario Kart's course-picker "×" clear glyph was rendering as illegible gray-on-dark (a real usability defect, not just a theme nuance) — now white.
- Rising Seasons' Compare FAB and Moadon Alef's language pills had `!important` *intentions* in their existing CSS but a missing `!important` on the relevant property let main.css's pressed/hover rules win; corrected.

## Deliberate non-changes (explicitly untouched)

- **`assets/css/main.css`** — never edited. It is the intentional marketing-site theme; fixes belong in app-owned overrides, not the global file.
- **Shared global auth/login chrome** (sign-in button, auth modal, tabs, sign-in/sign-up inputs; injected by `assets/js/main.js`) — left untouched. It is global chrome, not app-owned. Probes disagreed on whether it shows the trap inside apps (clean on marketing pages via `firebase-auth.css`); raised as an owner decision for a possible separate shared-CSS fix rather than guessed at here.
- **Generic marketing buttons/links/headings** on the root pages — the gray/red there is the deliberate brand theme; only the one Moadon Alex collision was unintended.
- **MapTap Rivals hero tagline em dash** ("head-to-head — track…") — noticed but out of scope for a theme audit; flagged for a separate copy fix.
- **In-flight maptap iOS-rounds work** (`mapTapHistoryToRounds`) — lives in its own worktree/branch `fix-maptap-ios-rounds-fallback`; explicitly NOT included here.

## How it was tested

- Per-app parallel sub-agents, each driving headless Chrome via the repo screenshot helper to read `getComputedStyle` `.color`/`.boxShadow`/`.backgroundColor` on every interactive element in default/hover/pressed at 1280px and 390px; every fix re-verified with fresh computed-style screenshots read back.
- `npm test` → **1117/1117 pass** with all 7 CSS changes applied together.
- Audit report (local, archived at `.features/archive/theme-collision-audit-2026-06-14.md`): one run-report entry covering all 7 surfaces, 18 collisions fixed.
