### PR TITLE
fix(netlify): declare @netlify/blobs at repo root so functions bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "enrich:rising-seasons:providers": "node apps/rising-seasons/scripts/enrich-providers.js",
     "export:rising-seasons": "node apps/rising-seasons/scripts/export-integrations.js",
     "watch-next": "node apps/rising-seasons/scripts/watch-next.js"
+  },
+  "dependencies": {
+    "@netlify/blobs": "^8.1.0"
   }
 }


### PR DESCRIPTION
## Problem

After PR #220 merged and deployed, `GET /.netlify/functions/wc-results` returned **502** with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@netlify/blobs' imported from /var/task/wc-results.mjs
```

Both functions (`wc-results.mjs`, `wc-results-cron.mjs`) import `@netlify/blobs`, but Netlify runs `npm install` against the **root** `package.json`, which did not declare it. The per-functions-dir `netlify/functions/package.json` was not installed, so esbuild left the import unresolved and the functions crashed at runtime.

## Fix

Declare `@netlify/blobs` in the root `package.json` `dependencies`, so Netlify installs it at build time and esbuild bundles it into the functions.

## Scope

- One file: root `package.json` (adds a `dependencies` block).
- No source/behavior change to the functions or the page.
- The redundant `netlify/functions/package.json` is left in place (harmless).

## Verification

Endpoint returned 502 before; will re-verify `/.netlify/functions/wc-results` returns `{updated, locks, results}` after this deploys.