### PR TITLE
Site polish: home CTA, moadon-alef switcher, GA dns-prefetch

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,6 +15,7 @@
   <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -15,6 +15,7 @@
   <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>

--- a/home.html
+++ b/home.html
@@ -231,9 +231,15 @@
           <span class="eyebrow">About</span>
           <h3>Who we are</h3>
           <p>A short read on what Shevato focuses on, the kinds of teams we work with, and the projects we take on.</p>
-          <span class="more">Read the about</span>
+          <span class="more">Read about us</span>
         </a>
       </div>
+
+      <section class="cta-banner">
+        <h3>Have a project in mind?</h3>
+        <p>If you are weighing a build or an integration, we are glad to talk it through. Most engagements start with a short conversation.</p>
+        <a href="contact.html" class="cta-button"><span class="icon fa-envelope" aria-hidden="true"></span>Start a conversation</a>
+      </section>
 
     </div>
   </main>

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -281,10 +281,6 @@
       </div>
       
       <header class="special">
-        <p lang="en">Welcome to Moadon Alef, your trusted partner for professional house call medical services. We bring quality healthcare directly to your home with our team of experienced doctors available 24/7.</p>
-        <p lang="ru">Добро пожаловать в Моадон Алеф - ваш надежный партнер в области профессиональных медицинских услуг на дому. Мы предоставляем качественную медицинскую помощь прямо у вас дома с нашей командой опытных врачей, доступных 24/7.</p>
-        <p lang="he">ברוכים הבאים למועדון אלף, השותף המהימן שלכם לשירותי רפואה מקצועיים עד הבית. אנו מביאים טיפול רפואי איכותי ישירות לביתכם עם צוות רופאים מנוסים הזמינים 24/7.</p>
-        
         <div class="lang-switcher" role="group" aria-label="Language selection">
           <button type="button" class="lang-btn active" data-lang="en" aria-pressed="true">
             🇬🇧 English
@@ -296,6 +292,9 @@
             🇮🇱 עברית
           </button>
         </div>
+        <p lang="en">Welcome to Moadon Alef, your trusted partner for professional house call medical services. We bring quality healthcare directly to your home with our team of experienced doctors available 24/7.</p>
+        <p lang="ru">Добро пожаловать в Моадон Алеф - ваш надежный партнер в области профессиональных медицинских услуг на дому. Мы предоставляем качественную медицинскую помощь прямо у вас дома с нашей командой опытных врачей, доступных 24/7.</p>
+        <p lang="he">ברוכים הבאים למועדון אלף, השותף המהימן שלכם לשירותי רפואה מקצועיים עד הבית. אנו מביאים טיפול רפואי איכותי ישירות לביתכם עם צוות רופאים מנוסים הזמינים 24/7.</p>
       </header>
       
       <div class="highlights">

--- a/work.html
+++ b/work.html
@@ -15,6 +15,7 @@
   <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>


### PR DESCRIPTION
Site-level improvement round (marketing pages). Static HTML/CSS only, no JS or backend changes. Source of truth: `git diff master...HEAD` (5 files).

## What changed, per file

### `home.html`
- **CTA copy fix:** the About preview card said "Read the about" (ungrammatical); now "Read about us". The sibling cards ("Browse the work", "Open the apps") are untouched.
- **Terminal CTA banner:** added a `<section class="cta-banner">` after the `.preview-row` and before the footer include. It reuses the existing `.cta-banner` component already used on work.html/about.html (no new CSS), with copy "Have a project in mind?" and an `<a href="contact.html" class="cta-button">` ("Start a conversation"). The highest-traffic page (site root via 301) previously had no conversion close.

### `moadon-alef.html`
- **Language switcher moved up:** the `.lang-switcher` was the last child of `header.special`, sitting below three English/Russian/Hebrew welcome paragraphs. It is now the first child of `header.special`, directly above the welcome copy, so the page's primary Russian/Hebrew audience reaches it without scrolling past English-first text. The switcher markup, its `.lang-btn` buttons, `data-lang`/`aria-pressed` attributes, the welcome paragraphs, and the three `.skip-link` anchors are all unchanged (pure reorder).

### `work.html`, `about.html`, `contact.html`
- **GA `dns-prefetch` standardized:** added `<link rel="dns-prefetch" href="https://www.google-analytics.com">` (one per file, before the GA `<script async>`). home.html, apps.html, and 404.html already had it; these three were the only marketing pages missing it.

## Bugfixes found along the way
None beyond the copy typo above.

## Deliberate non-changes (explicitly untouched)
- **Canonical / `og:url` / sitemap URLs:** left as `.html`. Verified against prod: both `/home.html` and `/home` (and `/work`, `/apps`) return `200` with no redirect, so the existing `.html` canonicals already correctly consolidate the duplicate extensionless URLs. Changing them would be lateral and SEO-risky, so it was dropped.
- **Active-nav `aria-current`:** already implemented in `assets/js/main.js` (handles app pages, the Apps dropdown, and Pretty URLs). No change needed.
- **`apps.html` filter taxonomy** and the **`@shevato` `twitter:site` handle:** both need an owner product/brand decision (category labels; whether the handle is owned). Surfaced to the owner, not changed in this round.
- No `apps/<name>/` files, no shared CSS, and no JS were modified.

## Judgment calls
- Kept the home CTA as an `<a class="cta-button">` (not a `<button>`) so the sitewide `main.css` `button:hover` red wash does not apply, matching the work.html banner exactly. Verified via computed style (bg `#ffffff`, text blue) and screenshots.
- moadon-alef change is a DOM reorder only, to avoid any RTL/theme regressions; verified in English and Hebrew (RTL) at desktop and mobile.

## How it was tested
- `npm test`: **1124 passed / 0 failed**.
- Acceptance plan `.features/site-claude.md` + `.features/site-human.md` (local-only/gitignored), sections 35-38; latest run report (2026-06-17, app-test-runner): **37/37 passed, 0 failed, 0 unverified**.
- Screenshot-verified on desktop 1280 and mobile 390 (home CTA banner desktop+mobile incl. hover; moadon-alef switcher in English and Hebrew/RTL on both viewports). Evidence removed post-verification per ship convention.