### PR TITLE
feat(site, maptap-rivals): extensionless SEO URLs, moadon-alef a11y, skip-link fix, leaderboard sort rotation

### DIFF
--- a/about.html
+++ b/about.html
@@ -30,12 +30,12 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
 
-  <link rel="canonical" href="https://shevato.com/about.html" />
+  <link rel="canonical" href="https://shevato.com/about" />
 
   <meta property="og:title" content="About | Software Engineering Firm | Shevato" />
   <meta property="og:description" content="About Shevato LLC. A small software engineering firm focused on Java, Spring Boot microservices, and full stack work for client teams." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://shevato.com/about.html" />
+  <meta property="og:url" content="https://shevato.com/about" />
   <meta property="og:image" content="https://shevato.com/images/og/about.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -55,9 +55,9 @@
   {
     "@context": "https://schema.org",
     "@type": "AboutPage",
-    "@id": "https://shevato.com/about.html#webpage",
+    "@id": "https://shevato.com/about#webpage",
     "name": "About Shevato",
-    "url": "https://shevato.com/about.html",
+    "url": "https://shevato.com/about",
     "isPartOf": { "@id": "https://shevato.com/#website" },
     "about": { "@id": "https://shevato.com/#organization" },
     "inLanguage": "en"
@@ -80,8 +80,8 @@
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-      { "@type": "ListItem", "position": 2, "name": "About", "item": "https://shevato.com/about.html" }
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+      { "@type": "ListItem", "position": 2, "name": "About", "item": "https://shevato.com/about" }
     ]
   }
   </script>

--- a/apps.html
+++ b/apps.html
@@ -28,13 +28,13 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
 
-  <link rel="canonical" href="https://shevato.com/apps.html" />
+  <link rel="canonical" href="https://shevato.com/apps" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Free Apps | Games, Fitness and TV Trackers from Shevato" />
   <meta property="og:description" content="Free web apps for Mario Kart racing, gym workouts, head-to-head football, TV episode-rating analytics, and MapTap.gg daily rivalry tracking." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://shevato.com/apps.html" />
+  <meta property="og:url" content="https://shevato.com/apps" />
   <meta property="og:image" content="https://shevato.com/images/og/apps.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -57,8 +57,8 @@
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" }
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps" }
     ]
   }
   </script>
@@ -70,7 +70,7 @@
     "@type": "CollectionPage",
     "name": "Shevato Apps",
     "description": "Free web applications including Mario Kart race tracker, gym workout logger, head-to-head football league manager, Rising Seasons TV episode-rating analytics, and MapTap Rivals daily MapTap.gg head-to-head tracker",
-    "url": "https://shevato.com/apps.html",
+    "url": "https://shevato.com/apps",
     "publisher": {
       "@type": "Organization",
       "name": "Shevato LLC",

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -2586,10 +2586,13 @@ body.maptap-rivals-app button {
   color: var(--accent-2);
 }
 .lb-th-sorted::after {
-  content: ' \25BC'; /* down triangle */
+  content: ' \25BC'; /* down triangle (descending) */
   font-size: 0.55rem;
   vertical-align: middle;
   opacity: 0.7;
+}
+.lb-th-sorted[aria-sort="ascending"]::after {
+  content: ' \25B2'; /* up triangle (ascending) */
 }
 /* Rivalry score tooltip trigger */
 .lb-th-hint {

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -208,7 +208,8 @@
     view: 'dashboard',
     matrixSelection: load(KEY.MATRIX_SEL, null), // string[] of rivalIds, or null = "all"
     matrixTab: 'record',           // overridden by URL hash on first paint
-    lbSort: 'winpct',              // 'winpct' | 'rivalry'
+    lbSort: 'winpct',              // sortable column key, e.g. 'winpct' | 'rivalry'
+    lbDir: 1,                      // 1 = column's natural order, -1 = reversed (toggled by re-clicking the header)
     historyFilters: { rival: 'all', result: 'all' },
     historyPage: 1,
     historyPageSize: 25,
@@ -4053,17 +4054,30 @@
       // active loss streaks (negative, longest = lowest).
       streak:  (a, b) => (b.streak.curMine - b.streak.curTheirs) - (a.streak.curMine - a.streak.curTheirs),
     };
+    // Each comparator above encodes the column's *natural* order (numeric
+    // columns descending, "rival" A→Z). Re-clicking the active header flips
+    // state.lbDir to -1, which reverses just the primary key; the games/name
+    // tie-breakers stay stable so equal rows keep a predictable order.
+    const dir = state.lbDir === -1 ? -1 : 1;
     const cmp = LB_SORTS[state.lbSort] || LB_SORTS.winpct;
     summaries.sort((a, b) =>
-      cmp(a, b) || b.total - a.total || a.rival.name.localeCompare(b.rival.name));
+      dir * cmp(a, b) || b.total - a.total || a.rival.name.localeCompare(b.rival.name));
 
