### PR TITLE
UI polish: gym-tracker set helper + rising-seasons Compare chart

### DIFF
--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -2671,7 +2671,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle i {
     padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    gap: 0.3rem;
 }
 
 /* Horizontal three-zone layout: [ num ] [ content ] [ actions + check ].
@@ -2686,7 +2686,7 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle i {
     align-items: center;
     flex-wrap: wrap;
     gap: 0.5rem;
-    padding: 0.5rem 0.55rem;
+    padding: 0.4rem 0.55rem;
     background: var(--bg-tertiary);
     border: 1px solid var(--border-color);
     border-left: 3px solid var(--border-color);

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -2539,26 +2539,46 @@ body.gym-tracker .strength-pr-date {
    ========================================================================== */
 
 /* Feature 6: one-tap restore-to-last-time chip. */
+/* Secondary "previous performance" affordance. Reads as muted helper text
+   beneath the inputs (icon + "Previous: 130lb × 8"), not a primary pill.
+   Still a button: tap to restore last session's numbers. */
 body.gym-tracker .gt-restore-chip {
     flex: 0 0 100%;
-    margin-top: 0.35rem;
-    padding: 0.25rem 0.5rem;
-    text-align: center;
-    border: 1px solid #3a6df0;
-    border-radius: 999px;
-    background: rgba(58, 109, 240, 0.12);
-    color: #8fb0ff;
-    font-size: 0.72rem;
-    line-height: 1.4;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    align-self: flex-start;
+    width: fit-content;
+    max-width: 100%;
+    margin-top: 0.15rem;
+    padding: 0.2rem 0.4rem;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--gt-muted-2, #8b93a7);
+    font-size: 0.68rem;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: 0.01em;
     cursor: pointer;
     white-space: nowrap;
+    transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+body.gym-tracker .gt-restore-chip i {
+    font-size: 0.66rem;
+    opacity: 0.7;
 }
 
 body.gym-tracker .gt-restore-chip:hover,
 body.gym-tracker .gt-restore-chip:focus-visible {
-    background: rgba(58, 109, 240, 0.22);
+    background: rgba(58, 109, 240, 0.12);
     color: #b9cdff;
-    border-color: #3a6df0;
+}
+
+body.gym-tracker .gt-restore-chip:hover i,
+body.gym-tracker .gt-restore-chip:focus-visible i {
+    opacity: 1;
 }
 
 /* Pass 2 #2: the notes toggle is now a .gt-iconbtn (sizing/colors inherited).

--- a/apps/gym-tracker/js/views/workout-view.js
+++ b/apps/gym-tracker/js/views/workout-view.js
@@ -1382,9 +1382,12 @@ class WorkoutView {
         chip.dataset.exerciseIndex = String(exerciseIndex);
         chip.dataset.slot = String(slot);
         chip.title = "Restore last session's weight and reps";
-        chip.textContent = `last time: ${priorWeight}${unit} x ${priorReps}`;
-        // Append after the toggle (own full-width line beneath the inputs), the
-        // same placement the Feature 1 bump chip uses.
+        chip.setAttribute('aria-label', `Previous: ${priorWeight}${unit} by ${priorReps} reps. Tap to restore.`);
+        // Compact, muted helper line: a history icon + "Previous: 130lb × 8".
+        // Reads as secondary metadata beneath the inputs while staying tappable.
+        chip.innerHTML = `<i class="fas fa-clock-rotate-left" aria-hidden="true"></i><span class="gt-restore-chip-text">Previous: ${priorWeight}${unit} × ${priorReps}</span>`;
+        // Append after the toggle (own line beneath the inputs), the same
+        // placement the Feature 1 bump chip uses.
         row.appendChild(chip);
     }
 

--- a/apps/rising-seasons/css/styles.css
+++ b/apps/rising-seasons/css/styles.css
@@ -2403,6 +2403,148 @@ button.shape-tag.is-clickable:hover {
   font-weight: 700;
 }
 
+/* ----- Compare modal: dashboard-style trajectory chart ----- */
+.compare-panel {
+  gap: 1rem;
+}
+.compare-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.compare-heading h2 {
+  margin: 0;
+}
+.compare-heading .modal-subtitle {
+  font-size: 0.85rem;
+}
+
+/* Legend sits directly above the chart and reads as its key; "Clear all"
+   rides flush-right on the same line so the controls stay compact. */
+.compare-legend-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem 0.9rem;
+  flex-wrap: wrap;
+}
+.compare-legend {
+  flex: 1 1 auto;
+}
+.compare-legend-name {
+  font-weight: 600;
+  color: var(--text);
+}
+.compare-clear {
+  flex: 0 0 auto;
+  padding: 0.32rem 0.7rem;
+  font-size: 0.78rem;
+}
+.compare-legend-remove .overlay-legend-swatch {
+  width: 0.85rem;
+  height: 0.32rem;
+  border-radius: 999px;
+}
+
+/* The chart is the focus: a single elevated card, generous but balanced
+   padding, no wasted vertical space. */
+.compare-chart {
+  position: relative;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 40%),
+    var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 0.9rem 1rem 0.7rem;
+}
+.compare-chart .compare-curve {
+  display: block;
+  width: 100%;
+  height: 270px;
+  background: none;
+  border-radius: 0;
+  padding: 0;
+}
+
+/* Vector layer: subtle grid, slightly firmer axis lines. Strokes are
+   non-scaling so they stay crisp under preserveAspectRatio="none". */
+.compare-grid {
+  stroke: rgba(255, 255, 255, 0.07);
+  stroke-width: 1;
+}
+.compare-grid-v {
+  stroke: rgba(255, 255, 255, 0.04);
+}
+.compare-axis-line {
+  stroke: rgba(255, 255, 255, 0.16);
+  stroke-width: 1;
+}
+
+/* HTML overlay: crisp dots + all text, positioned by percent so nothing is
+   stretched by the SVG's non-uniform scale. */
+.compare-overlay {
+  position: absolute;
+  inset: 0.9rem 1rem 0.7rem;
+  pointer-events: none;
+}
+.compare-dot {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 0 2px var(--surface-2);
+  pointer-events: auto;
+  cursor: default;
+}
+.compare-axis-label {
+  position: absolute;
+  font-size: 0.68rem;
+  line-height: 1;
+  color: var(--muted-2);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.compare-axis-y {
+  transform: translate(-100%, -50%);
+  padding-right: 0.3rem;
+}
+.compare-axis-x {
+  transform: translateX(-50%);
+  font-weight: 600;
+}
+.compare-val-label {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+  white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  .compare-chart {
+    padding: 0.75rem 0.7rem 0.6rem;
+  }
+  .compare-chart .compare-curve {
+    height: 220px;
+  }
+  .compare-overlay {
+    inset: 0.75rem 0.7rem 0.6rem;
+  }
+  .compare-axis-label,
+  .compare-val-label {
+    font-size: 0.62rem;
+  }
+  .compare-dot {
+    width: 8px;
+    height: 8px;
+  }
+}
+
 .provider-badges {
   display: flex;
   flex-wrap: wrap;

--- a/apps/rising-seasons/index.html
+++ b/apps/rising-seasons/index.html
@@ -749,15 +749,19 @@
   <!-- Compare modal (overlay trajectory across multiple series) -->
   <div class="modal" id="compareModal" role="dialog" aria-modal="true" aria-labelledby="compareModalTitle" aria-hidden="true" hidden>
     <div class="modal-backdrop" data-close="compare-modal"></div>
-    <article class="modal-panel" tabindex="-1" data-back-to-top>
+    <article class="modal-panel compare-panel" tabindex="-1" data-back-to-top>
       <button type="button" class="btn modal-close" data-close="compare-modal" aria-label="Close">×</button>
-      <h2 id="compareModalTitle">Compare shows</h2>
-      <p class="modal-subtitle">Season-average rating trajectory for each show. Click a show name to remove.</p>
-      <div class="modal-actions modal-actions-top">
-        <button type="button" class="btn btn-ghost" id="compareModalClear">Clear all</button>
+      <header class="compare-heading">
+        <h2 id="compareModalTitle">Compare shows</h2>
+        <p class="modal-subtitle">Season-average rating trajectory. Click a show in the legend to remove it.</p>
+      </header>
+      <div class="compare-legend-row">
+        <div class="overlay-legend compare-legend" id="compareModalLegend"></div>
+        <button type="button" class="btn btn-ghost compare-clear" id="compareModalClear">Clear all</button>
       </div>
-      <svg class="overlay-curve" id="compareModalCurve" viewBox="0 0 600 240" preserveAspectRatio="none" aria-hidden="true"></svg>
-      <div class="overlay-legend" id="compareModalLegend"></div>
+      <div class="compare-chart">
+        <svg class="overlay-curve compare-curve" id="compareModalCurve" viewBox="0 0 600 260" preserveAspectRatio="none" role="img" aria-label="Season-average rating trajectory chart"></svg>
+      </div>
     </article>
   </div>
 

--- a/apps/rising-seasons/js/app.js
+++ b/apps/rising-seasons/js/app.js
@@ -3063,39 +3063,145 @@ function syncCompareButton() {
     : inSet ? 'Remove this show from the compare set' : 'Add this show to the compare set';
 }
 
-// Trajectory chart: for each selected series, plot one polyline whose x is
-// the season index (1..N for that show) and y is that season's avg rating.
-// Series with different season counts share a normalized x so they overlay
-// cleanly. Hover the line for series + season detail.
+// Round a raw axis step up to a "nice" 1/2/5 × 10^n value so rating
+// gridlines land on readable numbers (…0.5, 1, 2…) instead of arbitrary
+// fractions.
+function niceStep(rawStep) {
+  if (!(rawStep > 0)) return 1;
+  const mag = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  const norm = rawStep / mag;
+  let step;
+  if (norm <= 1) step = 1;
+  else if (norm <= 2) step = 2;
+  else if (norm <= 5) step = 5;
+  else step = 10;
+  return step * mag;
+}
+
+// Trajectory chart: for each selected series, plot one line whose x is the
+// actual season number (so S1..Sn line up across shows and the magnitude of
+// each season-to-season change reads honestly) and y is that season's avg
+// rating. The SVG (preserveAspectRatio="none") carries only vector geometry —
+// gridlines, axis lines, area fills, the trend lines — while crisp dots and
+// all text live in an HTML overlay positioned by percent, so nothing is
+// stretched and labels stay at their CSS size on every viewport.
 function drawCompareChart(svg, seriesEntries, W, H) {
   while (svg.firstChild) svg.removeChild(svg.firstChild);
+  const host = svg.parentElement;
+  if (host) {
+    const old = host.querySelector(':scope > .compare-overlay');
+    if (old) old.remove();
+  }
   if (!seriesEntries.length) return;
 
-  const padX = 14;
-  const padY = 16;
   const NS = 'http://www.w3.org/2000/svg';
+  // Plot margins (viewBox units): left holds rating labels, bottom holds
+  // season labels, top leaves room for single-series value callouts.
+  const mL = 40, mR = 16, mT = 18, mB = 30;
+  const x0 = mL, x1 = W - mR, y0 = mT, y1 = H - mB;
+  const plotW = x1 - x0, plotH = y1 - y0;
 
-  let lo = Infinity, hi = -Infinity;
+  // --- domains -------------------------------------------------------------
+  let lo = Infinity, hi = -Infinity, maxSeason = 1;
   for (const { seasons } of seriesEntries) {
     for (const s of seasons) {
       if (s.avgRating < lo) lo = s.avgRating;
       if (s.avgRating > hi) hi = s.avgRating;
+      if (s.season > maxSeason) maxSeason = s.season;
     }
   }
-  lo = Math.max(0, lo - 0.3);
-  hi = Math.min(10, hi + 0.3);
+  // Snap the rating domain to half-points and guarantee at least a 1.0 span
+  // so a tight cluster of seasons still gets readable gridlines.
+  lo = Math.max(0, Math.floor((lo - 0.4) * 2) / 2);
+  hi = Math.min(10, Math.ceil((hi + 0.4) * 2) / 2);
+  if (hi - lo < 1) hi = Math.min(10, lo + 1);
   const span = Math.max(0.1, hi - lo);
 
+  const xMin = 1, xMax = Math.max(2, maxSeason);
+  const xPx = (season) => x0 + (xMax === xMin ? plotW / 2 : (season - xMin) / (xMax - xMin) * plotW);
+  const yPx = (r) => y0 + (1 - (r - lo) / span) * plotH;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'compare-overlay';
+  overlay.setAttribute('aria-hidden', 'true');
+  const xPct = (px) => (px / W * 100).toFixed(3);
+  const yPct = (py) => (py / H * 100).toFixed(3);
+
+  const mkLine = (xa, ya, xb, yb, cls) => {
+    const ln = document.createElementNS(NS, 'line');
+    ln.setAttribute('x1', xa.toFixed(1)); ln.setAttribute('y1', ya.toFixed(1));
+    ln.setAttribute('x2', xb.toFixed(1)); ln.setAttribute('y2', yb.toFixed(1));
+    ln.setAttribute('class', cls);
+    ln.setAttribute('vector-effect', 'non-scaling-stroke');
+    svg.appendChild(ln);
+  };
+  const mkLabel = (cls, left, top, text) => {
+    const el = document.createElement('span');
+    el.className = cls;
+    el.style.left = `${left}%`;
+    el.style.top = `${top}%`;
+    el.textContent = text;
+    overlay.appendChild(el);
+  };
+
+  // --- Y gridlines + rating labels ----------------------------------------
+  const yStep = niceStep((hi - lo) / 4);
+  const fmtRating = (v) => (Math.abs(v - Math.round(v)) < 1e-6 ? String(Math.round(v)) : v.toFixed(1));
+  for (let v = Math.ceil(lo / yStep) * yStep; v <= hi + 1e-6; v += yStep) {
+    const y = yPx(v);
+    mkLine(x0, y, x1, y, 'compare-grid');
+    mkLabel('compare-axis-label compare-axis-y', xPct(x0 - 8), yPct(y), fmtRating(v));
+  }
+
+  // --- X gridlines + season labels ----------------------------------------
+  const seasonSpan = xMax - xMin + 1;
+  const xStep = Math.max(1, Math.ceil(seasonSpan / 12));
+  const seasonTicks = [];
+  for (let s = xMin; s <= xMax; s += xStep) seasonTicks.push(s);
+  if (seasonTicks[seasonTicks.length - 1] !== xMax) seasonTicks.push(xMax);
+  for (const s of seasonTicks) {
+    const x = xPx(s);
+    mkLine(x, y0, x, y1, 'compare-grid compare-grid-v');
+    mkLabel('compare-axis-label compare-axis-x', xPct(x), yPct(y1 + 9), `S${s}`);
+  }
+
+  // --- axis lines ----------------------------------------------------------
+  mkLine(x0, y0, x0, y1, 'compare-axis-line');
+  mkLine(x0, y1, x1, y1, 'compare-axis-line');
+
+  // --- series --------------------------------------------------------------
+  const single = seriesEntries.length === 1;
   seriesEntries.forEach(({ title, seasons }, idx) => {
     const color = seasonColor(idx, seriesEntries.length);
-    const n = seasons.length;
-    const xStep = n > 1 ? (W - padX * 2) / (n - 1) : 0;
-    const points = seasons.map((s, i) => {
-      const x = padX + (n > 1 ? i * xStep : (W - padX * 2) / 2);
-      const y = padY + (1 - (s.avgRating - lo) / span) * (H - padY * 2);
-      return [x, y, s];
-    });
-    const d = points.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
+    const pts = seasons.map((s) => [xPx(s.season), yPx(s.avgRating), s]);
+
+    // Soft area fill under a lone series so the trajectory (and its final-
+    // season cliff) reads as a deliberate shape rather than a stray line.
+    if (single && pts.length > 1) {
+      const grad = document.createElementNS(NS, 'linearGradient');
+      const gid = 'compareFill';
+      grad.setAttribute('id', gid);
+      grad.setAttribute('x1', '0'); grad.setAttribute('y1', '0');
+      grad.setAttribute('x2', '0'); grad.setAttribute('y2', '1');
+      const stops = [['0%', 0.28], ['100%', 0.02]];
+      for (const [off, op] of stops) {
+        const st = document.createElementNS(NS, 'stop');
+        st.setAttribute('offset', off);
+        st.setAttribute('stop-color', color);
+        st.setAttribute('stop-opacity', String(op));
+        grad.appendChild(st);
+      }
+      svg.appendChild(grad);
+      const area = document.createElementNS(NS, 'path');
+      const dArea = pts.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ')
+        + ` L${pts[pts.length - 1][0].toFixed(1)},${y1.toFixed(1)} L${pts[0][0].toFixed(1)},${y1.toFixed(1)} Z`;
+      area.setAttribute('d', dArea);
+      area.setAttribute('fill', `url(#${gid})`);
+      area.setAttribute('stroke', 'none');
+      svg.appendChild(area);
+    }
+
+    const d = pts.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
     const path = document.createElementNS(NS, 'path');
     path.setAttribute('d', d);
     path.setAttribute('fill', 'none');
@@ -3104,23 +3210,36 @@ function drawCompareChart(svg, seriesEntries, W, H) {
     path.setAttribute('stroke-linecap', 'round');
     path.setAttribute('stroke-linejoin', 'round');
     path.setAttribute('vector-effect', 'non-scaling-stroke');
-    path.setAttribute('opacity', '0.9');
-    const title2 = document.createElementNS(NS, 'title');
-    title2.textContent = title;
-    path.appendChild(title2);
+    const ttl = document.createElementNS(NS, 'title');
+    ttl.textContent = title;
+    path.appendChild(ttl);
     svg.appendChild(path);
-    for (const [x, y, s] of points) {
-      const dot = document.createElementNS(NS, 'circle');
-      dot.setAttribute('cx', x.toFixed(1));
-      dot.setAttribute('cy', y.toFixed(1));
-      dot.setAttribute('r', '3.5');
-      dot.setAttribute('fill', color);
-      const dotTitle = document.createElementNS(NS, 'title');
-      dotTitle.textContent = `${title} - S${s.season}: avg ${s.avgRating.toFixed(1)}`;
-      dot.appendChild(dotTitle);
-      svg.appendChild(dot);
-    }
+
+    // Crisp HTML dots (round on every viewport) + per-point tooltip.
+    pts.forEach(([x, y, s], i) => {
+      const dot = document.createElement('span');
+      dot.className = 'compare-dot';
+      dot.style.left = `${xPct(x)}%`;
+      dot.style.top = `${yPct(y)}%`;
+      dot.style.background = color;
+      dot.title = `${title} — S${s.season}: avg ${s.avgRating.toFixed(1)}`;
+      overlay.appendChild(dot);
+      // For a lone series, call out each season's value above its dot.
+      if (single) {
+        const above = y - mT * 0.55 > y0;
+        mkLabel(
+          `compare-val-label${above ? '' : ' compare-val-label-below'}`,
+          xPct(x),
+          yPct(above ? y - 11 : y + 11),
+          s.avgRating.toFixed(1),
+        );
+        const last = overlay.lastChild;
+        if (last) last.style.color = color;
+      }
+    });
   });
+
+  if (host) host.appendChild(overlay);
 }
 
 function buildCompareEntries() {
@@ -3142,14 +3261,17 @@ function renderCompareLegend(entries) {
     const item = document.createElement('button');
     item.type = 'button';
     item.className = 'overlay-legend-item compare-legend-remove';
-    item.title = 'Remove from compare';
+    item.title = `Remove ${e.title} from compare`;
+    item.setAttribute('aria-label', `Remove ${e.title} from comparison`);
     const swatch = document.createElement('span');
     swatch.className = 'overlay-legend-swatch';
     swatch.style.background = colors[i];
     const label = document.createElement('span');
+    label.className = 'compare-legend-name';
     label.textContent = e.title;
     const x = document.createElement('span');
     x.className = 'compare-legend-x';
+    x.setAttribute('aria-hidden', 'true');
     x.textContent = '×';
     item.append(swatch, label, x);
     item.addEventListener('click', () => {
@@ -3173,7 +3295,7 @@ function renderCompareModal() {
     closeCompareModal();
     return;
   }
-  drawCompareChart(els.compareModalCurve, entries, 600, 240);
+  drawCompareChart(els.compareModalCurve, entries, 600, 260);
   renderCompareLegend(entries);
 }
 


### PR DESCRIPTION
Two independent, visual-only UI polish rounds. No data model, behavior, or feature add/remove. Source of truth: `git diff master...HEAD`.

## gym-tracker — active-workout set rows

Problem: the previous-performance value ("Last time: 130lb × 8") rendered as a large full-width rounded blue pill below the inputs, competing with weight/reps for attention.

- **`apps/gym-tracker/js/views/workout-view.js`** — `maybeToggleRestoreChip`: the restore chip's text/markup is now a history icon (`fa-clock-rotate-left`) + a compact `Previous: 130lb × 8` span, with a descriptive `aria-label`. Behavior unchanged: prior values still pre-fill the inputs, and the chip still appears only when you diverge from them; tapping it still restores the prior weight/reps (`restoreLastTime` untouched).
- **`apps/gym-tracker/css/refresh.css`** — `.gt-restore-chip` restyled from a full-width centered pill (border, pill radius, blue fill) into a left-aligned, auto-width, muted helper line: transparent background, no border, ~0.68rem, icon at 0.7 opacity, faint hover/focus surface for discoverability. Added `.gt-restore-chip i` and hover/focus rules.
- **`apps/gym-tracker/css/gym-tracker.css`** — densification: `.set-row-list` gap 0.4rem → 0.3rem; `.set-row` vertical padding 0.5rem → 0.4rem. 48px row min-height (touch target) preserved; active set still cued by its focus-within left accent border (no secondary box).

## rising-seasons — "Compare shows" modal

Problem: a single distorted line (`preserveAspectRatio="none"`, no axes/labels/gridlines), legend stranded below, lots of empty space.

- **`apps/rising-seasons/js/app.js`** —
  - New `niceStep(rawStep)` helper for readable 1/2/5×10^n axis steps.
  - `drawCompareChart` rewritten: rating Y axis with nice gridlines + labels; X axis labelled by ACTUAL season number (S1..Sn) so series align season-to-season and the magnitude of each change reads honestly; subtle grid + axis lines; single-series soft gradient area fill + per-season value callouts; multi-series = distinct colored lines with fill/labels suppressed to stay clean. Vector geometry stays in the SVG; crisp round dots and ALL text live in an HTML `.compare-overlay` positioned by percent (no stretching, labels stay at CSS size). The GoT S8 cliff now reads as an intentional, scale-contextualised drop. Per-point tooltips + chart `role="img"` aria-label retained.
  - `renderCompareLegend`: line-style swatch matching each line color, `compare-legend-name` class, clearer remove affordance (per-item `aria-label`, decorative ×). Remove-on-click and close-on-empty unchanged.
  - `renderCompareModal`: chart dims 600×240 → 600×260 to match the new viewBox.
- **`apps/rising-seasons/index.html`** — compare modal restructured: heading block (title + subtitle), a `.compare-legend-row` (legend + "Clear all" flush-right) directly above the chart, and a dedicated `.compare-chart` card wrapping the SVG. SVG gains `compare-curve` + `role="img"` + aria-label; the old `.modal-actions modal-actions-top` wrapper around Clear all was removed. `preserveAspectRatio="none"` deliberately kept (the percent-positioned HTML overlay depends on the viewBox filling the box).
- **`apps/rising-seasons/css/styles.css`** — new `.compare-*` rules: panel/heading/legend-row/clear styling, the chart card, grid/axis/dot/axis-label/value-label styles, line-style legend swatch, and a `max-width: 600px` breakpoint (shorter chart height, smaller labels, smaller dots) for mobile.

## Bugfixes found along the way
None — both rounds are scoped visual polish.

## Explicitly untouched
- The show-modal season-overlay chart (`#showModalOverlayCurve`) and its `.overlay-curve` / `.overlay-legend` / `.overlay-legend-toggle` base styles: all new compare styling is scoped to compare-specific classes so this shared chart is unaffected.
- Compare set persistence, the compare FAB, `buildCompareEntries`, `seasonColor`, and add/remove/clear logic.
- gym-tracker restore behavior, plate hints, and the duration-set rendering path.
- The unused legacy `.previous-data` / `.previous-sets-label` rules in `refresh.css` (not part of this UI).

## Judgment calls
- Kept the restore chip as a button (not static text) so the one-tap restore stays; only its weight/prominence changed — the request was to make the data feel secondary, not to drop the affordance.
- X axis uses real season numbers rather than normalized index so cross-show comparison and the final-season drop are positioned honestly.
- Area fill + value labels only for a single selected series; multiple series would clutter, so they're suppressed there.

## How it was tested
- `npm test`: **1124 passed / 0 failed**.
- Screenshot-verified both apps on desktop and 390px mobile via a faithful harness (real CSS + the exact chart functions; the rising-seasons dataset is 104MB so live-loading twice was impractical): gym-tracker compact "Previous:" line + denser rows; rising-seasons single-series GoT chart (axes, gridlines, area fill, value labels, S8 cliff) and a 3-series chart (season-aligned colored lines, legend swatches). Evidence dirs removed post-verification.
- Living plan pairs updated (local-only/gitignored): `gym-tracker-{claude,human}.md` and `rising-seasons-{claude,human}.md` each got a dated "Design round (2026-06-17)" section with the changed behavior and manual visual checks.