### PR TITLE
fix(site): make header and footer identical across all pages

### DIFF
--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -80,14 +80,6 @@ html {
   background-attachment: fixed;
   background-color: var(--bg);
   min-height: 100%;
-  /* Always show the vertical scrollbar so its gutter is permanently
-     reserved. Without this, expanding the More-filters panel grows the
-     page tall enough to surface the scrollbar, which steals ~15px from
-     the viewport width and yanks the centered .page sideways. Using
-     overflow-y:scroll instead of scrollbar-gutter:stable for universal
-     browser support (Safari < 18 ignores scrollbar-gutter). */
-  overflow-y: scroll;
-  scrollbar-gutter: stable;
 }
 
 body.rising-seasons-app {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3052,3 +3052,119 @@ body > [data-include="footer"] {
   #footer .content--two-col section:last-child {
     padding-left: 0; } }
 
+/* ==========================================================================
+   Shared header/footer typography lock
+   The header/footer partials are identical on every page, but their text
+   inherits font-family from body/*, which each app overrides. Pin the
+   typography here so the chrome renders identically site-wide regardless of
+   app CSS load order. Scoped to #header/#footer/#menu; !important because app
+   stylesheets load after main.css. Does NOT touch nav-link color/font-weight
+   (those carry the current-page indicator) or .icon/<i> (FontAwesome glyphs).
+   ========================================================================== */
+#header,
+#footer,
+#menu,
+#header .logo,
+#header .header-inline-nav a,
+#header .nav-apps__toggle,
+#header .nav-apps__menu a,
+#header [data-js="menu-toggle"],
+#header .auth-container .auth__button,
+#header .auth-container .auth__user-name,
+#header #header-user-email,
+#menu .links a,
+#footer h4,
+#footer .copyright {
+  font-family: "Raleway", Arial, Helvetica, sans-serif !important; }
+
+/* Normalize font rendering so the chrome looks the same on WebKit/macOS too;
+   several apps set `-webkit-font-smoothing: antialiased` on body/*, which makes
+   the header/footer text render thinner than on the marketing pages. */
+#header, #header *, #footer, #footer *, #menu, #menu * {
+  -webkit-font-smoothing: auto !important;
+  -moz-osx-font-smoothing: auto !important; }
+
+/* Pin the footer's base text color. Some apps set a white body/* color that the
+   footer containers inherit, which (via currentColor) tinted their borders and
+   any non-link text differently from the marketing pages. Links/headings/
+   copyright keep their own pinned colors above; this only fixes the base. */
+#footer,
+#footer .inner,
+#footer .content--two-col,
+#footer section,
+#footer ul,
+#footer li { color: rgba(255, 255, 255, 0.5) !important; }
+
+#footer h4 {
+  font-weight: 300 !important;
+  line-height: 1.5 !important;
+  letter-spacing: normal !important;
+  text-transform: uppercase !important;
+  color: #ffffff !important; }
+
+/* Logo is an image-only anchor; pin its (invisible) text styling so the
+   computed values match across pages and app `a {}` rules cannot bleed in. */
+#header .logo {
+  color: #ce1b28 !important;
+  text-decoration: none !important; }
+
+#footer .content--two-col a {
+  line-height: 1.65 !important; }
+
+#footer .copyright {
+  line-height: 1.65 !important; }
+
+#header .auth-container .auth__button:hover,
+#header .auth-container .auth__button:focus,
+#header .auth-container .auth__button:active {
+  color: #ffffff !important; }
+
+/* Signed-in user email in the header. It uses `color: inherit`, so on apps that
+   set a white body text color (e.g. gym-tracker `body { color: white }`) the
+   email rendered bright white while every other page showed it muted gray. Pin
+   it to the canonical header text color so the signed-in email matches the nav
+   links site-wide (the Sign Out button stays white via the rule above). */
+#header .auth-container .auth__user,
+#header .auth-container .auth__user-name {
+  color: rgba(255, 255, 255, 0.5) !important; }
+
+/* ==========================================================================
+   Site-wide page scrollbar
+   Normalize the main (page) scrollbar so it looks the same on every page.
+   Without this, marketing pages show a light native scrollbar, gym-tracker a
+   custom dark one, and the other apps a dark native one (via color-scheme).
+   A neutral gray thumb on a transparent track reads on both light and dark
+   backgrounds. `html`-scoped so it only affects the page scrollbar (apps keep
+   their own inner/modal scrollbars). Does not touch color-scheme, so native
+   form controls are unaffected.
+   ========================================================================== */
+html {
+  scrollbar-width: thin !important;
+  scrollbar-color: #6f7785 transparent !important; }
+html::-webkit-scrollbar { width: 12px; height: 12px; }
+html::-webkit-scrollbar-track { background: transparent; }
+html::-webkit-scrollbar-thumb {
+  background: #6f7785;
+  border-radius: 8px;
+  border: 3px solid transparent;
+  background-clip: padding-box; }
+html::-webkit-scrollbar-thumb:hover {
+  background: #8b93a4;
+  background-clip: padding-box; }
+html::-webkit-scrollbar-corner { background: transparent; }
+
+/* ==========================================================================
+   Footer contact icons (inline SVG)
+   These are inline SVG instead of FontAwesome so they render identically on
+   every page. Marketing pages load Font Awesome 4 and app pages load Font
+   Awesome 6, which draw the phone and LinkedIn glyphs differently - using SVG
+   removes that dependency entirely. Pinned so app `svg {}` rules cannot resize
+   or recolor them; fill follows the link color (currentColor).
+   ========================================================================== */
+#footer .footer-contact-icon {
+  width: 1.05em !important;
+  height: 1.05em !important;
+  fill: currentColor !important;
+  vertical-align: -0.16em;
+  margin-right: 0.5rem;
+  flex-shrink: 0; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1060,25 +1060,10 @@
           }
         }
 
