### PR TITLE
feat(score-predictor): server-collected 90-minute results + full-history v2

### DIFF
--- a/netlify/functions/lib/wc-store.mjs
+++ b/netlify/functions/lib/wc-store.mjs
@@ -1,0 +1,74 @@
+// Shared constants + match-key helper for the Score Predictor result store.
+//
+// The page (which talks to The Odds API) and this collector (which talks to
+// API-Football) never share match ids, so results are keyed by a normalized
+// "home|away|date" string that both providers can produce. The identical
+// normalizer is mirrored in tools/score-predictor.html (WC_normTeam); keep the
+// two in sync — the alias table is the only place provider spellings diverge.
+
+export const STORE_NAME = 'score-predictor';
+export const RESULTS_KEY = 'results';
+export const LOCKS_KEY = 'locks';
+
+// Median of a numeric list (used for consensus odds across bookmakers).
+export function median(arr) {
+  const xs = (arr || []).filter(function (n) { return Number.isFinite(n); }).sort(function (a, b) { return a - b; });
+  if (!xs.length) return NaN;
+  const mid = Math.floor(xs.length / 2);
+  return xs.length % 2 ? xs[mid] : (xs[mid - 1] + xs[mid]) / 2;
+}
+
+// Median home/away decimal odds across an Odds API event's bookmakers. Mirrors
+// the page's consensus() so server-frozen locks yield the same picks the page
+// would have computed from an open tab.
+export function oddsConsensus(event) {
+  const home = [], away = [];
+  ((event && event.bookmakers) || []).forEach(function (bk) {
+    const m = (bk.markets || []).find(function (x) { return x.key === 'h2h'; });
+    if (!m) return;
+    (m.outcomes || []).forEach(function (o) {
+      if (o.name === event.home_team || o.name === 'HOME') home.push(o.price);
+      else if (o.name === event.away_team || o.name === 'AWAY') away.push(o.price);
+    });
+  });
+  return { home: median(home), away: median(away) };
+}
+
+// Provider spellings that differ for the same national team, folded to one
+// canonical token. Keys are already normalized (lower-case, no punctuation).
+const ALIASES = {
+  unitedstates: 'usa',
+  us: 'usa',
+  korearepublic: 'southkorea',
+  republicofkorea: 'southkorea',
+  korea: 'southkorea',
+  iranislamicrepublic: 'iran',
+  iriran: 'iran',
+  czechia: 'czechrepublic',
+  cotedivoire: 'ivorycoast',
+  capeverdeislands: 'capeverde',
+  bosniaandherzegovina: 'bosnia',
+  drcongo: 'congodr',
+  democraticrepublicofcongo: 'congodr',
+};
+
+// Lower-case, strip diacritics, drop everything but a-z0-9, then de-alias.
+export function normTeam(name) {
+  const base = String(name || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+  return ALIASES[base] || base;
+}
+
+// UTC calendar date of a kickoff, used to disambiguate repeat pairings. The
+// client tolerates a +/- 1 day slip so provider timezone rounding never
+// splits a match into two keys.
+export function matchDate(commence) {
+  return String(commence || '').slice(0, 10);
+}
+
+export function matchKey(home, away, commence) {
+  return `${normTeam(home)}|${normTeam(away)}|${matchDate(commence)}`;
+}

--- a/netlify/functions/package.json
+++ b/netlify/functions/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "shevato-netlify-functions",
+  "private": true,
+  "type": "module",
+  "description": "Runtime dependencies for Netlify Functions. node_modules and lockfile are gitignored; Netlify installs from this manifest at build time.",
+  "dependencies": {
+    "@netlify/blobs": "^8.1.0"
+  }
+}

--- a/netlify/functions/wc-results-cron.mjs
+++ b/netlify/functions/wc-results-cron.mjs
@@ -1,0 +1,148 @@
+// Score Predictor — server-side results collector (scheduled).
+//
+// Why this exists: the browser page grades picks against final scores, but
+// The Odds API /scores endpoint only returns games from the last 3 days, so
+// a match whose final was never captured while a tab happened to be open
+// (and inside that 3-day window) could never be back-filled and was stuck
+// showing "awaiting result" forever. This function removes the tab entirely
+// from data collection: it runs on a schedule, pulls the World Cup fixtures
+// from API-Football, and accumulates results into a Netlify Blob that the
+// page reads on load. Once a result is stored it persists indefinitely.
+//
+// It also fixes the knockout problem: we store the 90-minute (regulation)
+// score only. API-Football exposes score.fulltime as the score at the end of
+// normal time, kept separate from score.extratime and score.penalty, so a
+// knockout that finishes 1-1 after 90 and 2-1 after extra time is stored as
+// 1-1. That is the only number the page cares about.
+//
+// Required env var (set in the Netlify UI, never in the repo):
+//   APIFOOTBALL_KEY   — api-sports.io key (header x-apisports-key)
+// Optional overrides:
+//   WC_APIFOOTBALL_LEAGUE  (default 1 = FIFA World Cup)
+//   WC_APIFOOTBALL_SEASON  (default 2026)
+
+import { getStore } from '@netlify/blobs';
+import { STORE_NAME, RESULTS_KEY, LOCKS_KEY, matchKey, oddsConsensus } from './lib/wc-store.mjs';
+
+// Hourly. Idle runs are cheap: one API-Football call returns the whole
+// tournament, and results only ever change right after a match, so an hour
+// of latency is invisible while the 3-day-window problem disappears entirely.
+export const config = { schedule: '0 * * * *' };
+
+const API_URL = 'https://v3.football.api-sports.io/fixtures';
+const LEAGUE = process.env.WC_APIFOOTBALL_LEAGUE || '1';
+const SEASON = process.env.WC_APIFOOTBALL_SEASON || '2026';
+
+// The Odds API — same feed the page uses, polled server-side so odds are
+// frozen into locks before kickoff even when no tab is open. Without this the
+// page could never show picks for a match nobody had open at kickoff.
+const ODDS_URL = 'https://api.the-odds-api.com/v4/sports/soccer_fifa_world_cup/odds/?regions=eu&markets=h2h&oddsFormat=decimal&apiKey=';
+
+// API-Football status short codes. Once a match is at or past full time the
+// 90-minute score can no longer change, so score.fulltime is final even while
+// the game continues into extra time or penalties.
+const POST_REGULATION = new Set(['FT', 'AET', 'PEN', 'ET', 'BT', 'P', 'LIVE']);
+
+export default async function handler() {
+  const key = process.env.APIFOOTBALL_KEY;
+  if (!key) {
+    return new Response('APIFOOTBALL_KEY is not configured', { status: 500 });
+  }
+
+  let body;
+  try {
+    const res = await fetch(`${API_URL}?league=${LEAGUE}&season=${SEASON}`, {
+      headers: { 'x-apisports-key': key },
+    });
+    if (!res.ok) {
+      return new Response(`api-football ${res.status}`, { status: 502 });
+    }
+    body = await res.json();
+  } catch (err) {
+    return new Response(`fetch failed: ${err.message}`, { status: 502 });
+  }
+
+  const store = getStore(STORE_NAME);
+  const prev = (await store.get(RESULTS_KEY, { type: 'json' })) || {};
+  const results = { ...(prev.results || {}) };
+
+  let stored = 0;
+  for (const item of body.response || []) {
+    const home = item?.teams?.home?.name;
+    const away = item?.teams?.away?.name;
+    const commence = item?.fixture?.date;
+    const status = item?.fixture?.status?.short;
+    const ft = item?.score?.fulltime;
+    if (!home || !away || !commence || !ft) continue;
+
+    const hs = Number(ft.home);
+    const as = Number(ft.away);
+    // fulltime is null until 90 minutes are played; guard against half-time.
+    if (!Number.isFinite(hs) || !Number.isFinite(as)) continue;
+
+    const completed = POST_REGULATION.has(status);
+    const k = matchKey(home, away, commence);
+    results[k] = {
+      home_score: hs,
+      away_score: as,
+      completed,
+      status,
+      home_team: home,
+      away_team: away,
+      commence_time: commence,
+    };
+    stored += 1;
+  }
+
+  await store.setJSON(RESULTS_KEY, {
+    updated: new Date().toISOString(),
+    league: LEAGUE,
+    season: SEASON,
+    results,
+  });
+
+  const locked = await snapshotOdds(store);
+
+  return new Response(`ok: scanned ${(body.response || []).length}, results ${stored}, locks ${locked}`);
+}
+
+// Freeze median odds for every not-yet-started match into the locks blob so the
+// page can compute picks from the server alone. Best-effort: a failure here
+// must not affect the results already stored above. Once a match kicks off it
+// drops out of the odds feed, so its last snapshot persists untouched.
+async function snapshotOdds(store) {
+  const key = process.env.ODDS_API_KEY;
+  if (!key) return 'skipped (no ODDS_API_KEY)';
+
+  let events;
+  try {
+    const res = await fetch(ODDS_URL + encodeURIComponent(key));
+    if (!res.ok) return `odds ${res.status}`;
+    events = await res.json();
+  } catch (err) {
+    return `odds fetch failed: ${err.message}`;
+  }
+
+  const prev = (await store.get(LOCKS_KEY, { type: 'json' })) || {};
+  const locks = { ...(prev.locks || {}) };
+  const now = Date.now();
+
+  let n = 0;
+  for (const ev of events || []) {
+    if (!ev || !ev.id || !ev.home_team || !ev.away_team || !ev.commence_time) continue;
+    if (new Date(ev.commence_time).getTime() <= now) continue; // started: keep frozen lock
+    const o = oddsConsensus(ev);
+    if (!Number.isFinite(o.home) || !Number.isFinite(o.away)) continue;
+    locks[matchKey(ev.home_team, ev.away_team, ev.commence_time)] = {
+      home: o.home,
+      away: o.away,
+      commence_time: ev.commence_time,
+      home_team: ev.home_team,
+      away_team: ev.away_team,
+    };
+    n += 1;
+  }
+
+  await store.setJSON(LOCKS_KEY, { updated: new Date().toISOString(), locks });
+  return String(n);
+}

