### PR TITLE
feat(score-predictor): collect results from The Odds API, drop API-Football

### DIFF
--- a/netlify/functions/wc-results-cron.mjs
+++ b/netlify/functions/wc-results-cron.mjs
@@ -1,131 +1,126 @@
-// Score Predictor — server-side results collector (scheduled).
+// Score Predictor — server-side data collector (scheduled).
 //
-// Why this exists: the browser page grades picks against final scores, but
-// The Odds API /scores endpoint only returns games from the last 3 days, so
-// a match whose final was never captured while a tab happened to be open
-// (and inside that 3-day window) could never be back-filled and was stuck
-// showing "awaiting result" forever. This function removes the tab entirely
-// from data collection: it runs on a schedule, pulls the World Cup fixtures
-// from API-Football, and accumulates results into a Netlify Blob that the
-// page reads on load. Once a result is stored it persists indefinitely.
+// Why this exists: the browser page grades picks against odds it freezes at
+// kickoff and scores it fetches from The Odds API, but that /scores endpoint
+// only returns games from the last 3 days, and odds vanish from the feed once
+// a match starts. So anything not captured while a tab happened to be open
+// (inside those windows) was lost forever. This function removes the tab from
+// data collection entirely: on a schedule it freezes upcoming odds into a
+// locks blob and accumulates final scores into a results blob, both of which
+// the page reads on load. Once stored, data persists indefinitely.
 //
-// It also fixes the knockout problem: we store the 90-minute (regulation)
-// score only. API-Football exposes score.fulltime as the score at the end of
-// normal time, kept separate from score.extratime and score.penalty, so a
-// knockout that finishes 1-1 after 90 and 2-1 after extra time is stored as
-// 1-1. That is the only number the page cares about.
+// Both feeds come from The Odds API (the same provider the fixtures come
+// from), so team names line up exactly on both sides. Scores are the feed's
+// final score: for group-stage matches that is the 90-minute result; knockout
+// matches that go to extra time would include it (that feed exposes no
+// regulation-only split).
 //
 // Required env var (set in the Netlify UI, never in the repo):
-//   APIFOOTBALL_KEY   — api-sports.io key (header x-apisports-key)
-// Optional overrides:
-//   WC_APIFOOTBALL_LEAGUE  (default 1 = FIFA World Cup)
-//   WC_APIFOOTBALL_SEASON  (default 2026)
+//   ODDS_API_KEY — The Odds API key
+//
+// Credits: to avoid burning the monthly Odds API quota, each feed is only
+// called when it can actually do something — scores only when a known match
+// kicked off in the last 3 days and is not yet final; odds only when a known
+// match kicks off within 12 hours or the last snapshot is over 6 hours old.
+// A cold start (no data yet) calls both once to bootstrap.
 
 import { getStore } from '@netlify/blobs';
 import { STORE_NAME, RESULTS_KEY, LOCKS_KEY, matchKey, oddsConsensus } from './lib/wc-store.mjs';
 
-// Hourly. Idle runs are cheap: one API-Football call returns the whole
-// tournament, and results only ever change right after a match, so an hour
-// of latency is invisible while the 3-day-window problem disappears entirely.
 export const config = { schedule: '0 * * * *' };
 
-const API_URL = 'https://v3.football.api-sports.io/fixtures';
-const LEAGUE = process.env.WC_APIFOOTBALL_LEAGUE || '1';
-const SEASON = process.env.WC_APIFOOTBALL_SEASON || '2026';
+const SPORT = 'soccer_fifa_world_cup';
+const ODDS_URL = `https://api.the-odds-api.com/v4/sports/${SPORT}/odds/?regions=eu&markets=h2h&oddsFormat=decimal&apiKey=`;
+const SCORES_URL = `https://api.the-odds-api.com/v4/sports/${SPORT}/scores/?daysFrom=3&apiKey=`;
 