-        // Footer: hide the Navigate link for the page we're on so the column
-        // shows the other four. Inside an app (/apps/<name>/) all five links
-        // stay visible: the Apps link is the way back to the hub, not the
-        // current page. Compare basenames without the .html extension:
-        // Netlify Pretty URLs rewrites partial hrefs to extensionless
-        // (/apps.html -> /apps) and serves pages at extensionless paths,
-        // so an extension-sensitive match never fires in production.
-        if (includeFile === 'footer.html') {
-          const stripExt = function(name) { return name.replace(/\.html$/, ''); };
-          const fpath = window.location.pathname;
-          if (fpath.indexOf('/apps/') === -1) {
-            const currentPage = stripExt(fpath.split('/').pop() || 'home.html') || 'home';
-            $('#footer .footer-nav a').each(function() {
-              if (stripExt(($(this).attr('href') || '').split('/').pop()) === currentPage) {
-                $(this).closest('li').hide();
-              }
-            });
-          }
-        }
+        // Footer: every page shows all five Navigate links so the footer is
+        // byte-identical site-wide (no per-page hiding of the current page's
+        // link, which previously made the footer one row shorter on the five
+        // top-level marketing pages and inconsistent against the app pages).
       });
     });
 

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -4,9 +4,9 @@
       <section>
         <h4>Contact Us</h4>
         <ul class="plain">
-          <li><a href="mailto:nikita@shevato.com"><i class="icon fa-envelope" aria-hidden="true">&nbsp;</i>nikita@shevato.com</a></li>
-          <li><a href="tel:+1504-638-3370"><i class="icon fa-phone" aria-hidden="true">&nbsp;</i>+1 (504) 638-3370</a></li>
-          <li><a href="https://www.linkedin.com/in/nikita-soifer/" target="_blank" rel="noopener noreferrer" aria-label="Shevato on LinkedIn"><i class="icon fa-linkedin" aria-hidden="true">&nbsp;</i>LinkedIn</a></li>
+          <li><a href="mailto:nikita@shevato.com"><svg class="footer-contact-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Zm0 4-8 5-8-5V6l8 5 8-5v2Z"/></svg>nikita@shevato.com</a></li>
+          <li><a href="tel:+1504-638-3370"><svg class="footer-contact-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M6.62 10.79a15.53 15.53 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.02-.24 11.36 11.36 0 0 0 3.57.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1 11.36 11.36 0 0 0 .57 3.57 1 1 0 0 1-.25 1.02l-2.2 2.2Z"/></svg>+1 (504) 638-3370</a></li>
+          <li><a href="https://www.linkedin.com/in/nikita-soifer/" target="_blank" rel="noopener noreferrer" aria-label="Shevato on LinkedIn"><svg class="footer-contact-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14ZM8.34 18V9.67H5.67V18h2.67ZM7 8.6a1.55 1.55 0 1 0 0-3.1 1.55 1.55 0 0 0 0 3.1Zm11.33 9.4v-4.57c0-2.45-1.31-3.59-3.06-3.59-1.41 0-2.04.78-2.39 1.32V9.67h-2.67V18h2.67v-4.65c0-.25.02-.49.09-.67.2-.49.65-1 1.4-1 .99 0 1.39.75 1.39 1.86V18h2.57Z"/></svg>LinkedIn</a></li>
         </ul>
       </section>
       <section>


### PR DESCRIPTION
## Summary

Makes the shared site header and footer render **identically on every page** (font, color, hover, size, spacing, layout, and the signed-in auth email), and normalizes the page scrollbar site-wide. The header/footer partials were already shared, but per-app stylesheets were bleeding into the chrome via inheritance and load order; this round pins the chrome so no app CSS can change it.

Scope: site chrome only. Marketing pages, all six apps, and the shared partials are affected through shared CSS/JS + the footer partial. `moadon-alef.html` is explicitly untouched (separate multilingual footer by design).

## Changes by file

