### PR TITLE
feat(score-predictor): 90-minute scores + show all completed games

### DIFF
--- a/netlify/functions/wc-results-cron.mjs
+++ b/netlify/functions/wc-results-cron.mjs
@@ -1,28 +1,15 @@
 // Score Predictor — server-side data collector (scheduled).
 //
-// Why this exists: the browser page grades picks against odds it freezes at
-// kickoff and scores it fetches from The Odds API, but that /scores endpoint
-// only returns games from the last 3 days, and odds vanish from the feed once
-// a match starts. So anything not captured while a tab happened to be open
-// (inside those windows) was lost forever. This function removes the tab from
-// data collection entirely: on a schedule it freezes upcoming odds into a
-// locks blob and accumulates final scores into a results blob, both of which
-// the page reads on load. Once stored, data persists indefinitely.
+// Scores come from football-data.org: it carries the full World Cup schedule
+// (no 3-day window) and lets us compute the 90-minute (regulation) score, which
+// is the only number this tool cares about. The Odds API is used only for odds,
+// frozen into locks before kickoff so the page can show picks without a tab
+// open. Both feeds come from services whose team names line up with The Odds
+// API fixtures after the shared normalizer.
 //
-// Both feeds come from The Odds API (the same provider the fixtures come
-// from), so team names line up exactly on both sides. Scores are the feed's
-// final score: for group-stage matches that is the 90-minute result; knockout
-// matches that go to extra time would include it (that feed exposes no
-// regulation-only split).
-//
-// Required env var (set in the Netlify UI, never in the repo):
-//   ODDS_API_KEY — The Odds API key
-//
-// Credits: to avoid burning the monthly Odds API quota, each feed is only
-// called when it can actually do something — scores only when a known match
-// kicked off in the last 3 days and is not yet final; odds only when a known
-// match kicks off within 12 hours or the last snapshot is over 6 hours old.
-// A cold start (no data yet) calls both once to bootstrap.
+// This site does not inject env vars into functions, so both credentials live
+// in the Blob `config` (fields oddsApiKey, footballDataToken), written once via
+// the one-time ?setkey= / ?setfd= query params below.
 
 import { getStore } from '@netlify/blobs';
 import { STORE_NAME, RESULTS_KEY, LOCKS_KEY, CONFIG_KEY, matchKey, oddsConsensus } from './lib/wc-store.mjs';
@@ -31,87 +18,106 @@ export const config = { schedule: '0 * * * *' };
 
 const SPORT = 'soccer_fifa_world_cup';
 const ODDS_URL = `https://api.the-odds-api.com/v4/sports/${SPORT}/odds/?regions=eu&markets=h2h&oddsFormat=decimal&apiKey=`;
-const SCORES_URL = `https://api.the-odds-api.com/v4/sports/${SPORT}/scores/?daysFrom=3&apiKey=`;
-
-const DAY = 86400000;
+const FD_URL = 'https://api.football-data.org/v4/competitions/WC/matches';
 const HOUR = 3600000;
 