-// The Odds API — same feed the page uses, polled server-side so odds are
-// frozen into locks before kickoff even when no tab is open. Without this the
-// page could never show picks for a match nobody had open at kickoff.
-const ODDS_URL = 'https://api.the-odds-api.com/v4/sports/soccer_fifa_world_cup/odds/?regions=eu&markets=h2h&oddsFormat=decimal&apiKey=';
-
-// API-Football status short codes. Once a match is at or past full time the
-// 90-minute score can no longer change, so score.fulltime is final even while
-// the game continues into extra time or penalties.
-const POST_REGULATION = new Set(['FT', 'AET', 'PEN', 'ET', 'BT', 'P', 'LIVE']);
+const DAY = 86400000;
+const HOUR = 3600000;
 
 export default async function handler() {
-  const key = process.env.APIFOOTBALL_KEY;
-  if (!key) {
-    return new Response('APIFOOTBALL_KEY is not configured', { status: 500 });
-  }
-
-  let body;
-  try {
-    const res = await fetch(`${API_URL}?league=${LEAGUE}&season=${SEASON}`, {
-      headers: { 'x-apisports-key': key },
-    });
-    if (!res.ok) {
-      return new Response(`api-football ${res.status}`, { status: 502 });
-    }
-    body = await res.json();
-  } catch (err) {
-    return new Response(`fetch failed: ${err.message}`, { status: 502 });
-  }
+  const key = process.env.ODDS_API_KEY;
+  if (!key) return new Response('ODDS_API_KEY is not configured', { status: 500 });
 
   const store = getStore(STORE_NAME);
-  const prev = (await store.get(RESULTS_KEY, { type: 'json' })) || {};
-  const results = { ...(prev.results || {}) };
+  const prevResults = (await store.get(RESULTS_KEY, { type: 'json' })) || {};
+  const prevLocks = (await store.get(LOCKS_KEY, { type: 'json' })) || {};
+  const results = { ...(prevResults.results || {}) };
+  const locks = { ...(prevLocks.locks || {}) };
+  const now = Date.now();
 
-  let stored = 0;
-  for (const item of body.response || []) {
-    const home = item?.teams?.home?.name;
-    const away = item?.teams?.away?.name;
-    const commence = item?.fixture?.date;
-    const status = item?.fixture?.status?.short;
-    const ft = item?.score?.fulltime;
-    if (!home || !away || !commence || !ft) continue;
+  // Kickoff time per known match, from everything we have already stored.
+  const commenceByKey = {};
+  for (const [k, v] of Object.entries(locks)) if (v.commence_time) commenceByKey[k] = v.commence_time;
+  for (const [k, v] of Object.entries(results)) if (v.commence_time) commenceByKey[k] = v.commence_time;
+  const cold = Object.keys(commenceByKey).length === 0;
 
-    const hs = Number(ft.home);
-    const as = Number(ft.away);
-    // fulltime is null until 90 minutes are played; guard against half-time.
-    if (!Number.isFinite(hs) || !Number.isFinite(as)) continue;
+  // Scores: worth a call only if some known match kicked off within the /scores
+  // window (3 days) and is not yet recorded as final.
+  const scoresNeeded = Object.entries(commenceByKey).some(function ([k, c]) {
+    const t = Date.parse(c);
+    return t <= now && t >= now - 3 * DAY && !(results[k] && results[k].completed);
+  });
+  // Odds: worth a call if a known match kicks off soon, or our snapshot is stale
+  // (stale also re-discovers newly listed fixtures).
+  const upcomingSoon = Object.values(locks).some(function (l) {
+    const t = Date.parse(l.commence_time);
+    return t > now && t <= now + 12 * HOUR;
+  });
+  const oddsStale = !prevLocks.updated || (now - Date.parse(prevLocks.updated)) > 6 * HOUR;
 
-    const completed = POST_REGULATION.has(status);
-    const k = matchKey(home, away, commence);
-    results[k] = {
-      home_score: hs,
-      away_score: as,
-      completed,
-      status,
-      home_team: home,
-      away_team: away,
-      commence_time: commence,
-    };
-    stored += 1;
+  const scoresMsg = (cold || scoresNeeded) ? await collectScores(key, results, store) : 'skipped';
+  const locksMsg = (cold || upcomingSoon || oddsStale) ? await snapshotOdds(key, locks, store, now) : 'skipped';
+
+  return new Response(`ok: results ${scoresMsg}, locks ${locksMsg}`);
+}
+
+// Accumulate final scores from The Odds API /scores into the results blob.
+async function collectScores(key, results, store) {
+  let arr;
+  try {
+    const res = await fetch(SCORES_URL + encodeURIComponent(key));
+    if (!res.ok) return `scores ${res.status}`;
+    arr = await res.json();
+  } catch (err) {
+    return `scores failed: ${err.message}`;
   }
 
-  await store.setJSON(RESULTS_KEY, {
-    updated: new Date().toISOString(),
-    league: LEAGUE,
-    season: SEASON,
-    results,
-  });
+  let n = 0;
+  for (const g of arr || []) {
+    if (!g || !g.home_team || !g.away_team || !g.commence_time || !g.scores) continue;
+    let hs = null, as = null;
+    for (const s of g.scores) {
+      const v = Number(s.score);
+      if (s.name === g.home_team) hs = v;
+      else if (s.name === g.away_team) as = v;
+    }
+    if (!Number.isFinite(hs) || !Number.isFinite(as)) continue;
+    results[matchKey(g.home_team, g.away_team, g.commence_time)] = {
+      home_score: hs,
+      away_score: as,
+      completed: !!g.completed,
+      home_team: g.home_team,
+      away_team: g.away_team,
+      commence_time: g.commence_time,
+    };
+    n += 1;
+  }
 
-  const locked = await snapshotOdds(store);
-
-  return new Response(`ok: scanned ${(body.response || []).length}, results ${stored}, locks ${locked}`);
+  await store.setJSON(RESULTS_KEY, { updated: new Date().toISOString(), results });
+  return String(n);
 }
 
 // Freeze median odds for every not-yet-started match into the locks blob so the
-// page can compute picks from the server alone. Best-effort: a failure here
-// must not affect the results already stored above. Once a match kicks off it
-// drops out of the odds feed, so its last snapshot persists untouched.
-async function snapshotOdds(store) {
-  const key = process.env.ODDS_API_KEY;
-  if (!key) return 'skipped (no ODDS_API_KEY)';
-
+// page can compute picks from the server alone. Once a match kicks off it drops
+// out of the odds feed, so its last snapshot persists untouched.
+async function snapshotOdds(key, locks, store, now) {
   let events;
   try {
     const res = await fetch(ODDS_URL + encodeURIComponent(key));
     if (!res.ok) return `odds ${res.status}`;
     events = await res.json();
   } catch (err) {
-    return `odds fetch failed: ${err.message}`;
+    return `odds failed: ${err.message}`;
   }
-
-  const prev = (await store.get(LOCKS_KEY, { type: 'json' })) || {};
-  const locks = { ...(prev.locks || {}) };
-  const now = Date.now();
 
   let n = 0;
   for (const ev of events || []) {

--- a/tools/score-predictor-v2.html
+++ b/tools/score-predictor-v2.html
@@ -350,7 +350,7 @@
         <summary>How this works</summary>
         <div class="wc-collapse-body">
           <p class="section-sub">Upcoming and played matches use median 1X2 odds from The Odds API, scored under both models. Once a match kicks off its odds and picks lock and never change; only future matches update when you Load or Refresh. Your key is stored in this browser only, never in this file. Odds are cached for 6 hours; Refresh refetches odds plus final scores (about 3 credits) and the scoreboard builds up over time.</p>
-          <p class="section-sub">Both the odds (frozen before each kickoff) and the final scores are collected server-side every hour, so the full table and scoreboard rebuild themselves even on a brand-new browser and even if this tab was never open during a match. Your own key is still only needed to pull fresh odds for matches you want to watch live. Every result is the 90-minute (regulation) score only: for knockout games that go to extra time or penalties, the extra-time and shootout goals are ignored, so a match that is 1-1 after 90 counts as 1-1 in both models.</p>
+          <p class="section-sub">Both the odds (frozen before each kickoff) and the final scores are collected server-side every hour, so the full table and scoreboard rebuild themselves even on a brand-new browser and even if this tab was never open during a match. Your own key is still only needed to pull fresh odds for matches you want to watch live. Scores are the feed's final result: for group-stage matches that is the 90-minute score, so a 1-1 group game counts as 1-1 in both models. Knockout games that go to extra time would include those goals, since the feed exposes no regulation-only split.</p>
           <p class="section-sub">Both columns are scored in your points (3 exact, 2 outcome, 0 otherwise), so a 1-1 pick on a 2-2 result earns 2 in either column. The models differ only in how they choose a pick: the Points model picks the score that maximizes expected points, so it leans toward the most likely outcome, while the Exact model chases the single most likely exact scoreline. An Exact pick still earns 2 whenever its outcome is right; the difference is that the Points model is optimizing for the points you actually score, so it should come out ahead over a full tournament. Use Points for your entries; the Exact column is just a sanity check, and any single match can go either way.</p>
         </div>
       </details>
@@ -1113,7 +1113,7 @@
 
     wcSummary.innerHTML =
       '<div class="wc-sb-head">Model scoreboard <span class="wc-sb-sub">· through ' + n +
-        ' completed match' + (n === 1 ? '' : 'es') + ' · 90-minute scores</span></div>' +
+        ' completed match' + (n === 1 ? '' : 'es') + ' · final scores</span></div>' +
       '<div class="wc-sb-cards">' + pointsCard + '<div class="wc-sb-vs">vs</div>' + exactCard + '</div>';
   }
 


### PR DESCRIPTION
## Why

After deploying, the results half never populated: **API-Football's free plan cannot read the 2026 World Cup season** (`Free plans do not have access to this season, try from 2022 to 2024`). It is also a different provider from the one the page's fixtures come from, so it may not carry these matches at all.

The Odds API `/scores` endpoint - the **same provider** as the fixtures and odds - was tested and returns the completed matches with scores on the existing `ODDS_API_KEY`. Switching to it makes results work immediately and makes team-name matching exact on both sides.

## Changes

**`netlify/functions/wc-results-cron.mjs`**
- Results now come from The Odds API `/scores` (`daysFrom=3`), accumulated into the `results` blob so the 3-day window no longer strands anything.
- Odds → `locks` snapshot is unchanged.
- **Credit-saving gates** (verified with a unit test): fetch scores only when a known match kicked off within the last 3 days and is not yet final; fetch odds only when a known match kicks off within 12h or the last snapshot is over 6h old; a cold start calls both once. During quiet periods (overnight, post-tournament) this drops to at most one discovery call every 6h.
- API-Football removed. **Only `ODDS_API_KEY` is now required** (`APIFOOTBALL_KEY` is unused and can be deleted from Netlify).

**`tools/score-predictor-v2.html`**
- Help copy and the scoreboard label corrected: scores are the feed's final result - 90-minute for group-stage games; knockout extra time would be included, since the feed exposes no regulation-only split.

## Tradeoff (owner-selected)

Group-stage matches are all 90 minutes, so they are exactly what's wanted. Knockout matches that go to extra time will include those goals. If true 90-minute knockout scores are needed later, that requires a paid data source that carries these fixtures; the collector can be pointed at it then.

## Explicitly unchanged

- `tools/score-predictor.html` (original) - untouched.
- `netlify/functions/wc-results.mjs`, `lib/wc-store.mjs` (still used for keys, normalizer, median/consensus).
- Client merge/dedup logic - team names now match exactly since both sides are The Odds API, so the alias table is simply belt-and-suspenders.

## Testing

- `node --check` on the cron; v2 script parses.
- Unit test of the gating decisions (cold start, recent-uncompleted, all-completed, upcoming-soon, stale-snapshot): all pass.
- Live-validated both Odds API endpoints (odds: 9 events; scores: 17 games, 8 completed) against the production key.
- `npm test`: 1124/1124 pass.