-    // Update sort-active state on the column headers.
+    // Update sort-active state on the column headers. aria-sort reflects the
+    // actual direction (the ::after caret follows aria-sort in CSS), so the
+    // "rival" column reads ascending by default and the numeric ones descending.
     for (const key of Object.keys(LB_SORTS)) {
       const th = $('#lb-th-' + key);
       if (!th) continue;
       const active = state.lbSort === key;
       th.classList.toggle('lb-th-sorted', active);
-      th.setAttribute('aria-sort', active ? (key === 'rival' ? 'ascending' : 'descending') : 'none');
+      if (active) {
+        const naturalAscending = key === 'rival';
+        const ascending = dir === 1 ? naturalAscending : !naturalAscending;
+        th.setAttribute('aria-sort', ascending ? 'ascending' : 'descending');
+      } else {
+        th.setAttribute('aria-sort', 'none');
+      }
     }
 
     summaries.forEach((s, i) => {
@@ -6119,8 +6133,14 @@
       return function (e) {
         if (e.type === 'keydown' && e.key !== 'Enter' && e.key !== ' ') return;
         if (e.type === 'keydown') e.preventDefault();
-        if (state.lbSort === sortKey) return;
-        state.lbSort = sortKey;
+        if (state.lbSort === sortKey) {
+          // Re-clicking the active column rotates the direction.
+          state.lbDir = state.lbDir === -1 ? 1 : -1;
+        } else {
+          // A new column starts in its natural order.
+          state.lbSort = sortKey;
+          state.lbDir = 1;
+        }
         if (state.view === 'leaderboard') renderLeaderboard();
       };
     }

--- a/assets/css/brand-colors.css
+++ b/assets/css/brand-colors.css
@@ -46,8 +46,14 @@
    top-level page that loads this stylesheet. */
 .skip-link {
   position: absolute;
-  top: -40px;
+  top: 0;
   left: 0;
+  /* Hide by the link's own full height (height-independent) rather than a
+     magic top:-40px. The old fixed offset assumed the link was exactly 40px
+     tall, so a 1-2px blue sliver peeked below y=0; on pages with the fixed
+     header that sliver is hidden behind it, but moadon-alef has no header so
+     it showed as a stray blue line in the top-left corner. */
+  transform: translateY(-100%);
   z-index: 1000;
   padding: 8px 16px;
   background: var(--brand-blue);
@@ -56,7 +62,7 @@
   font-weight: 600;
 }
 .skip-link:focus {
-  top: 0;
+  transform: translateY(0);
   outline: 2px solid #ffffff;
   outline-offset: -2px;
 }

--- a/assets/js/language-switcher.js
+++ b/assets/js/language-switcher.js
@@ -20,6 +20,13 @@ function isStructuralLangHost(el) {
   return el === document.documentElement || el === document.body;
 }
 
+function isLangContainer(el) {
+  // The brand H1 carries a `lang` attribute for a11y/SEO but stays visible in
+  // every language; its inner spans are the ones toggled. It is handled
+  // explicitly below so the default-hide CSS rule never collapses it.
+  return el.classList.contains('brand-title');
+}
+
 function switchLanguage(lang) {
   if (!SUPPORTED_LANGS.has(lang)) return;
 
@@ -30,16 +37,25 @@ function switchLanguage(lang) {
   });
 
   document.querySelectorAll('[lang]').forEach(el => {
-    if (el.classList.contains('lang-btn') || isStructuralLangHost(el)) return;
+    if (el.classList.contains('lang-btn') || isStructuralLangHost(el) || isLangContainer(el)) return;
     el.style.display = 'none';
   });
 
   document.querySelectorAll(`[lang="${lang}"]`).forEach(el => {
-    if (el.classList.contains('lang-btn') || isStructuralLangHost(el)) return;
+    if (el.classList.contains('lang-btn') || isStructuralLangHost(el) || isLangContainer(el)) return;
     el.style.display = LANG_BLOCK_ELEMENTS.has(el.tagName) ? 'block' : 'inline';
   });
 
   document.body.dir = (lang === 'he') ? 'rtl' : 'ltr';
+  document.documentElement.lang = lang;
+
+  const brandTitle = document.querySelector('h1.brand-title');
+  if (brandTitle) {
+    // Updating the H1's own lang would otherwise trip the default-hide CSS
+    // rule for non-English; pin its display so it stays visible in every lang.
+    brandTitle.lang = lang;
+    brandTitle.style.display = 'block';
+  }
 
   try {
     localStorage.setItem(STORAGE_KEY, lang);

--- a/contact.html
+++ b/contact.html
@@ -30,12 +30,12 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
 
-  <link rel="canonical" href="https://shevato.com/contact.html" />
+  <link rel="canonical" href="https://shevato.com/contact" />
 
   <meta property="og:title" content="Contact | Hire a Software Engineering Firm | Shevato" />
   <meta property="og:description" content="Reach Shevato LLC by email, phone, or LinkedIn for Java, Spring Boot, microservices, or full stack contracting work." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://shevato.com/contact.html" />
+  <meta property="og:url" content="https://shevato.com/contact" />
   <meta property="og:image" content="https://shevato.com/images/og/contact.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -55,9 +55,9 @@
   {
     "@context": "https://schema.org",
     "@type": "ContactPage",
-    "@id": "https://shevato.com/contact.html#webpage",
+    "@id": "https://shevato.com/contact#webpage",
     "name": "Contact Shevato",
-    "url": "https://shevato.com/contact.html",
+    "url": "https://shevato.com/contact",
     "isPartOf": { "@id": "https://shevato.com/#website" },
     "about": { "@id": "https://shevato.com/#organization" },
     "inLanguage": "en"
@@ -69,8 +69,8 @@
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-      { "@type": "ListItem", "position": 2, "name": "Contact", "item": "https://shevato.com/contact.html" }
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+      { "@type": "ListItem", "position": 2, "name": "Contact", "item": "https://shevato.com/contact" }
     ]
   }
   </script>

--- a/home.html
+++ b/home.html
@@ -33,13 +33,13 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
 
-  <link rel="canonical" href="https://shevato.com/home.html" />
+  <link rel="canonical" href="https://shevato.com/home" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Shevato | Software Engineering Firm" />
   <meta property="og:description" content="Shevato LLC delivers Spring Boot microservices, REST APIs, and full stack web applications for client teams, plus a handful of free web apps." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://shevato.com/home.html" />
+  <meta property="og:url" content="https://shevato.com/home" />
   <meta property="og:image" content="https://shevato.com/images/og-card.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -87,15 +87,15 @@
           "@type": "SearchAction",
           "target": {
             "@type": "EntryPoint",
-            "urlTemplate": "https://shevato.com/apps.html?q={search_term_string}"
+            "urlTemplate": "https://shevato.com/apps?q={search_term_string}"
           },
           "query-input": "required name=search_term_string"
         }
       },
       {
         "@type": "WebPage",
-        "@id": "https://shevato.com/home.html#webpage",
-        "url": "https://shevato.com/home.html",
+        "@id": "https://shevato.com/home#webpage",
+        "url": "https://shevato.com/home",
         "name": "Shevato | Software Engineering Firm",
         "isPartOf": { "@id": "https://shevato.com/#website" },
         "about": { "@id": "https://shevato.com/#organization" },

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html lang="he" dir="rtl">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -257,7 +257,7 @@
     <div class="inner">
       <div class="contact-header">
         <!-- Single H1 wrapper; language-specific spans are toggled by the language switcher so the DOM always has exactly one <h1>. -->
-        <h1 class="brand-title">
+        <h1 class="brand-title" lang="en">
           <span lang="en">Moadon Alef</span>
           <span lang="ru">Моадон Алеф</span>
           <span lang="he">מועדון אלף</span>

--- a/sitemap-pages.xml
+++ b/sitemap-pages.xml
@@ -2,35 +2,35 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>https://shevato.com/home.html</loc>
+    <loc>https://shevato.com/home</loc>
     <lastmod>2026-05-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
-    <loc>https://shevato.com/work.html</loc>
+    <loc>https://shevato.com/work</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
-    <loc>https://shevato.com/about.html</loc>
+    <loc>https://shevato.com/about</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://shevato.com/contact.html</loc>
+    <loc>https://shevato.com/contact</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://shevato.com/apps.html</loc>
+    <loc>https://shevato.com/apps</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/work.html
+++ b/work.html
@@ -30,12 +30,12 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
 
-  <link rel="canonical" href="https://shevato.com/work.html" />
+  <link rel="canonical" href="https://shevato.com/work" />
 
   <meta property="og:title" content="Selected Work | Shevato" />
   <meta property="og:description" content="Selected work from Shevato LLC. Spring Boot microservices, retail e-commerce, partner integrations, and personal web apps." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://shevato.com/work.html" />
+  <meta property="og:url" content="https://shevato.com/work" />
   <meta property="og:image" content="https://shevato.com/images/og/work.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -56,8 +56,8 @@
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-      { "@type": "ListItem", "position": 2, "name": "Work", "item": "https://shevato.com/work.html" }
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+      { "@type": "ListItem", "position": 2, "name": "Work", "item": "https://shevato.com/work" }
     ]
   }
   </script>