-export default async function handler() {
+// 90-minute score from a football-data score object. regularTime is populated
+// for some knockout games but null for others, so fall back to
+// fullTime minus extra-time minus penalties (fullTime bundles them all in).
+function score90(s) {
+  if (!s) return null;
+  const rt = s.regularTime;
+  if (rt && rt.home != null && rt.away != null) {
+    return { home: Number(rt.home), away: Number(rt.away) };
+  }
+  const ft = s.fullTime;
+  if (!ft || ft.home == null || ft.away == null) return null;
+  let h = Number(ft.home), a = Number(ft.away);
+  const et = s.extraTime, pen = s.penalties;
+  if (et && et.home != null) { h -= Number(et.home); a -= Number(et.away); }
+  if (pen && pen.home != null) { h -= Number(pen.home); a -= Number(pen.away); }
+  return { home: h, away: a };
+}
+
+export default async function handler(req) {
   const store = getStore(STORE_NAME);
 
-  // The key lives in the config blob (this site does not inject env vars into
-  // functions). It was written once through this function's own store; env var
-  // is still preferred if it ever starts resolving.
-  const cfg = (await store.get(CONFIG_KEY, { type: 'json' })) || {};
-  const key = process.env.ODDS_API_KEY || cfg.oddsApiKey;
-  if (!key) return new Response('Odds API key not configured (env or config blob)', { status: 500 });
+  // One-time credential setup (env vars are not injected into functions here).
+  try {
+    const u = new URL(req.url);
+    const setfd = u.searchParams.get('setfd');
+    const setkey = u.searchParams.get('setkey');
+    if (setfd || setkey) {
+      const c = (await store.get(CONFIG_KEY, { type: 'json' })) || {};
+      if (setfd) c.footballDataToken = setfd;
+      if (setkey) c.oddsApiKey = setkey;
+      await store.setJSON(CONFIG_KEY, c);
+      return new Response('config stored');
+    }
+  } catch (e) { /* scheduled run: no url */ }
 
-  const prevResults = (await store.get(RESULTS_KEY, { type: 'json' })) || {};
+  const cfg = (await store.get(CONFIG_KEY, { type: 'json' })) || {};
+  const oddsKey = process.env.ODDS_API_KEY || cfg.oddsApiKey;
+  const fdToken = process.env.FD_TOKEN || cfg.footballDataToken;
+
   const prevLocks = (await store.get(LOCKS_KEY, { type: 'json' })) || {};
-  const results = { ...(prevResults.results || {}) };
   const locks = { ...(prevLocks.locks || {}) };
   const now = Date.now();
 
-  // Kickoff time per known match, from everything we have already stored.
-  const commenceByKey = {};
-  for (const [k, v] of Object.entries(locks)) if (v.commence_time) commenceByKey[k] = v.commence_time;
-  for (const [k, v] of Object.entries(results)) if (v.commence_time) commenceByKey[k] = v.commence_time;
-  const cold = Object.keys(commenceByKey).length === 0;
+  // Scores: football-data every run (free, generous limits, full history).
+  const resultsMsg = fdToken ? await collectResults(fdToken, store) : 'no fd token';
 
-  // Scores: worth a call only if some known match kicked off within the /scores
-  // window (3 days) and is not yet recorded as final.
-  const scoresNeeded = Object.entries(commenceByKey).some(function ([k, c]) {
-    const t = Date.parse(c);
-    return t <= now && t >= now - 3 * DAY && !(results[k] && results[k].completed);
-  });
-  // Odds: worth a call if a known match kicks off soon, or our snapshot is stale
-  // (stale also re-discovers newly listed fixtures).
+  // Odds: gated to save Odds API credits — only when a match kicks off within
+  // 12h or the snapshot is over 6h old (or nothing is locked yet).
   const upcomingSoon = Object.values(locks).some(function (l) {
     const t = Date.parse(l.commence_time);
     return t > now && t <= now + 12 * HOUR;
   });
   const oddsStale = !prevLocks.updated || (now - Date.parse(prevLocks.updated)) > 6 * HOUR;
+  const cold = Object.keys(locks).length === 0;
+  const locksMsg = (oddsKey && (cold || upcomingSoon || oddsStale))
+    ? await snapshotOdds(oddsKey, locks, store, now)
+    : 'skipped';
 
-  const scoresMsg = (cold || scoresNeeded) ? await collectScores(key, results, store) : 'skipped';
-  const locksMsg = (cold || upcomingSoon || oddsStale) ? await snapshotOdds(key, locks, store, now) : 'skipped';
-
-  return new Response(`ok: results ${scoresMsg}, locks ${locksMsg}`);
+  return new Response(`ok: results ${resultsMsg}, locks ${locksMsg}`);
 }
 
-// Accumulate final scores from The Odds API /scores into the results blob.
-async function collectScores(key, results, store) {
-  let arr;
+// Rebuild the results blob from football-data's finished matches, storing the
+// 90-minute score. Rebuilt fresh each run so a corrected score replaces any
+// earlier value; skipped entirely if the feed returns nothing (never wipes).
+async function collectResults(token, store) {
+  let body;
   try {
-    const res = await fetch(SCORES_URL + encodeURIComponent(key));
-    if (!res.ok) return `scores ${res.status}`;
-    arr = await res.json();
+    const res = await fetch(FD_URL, { headers: { 'X-Auth-Token': token } });
+    if (!res.ok) return `fd ${res.status}`;
+    body = await res.json();
   } catch (err) {
-    return `scores failed: ${err.message}`;
+    return `fd failed: ${err.message}`;
   }
 
-  let n = 0;
-  for (const g of arr || []) {
-    if (!g || !g.home_team || !g.away_team || !g.commence_time || !g.scores) continue;
-    let hs = null, as = null;
-    for (const s of g.scores) {
-      const v = Number(s.score);
-      if (s.name === g.home_team) hs = v;
-      else if (s.name === g.away_team) as = v;
-    }
-    if (!Number.isFinite(hs) || !Number.isFinite(as)) continue;
-    results[matchKey(g.home_team, g.away_team, g.commence_time)] = {
-      home_score: hs,
-      away_score: as,
-      completed: !!g.completed,
-      home_team: g.home_team,
-      away_team: g.away_team,
-      commence_time: g.commence_time,
+  const finished = (body.matches || []).filter(function (m) { return m.status === 'FINISHED'; });
+  if (!finished.length) return 'no finished games';
+
+  const results = {};
+  for (const m of finished) {
+    const s90 = score90(m.score);
+    if (!s90 || !Number.isFinite(s90.home) || !Number.isFinite(s90.away)) continue;
+    const home = m.homeTeam && m.homeTeam.name;
+    const away = m.awayTeam && m.awayTeam.name;
+    const commence = m.utcDate;
+    if (!home || !away || !commence) continue;
+    results[matchKey(home, away, commence)] = {
+      home_score: s90.home,
+      away_score: s90.away,
+      completed: true,
+      home_team: home,
+      away_team: away,
+      commence_time: commence,
     };
-    n += 1;
   }
 
   await store.setJSON(RESULTS_KEY, { updated: new Date().toISOString(), results });
-  return String(n);
+  return String(Object.keys(results).length);
 }
 
 // Freeze median odds for every not-yet-started match into the locks blob so the

--- a/tools/score-predictor-v2.html
+++ b/tools/score-predictor-v2.html
@@ -205,6 +205,7 @@
   .wc-status { color: var(--muted); font-size: 0.85rem; width: 100%; }
   .wc-table .wc-match { white-space: normal; min-width: 12rem; }
   .wc-table .wc-pick { font-family: var(--mono); font-weight: 700; color: var(--good); }
+  .wc-table .wc-nopick { color: var(--muted-2); font-weight: 400; }
   .wc-table .wc-odds, .wc-table .wc-time { font-family: var(--mono); }
   .wc-table tr.wc-changed td { background: rgba(74, 222, 128, 0.10); }
   .wc-changed-tag {
@@ -802,16 +803,56 @@
     if (touched) saveResults();
     return touched;
   }
+  // Every match key currently represented by a row (real or synthetic), with
+  // the +/- 1 day variants, so a server result already shown isn't duplicated.
+  function coveredMatchKeys() {
+    const set = {};
+    [wcLocks, wcResults].forEach(function (map) {
+      Object.keys(map).forEach(function (id) {
+        const m = map[id];
+        if (m && m.home_team && m.away_team && m.commence_time) {
+          keyVariants(m.home_team, m.away_team, m.commence_time).forEach(function (k) { set[k] = true; });
+        }
+      });
+    });
+    return set;
+  }
+  // Add a result-only row for every completed server match that no lock covers,
+  // so finished games nobody predicted still show their score (ungraded).
+  function mergeServerResults() {
+    if (!wcServer) return false;
+    const covered = coveredMatchKeys();
+    let touched = false;
+    Object.keys(wcServer).forEach(function (k) {
+      const sr = wcServer[k];
+      if (!sr || !Number.isFinite(sr.home_score) || !Number.isFinite(sr.away_score)) return;
+      const variants = keyVariants(sr.home_team, sr.away_team, sr.commence_time);
+      if (variants.some(function (v) { return covered[v]; })) return; // a lock/result already shows it
+      const id = 'srv:' + k;
+      const cur = wcResults[id];
+      if (cur && cur.home_score === sr.home_score && cur.away_score === sr.away_score) return;
+      wcResults[id] = {
+        completed: !!sr.completed, home_score: sr.home_score, away_score: sr.away_score,
+        home_team: sr.home_team, away_team: sr.away_team,
+        commence_time: sr.commence_time, src: 'reg', noPick: true,
+      };
+      touched = true;
+    });
+    if (touched) saveResults();
+    return touched;
+  }
   function fetchServerState() {
     return fetch(WC_RESULTS_FN, { cache: 'no-store' })
       .then(function (res) { return res.ok ? res.json() : null; })
       .then(function (data) {
         if (!data) return;
         wcServer = data.results || {};
-        // Locks first (they create the rows), then results (they grade them).
+        // Locks first (they create predicted rows), then attach results to
+        // them, then add result-only rows for completed games nobody locked.
         const a = mergeServerLocks(data.locks || {});
         const b = applyServerResults();
-        if (a || b) renderFixtures();
+        const c = mergeServerResults();
+        if (a || b || c) renderFixtures();
       })
       .catch(function () { /* offline or not deployed yet: leave local data */ });
   }
@@ -982,7 +1023,16 @@
       if (started && lock) { home = lock.home; away = lock.away; locked = true; }
       else if (live) { const o = consensus(live); home = o.home; away = o.away; locked = started; }
       else if (lock) { home = lock.home; away = lock.away; locked = started; }
-      if (!Number.isFinite(home) || !Number.isFinite(away)) return;
+
+      if (!Number.isFinite(home) || !Number.isFinite(away)) {
+        // No odds were ever captured for this match, but if it finished we can
+        // still show the score (ungraded, no pick) so no completed game is hidden.
+        if (res && res.completed) {
+          rows.push({ id: id, home_team: home_team, away_team: away_team, commence_time: commence_time,
+            started: true, locked: false, home: NaN, away: NaN, picks: null, result: res });
+        }
+        return;
+      }
 
       rows.push({ id: id, home_team: home_team, away_team: away_team, commence_time: commence_time,
         started: started, locked: locked, home: home, away: away,
@@ -1016,13 +1066,19 @@
     const res = r.result;
     const done = res && res.completed;
     const live = res && !res.completed;
+    const noPick = !r.picks;
 
-    let ptsCell = '<span class="wc-pick">' + pickStr(r.picks.points) + '</span>';
-    let exactCell = '<span class="wc-pick">' + pickStr(r.picks.exact) + '</span>';
+    // Result-only row: a finished match nobody had odds/picks for. Show the
+    // score, dash out the odds and both picks, and don't grade it.
+    let ptsCell = noPick ? '<span class="wc-pick wc-nopick">&mdash;</span>' : '<span class="wc-pick">' + pickStr(r.picks.points) + '</span>';
+    let exactCell = noPick ? '<span class="wc-pick wc-nopick">&mdash;</span>' : '<span class="wc-pick">' + pickStr(r.picks.exact) + '</span>';
+    const oddsCell = noPick ? '<span class="wc-nopick">&mdash;</span>' : (r.home.toFixed(2) + ' / ' + r.away.toFixed(2));
     let resultCell;
     if (done) {
-      ptsCell += ' ' + ptsBadge(grade(r.picks.points, res.home_score, res.away_score));
-      exactCell += ' ' + ptsBadge(grade(r.picks.exact, res.home_score, res.away_score));
+      if (!noPick) {
+        ptsCell += ' ' + ptsBadge(grade(r.picks.points, res.home_score, res.away_score));
+        exactCell += ' ' + ptsBadge(grade(r.picks.exact, res.home_score, res.away_score));
+      }
       resultCell = '<span class="wc-result">' + res.home_score + '-' + res.away_score + '</span>';
     } else if (live) {
       resultCell = '<span class="wc-result wc-live">' + res.home_score + '-' + res.away_score + ' live</span>';
@@ -1038,7 +1094,7 @@
     tr.innerHTML =
       '<td class="wc-time">' + fmtWhen(r.commence_time) + ' ' + lockTag + '</td>' +
       '<td class="wc-match">' + r.home_team + ' vs ' + r.away_team + changedTag + '</td>' +
-      '<td class="wc-odds">' + r.home.toFixed(2) + ' / ' + r.away.toFixed(2) + '</td>' +
+      '<td class="wc-odds">' + oddsCell + '</td>' +
       '<td>' + ptsCell + '</td>' +
       '<td>' + exactCell + '</td>' +
       '<td>' + resultCell + '</td>';
@@ -1073,7 +1129,7 @@
   function renderSummary(rows) {
     let n = 0, ptsTotal = 0, ptsExact = 0, ptsOutcome = 0, exactHits = 0, exactPts = 0;
     rows.forEach(function (r) {
-      if (!r.result || !r.result.completed) return;
+      if (!r.result || !r.result.completed || !r.picks) return; // result-only rows aren't graded
       n++;
       const hs = r.result.home_score, as = r.result.away_score;
       const gp = grade(r.picks.points, hs, as);


### PR DESCRIPTION
Fixes two issues reported on v2: knockout scores included extra time, and completed matches without a captured pick didn't show at all.

## Backend (wc-results-cron.mjs)
- **Scores from football-data.org** (was The Odds API). Computes the true **90-minute** score: `score.regularTime` when populated, else `fullTime - extraTime - penalties`. Verified against real data (Argentina-Cape Verde 90-min = 1-1 not 3-2; Belgium-Senegal 2-2; Germany-Paraguay 1-1; group games unchanged).
- No 3-day window (football-data has the whole tournament); results blob rebuilt each run, never wiped on an empty feed.
- The Odds API is now used **only** for odds → locks (still credit-gated).
- Credentials in the config blob (`oddsApiKey`, `footballDataToken`) via one-time `?setkey=`/`?setfd=` params (env vars aren't injected into this site's functions).
- This also makes the separate backfill unnecessary going forward - the cron pulls full history every run.

## Frontend (score-predictor-v2.html)
- **Result-only rows**: every completed match with no captured odds now shows with its score, dashes for odds and both picks, ungraded, excluded from the model scoreboard. So games nobody predicted (and everything before the collector started) appear.
- `mergeServerResults` injects server results not covered by a lock, deduped against real/synthetic rows; `buildRows` renders the no-odds completed rows; `renderSummary` skips them.

## Tests
- 90-minute computation: 4/4 cases + all 88 finished matches produce a valid score.
- Frontend merge: fresh browser shows upcoming (graded) + all completed (result-only) incl. Argentina 1-1 and England-Congo; a real lock grades without duplicating. 
- `npm test`: full suite passes.