--- a/netlify/functions/wc-results.mjs
+++ b/netlify/functions/wc-results.mjs
@@ -1,0 +1,32 @@
+// Score Predictor — public read endpoint for collected 90-minute results.
+//
+// Serves whatever wc-results-cron.mjs has accumulated in the Blob store. The
+// page fetches this on load and on Load/Refresh, then merges each result onto
+// the matching fixture by team + date. No key required: reading finals is
+// harmless and lets the scoreboard fill in even for a visitor who has never
+// entered an Odds API key.
+
+import { getStore } from '@netlify/blobs';
+import { STORE_NAME, RESULTS_KEY, LOCKS_KEY } from './lib/wc-store.mjs';
+
+export default async function handler() {
+  const store = getStore(STORE_NAME);
+  const resultsBlob = (await store.get(RESULTS_KEY, { type: 'json' })) || {};
+  const locksBlob = (await store.get(LOCKS_KEY, { type: 'json' })) || {};
+
+  const data = {
+    updated: resultsBlob.updated || null,
+    locks: locksBlob.locks || {},
+    results: resultsBlob.results || {},
+  };
+
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      // Short cache: results change at most once an hour, and the client also
+      // holds its own copy, so a few minutes of edge cache is free freshness.
+      'cache-control': 'public, max-age=300, stale-while-revalidate=3600',
+    },
+  });
+}