### `assets/css/main.css` (+116)
- **Header/footer typography lock** (block appended at end): pins `font-family` to the site Raleway stack on `#header`/`#footer`/`#menu` and all their text-bearing descendants (nav links, Apps dropdown, menu toggle, logo, auth button + user-name, footer h4/links/copyright), so the per-app body/`*` fonts (Outfit/Inter/system) no longer bleed into the chrome. Does NOT pin nav link color/weight (preserves the current-page indicator) and does NOT touch `.icon`/`<i>` (FontAwesome glyphs).
- Pins `#footer h4` weight/line-height/letter-spacing/transform/color and footer link/copyright line-heights to the marketing baseline.
- Pins `#header .logo` color + text-decoration (image-only anchor; removes invisible cross-page variance).
- Pins the auth Sign In/Sign Out button `:hover/:focus/:active` to white (overrides the global `button:hover { color:#ce1b28 !important }` that was turning it red).
- Normalizes `-webkit-/-moz-osx-font-smoothing` on the chrome (apps set `antialiased`, which rendered chrome text thinner on WebKit/macOS).
- Pins footer container base color to `rgba(255,255,255,0.5)` (gym's white body color was bleeding in).
- **Signed-in email pin**: `#header .auth-container .auth__user / .auth__user-name { color: rgba(255,255,255,0.5) !important }` — the email used `color: inherit` and rendered bright white on gym-tracker (white body color) while gray everywhere else.
- **Site-wide page scrollbar**: uniform thin neutral-gray (`#6f7785`) thumb on a transparent track via `html` `scrollbar-color`/`scrollbar-width` + `::-webkit-scrollbar*` rules. Previously marketing pages showed a light native scrollbar, gym a custom dark one, and the other apps a dark native one. Does not change `color-scheme`, so form controls are unaffected; apps keep their own inner/modal scrollbars.
- **Footer contact icons**: `#footer .footer-contact-icon` sizes/colors the new inline-SVG icons (1.05em, `fill: currentColor`), pinned so app `svg {}` rules cannot resize/recolor them.

### `assets/js/main.js` (-/+ net -)
- Removed the logic that hid the footer Navigate link for the current page on the five top-level marketing pages. All pages now show all five footer links, so the footer is the same height/content everywhere (previously marketing footers were one row shorter than app footers).

### `partials/footer.html` (+/-)
- Replaced the three FontAwesome contact icons (`<i class="icon fa-envelope/fa-phone/fa-linkedin">`) with inline `<svg>` icons. Marketing pages load FontAwesome 4 and app pages load FontAwesome 6, which draw the phone and LinkedIn glyphs differently; inline SVG removes the version dependency so the icons are pixel-identical everywhere.

### `apps/rising-seasons/css/styles.css` (-8)
- Removed `overflow-y: scroll` + `scrollbar-gutter: stable` from the `html` rule (owner decision). rising-seasons no longer reserves a permanent 15px scrollbar gutter, so its header/footer are 1280px wide like every other page.

## Explicitly untouched / reverted (deliberate)
- **gym-tracker**: an interim full-width-footer change (with a JS sidebar clamp) was implemented and then **reverted at the owner's request** — gym-tracker's footer is intentionally offset 250px to clear its fixed sidebar. No gym-tracker files are in this diff.
- **Mobile footer redesign**: a `@media (max-width:767px)` redesign of the footer + back-to-top was implemented and then **reverted at the owner's request**. `assets/css/back-to-top.css` is unchanged in this diff.
- **arena**: a FontAwesome `<link>` added in an earlier step was reverted once the footer icons became SVG (arena uses FA nowhere else). No arena files in this diff.
- `moadon-alef.html` and its separate footer: untouched by design.

## Judgment calls
- Chrome pins use `!important` scoped to `#header`/`#footer`/`#menu` because app stylesheets load after `main.css`; no app CSS uses `!important` on these selectors, so the pins win without an escalation war.
- Footer link color/weight intentionally left as the existing muted gray (consistent across pages) rather than restyled.
- Scrollbar thumb is a neutral gray that reads on both light and dark backgrounds; `color-scheme` deliberately left alone to avoid changing native form controls on the light marketing pages.

## Testing
- `npm test`: **1124/1124 pass.**
- Headless computed-style probes (getComputedStyle + getBoundingClientRect on the header/footer/auth selectors, all 12 pages) confirmed **zero** cross-page differences in font-family, size, weight, line-height, letter-spacing, color, hover, and the footer box model (gym's 250px offset intentional).
- Signed-in email verified by simulating the auth markup and reading computed color: gray on every page; Sign Out stays white.
- Footer icons verified identical via screenshots on home (FA4), football-h2h (FA6), and arena (no FA).
- Scrollbar `scrollbar-color`/`scrollbar-width` verified identical across pages.
- Living plan pair `.features/site-claude.md` + `site-human.md` updated (sections 30-34 + run report 2026-06-14).

## Needs a human (real browser / login)
- Signed-in email color on a real Firebase login (probe simulated the markup).
- Page scrollbar appearance on the light marketing pages (headless hides scrollbars).