@@ -66,8 +66,8 @@
   {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "@id": "https://shevato.com/work.html#webpage",
-    "url": "https://shevato.com/work.html",
+    "@id": "https://shevato.com/work#webpage",
+    "url": "https://shevato.com/work",
     "name": "Selected Work | Shevato",
     "isPartOf": { "@id": "https://shevato.com/#website" },
     "about": { "@id": "https://shevato.com/#organization" },


### PR DESCRIPTION
## Summary

A mixed round touching the **marketing site** (SEO, moadon-alef accessibility, a sitewide skip-link fix) and the **MapTap Rivals app** (leaderboard sorting). Every changed file is enumerated below, derived from `git diff master...HEAD`.

## Site: extensionless URL sweep (SEO)

Netlify serves these pages extensionless in production (`/home`, not `/home.html`), but their declared self-URLs still carried `.html`. A canonical that does not match the served URL lets Google ignore the canonical and pick its own. Stripped `.html` from all declared self-URLs:

- **`home.html`** - canonical, `og:url`, WebSite SearchAction `urlTemplate` (`apps.html?q=` -> `apps?q=`), WebPage `@id` + `url`.
- **`work.html`** - canonical, `og:url`, WebPage `@id` + `url`, BreadcrumbList items.
- **`about.html`** - canonical, `og:url`, AboutPage `@id` + `url`, BreadcrumbList items.
- **`contact.html`** - canonical, `og:url`, ContactPage `@id` + `url`, BreadcrumbList items.
- **`apps.html`** - canonical, `og:url`, CollectionPage `url`, BreadcrumbList items. (This file also briefly carried a per-card "Saves locally" trust badge that was added and then removed at owner request during the round; net change here is the SEO metadata only.)
- **`sitemap-pages.xml`** - `<loc>` for home/work/about/contact/apps made extensionless.

**Explicitly untouched (deliberate non-changes):** `moadon-alef.html` and its hreflang alternates in the sitemap stay `.html` (it is served at its literal filename, not pretty-rewritten); the root `https://shevato.com/`; the `/apps/<app>/` directory URLs (already extensionless); `404.html` (noindex); and all `<lastmod>` values (metadata-only change).

## Site: moadon-alef language accessibility

- **`moadon-alef.html`** - opening element changed from `<html lang="he" dir="rtl">` to `<html lang="en">` (the page loads English by default; `dir` is now applied dynamically). The brand `<h1>` got `lang="en"` so its three translated spans are no longer read as one concatenated string.
- **`assets/js/language-switcher.js`** - the `switchLanguage` path now also sets `document.documentElement.lang` and the brand H1's `lang` to the active language on initial load and every switch, and pins the H1's `display:block` so the existing `[lang]:not([lang="en"]){display:none}` rule cannot collapse it (a bug the H1 `lang` addition would otherwise have introduced). Visible rendering is unchanged in all three languages.

## Site: skip-link blue-line fix (owner-reported)

- **`assets/css/brand-colors.css`** - the accessibility skip-link hid itself with a magic `top:-40px` that assumed the link was exactly 40px tall; it renders slightly taller, leaking a 1-2px blue sliver at the top-left. On pages with the fixed `#header` that sliver is covered, but moadon-alef has no header, so it showed as a stray blue line (this is what the owner reported). Now hidden by the link's own full height with `transform: translateY(-100%)` (height-independent), and `:focus` reveals it via `transform: translateY(0)`. **Bugfix found along the way / pre-existing:** this defect existed before this round; the branch's moadon changes only touched `lang` attributes.

## MapTap Rivals: leaderboard sort direction rotates

- **`apps/maptap-rivals/js/app.js`** - previously each leaderboard column sorted one fixed way and re-clicking the active header did nothing (`if (state.lbSort === sortKey) return;`). Added a direction state `lbDir` (1 = column's natural order, -1 = reversed); re-clicking the active column flips it, clicking a different column resets to natural order. `renderLeaderboard` multiplies the comparator by `dir` (reversing only the primary key; games/name tie-breakers stay stable) and sets each header's `aria-sort` to the real direction.
- **`apps/maptap-rivals/css/styles.css`** - the sort caret now follows `aria-sort`: down triangle (▼) for descending, new `.lb-th-sorted[aria-sort="ascending"]::after` rule shows the up triangle (▲) for ascending.

## Judgment calls

- The per-card trust badge (originally part of this round) was reverted at owner request; `assets/css/content-alignment.css` is back to its master state and is not in this diff.
- The skip-link fix was made in the shared `brand-colors.css` (helps every page) rather than scoped to moadon-alef, because the magic-number hide was genuinely fragile everywhere; verified no regression on a page that has the header.
- The moadon-alef shared-site header was intentionally NOT added (its separate branding was preserved per owner decision), so the page still has no top nav by design.

## How it was tested

- `npm test`: **1124 passed, 0 failed.**
- Site plan pair `.features/site-claude.md` + `-human.md`, latest run report: machine assertions for the extensionless sweep, moadon lang fixes, and skip-link fix all pass; visual/live-switcher items routed to the human checklist.
- MapTap Rivals plan pair `.features/maptap-rivals-claude.md` + `-human.md` (Section 33): rotation verified by seeding a 3-rival leaderboard (win% 100/33/0) and driving the real headers - Win% went descending -> ascending -> descending -> ascending on successive clicks with `aria-sort` flipping each time; switching to the Wins column reset to descending and cleared the old indicator.
- Visual changes screenshot-verified on desktop 1280 and mobile 390 (moadon top-left clear, skip-link focus reveal, home.html no regression, leaderboard caret/order).
