### PR TITLE
debug: temporary env-presence probe

### DIFF
--- a/netlify/functions/wc-results.mjs
+++ b/netlify/functions/wc-results.mjs
@@ -9,7 +9,17 @@
 import { getStore } from '@netlify/blobs';
 import { STORE_NAME, RESULTS_KEY, LOCKS_KEY } from './lib/wc-store.mjs';
 
-export default async function handler() {
+export default async function handler(req) {
+  // Temporary diagnostic: report which env vars reach this function at runtime
+  // (booleans only, never values). Remove once the cron env issue is resolved.
+  if (req && typeof req.url === 'string' && req.url.includes('debug=env')) {
+    return new Response(JSON.stringify({
+      ODDS_API_KEY: !!process.env.ODDS_API_KEY,
+      FIREBASE_API_KEY: !!process.env.FIREBASE_API_KEY,
+      total_env_keys: Object.keys(process.env).length,
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }
+
   const store = getStore(STORE_NAME);
   const resultsBlob = (await store.get(RESULTS_KEY, { type: 'json' })) || {};
   const locksBlob = (await store.get(LOCKS_KEY, { type: 'json' })) || {};


### PR DESCRIPTION
Temporary diagnostic to determine whether env vars reach Netlify functions at runtime. Returns booleans only (no secret values) on `?debug=env`. Will be reverted.