### PR TITLE
fix(score-predictor): read Odds API key from Blob (env vars not injected into functions)

### DIFF
--- a/netlify/functions/lib/wc-store.mjs
+++ b/netlify/functions/lib/wc-store.mjs
@@ -9,6 +9,9 @@
 export const STORE_NAME = 'score-predictor';
 export const RESULTS_KEY = 'results';
 export const LOCKS_KEY = 'locks';
+// Holds { oddsApiKey } written out-of-band (netlify blobs:set) because this
+// site does not inject env vars into functions. Never served to the browser.
+export const CONFIG_KEY = 'config';
 
 // Median of a numeric list (used for consensus odds across bookmakers).
 export function median(arr) {

--- a/netlify/functions/wc-results-cron.mjs
+++ b/netlify/functions/wc-results-cron.mjs
@@ -25,7 +25,7 @@
 // A cold start (no data yet) calls both once to bootstrap.
 
 import { getStore } from '@netlify/blobs';
-import { STORE_NAME, RESULTS_KEY, LOCKS_KEY, matchKey, oddsConsensus } from './lib/wc-store.mjs';
+import { STORE_NAME, RESULTS_KEY, LOCKS_KEY, CONFIG_KEY, matchKey, oddsConsensus } from './lib/wc-store.mjs';
 
 export const config = { schedule: '0 * * * *' };
 
@@ -37,10 +37,15 @@ const DAY = 86400000;
 const HOUR = 3600000;
 
 export default async function handler() {
-  const key = process.env.ODDS_API_KEY;
-  if (!key) return new Response('ODDS_API_KEY is not configured', { status: 500 });
-
   const store = getStore(STORE_NAME);
+
+  // This site does not inject env vars into functions, so the key is read from
+  // a Blob written out-of-band (netlify blobs:set). Env var is still preferred
+  // if it ever starts working.
+  const cfg = (await store.get(CONFIG_KEY, { type: 'json' })) || {};
+  const key = process.env.ODDS_API_KEY || cfg.oddsApiKey;
+  if (!key) return new Response('Odds API key not configured (env or config blob)', { status: 500 });
+
   const prevResults = (await store.get(RESULTS_KEY, { type: 'json' })) || {};
   const prevLocks = (await store.get(LOCKS_KEY, { type: 'json' })) || {};
   const results = { ...(prevResults.results || {}) };

--- a/netlify/functions/wc-results.mjs
+++ b/netlify/functions/wc-results.mjs
@@ -9,21 +9,7 @@
 import { getStore } from '@netlify/blobs';
 import { STORE_NAME, RESULTS_KEY, LOCKS_KEY } from './lib/wc-store.mjs';
 
-export default async function handler(req) {
-  // Temporary diagnostic: report which env vars reach this function at runtime
-  // (booleans only, never values). Remove once the cron env issue is resolved.
-  if (req && typeof req.url === 'string' && req.url.includes('debug=env')) {
-    const names = Object.keys(process.env)
-      .filter((k) => !/AWS|LAMBDA|SECRET|SESSION|TOKEN|KEY|PASS/i.test(k))
-      .sort();
-    return new Response(JSON.stringify({
-      ODDS_API_KEY: !!process.env.ODDS_API_KEY,
-      FIREBASE_API_KEY: !!process.env.FIREBASE_API_KEY,
-      total_env_keys: Object.keys(process.env).length,
-      safe_names: names,
-    }), { status: 200, headers: { 'content-type': 'application/json' } });
-  }
-
+export default async function handler() {
   const store = getStore(STORE_NAME);
   const resultsBlob = (await store.get(RESULTS_KEY, { type: 'json' })) || {};
   const locksBlob = (await store.get(LOCKS_KEY, { type: 'json' })) || {};


### PR DESCRIPTION
This site does not inject user env vars into functions (verified via a probe: neither ODDS_API_KEY nor FIREBASE_API_KEY reaches process.env; only system vars do). The cron now reads the key from the Blob store (key `config`, field `oddsApiKey`), written out-of-band via `netlify blobs:set`, with the env var still preferred if it ever works. Removes the temporary env probe. The config blob is never exposed by the read endpoint.