--- a/tools/score-predictor-v2.html
+++ b/tools/score-predictor-v2.html
@@ -1,0 +1,1382 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex, nofollow">
+<title>Score Predictor v2</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚽</text></svg>">
+<style>
+  /*
+   * Score Predictor - fully self-contained local tool. No build step, no
+   * dependencies. Open this file directly in any browser. The only network
+   * call is the optional fixtures/scores fetch to The Odds API.
+   */
+  :root {
+    color-scheme: dark;
+    --bg: #0b0d12;
+    --surface: #161922;
+    --surface-2: #1f232f;
+    --text: #e7e9ee;
+    --muted: #9aa3b2;
+    --muted-2: #6b7280;
+    --accent: #6366f1;
+    --accent-2: #818cf8;
+    --accent-soft: rgba(99, 102, 241, 0.16);
+    --good: #4ade80;
+    --border: #252938;
+    --border-strong: #353a4b;
+    --radius: 14px;
+    --mono: "JetBrains Mono", "SF Mono", "Cascadia Code", ui-monospace, "Roboto Mono", Menlo, monospace;
+  }
+
+  * { box-sizing: border-box; }
+
+  html {
+    background: var(--bg);
+    background-image:
+      radial-gradient(circle at 18% 0%, rgba(99, 102, 241, 0.10), transparent 55%),
+      radial-gradient(circle at 82% 0%, rgba(74, 222, 128, 0.06), transparent 55%);
+    background-attachment: fixed;
+    min-height: 100%;
+  }
+
+  body {
+    margin: 0;
+    color: var(--text);
+    line-height: 1.5;
+    font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .page { max-width: 880px; margin: 0 auto; padding: 1.5rem 1rem 4rem; }
+
+  .hero { text-align: center; padding: 1.5rem 0 1.75rem; }
+  .hero h1 { margin: 0; font-size: clamp(1.8rem, 4.5vw, 2.5rem); font-weight: 800; letter-spacing: -0.02em; }
+  .tagline { color: var(--muted); margin: 0.5rem auto 0; max-width: 36rem; }
+
+  .section-title { font-size: 1.15rem; font-weight: 700; margin: 0 0 0.35rem; }
+  .section-sub { color: var(--muted); font-size: 0.9rem; margin: 0 0 1rem; }
+
+  /* Mode toggle */
+  .mode-toggle {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1.4rem;
+    flex-wrap: wrap;
+  }
+  .mode-btn {
+    background: var(--surface-2);
+    border: 1px solid var(--border-strong);
+    border-radius: 999px;
+    color: var(--muted);
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.45rem 1rem;
+    cursor: pointer;
+  }
+  .mode-btn:hover { color: var(--text); }
+  .mode-btn.is-active {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: var(--accent-2);
+  }
+
+  /* Calculator */
+  .calc-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+  }
+  .calc-inputs { display: flex; align-items: flex-end; justify-content: center; gap: 1rem; }
+  .odds-field { display: flex; flex-direction: column; gap: 0.4rem; flex: 1; max-width: 16rem; }
+  .odds-label {
+    font-size: 0.8rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.06em; color: var(--muted);
+  }
+  .odds-field input {
+    background: var(--surface-2);
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    color: var(--text);
+    font-size: 1.25rem;
+    font-family: var(--mono);
+    padding: 0.55rem 0.8rem;
+    width: 100%;
+    appearance: textfield;
+    -moz-appearance: textfield;
+  }
+  .odds-field input::-webkit-outer-spin-button,
+  .odds-field input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+  .odds-field input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .calc-vs {
+    color: var(--muted-2); font-size: 0.85rem; font-weight: 700;
+    text-transform: uppercase; padding-bottom: 0.85rem;
+  }
+
+  /* Result */
+  .result {
+    text-align: center; margin-top: 1.5rem; padding-top: 1.25rem;
+    border-top: 1px solid var(--border); min-height: 5.5rem;
+  }
+  .result-hint { color: var(--muted); margin: 1rem 0; }
+  .result-score {
+    font-family: var(--mono);
+    font-size: clamp(2.6rem, 9vw, 4rem);
+    font-weight: 700; letter-spacing: 0.04em; line-height: 1.1;
+    color: var(--good);
+  }
+  .result-outcome {
+    font-size: 0.95rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--accent-2); margin-top: 0.25rem;
+  }
+  .result-detail { color: var(--muted); font-size: 0.9rem; max-width: 36rem; margin: 0.85rem auto 0; }
+
+  /* Reference table */
+  .bands-section { margin-bottom: 2rem; }
+  .bands-table-wrap {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow-x: auto;
+  }
+  .bands-table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  .bands-table th, .bands-table td { padding: 0.6rem 0.9rem; text-align: left; white-space: nowrap; }
+  .bands-table th {
+    font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--muted); border-bottom: 1px solid var(--border-strong);
+  }
+  .bands-table td { border-bottom: 1px solid var(--border); }
+  .bands-table tbody tr:last-child td { border-bottom: none; }
+  .band-range, .band-score, .band-stat, .band-sample { font-family: var(--mono); }
+  .band-score { font-weight: 700; color: var(--good); }
+  .band-note { color: var(--muted); white-space: normal; min-width: 14rem; }
+  .bands-table tr.is-active td { background: var(--accent-soft); }
+
+  /* Methodology */
+  .method-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+  }
+  .method-card p { color: var(--muted); font-size: 0.92rem; margin: 0 0 0.85rem; }
+  .method-card p:last-child { margin-bottom: 0; }
+  .method-note { font-style: italic; color: var(--muted-2); }
+
+  /* World Cup fixtures */
+  .wc-section { margin-bottom: 2rem; }
+  .wc-controls {
+    display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+  /* Key field + its show/hide toggle share one bordered shell so the eye
+     button sits flush inside the input regardless of type=password/text. */
+  .wc-key-field {
+    display: flex; align-items: stretch; flex: 1; min-width: 12rem; max-width: 20rem;
+    background: var(--surface-2); border: 1px solid var(--border-strong); border-radius: 8px;
+  }
+  .wc-key-field:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .wc-controls #wc-key {
+    background: transparent; border: 0; color: var(--text); font-family: var(--mono);
+    font-size: 0.9rem; padding: 0.45rem 0.7rem; flex: 1; min-width: 0;
+  }
+  .wc-controls #wc-key:focus { outline: none; }
+  .wc-key-toggle {
+    background: transparent; border: 0; border-left: 1px solid var(--border-strong);
+    color: var(--muted); cursor: pointer; font: inherit; font-size: 0.78rem; font-weight: 600;
+    padding: 0 0.7rem; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .wc-key-toggle:hover { color: var(--text); }
+  .wc-btn {
+    background: var(--accent-soft); border: 1px solid var(--accent);
+    border-radius: 8px; color: var(--accent-2); font: inherit; font-size: 0.9rem;
+    font-weight: 600; padding: 0.45rem 1rem; cursor: pointer;
+  }
+  .wc-btn:hover { background: rgba(99, 102, 241, 0.28); }
+  .wc-nodraw {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    color: var(--muted); font-size: 0.85rem; cursor: pointer;
+  }
+  .wc-status { color: var(--muted); font-size: 0.85rem; width: 100%; }
+  .wc-table .wc-match { white-space: normal; min-width: 12rem; }
+  .wc-table .wc-pick { font-family: var(--mono); font-weight: 700; color: var(--good); }
+  .wc-table .wc-odds, .wc-table .wc-time { font-family: var(--mono); }
+  .wc-table tr.wc-changed td { background: rgba(74, 222, 128, 0.10); }
+  .wc-changed-tag {
+    color: var(--good); font-size: 0.7rem; font-weight: 700;
+    margin-left: 0.4rem; text-transform: uppercase; letter-spacing: 0.05em;
+  }
+
+  /* Model scoreboard — Points vs Exact, head to head */
+  .wc-summary {
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 1rem 1.1rem 1.1rem; margin-bottom: 1rem;
+  }
+  .wc-sb-head {
+    font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--muted); margin-bottom: 0.8rem;
+  }
+  .wc-sb-head .wc-sb-sub { color: var(--muted-2); font-weight: 600; }
+  .wc-sb-cards { display: flex; align-items: stretch; gap: 0.75rem; flex-wrap: wrap; }
+  .wc-sb-card {
+    flex: 1; min-width: 12rem; background: var(--surface-2);
+    border: 1px solid var(--border-strong); border-radius: 12px; padding: 0.8rem 0.95rem;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .wc-sb-card.leader {
+    border-color: var(--good);
+    box-shadow: 0 0 0 1px var(--good), 0 6px 20px rgba(74, 222, 128, 0.12);
+    background: rgba(74, 222, 128, 0.06);
+  }
+  .wc-sb-card.trail { opacity: 0.82; }
+  .wc-sb-top { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; margin-bottom: 0.35rem; }
+  .wc-sb-name { font-size: 0.9rem; font-weight: 700; color: var(--text); }
+  .wc-sb-badge {
+    font-size: 0.66rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 0.12rem 0.45rem; border-radius: 999px; white-space: nowrap;
+  }
+  .wc-sb-badge.win { background: rgba(74, 222, 128, 0.18); color: var(--good); }
+  .wc-sb-badge.tie { background: rgba(148, 163, 184, 0.16); color: var(--muted); }
+  .wc-sb-score { font-family: var(--mono); font-size: 2.1rem; font-weight: 800; line-height: 1; color: var(--text); }
+  .wc-sb-card.leader .wc-sb-score { color: var(--good); }
+  .wc-sb-score .wc-sb-unit { font-size: 0.8rem; font-weight: 600; color: var(--muted); margin-left: 0.3rem; }
+  .wc-sb-meta { color: var(--muted); font-size: 0.78rem; margin-top: 0.45rem; }
+  .wc-sb-vs {
+    align-self: center; color: var(--muted-2); font-size: 0.75rem; font-weight: 800;
+    text-transform: uppercase; letter-spacing: 0.08em;
+  }
+  @media (max-width: 30rem) {
+    .wc-sb-vs { width: 100%; text-align: center; padding: 0.1rem 0; }
+  }
+
+  /* Per-model grade badges and result cells */
+  .wc-grade {
+    display: inline-block; font-family: var(--mono); font-size: 0.72rem; font-weight: 700;
+    padding: 0.05rem 0.4rem; border-radius: 999px; margin-left: 0.35rem;
+    text-transform: uppercase; letter-spacing: 0.03em; vertical-align: middle;
+  }
+  .wc-grade.g3 { background: rgba(74, 222, 128, 0.16); color: var(--good); }
+  .wc-grade.g2 { background: var(--accent-soft); color: var(--accent-2); }
+  .wc-grade.g0 { background: rgba(148, 163, 184, 0.14); color: var(--muted); }
+  .wc-table .wc-result { font-family: var(--mono); font-weight: 700; color: var(--text); }
+  .wc-table .wc-result.wc-live { color: var(--accent-2); }
+  .wc-pending { color: var(--muted-2); font-size: 0.85rem; }
+  .wc-lock {
+    color: var(--muted-2); font-size: 0.68rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.04em; margin-left: 0.35rem;
+  }
+
+  /* Collapsible sections (calculator, mapping, methodology, help) */
+  details.wc-collapse { margin-bottom: 1.25rem; border-top: 1px solid var(--border); }
+  details.wc-collapse > summary,
+  details.wc-done > summary {
+    cursor: pointer; list-style: none; user-select: none;
+    padding: 0.85rem 0.2rem; font-weight: 700; color: var(--text); font-size: 1.02rem;
+  }
+  details.wc-collapse > summary::-webkit-details-marker,
+  details.wc-done > summary::-webkit-details-marker { display: none; }
+  details.wc-collapse > summary::before,
+  details.wc-done > summary::before {
+    content: '\25B8'; color: var(--muted); margin-right: 0.5rem;
+    display: inline-block; transition: transform 0.15s ease;
+  }
+  details[open] > summary::before { transform: rotate(90deg); }
+  details.wc-collapse > summary:hover,
+  details.wc-done > summary:hover { color: var(--accent-2); }
+  .wc-collapse-body { padding: 0.25rem 0 0.5rem; }
+
+  /* Completed matches sit in their own block below the upcoming table */
+  details.wc-done { margin: 1.25rem 0 0; }
+  details.wc-done > summary { color: var(--muted); font-size: 0.95rem; font-weight: 600; }
+
+  @media (max-width: 540px) {
+    .calc-inputs { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+    .odds-field { max-width: none; }
+    .calc-vs { text-align: center; padding-bottom: 0; }
+  }
+</style>
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <h1>⚽ Score Predictor</h1>
+      <p class="tagline">World Cup score picks under both scoring models, with live results and a running scoreboard for how each model does.</p>
+    </header>
+
+    <section class="bands-section wc-section" aria-label="World Cup fixtures">
+      <div class="wc-controls">
+        <span class="wc-key-field">
+          <input type="password" id="wc-key" placeholder="The Odds API key" autocomplete="off" aria-label="The Odds API key">
+          <button type="button" class="wc-key-toggle" id="wc-key-toggle" aria-label="Show API key" aria-pressed="false" title="Show or hide the API key">Show</button>
+        </span>
+        <button type="button" class="wc-btn" id="wc-load">Load fixtures</button>
+        <button type="button" class="wc-btn" id="wc-refresh" title="Ignore the 6 hour cache and refetch odds and results now">Refresh</button>
+        <label class="wc-nodraw" title="Keep this tab open. 10 minutes before each kickoff the page checks whether a realistic late odds move could flip either model's pick; only then does it spend credits on a live refresh."><input type="checkbox" id="wc-auto"> Auto-refresh 10 min before kickoff if a pick could flip</label>
+        <label class="wc-nodraw" title="Keep this tab open. Plays a chime 10 minutes before each kickoff so you can lock in your pick in time. Works on its own and spends no credits."><input type="checkbox" id="wc-sound"> Sound alert 10 min before kickoff</label>
+        <button type="button" class="wc-btn" id="wc-test-sound" title="Play the kickoff chime right now to check your sound works">Test sound</button>
+        <span class="wc-status" id="wc-status">No fixtures loaded yet. Paste your key and hit Load fixtures (or use the key "demo" to preview with sample data).</span>
+        <span class="wc-status" id="wc-auto-status" hidden></span>
+      </div>
+
+      <div class="wc-summary" id="wc-summary" hidden></div>
+
+      <div class="bands-table-wrap" id="wc-wrap" hidden>
+        <table class="bands-table wc-table">
+          <thead>
+            <tr><th>Kickoff</th><th>Match</th><th>Odds H / A</th><th>Points pick</th><th>Exact pick</th><th>Result</th></tr>
+          </thead>
+          <tbody id="wc-body"></tbody>
+        </table>
+      </div>
+
+      <details class="wc-done" id="wc-done" hidden>
+        <summary id="wc-done-summary">Completed matches</summary>
+        <div class="bands-table-wrap">
+          <table class="bands-table wc-table">
+            <thead>
+              <tr><th>Kickoff</th><th>Match</th><th>Odds H / A</th><th>Points pick</th><th>Exact pick</th><th>Result</th></tr>
+            </thead>
+            <tbody id="wc-done-body"></tbody>
+          </table>
+        </div>
+      </details>
+
+      <details class="wc-collapse wc-help">
+        <summary>How this works</summary>
+        <div class="wc-collapse-body">
+          <p class="section-sub">Upcoming and played matches use median 1X2 odds from The Odds API, scored under both models. Once a match kicks off its odds and picks lock and never change; only future matches update when you Load or Refresh. Your key is stored in this browser only, never in this file. Odds are cached for 6 hours; Refresh refetches odds plus final scores (about 3 credits) and the scoreboard builds up over time.</p>
+          <p class="section-sub">Both the odds (frozen before each kickoff) and the final scores are collected server-side every hour, so the full table and scoreboard rebuild themselves even on a brand-new browser and even if this tab was never open during a match. Your own key is still only needed to pull fresh odds for matches you want to watch live. Every result is the 90-minute (regulation) score only: for knockout games that go to extra time or penalties, the extra-time and shootout goals are ignored, so a match that is 1-1 after 90 counts as 1-1 in both models.</p>
+          <p class="section-sub">Both columns are scored in your points (3 exact, 2 outcome, 0 otherwise), so a 1-1 pick on a 2-2 result earns 2 in either column. The models differ only in how they choose a pick: the Points model picks the score that maximizes expected points, so it leans toward the most likely outcome, while the Exact model chases the single most likely exact scoreline. An Exact pick still earns 2 whenever its outcome is right; the difference is that the Points model is optimizing for the points you actually score, so it should come out ahead over a full tournament. Use Points for your entries; the Exact column is just a sanity check, and any single match can go either way.</p>
+        </div>
+      </details>
+    </section>
+
+    <details class="wc-collapse">
+      <summary>Manual odds calculator</summary>
+      <div class="wc-collapse-body">
+        <p class="section-sub">Type any two teams' win odds to get the score to predict, based on 61,860 real matches. The Points / Exact toggle here also controls the reference mapping below.</p>
+        <section class="calc-card" aria-label="Score calculator">
+          <div class="mode-toggle" role="radiogroup" aria-label="Scoring mode">
+            <button type="button" class="mode-btn is-active" data-mode="points" role="radio" aria-checked="true">Points game: 3 exact, 2 outcome</button>
+            <button type="button" class="mode-btn" data-mode="exact" role="radio" aria-checked="false">Exact score only</button>
+          </div>
+
+          <div class="calc-inputs">
+            <label class="odds-field" for="odds-a">
+              <span class="odds-label">Team A win odds</span>
+              <input type="number" id="odds-a" min="1.01" max="1000" step="0.01" inputmode="decimal" placeholder="e.g. 1.45" autocomplete="off">
+            </label>
+            <span class="calc-vs" aria-hidden="true">vs</span>
+            <label class="odds-field" for="odds-b">
+              <span class="odds-label">Team B win odds</span>
+              <input type="number" id="odds-b" min="1.01" max="1000" step="0.01" inputmode="decimal" placeholder="e.g. 7.50" autocomplete="off">
+            </label>
+          </div>
+
+          <div class="result" id="result" role="status" aria-live="polite">
+            <p class="result-hint" id="result-hint">Enter both teams' win odds to get a score.</p>
+            <div class="result-score" id="result-score"></div>
+            <div class="result-outcome" id="result-outcome"></div>
+            <p class="result-detail" id="result-detail"></p>
+          </div>
+        </section>
+      </div>
+    </details>
+
+    <details class="wc-collapse">
+      <summary>The full odds-to-score mapping</summary>
+      <div class="wc-collapse-body">
+        <section class="bands-section" aria-label="Odds to score reference table">
+          <p class="section-sub" id="bands-sub"></p>
+          <div class="bands-table-wrap">
+            <table class="bands-table">
+              <thead>
+                <tr id="bands-head"></tr>
+              </thead>
+              <tbody id="bands-body"></tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </details>
+
+    <details class="wc-collapse">
+      <summary>Where the numbers come from</summary>
+      <div class="wc-collapse-body">
+        <section class="method-card" aria-label="Methodology">
+          <p>
+            Everything on this page is empirical. The data covers 61,860 matches (123,720
+            team-observations) across the Premier League, Championship, La Liga, Bundesliga, Serie A,
+            Ligue 1, Eredivisie, and Primeira Liga, seasons 2005/06 through 2025/26, with closing 1X2
+            odds from football-data.co.uk.
+          </p>
+          <p>
+            Points mode maximizes expected points under the scoring 3 for the exact score, 2 for the
+            right outcome, 0 otherwise. Because the outcome is worth two thirds of the prize, the draw
+            band nearly disappears: predicting the favorite to win 1-0 beats 1-1 until the favorite's
+            own odds reach 2.70, the point where draws finally overtake the favorite's win probability.
+            Backtested on 17,716 held-out matches (seasons 2020/21 to 2025/26) this table averages 1.17
+            points per match versus 0.98 for the exact-score table and 0.63 for always predicting 1-1.
+          </p>
+          <p>
+            Exact mode maximizes the chance of nailing the scoreline, ignoring partial credit. Each
+            range's score is the single most common exact final score among matches where a team's win
+            odds fell in that range. Here the draw band is huge (1.71 to 4.50) because the favorite's
+            win probability spreads across many scorelines while the draw concentrates on 1-1. In the
+            same backtest no fancier method (home/away splits, draw-odds refinements, Poisson models)
+            beat this simple table on exact-score hit rate.
+          </p>
+          <p class="method-note">Built for score-prediction games with friends, not betting advice.</p>
+        </section>
+      </div>
+    </details>
+  </main>
+
+<script>
+(function () {
+  'use strict';
+
+  /*
+   * Two mode tables, both derived from 61,860 matches, 8 European leagues,
+   * seasons 2005/06 to 2025/26, closing 1X2 odds from football-data.co.uk.
+   *
+   * EXACT mode: bands keyed on a single team's win odds; gf/ga from that
+   * team's perspective; pick = most common exact score in the range;
+   * stat = how often the pick hits exactly.
+   *
+   * POINTS mode (3 pts exact, 2 pts outcome, 0 otherwise): bands keyed on
+   * the FAVORITE's win odds; pick = argmax of 2*P(outcome) + P(score);
+   * stat = average points per match for that pick in the range.
+   *
+   * Band edges sit at .005 midpoints so typed two-decimal odds can never
+   * land exactly on an edge.
+   */
+  const EXACT_BANDS = [
+    { min: 1.01,   max: 1.115,    label: '1.01 to 1.11',  gf: 3, ga: 0, stat: '11.7%', sample: 494,    note: '2-0 is statistically tied at 12.1%' },
+    { min: 1.115,  max: 1.555,    label: '1.12 to 1.55',  gf: 2, ga: 0, stat: '12.7%', sample: 13027,  note: 'next best: 1-0 at 11.3%, 2-1 at 10.4%' },
+    { min: 1.555,  max: 1.705,    label: '1.56 to 1.70',  gf: 1, ga: 0, stat: '12.2%', sample: 6360,   note: 'next best: 1-1 at 11.8%, 2-1 at 10.7%' },
+    { min: 1.705,  max: 4.505,    label: '1.71 to 4.50',  gf: 1, ga: 1, stat: '13.5%', sample: 81133,  note: 'next best: 1-0 at 9.5%, 0-1 at 9.2%' },
+    { min: 4.505,  max: 6.505,    label: '4.51 to 6.50',  gf: 0, ga: 1, stat: '12.0%', sample: 11634,  note: 'next best: 1-1 at 11.7%, 1-2 at 10.6%' },
+    { min: 6.505,  max: 20.005,   label: '6.51 to 20.00', gf: 0, ga: 2, stat: '13.1%', sample: 10525,  note: 'next best: 0-1 at 11.5%, 1-2 at 10.4%' },
+    { min: 20.005, max: Infinity, label: '20.01 and up',  gf: 0, ga: 3, stat: '11.5%', sample: 547,    note: '0-2 is statistically tied at 11.7%' },
+  ];
+  const EXACT_DRAW_INDEX = 3;
+
+  const POINTS_BANDS = [
+    { min: 1.01,  max: 1.055,    label: '1.01 to 1.05', gf: 3, ga: 0, stat: '2.06', sample: 53,    note: 'favorite wins 96.2% of these; 3-0 edges 2-0 on the exact bonus' },
+    { min: 1.055, max: 1.505,    label: '1.06 to 1.50', gf: 2, ga: 0, stat: '1.62', sample: 12019, note: 'favorite wins 74.6%; 2-0 is the most valuable winning score' },
+    { min: 1.505, max: 2.695,    label: '1.51 to 2.69', gf: 1, ga: 0, stat: '1.06', sample: 48845, note: 'favorite wins 47.4%, still the most likely outcome by far' },
+    { min: 2.695, max: Infinity, label: '2.70 and up',  gf: 1, ga: 1, stat: '0.84', sample: 943,   note: 'coin flips: draws (33.8%) edge the favorite wins (32.7%)' },
+  ];
+  const POINTS_DRAW_INDEX = 3;
+
+  const MIN_ODDS = 1.01;
+  const MAX_ODDS = 1000;
+
+  const MODES = {
+    points: {
+      bands: POINTS_BANDS,
+      drawIndex: POINTS_DRAW_INDEX,
+      columns: ['Favorite odds', 'Score to predict', 'Avg points', 'Matches', 'Worth knowing'],
+      sub: 'Ranges are keyed on the favorite’s win odds, score written favorite-first. The calculator flips the score when Team B is the favorite. Avg points is what the pick earns per match under 3 exact / 2 outcome / 0 scoring.',
+    },
+    exact: {
+      bands: EXACT_BANDS,
+      drawIndex: EXACT_DRAW_INDEX,
+      columns: ['Win odds', 'Score to predict', 'Hit rate', 'Matches', 'Worth knowing'],
+      sub: 'Ranges are keyed on one team’s win odds, score written as that team’s goals first. The calculator reads the favorite’s odds and flips the score when Team B is the favorite.',
+    },
+  };
+
+  let mode = 'points';
+
+  function parseOdds(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'string' && value.trim() !== '') {
+      // Accept a decimal comma so "1,85" works like "1.85".
+      return parseFloat(value.trim().replace(',', '.'));
+    }
+    return NaN;
+  }
+
+  function validOdds(o) {
+    return Number.isFinite(o) && o >= MIN_ODDS && o <= MAX_ODDS;
+  }
+
+  function bandFor(bands, odds) {
+    return bands.find((b) => odds >= b.min && odds < b.max) || null;
+  }
+
+  // Core predictor, parameterized by mode name so the fixtures table can ask
+  // for both models at once while the calculator uses the active toggle.
+  function predictScoreMode(modeName, oddsA, oddsB) {
+    const cfg = MODES[modeName];
+    const a = parseOdds(oddsA);
+    const b = parseOdds(oddsB);
+    if (!validOdds(a) || !validOdds(b)) return null;
+
+    if (a === b) {
+      const band = cfg.bands[cfg.drawIndex];
+      return { scoreA: 1, scoreB: 1, favorite: 'even', band: band, outcome: 'draw' };
+    }
+
+    const aIsFav = a < b;
+    let band = bandFor(cfg.bands, aIsFav ? a : b);
+    // In exact mode the favorite can map into a losing band only on nonsense
+    // input (its own odds above 4.50); fall back to the draw band. Points
+    // bands are favorite-keyed and never lose, so this is a no-op there.
+    if (band.gf < band.ga) band = cfg.bands[cfg.drawIndex];
+
+    const scoreA = aIsFav ? band.gf : band.ga;
+    const scoreB = aIsFav ? band.ga : band.gf;
+    return {
+      scoreA: scoreA, scoreB: scoreB,
+      favorite: aIsFav ? 'A' : 'B',
+      band: band,
+      outcome: scoreA === scoreB ? 'draw' : (scoreA > scoreB ? 'A' : 'B'),
+    };
+  }
+
+  function predictScore(oddsA, oddsB) { return predictScoreMode(mode, oddsA, oddsB); }
+
+  // --- page wiring ---------------------------------------------------------
+
+  const inputA = document.getElementById('odds-a');
+  const inputB = document.getElementById('odds-b');
+  const resultEl = document.getElementById('result');
+  const scoreEl = document.getElementById('result-score');
+  const outcomeEl = document.getElementById('result-outcome');
+  const detailEl = document.getElementById('result-detail');
+  const hintEl = document.getElementById('result-hint');
+  const tableHead = document.getElementById('bands-head');
+  const tableBody = document.getElementById('bands-body');
+  const tableSub = document.getElementById('bands-sub');
+  const modeButtons = Array.prototype.slice.call(document.querySelectorAll('.mode-btn'));
+
+  function renderTable() {
+    const cfg = MODES[mode];
+    tableHead.innerHTML = cfg.columns.map((c) => '<th>' + c + '</th>').join('');
+    tableSub.textContent = cfg.sub;
+    tableBody.innerHTML = '';
+    cfg.bands.forEach(function (band, i) {
+      const tr = document.createElement('tr');
+      tr.dataset.band = String(i);
+      tr.innerHTML =
+        '<td class="band-range">' + band.label + '</td>' +
+        '<td class="band-score">' + band.gf + '-' + band.ga + '</td>' +
+        '<td class="band-stat">' + band.stat + '</td>' +
+        '<td class="band-sample">' + band.sample.toLocaleString('en-US') + '</td>' +
+        '<td class="band-note">' + band.note + '</td>';
+      tableBody.appendChild(tr);
+    });
+  }
+
+  function setActiveBand(band) {
+    const idx = band ? MODES[mode].bands.indexOf(band) : -1;
+    tableBody.querySelectorAll('tr').forEach(function (tr) {
+      tr.classList.toggle('is-active', tr.dataset.band === String(idx));
+    });
+  }
+
+  function describe(prediction, oddsA, oddsB) {
+    const band = prediction.band;
+    if (prediction.favorite === 'even') {
+      return mode === 'points'
+        ? 'Both teams are priced at ' + oddsA + ', a coin flip. In dead-even matches the draw is the single best pick, and 1-1 is its most common scoreline.'
+        : 'Both teams are priced at ' + oddsA + ', an even match. Evenly matched games land on 1-1 more than any other exact score.';
+    }
+    const favName = prediction.favorite === 'A' ? 'Team A' : 'Team B';
+    const favOdds = prediction.favorite === 'A' ? oddsA : oddsB;
+    if (mode === 'points') {
+      return favName + ' is the favorite at ' + favOdds + ', in the ' + band.label +
+        ' range: this pick averages ' + band.stat + ' points per match under your scoring. ' +
+        band.note.charAt(0).toUpperCase() + band.note.slice(1) + '.';
+    }
+    return favName + ' is the favorite at ' + favOdds + ', which falls in the ' +
+      band.label + ' range: the most common exact score there is ' +
+      band.gf + '-' + band.ga + ' (for the favorite), hitting ' + band.stat + ' of ' +
+      band.sample.toLocaleString('en-US') + ' historical matches. Also common, ' + band.note + '.';
+  }
+
+  function update() {
+    const rawA = inputA.value;
+    const rawB = inputB.value;
+    const hasInput = rawA.trim() !== '' || rawB.trim() !== '';
+    const prediction = predictScore(rawA, rawB);
+
+    if (!prediction) {
+      resultEl.classList.remove('has-score');
+      scoreEl.textContent = '';
+      outcomeEl.textContent = '';
+      detailEl.textContent = '';
+      hintEl.textContent = hasInput
+        ? 'Enter both odds as decimal numbers between ' + MIN_ODDS + ' and ' + MAX_ODDS + '.'
+        : 'Enter both teams’ win odds to get a score.';
+      hintEl.hidden = false;
+      setActiveBand(null);
+      return;
+    }
+
+    resultEl.classList.add('has-score');
+    hintEl.hidden = true;
+    scoreEl.textContent = prediction.scoreA + ' - ' + prediction.scoreB;
+    outcomeEl.textContent =
+      prediction.outcome === 'draw' ? 'Draw' :
+      prediction.outcome === 'A' ? 'Team A wins' : 'Team B wins';
+    detailEl.textContent = describe(prediction, rawA.trim(), rawB.trim());
+    setActiveBand(prediction.band);
+  }
+
+  function setMode(next) {
+    mode = next;
+    modeButtons.forEach(function (btn) {
+      const active = btn.dataset.mode === next;
+      btn.classList.toggle('is-active', active);
+      btn.setAttribute('aria-checked', String(active));
+    });
+    renderTable();
+    update();
+  }
+
+  modeButtons.forEach(function (btn) {
+    btn.addEventListener('click', function () { setMode(btn.dataset.mode); });
+  });
+  inputA.addEventListener('input', update);
+  inputB.addEventListener('input', update);
+
+  // --- World Cup fixtures (The Odds API) -----------------------------------
+
+  const WC_ODDS_URL = 'https://api.the-odds-api.com/v4/sports/soccer_fifa_world_cup/odds/?regions=eu&markets=h2h&oddsFormat=decimal&apiKey=';
+  const WC_SCORES_URL = 'https://api.the-odds-api.com/v4/sports/soccer_fifa_world_cup/scores/?daysFrom=3&apiKey=';
+  const WC_KEY_LS = 'sp-wc-key';
+  const WC_CACHE_LS = 'sp-wc-cache';
+  const WC_LOCKS_LS = 'sp-wc-locks';      // odds frozen at kickoff, per event id
+  const WC_RESULTS_LS = 'sp-wc-results';  // final/live scores, per event id
+  // Server-collected 90-minute results (netlify/functions/wc-results.mjs).
+  const WC_RESULTS_FN = '/.netlify/functions/wc-results';
+  const WC_AUTO_LS = 'sp-wc-auto';
+  const WC_SOUND_LS = 'sp-wc-sound';
+  const WC_CACHE_MS = 6 * 60 * 60 * 1000;
+
+  const wcKeyInput = document.getElementById('wc-key');
+  const wcKeyToggle = document.getElementById('wc-key-toggle');
+  const wcLoadBtn = document.getElementById('wc-load');
+  const wcRefreshBtn = document.getElementById('wc-refresh');
+  const wcStatus = document.getElementById('wc-status');
+  const wcWrap = document.getElementById('wc-wrap');
+  const wcBody = document.getElementById('wc-body');
+  const wcSummary = document.getElementById('wc-summary');
+  const wcDone = document.getElementById('wc-done');
+  const wcDoneBody = document.getElementById('wc-done-body');
+  const wcDoneSummary = document.getElementById('wc-done-summary');
+  const wcAuto = document.getElementById('wc-auto');
+  const wcSound = document.getElementById('wc-sound');
+  const wcTestSound = document.getElementById('wc-test-sound');
+  const wcAutoStatus = document.getElementById('wc-auto-status');
+
+  let wcEvents = null;     // live odds events from the last fetch (may be null)
+  let wcMeta = '';
+  let wcChanged = {};      // event id -> true when the last live refresh flipped a future pick
+  let wcAutoTimer = null;
+  let wcAudioCtx = null;   // created on first user gesture (the sound toggle)
+  let wcLocks = {};        // event id -> { home, away, commence_time, home_team, away_team }
+  let wcResults = {};      // event id -> { completed, home_score, away_score, ... }
+  let wcServer = null;     // server 90-min results, keyed by home|away|date
+
+  function now() { return Date.now(); }
+  function ts(t) { return new Date(t).getTime(); }
+  function hasStarted(t) { return ts(t) <= now(); }
+
+  // --- persistence ---------------------------------------------------------
+  function readJSON(k) { try { return JSON.parse(localStorage.getItem(k)) || {}; } catch (e) { return {}; } }
+  function loadLocks() { return readJSON(WC_LOCKS_LS); }
+  function loadResults() { return readJSON(WC_RESULTS_LS); }
+  function saveLocks() { localStorage.setItem(WC_LOCKS_LS, JSON.stringify(wcLocks)); }
+  function saveResults() { localStorage.setItem(WC_RESULTS_LS, JSON.stringify(wcResults)); }
+
+  // --- server 90-minute results --------------------------------------------
+  // The scheduled collector stores regulation-time (90') scores from
+  // API-Football keyed by a normalized home|away|date string, because the
+  // page (Odds API ids) and the collector (API-Football) share no ids. This
+  // normalizer MUST stay identical to netlify/functions/wc-store.mjs.
+  const WC_TEAM_ALIASES = {
+    unitedstates: 'usa', us: 'usa',
+    korearepublic: 'southkorea', republicofkorea: 'southkorea', korea: 'southkorea',
+    iranislamicrepublic: 'iran', iriran: 'iran',
+    czechia: 'czechrepublic', cotedivoire: 'ivorycoast',
+    capeverdeislands: 'capeverde', bosniaandherzegovina: 'bosnia',
+    drcongo: 'congodr', democraticrepublicofcongo: 'congodr',
+  };
+  function normTeam(name) {
+    const base = String(name || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase().replace(/[^a-z0-9]/g, '');
+    return WC_TEAM_ALIASES[base] || base;
+  }
+  function dayKey(msOrIso) {
+    return new Date(msOrIso).toISOString().slice(0, 10);
+  }
+  // Try the exact UTC day and +/- 1 to absorb any provider timezone rounding.
+  function lookupServer(home, away, commence) {
+    if (!wcServer) return null;
+    const t = ts(commence), day = 86400000;
+    const days = [dayKey(t), dayKey(t - day), dayKey(t + day)];
+    for (let i = 0; i < days.length; i++) {
+      const r = wcServer[normTeam(home) + '|' + normTeam(away) + '|' + days[i]];
+      if (r) return r;
+    }
+    return null;
+  }
+  // The exact match key plus +/- 1 day, mirroring lookupServer's tolerance.
+  function keyVariants(home, away, commence) {
+    const t = ts(commence), day = 86400000;
+    return [dayKey(t), dayKey(t - day), dayKey(t + day)].map(function (d) {
+      return normTeam(home) + '|' + normTeam(away) + '|' + d;
+    });
+  }
+  // Is this match already covered by a real (browser-captured) lock? If so we
+  // must not also inject the server's synthetic 'srv:' lock, or the match would
+  // render twice.
+  function realLockCovers(home, away, commence) {
+    const variants = keyVariants(home, away, commence);
+    return Object.keys(wcLocks).some(function (id) {
+      if (id.indexOf('srv:') === 0) return false;
+      const l = wcLocks[id];
+      if (!l || !l.home_team) return false;
+      const lk = normTeam(l.home_team) + '|' + normTeam(l.away_team) + '|' + dayKey(l.commence_time);
+      return variants.indexOf(lk) !== -1;
+    });
+  }
+  // Fold server-frozen odds into wcLocks under synthetic 'srv:<key>' ids so the
+  // page can render + grade matches this browser never had open. A real lock
+  // for the same match always wins (its odds were captured at kickoff).
+  function mergeServerLocks(serverLocks) {
+    if (!serverLocks) return false;
+    let touched = false;
+    Object.keys(serverLocks).forEach(function (mk) {
+      const sl = serverLocks[mk];
+      if (!sl || !Number.isFinite(sl.home) || !Number.isFinite(sl.away)) return;
+      const id = 'srv:' + mk;
+      if (realLockCovers(sl.home_team, sl.away_team, sl.commence_time)) {
+        if (wcLocks[id]) { delete wcLocks[id]; touched = true; }
+        return;
+      }
+      const cur = wcLocks[id];
+      if (cur && cur.home === sl.home && cur.away === sl.away && cur.commence_time === sl.commence_time) return;
+      wcLocks[id] = {
+        home: sl.home, away: sl.away, commence_time: sl.commence_time,
+        home_team: sl.home_team, away_team: sl.away_team,
+      };
+      touched = true;
+    });
+    if (touched) saveLocks();
+    return touched;
+  }
+  // Merge server results onto known fixtures. Regulation results (src 'reg')
+  // always win over Odds API finals, which for knockouts include extra time.
+  function applyServerResults() {
+    if (!wcServer) return false;
+    let touched = false;
+    const ids = {};
+    Object.keys(wcLocks).forEach(function (id) { ids[id] = true; });
+    Object.keys(wcResults).forEach(function (id) { ids[id] = true; });
+    Object.keys(ids).forEach(function (id) {
+      const meta = wcLocks[id] || wcResults[id];
+      if (!meta || !meta.home_team || !meta.away_team || !meta.commence_time) return;
+      const sr = lookupServer(meta.home_team, meta.away_team, meta.commence_time);
+      if (!sr || !Number.isFinite(sr.home_score) || !Number.isFinite(sr.away_score)) return;
+      const cur = wcResults[id];
+      if (cur && cur.src === 'reg' && cur.home_score === sr.home_score &&
+          cur.away_score === sr.away_score && cur.completed === !!sr.completed) return;
+      wcResults[id] = {
+        completed: !!sr.completed, home_score: sr.home_score, away_score: sr.away_score,
+        home_team: meta.home_team, away_team: meta.away_team,
+        commence_time: meta.commence_time, src: 'reg',
+      };
+      touched = true;
+    });
+    if (touched) saveResults();
+    return touched;
+  }
+  function fetchServerState() {
+    return fetch(WC_RESULTS_FN, { cache: 'no-store' })
+      .then(function (res) { return res.ok ? res.json() : null; })
+      .then(function (data) {
+        if (!data) return;
+        wcServer = data.results || {};
+        // Locks first (they create the rows), then results (they grade them).
+        const a = mergeServerLocks(data.locks || {});
+        const b = applyServerResults();
+        if (a || b) renderFixtures();
+      })
+      .catch(function () { /* offline or not deployed yet: leave local data */ });
+  }
+
+  // --- demo data -----------------------------------------------------------
+  function demoBook(h, d, a) {
+    return { markets: [{ key: 'h2h', outcomes: [
+      { name: 'HOME', price: h }, { name: 'Draw', price: d }, { name: 'AWAY', price: a },
+    ] }] };
+  }
+  // Two demo games sit in the past (completed, locked, graded) and two in the
+  // future (still updatable), so the preview shows both halves of the feature.
+  function demoEvents() {
+    const t = now(), h = 3600 * 1000;
+    return [
+      { id: 'd1', commence_time: new Date(t - 26 * h).toISOString(), home_team: 'Mexico', away_team: 'Poland',
+        bookmakers: [demoBook(1.95, 3.40, 4.10), demoBook(1.92, 3.45, 4.20), demoBook(2.00, 3.35, 4.00)] },
+      { id: 'd2', commence_time: new Date(t - 3 * h).toISOString(), home_team: 'United States', away_team: 'Paraguay',
+        bookmakers: [demoBook(2.10, 3.30, 3.70), demoBook(2.15, 3.30, 3.60), demoBook(2.05, 3.40, 3.80)] },
+      { id: 'd3', commence_time: new Date(t + 5 * h).toISOString(), home_team: 'France', away_team: 'Jordan',
+        bookmakers: [demoBook(1.12, 9.00, 26.0), demoBook(1.11, 9.50, 29.0), demoBook(1.13, 8.80, 25.0)] },
+      { id: 'd4', commence_time: new Date(t + 28 * h).toISOString(), home_team: 'Croatia', away_team: 'Denmark',
+        bookmakers: [demoBook(2.75, 3.10, 2.80), demoBook(2.80, 3.05, 2.75), demoBook(2.70, 3.15, 2.85)] },
+    ];
+  }
+  function demoScores() {
+    const evs = wcEvents || [];
+    const find = function (id) { return evs.find(function (e) { return e.id === id; }) || {}; };
+    return [
+      { id: 'd1', completed: true, home_team: 'Mexico', away_team: 'Poland', commence_time: find('d1').commence_time,
+        scores: [{ name: 'Mexico', score: '2' }, { name: 'Poland', score: '0' }] },
+      { id: 'd2', completed: true, home_team: 'United States', away_team: 'Paraguay', commence_time: find('d2').commence_time,
+        scores: [{ name: 'United States', score: '1' }, { name: 'Paraguay', score: '1' }] },
+    ];
+  }
+
+  // --- odds consensus ------------------------------------------------------
+  function median(arr) {
+    if (!arr.length) return NaN;
+    const s = arr.slice().sort(function (x, y) { return x - y; });
+    const mid = Math.floor(s.length / 2);
+    return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+  }
+  // Median decimal odds for home and away across all bookmakers' h2h markets.
+  function consensus(event) {
+    const home = [], away = [];
+    (event.bookmakers || []).forEach(function (bk) {
+      const m = (bk.markets || []).find(function (x) { return x.key === 'h2h'; });
+      if (!m) return;
+      m.outcomes.forEach(function (o) {
+        if (o.name === event.home_team || o.name === 'HOME') home.push(o.price);
+        else if (o.name === event.away_team || o.name === 'AWAY') away.push(o.price);
+      });
+    });
+    return { home: median(home), away: median(away), books: Math.min(home.length, away.length) };
+  }
+
+  // --- predictions (home-first) --------------------------------------------
+  // Both models' picks for a fixture, home goals first. Draws are valid picks:
+  // the game scores the result at the end of ordinary time, so a 1-1 stands.
+  function picksFor(homeOdds, awayOdds) {
+    return {
+      points: predictScoreMode('points', homeOdds, awayOdds),
+      exact: predictScoreMode('exact', homeOdds, awayOdds),
+    };
+  }
+  function pickStr(p) { return p ? p.scoreA + '-' + p.scoreB : '?'; }
+  function combinedPickKey(homeOdds, awayOdds) {
+    if (!Number.isFinite(homeOdds) || !Number.isFinite(awayOdds)) return null;
+    const p = picksFor(homeOdds, awayOdds);
+    if (!p.points || !p.exact) return null;
+    return pickStr(p.points) + '|' + pickStr(p.exact);
+  }
+  function combinedPickKeyEv(ev) {
+    const o = consensus(ev);
+    return combinedPickKey(o.home, o.away);
+  }
+
+  // --- grading -------------------------------------------------------------
+  function outcomeOf(a, b) { return a === b ? 'draw' : (a > b ? 'A' : 'B'); }
+  // Score one model's pick against a final result: 3 exact, 2 outcome, 0 else.
+  function grade(pred, hs, as) {
+    if (!pred) return { pts: 0, exact: false, outcome: false };
+    const exact = pred.scoreA === hs && pred.scoreB === as;
+    if (exact) return { pts: 3, exact: true, outcome: true };
+    const ok = outcomeOf(pred.scoreA, pred.scoreB) === outcomeOf(hs, as);
+    return { pts: ok ? 2 : 0, exact: false, outcome: ok };
+  }
+
+  // --- locks and results ---------------------------------------------------
+  // Freeze the odds snapshot for any event still in the future; a started
+  // game is never relocked, so its picks can never move after kickoff.
+  function updateLocks(events, persist) {
+    let touched = false;
+    (events || []).forEach(function (ev) {
+      if (!ev.id || hasStarted(ev.commence_time)) return;
+      const o = consensus(ev);
+      if (!Number.isFinite(o.home) || !Number.isFinite(o.away)) return;
+      wcLocks[ev.id] = { home: o.home, away: o.away, commence_time: ev.commence_time,
+        home_team: ev.home_team, away_team: ev.away_team };
+      touched = true;
+    });
+    if (persist && touched) saveLocks();
+  }
+  function applyScores(arr, persist) {
+    let touched = false;
+    (arr || []).forEach(function (s) {
+      if (!s.id || !s.scores) return;
+      // A server 90-minute result is authoritative; never overwrite it with an
+      // Odds API final, which for knockouts includes extra time.
+      if (wcResults[s.id] && wcResults[s.id].src === 'reg') return;
+      let hs = null, as = null;
+      s.scores.forEach(function (sc) {
+        const v = Number(sc.score);
+        if (sc.name === s.home_team) hs = v;
+        else if (sc.name === s.away_team) as = v;
+      });
+      if (!Number.isFinite(hs) || !Number.isFinite(as)) return;
+      wcResults[s.id] = { completed: !!s.completed, home_score: hs, away_score: as,
+        home_team: s.home_team, away_team: s.away_team, commence_time: s.commence_time };
+      touched = true;
+    });
+    if (persist && touched) saveResults();
+  }
+
+  // Merge live odds, locked snapshots, and stored results into one row set so
+  // played games stay visible (and graded) even after the odds feed drops them.
+  function buildRows() {
+    const liveById = {};
+    (wcEvents || []).forEach(function (ev) { if (ev.id) liveById[ev.id] = ev; });
+
+    const ids = {};
+    Object.keys(wcLocks).forEach(function (id) { ids[id] = true; });
+    Object.keys(wcResults).forEach(function (id) { ids[id] = true; });
+    Object.keys(liveById).forEach(function (id) { ids[id] = true; });
+
+    // Drop a synthetic server ('srv:') id when a real id (live event or
+    // browser-captured lock/result) already covers the same match, so a match
+    // the browser knows first-hand is never rendered twice.
+    const realMatchKeys = {};
+    Object.keys(ids).forEach(function (id) {
+      if (id.indexOf('srv:') === 0) return;
+      const m = liveById[id] || wcLocks[id] || wcResults[id];
+      if (m && m.home_team && m.away_team && m.commence_time) {
+        realMatchKeys[normTeam(m.home_team) + '|' + normTeam(m.away_team) + '|' + dayKey(m.commence_time)] = true;
+      }
+    });
+    Object.keys(ids).forEach(function (id) {
+      if (id.indexOf('srv:') !== 0) return;
+      const m = wcLocks[id] || wcResults[id];
+      if (!m || !m.home_team) return;
+      const variants = keyVariants(m.home_team, m.away_team, m.commence_time);
+      if (variants.some(function (k) { return realMatchKeys[k]; })) delete ids[id];
+    });
+
+    const rows = [];
+    Object.keys(ids).forEach(function (id) {
+      const live = liveById[id];
+      const lock = wcLocks[id];
+      const res = wcResults[id];
+      const home_team = (live && live.home_team) || (lock && lock.home_team) || (res && res.home_team);
+      const away_team = (live && live.away_team) || (lock && lock.away_team) || (res && res.away_team);
+      const commence_time = (live && live.commence_time) || (lock && lock.commence_time) || (res && res.commence_time);
+      if (!home_team || !away_team || !commence_time) return;
+      const started = hasStarted(commence_time);
+
+      let home = NaN, away = NaN, locked = false;
+      if (started && lock) { home = lock.home; away = lock.away; locked = true; }
+      else if (live) { const o = consensus(live); home = o.home; away = o.away; locked = started; }
+      else if (lock) { home = lock.home; away = lock.away; locked = started; }
+      if (!Number.isFinite(home) || !Number.isFinite(away)) return;
+
+      rows.push({ id: id, home_team: home_team, away_team: away_team, commence_time: commence_time,
+        started: started, locked: locked, home: home, away: away,
+        picks: picksFor(home, away), result: res || null });
+    });
+    rows.sort(function (a, b) { return ts(a.commence_time) - ts(b.commence_time); });
+    return rows;
+  }
+
+  // --- rendering -----------------------------------------------------------
+  function fmtWhen(t) {
+    return new Date(t).toLocaleString([], {
+      weekday: 'short', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    });
+  }
+  function fmtClock(t) {
+    return new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  // Both models are graded in your points so the columns compare directly:
+  // 3 (exact) is green, 2 (outcome) is accent, 0 is muted. An exact hit is the
+  // only way to score 3, so the green badge already doubles as the hit marker.
+  function ptsBadge(g) {
+    const cls = g.pts === 3 ? 'g3' : g.pts === 2 ? 'g2' : 'g0';
+    return '<span class="wc-grade ' + cls + '" title="' +
+      (g.exact ? 'exact score' : g.outcome ? 'right outcome, wrong score' : 'wrong outcome') +
+      '">' + g.pts + ' pt' + (g.pts === 1 ? '' : 's') + '</span>';
+  }
+
+  function buildRow(r) {
+    const changed = r.id && wcChanged[r.id] && !r.started;
+    const res = r.result;
+    const done = res && res.completed;
+    const live = res && !res.completed;
+
+    let ptsCell = '<span class="wc-pick">' + pickStr(r.picks.points) + '</span>';
+    let exactCell = '<span class="wc-pick">' + pickStr(r.picks.exact) + '</span>';
+    let resultCell;
+    if (done) {
+      ptsCell += ' ' + ptsBadge(grade(r.picks.points, res.home_score, res.away_score));
+      exactCell += ' ' + ptsBadge(grade(r.picks.exact, res.home_score, res.away_score));
+      resultCell = '<span class="wc-result">' + res.home_score + '-' + res.away_score + '</span>';
+    } else if (live) {
+      resultCell = '<span class="wc-result wc-live">' + res.home_score + '-' + res.away_score + ' live</span>';
+    } else {
+      resultCell = '<span class="wc-pending">' + (r.started ? 'awaiting result' : 'not started') + '</span>';
+    }
+
+    const lockTag = r.started ? '<span class="wc-lock" title="Kicked off: odds and picks are locked">locked</span>' : '';
+    const changedTag = changed ? '<span class="wc-changed-tag">updated</span>' : '';
+
+    const tr = document.createElement('tr');
+    if (changed) tr.className = 'wc-changed';
+    tr.innerHTML =
+      '<td class="wc-time">' + fmtWhen(r.commence_time) + ' ' + lockTag + '</td>' +
+      '<td class="wc-match">' + r.home_team + ' vs ' + r.away_team + changedTag + '</td>' +
+      '<td class="wc-odds">' + r.home.toFixed(2) + ' / ' + r.away.toFixed(2) + '</td>' +
+      '<td>' + ptsCell + '</td>' +
+      '<td>' + exactCell + '</td>' +
+      '<td>' + resultCell + '</td>';
+    return tr;
+  }
+
+  function renderFixtures() {
+    const rows = buildRows();
+    // Upcoming and in-progress fill the main table; finished games drop into
+    // their own collapsible block (newest first) so they never crowd the top.
+    const upcoming = rows.filter(function (r) { return !(r.result && r.result.completed); });
+    const finished = rows.filter(function (r) { return r.result && r.result.completed; })
+      .sort(function (a, b) { return ts(b.commence_time) - ts(a.commence_time); });
+
+    wcBody.innerHTML = '';
+    upcoming.forEach(function (r) { wcBody.appendChild(buildRow(r)); });
+    wcWrap.hidden = upcoming.length === 0;
+
+    wcDoneBody.innerHTML = '';
+    finished.forEach(function (r) { wcDoneBody.appendChild(buildRow(r)); });
+    wcDone.hidden = finished.length === 0;
+    wcDoneSummary.textContent = 'Completed matches (' + finished.length + ')';
+
+    renderSummary(rows);
+
+    wcStatus.textContent = rows.length
+      ? rows.length + ' match' + (rows.length === 1 ? '' : 'es') + ' loaded' + wcMeta
+      : 'No fixtures loaded yet. Paste your key and hit Load fixtures (or use the key "demo" to preview).';
+    updateAutoStatus();
+  }
+
+  function renderSummary(rows) {
+    let n = 0, ptsTotal = 0, ptsExact = 0, ptsOutcome = 0, exactHits = 0, exactPts = 0;
+    rows.forEach(function (r) {
+      if (!r.result || !r.result.completed) return;
+      n++;
+      const hs = r.result.home_score, as = r.result.away_score;
+      const gp = grade(r.picks.points, hs, as);
+      ptsTotal += gp.pts;
+      if (gp.exact) ptsExact++; else if (gp.outcome) ptsOutcome++;
+      const ge = grade(r.picks.exact, hs, as);
+      if (ge.exact) exactHits++;
+      exactPts += ge.pts;
+    });
+    if (!n) { wcSummary.hidden = true; return; }
+    wcSummary.hidden = false;
+
+    // Head-to-head: which model has more of your points so far, and by how much.
+    const margin = Math.abs(ptsTotal - exactPts);
+    const pointsLead = ptsTotal > exactPts, exactLead = exactPts > ptsTotal, tie = ptsTotal === exactPts;
+    const plural = margin === 1 ? '' : 's';
+
+    function card(name, cls, badge, total, meta) {
+      return '<div class="wc-sb-card ' + cls + '">' +
+        '<div class="wc-sb-top"><span class="wc-sb-name">' + name + '</span>' + badge + '</div>' +
+        '<div class="wc-sb-score">' + total + '<span class="wc-sb-unit">pts</span></div>' +
+        '<div class="wc-sb-meta">' + meta + '</div></div>';
+    }
+    const winBadge = '<span class="wc-sb-badge win">Leading +' + margin + ' pt' + plural + '</span>';
+    const tieBadge = '<span class="wc-sb-badge tie">Tied</span>';
+
+    const pointsCard = card('Points model',
+      pointsLead ? 'leader' : (tie ? '' : 'trail'),
+      pointsLead ? winBadge : (tie ? tieBadge : ''),
+      ptsTotal,
+      (ptsTotal / n).toFixed(2) + ' / match · ' + ptsExact + ' exact · ' + ptsOutcome + ' outcome-only');
+    const exactCard = card('Exact model',
+      exactLead ? 'leader' : (tie ? '' : 'trail'),
+      exactLead ? winBadge : (tie ? tieBadge : ''),
+      exactPts,
+      (exactPts / n).toFixed(2) + ' / match · ' + exactHits + ' exact = ' + Math.round((exactHits / n) * 100) + '%');
+
+    wcSummary.innerHTML =
+      '<div class="wc-sb-head">Model scoreboard <span class="wc-sb-sub">· through ' + n +
+        ' completed match' + (n === 1 ? '' : 'es') + ' · 90-minute scores</span></div>' +
+      '<div class="wc-sb-cards">' + pointsCard + '<div class="wc-sb-vs">vs</div>' + exactCard + '</div>';
+  }
+
+  function showFixtures(events, meta, live) {
+    // On a live refresh, flag FUTURE picks that flipped (started games are locked).
+    wcChanged = {};
+    if (live && wcEvents) {
+      const old = {};
+      wcEvents.forEach(function (ev) {
+        if (!ev.id || hasStarted(ev.commence_time)) return;
+        const k = combinedPickKeyEv(ev);
+        if (k) old[ev.id] = k;
+      });
+      events.forEach(function (ev) {
+        if (!ev.id || hasStarted(ev.commence_time)) return;
+        const k = combinedPickKeyEv(ev);
+        if (k && old[ev.id] && old[ev.id] !== k) wcChanged[ev.id] = true;
+      });
+      const nch = Object.keys(wcChanged).length;
+      if (nch) document.title = '⚽ ' + nch + ' pick' + (nch > 1 ? 's' : '') + ' changed!';
+    }
+    wcEvents = events;
+    wcMeta = meta || '';
+    renderFixtures();
+    scheduleAuto();
+  }
+
+  // Results are best-effort: a scores failure must never block the odds render.
+  function fetchScores(key) {
+    if (key === 'demo') { applyScores(demoScores(), false); return Promise.resolve(undefined); }
+    return fetch(WC_SCORES_URL + encodeURIComponent(key))
+      .then(function (res) {
+        if (!res.ok) throw new Error('scores ' + res.status);
+        const left = res.headers.get('x-requests-remaining');
+        return res.json().then(function (arr) { applyScores(arr, true); return left; });
+      })
+      .catch(function () { return undefined; });
+  }
+
+  function fetchFixtures(force) {
+    const key = wcKeyInput.value.trim();
+    if (!key) { wcStatus.textContent = 'Paste your API key first (or "demo" for sample data).'; return; }
+    localStorage.setItem(WC_KEY_LS, key);
+
+    if (key === 'demo') {
+      wcLocks = {};
+      wcResults = {};
+      wcEvents = demoEvents();
+      applyScores(demoScores(), false);
+      wcMeta = ' · demo data, not live';
+      wcChanged = {};
+      renderFixtures();
+      scheduleAuto();
+      return;
+    }
+
+    // Reset in-memory state from persisted truth (drops any demo preview).
+    wcLocks = loadLocks();
+    wcResults = loadResults();
+    // Pull server-collected 90-minute results (no key needed); this re-renders
+    // on its own when anything changes.
+    fetchServerState();
+
+    if (!force) {
+      try {
+        const cached = JSON.parse(localStorage.getItem(WC_CACHE_LS));
+        if (cached && now() - cached.ts < WC_CACHE_MS) {
+          updateLocks(cached.events, true);
+          showFixtures(cached.events, ' · cached ' + fmtClock(cached.ts), false);
+          return;
+        }
+      } catch (e) { /* bad cache, fall through to fetch */ }
+    }
+
+    wcStatus.textContent = 'Fetching odds and results...';
+    let quota = '';
+    fetch(WC_ODDS_URL + encodeURIComponent(key))
+      .then(function (res) {
+        if (res.status === 401) throw new Error('Invalid API key (401).');
+        if (res.status === 429) throw new Error('Out of API credits for this month (429).');
+        if (!res.ok) throw new Error('API error ' + res.status + '.');
+        const left = res.headers.get('x-requests-remaining');
+        if (left !== null) quota = ' · ' + left + ' credits left';
+        return res.json();
+      })
+      .then(function (events) {
+        localStorage.setItem(WC_CACHE_LS, JSON.stringify({ ts: now(), events: events }));
+        updateLocks(events, true);
+        return fetchScores(key).then(function (left) {
+          if (left !== null && left !== undefined) quota = ' · ' + left + ' credits left';
+          showFixtures(events, ' · live' + quota + ' · ' + fmtClock(now()), true);
+        });
+      })
+      .catch(function (err) {
+        wcStatus.textContent = 'Could not load fixtures: ' + err.message;
+      });
+  }
+
+  // --- pre-kickoff auto-refresh --------------------------------------------
+
+  // A pick is "at risk" when nudging either side's odds by 6 percent in any
+  // direction flips either model's predicted score; that is the only case
+  // where a late line move could change a pick, so only then is a refresh
+  // worth a credit. 6 percent is the size of a typical late market move.
+  const WC_NUDGE = [1 / 1.06, 1, 1.06];
+  function atRisk(ev) {
+    const o = consensus(ev);
+    if (!Number.isFinite(o.home) || !Number.isFinite(o.away)) return false;
+    const base = combinedPickKey(o.home, o.away);
+    if (!base) return false;
+    for (let i = 0; i < WC_NUDGE.length; i++) {
+      for (let j = 0; j < WC_NUDGE.length; j++) {
+        const k = combinedPickKey(o.home * WC_NUDGE[i], o.away * WC_NUDGE[j]);
+        if (k && k !== base) return true;
+      }
+    }
+    return false;
+  }
+
+  // --- pre-kickoff chime (Web Audio, no external file) ----------------------
+  // Unlocked by the user gesture of ticking the sound box; once unlocked the
+  // scheduled timer can sound it later without a fresh gesture.
+  function ensureAudio() {
+    try {
+      if (!wcAudioCtx) {
+        const AC = window.AudioContext || window.webkitAudioContext;
+        if (!AC) return null;
+        wcAudioCtx = new AC();
+      }
+      if (wcAudioCtx.state === 'suspended') wcAudioCtx.resume();
+      return wcAudioCtx;
+    } catch (e) { return null; }
+  }
+  function chirp(ctx, at, freq, dur) {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = freq;
+    gain.gain.setValueAtTime(0.0001, at);
+    gain.gain.exponentialRampToValueAtTime(0.6, at + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, at + dur);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(at);
+    osc.stop(at + dur + 0.02);
+  }
+  // A ~5 second alarm: three rising notes repeated, loud enough to catch
+  // from another tab. Distinctive triad so it does not sound like a notification.
+  function playKickoffSound() {
+    const ctx = ensureAudio();
+    if (!ctx) return;
+    const t0 = ctx.currentTime;
+    const cycle = 0.85;   // one rising motif plus a short gap
+    const cycles = 6;     // 6 x 0.85 = ~5.1 seconds
+    for (let i = 0; i < cycles; i++) {
+      const t = t0 + i * cycle;
+      chirp(ctx, t,        880, 0.18);
+      chirp(ctx, t + 0.22, 1175, 0.18);
+      chirp(ctx, t + 0.44, 1568, 0.34);
+    }
+  }
+
+  const WC_LEAD_MS = 10 * 60 * 1000;
+
+  function nextFire() {
+    const n = now();
+    let best = null;
+    (wcEvents || []).forEach(function (ev) {
+      const at = ts(ev.commence_time) - WC_LEAD_MS;
+      if (at > n + 5000 && (!best || at < best.at)) best = { ev: ev, at: at };
+    });
+    return best;
+  }
+
+  function scheduleAuto() {
+    clearTimeout(wcAutoTimer);
+    wcAutoTimer = null;
+    updateAutoStatus();
+    if (!wcAuto.checked && !wcSound.checked) return;
+    const next = nextFire();
+    if (!next) return;
+    // setTimeout overflows past ~24.8 days; clamp and re-arm when it fires.
+    wcAutoTimer = setTimeout(autoFire, Math.min(next.at - now(), 2147000000));
+  }
+
+  function autoFire() {
+    const n = now();
+    // Background tabs can fire timers late; accept anything kicking off within
+    // the lead window plus a couple of minutes of throttle slack.
+    const due = (wcEvents || []).filter(function (ev) {
+      const k = ts(ev.commence_time);
+      return k > n && k - n <= WC_LEAD_MS + 2 * 60 * 1000;
+    });
+    // Sound the chime for any imminent kickoff, independent of refreshing.
+    if (due.length && wcSound.checked) playKickoffSound();
+    const risky = due.filter(atRisk);
+    const key = wcKeyInput.value.trim();
+    if (wcAuto.checked && risky.length && key && key !== 'demo') {
+      fetchFixtures(true); // showFixtures re-arms the timer afterwards
+      return;
+    }
+    if (due.length && wcAuto.checked) {
+      wcStatus.textContent = 'Pre-kickoff check: no pick close enough to flip, refresh skipped.';
+    }
+    scheduleAuto();
+  }
+
+  function updateAutoStatus() {
+    if (!wcAuto.checked && !wcSound.checked) { wcAutoStatus.hidden = true; return; }
+    const what = wcAuto.checked && wcSound.checked ? 'Pre-kickoff sound + auto-check'
+      : wcAuto.checked ? 'Pre-kickoff auto-check' : 'Pre-kickoff sound alert';
+    const next = nextFire();
+    if (!next) {
+      wcAutoStatus.textContent = what + ' is on, but there are no upcoming kickoffs loaded.';
+      wcAutoStatus.hidden = false;
+      return;
+    }
+    wcAutoStatus.textContent = what + ': ' + fmtWhen(next.at) + ' (10 min before ' +
+      next.ev.home_team + ' vs ' + next.ev.away_team + '). Keep this tab open.';
+    wcAutoStatus.hidden = false;
+  }
+
+  // Clear the "pick changed" title alert once the user looks at the tab.
+  window.addEventListener('focus', function () { document.title = 'Score Predictor'; });
+
+  // --- init ----------------------------------------------------------------
+  wcLocks = loadLocks();
+  wcResults = loadResults();
+  wcKeyInput.value = localStorage.getItem(WC_KEY_LS) || '';
+  wcAuto.checked = localStorage.getItem(WC_AUTO_LS) === '1';
+  wcSound.checked = localStorage.getItem(WC_SOUND_LS) === '1';
+  wcKeyToggle.addEventListener('click', function () {
+    const show = wcKeyInput.type === 'password';
+    wcKeyInput.type = show ? 'text' : 'password';
+    wcKeyToggle.textContent = show ? 'Hide' : 'Show';
+    wcKeyToggle.setAttribute('aria-pressed', show ? 'true' : 'false');
+    wcKeyToggle.setAttribute('aria-label', show ? 'Hide API key' : 'Show API key');
+  });
+  wcLoadBtn.addEventListener('click', function () { fetchFixtures(false); });
+  wcRefreshBtn.addEventListener('click', function () { fetchFixtures(true); });
+  wcAuto.addEventListener('change', function () {
+    localStorage.setItem(WC_AUTO_LS, wcAuto.checked ? '1' : '0');
+    scheduleAuto();
+  });
+  wcSound.addEventListener('change', function () {
+    localStorage.setItem(WC_SOUND_LS, wcSound.checked ? '1' : '0');
+    // Ticking the box is a user gesture: unlock audio and preview the chime.
+    if (wcSound.checked) playKickoffSound();
+    scheduleAuto();
+  });
+  wcTestSound.addEventListener('click', function () {
+    // A click is a user gesture, so this also unlocks audio for later alerts.
+    const ctx = ensureAudio();
+    if (ctx) playKickoffSound();
+    wcStatus.textContent = ctx
+      ? 'Played the kickoff chime. If you heard it, the 10-min alert uses the same sound (keep this tab open and in the foreground).'
+      : 'This browser blocked audio for the page. Check the tab is not muted, then press Test sound again.';
+  });
+
+  renderTable();
+  update();
+  renderFixtures();   // show any persisted history immediately on load
+  fetchServerState();   // then fold in server-collected 90-min finals (no key needed)
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a throwaway World Cup variant of the Score Predictor, `tools/score-predictor-v2.html`, backed by Netlify functions that collect match data server-side. This fixes three problems with the original tool:

1. **Results were stranded.** The Odds API `/scores` endpoint only returns games from the last 3 days, so a match whose final was never captured while a tab happened to be open (inside that window) could never be back-filled and showed "awaiting result" forever.
2. **Knockout scores were wrong.** The page graded against final scores, which for knockouts include extra time and penalties. The owner only cares about the 90-minute (regulation) result.
3. **History was per-browser.** The whole scoreboard lived in `localStorage`, so a fresh browser (or a branch-preview URL) showed nothing.

The v2 page is intentionally a standalone copy (dupes are fine) so the owner can delete it plus the functions in one go when the World Cup ends. The original `tools/score-predictor.html` is left byte-identical to master.

## Files changed (complete diff)

All files are **new**; no existing tracked file is modified.

**`netlify/functions/wc-results-cron.mjs`** (new) — hourly scheduled function (`0 * * * *`):
- Pulls WC fixtures from **API-Football** and stores **90-minute-only** scores (`score.fulltime`, ignoring `extratime`/`penalty`) into Netlify Blobs store `score-predictor`, key `results`. A match 1-1 after 90 is stored as 1-1 regardless of what happens in ET.
- Polls **The Odds API** odds endpoint and freezes median consensus odds for not-yet-started matches into key `locks`, so the page can compute picks server-side without an open tab. Started matches are left frozen (they drop out of the odds feed anyway).
- Both halves are best-effort and independent: a failure in one does not block the other. Results persist forever once captured.

**`netlify/functions/wc-results.mjs`** (new) — public GET endpoint returning `{ updated, locks, results }` with a short edge cache. No key required (reading finals is harmless).

**`netlify/functions/lib/wc-store.mjs`** (new) — shared constants, the team-name normalizer + alias table, and `median`/`oddsConsensus` helpers. Placed in `lib/` **deliberately** so Netlify does not register it as its own function endpoint.

**`netlify/functions/package.json`** (new) — declares `@netlify/blobs`. `node_modules` and the lockfile stay gitignored per the existing repo convention.

**`tools/score-predictor-v2.html`** (new) — copy of the original plus:
- Reads the server endpoint on init and on Load/Refresh. Server 90-minute results are tagged `src:'reg'` and **win** over Odds API finals; `applyScores` refuses to overwrite a `reg` result.
- Injects server-frozen odds as synthetic `srv:<key>` locks so the full table and scoreboard rebuild on any browser. A real browser-captured lock or live event always wins, and `buildRows` dedups a `srv:` row when a real id covers the same match.
- **Show/Hide toggle** for the API key. The key-field CSS was reworked (shared bordered shell, `#wc-key` selector) so styling survives the `password`↔`text` switch.
- **Model scoreboard**: Points vs Exact as side-by-side cards with big totals, a green "LEADING +N pts" badge on the winner, and per-match detail. Stacks on mobile.
- Help copy updated to explain server collection and 90-minute scoring. Title set to "Score Predictor v2".

## Cross-provider matching

The page (Odds API ids) and the collector (API-Football) share no match ids, so results/locks are keyed by a normalized `home|away|date` string. The normalizer + alias table is mirrored in both `lib/wc-store.mjs` and the page; they were verified to produce identical keys, including aliases (USA↔United States, Iran↔IR Iran, Ivory Coast↔Côte d'Ivoire, etc.). Lookups tolerate ±1 day to absorb timezone rounding.

## Explicitly untouched

- `tools/score-predictor.html` — reverted to and confirmed identical to master.
- `netlify.toml` — no change needed; the functions dir and esbuild bundler are already configured, and scheduled functions self-declare via `export const config`.
- CSP / `connect-src` — the page fetches only a same-origin function; external APIs are called server-side.

## Judgment calls

- **API-Football for scores** (owner-selected) is the only source that cleanly exposes the 90-minute score separate from ET/penalties.
- **Hourly cadence** (owner-selected). One API-Football call covers the whole tournament; the 3-day scores window gives many retries, so an hour of latency is invisible.
- **v2 as a standalone copy** with duplicated code, per the owner's request for a one-shot cleanup later.

## Configuration required to activate

Set on Netlify (Site settings → Environment variables), never in the repo:
- `APIFOOTBALL_KEY` — api-sports.io key (header `x-apisports-key`)
- `ODDS_API_KEY` — The Odds API key
- Optional: `WC_APIFOOTBALL_LEAGUE` (default `1` = World Cup), `WC_APIFOOTBALL_SEASON` (default `2026`)

Missing either key degrades gracefully (the cron skips that half; the page falls back to local Odds API data).

## Testing

- `node --check` on all three functions; unit tests for the normalizer, `median`, `oddsConsensus`, and `matchKey`.
- An 8-assertion functional test of the client merge: fresh-browser reconstruction, no duplicate rows when a real lock exists, real-lock odds preserved, and idempotent re-merge.
- Full `npm test`: 1124/1124 pass.
- Desktop + mobile screenshots with demo data (scoreboard prominence, key toggle).

## Known limitation

Matches that kicked off before the first cron run can't have their odds back-filled (odds leave the feed at kickoff). Everything from first deploy onward is fully covered.