### PR TITLE
chore(score-predictor): remove one-time credential setup path

### DIFF
--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -3864,28 +3864,37 @@ body.maptap-rivals-app select option {
   color: #fff;
   opacity: 1;
   /* Never exceed the (fixed-layout) cell; the name shrinks so the icon and
-     the (avg) annotation always stay inside the cell. */
+     the text column always stay inside the cell. */
   max-width: 100%;
 }
 .matrix-head-chip .matrix-head-name { color: #fff; }
-/* Icon and avg keep their intrinsic width; only the name gives ground. */
+/* Icon keeps its intrinsic width; the text column gives ground. */
 .matrix-head-icon { font-size: 1rem; flex: none; }
+/* Name over avg: a vertical column beside the icon. The name uses the full
+   remaining width for its single (ellipsized) line; the avg sits under it. */
+.matrix-head-text {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  flex: 0 1 auto;
+  line-height: 1.1;
+}
 .matrix-head-name {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
-  flex: 0 1 auto;
   max-width: 9rem;
 }
-/* Player's average daily score, shown after the name since the Avg score
-   subtab was removed. Quiet, smaller, never wraps away from the name. */
+/* Player's average daily score, stacked directly under the name. Quiet and
+   smaller; a tight line-height keeps the two lines within the cell height. */
 .matrix-head-avg {
   color: var(--muted);
   font-size: 0.72rem;
   font-weight: 500;
+  line-height: 1.1;
   white-space: nowrap;
-  flex: none;
 }
 
 .matrix-cell {
@@ -4064,21 +4073,15 @@ body.maptap-rivals-app select option {
     min-width: 5rem;
     max-width: 7rem;
   }
-  .matrix-row-head .matrix-head-chip {
-    flex-wrap: wrap;
-    gap: 0 0.3rem;
-    align-items: center;
-  }
+  .matrix-row-head .matrix-head-chip { gap: 0.3rem; align-items: center; }
   .matrix-row-head .matrix-head-name {
     max-width: 4.6rem;
     font-size: 0.78rem;
   }
-  /* avg moves UNDER the name as its own quiet line. */
+  /* avg stays UNDER the name (the text column stacks it) as a quiet line. */
   .matrix-row-head .matrix-head-avg {
-    flex-basis: 100%;
     font-size: 0.62rem;
     line-height: 1.1;
-    margin-top: 0.05rem;
   }
 
   /* Cells: consistent size, records forced single-line, tighter padding. */

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -4416,7 +4416,7 @@
   function matrixLegendText(subtab) {
     if (subtab === 'margin') return 'Avg point margin per game from the row\'s perspective; the small line shows the row\'s best single result vs that column.';
     if (subtab === 'form')   return 'Dots = last 5 meetings (oldest left → newest right) from the row\'s perspective; cell color follows the dots\' majority. The label shows a live streak only when longer than 5 games, otherwise the row\'s longest win streak ("best W4").';
-    return 'Wins-losses(-ties) and the row\'s win % — ties count as half a win. (avg) next to each name = that player\'s average daily score.';
+    return 'Wins-losses(-ties) and the row\'s win % — ties count as half a win. The number under each name is that player\'s average daily score.';
   }
 
   function renderMatrix() {
@@ -4471,10 +4471,15 @@
     // owner request; the top row stays just icon + name.
     const headChip = (p, withAvg) => {
       const avg = withAvg ? avgFor(p) : null;
+      // Name and avg stack in a text column beside the icon so the score sits
+      // directly under the name. The cell is already two lines tall (data cells
+      // carry a value + a sub-line), so this adds no height.
       return el('span', { class: 'matrix-head-chip', style: `--p-color:${p.color}` }, [
         el('span', { class: 'matrix-head-icon' }, p.icon),
-        el('span', { class: 'matrix-head-name' }, p.label),
-        avg != null ? el('span', { class: 'matrix-head-avg' }, `(${Math.round(avg)})`) : null,
+        el('span', { class: 'matrix-head-text' }, [
+          el('span', { class: 'matrix-head-name' }, p.label),
+          avg != null ? el('span', { class: 'matrix-head-avg' }, `${Math.round(avg)}`) : null,
+        ]),
       ]);
     };
 

--- a/netlify/functions/wc-results-cron.mjs
+++ b/netlify/functions/wc-results-cron.mjs
@@ -39,23 +39,11 @@ function score90(s) {
   return { home: h, away: a };
 }
 
-export default async function handler(req) {
+export default async function handler() {
   const store = getStore(STORE_NAME);
 
-  // One-time credential setup (env vars are not injected into functions here).
-  try {
-    const u = new URL(req.url);
-    const setfd = u.searchParams.get('setfd');
-    const setkey = u.searchParams.get('setkey');
-    if (setfd || setkey) {
-      const c = (await store.get(CONFIG_KEY, { type: 'json' })) || {};
-      if (setfd) c.footballDataToken = setfd;
-      if (setkey) c.oddsApiKey = setkey;
-      await store.setJSON(CONFIG_KEY, c);
-      return new Response('config stored');
-    }
-  } catch (e) { /* scheduled run: no url */ }
-
+  // Credentials live in the config blob (oddsApiKey, footballDataToken),
+  // written once out-of-band; env vars are not injected into functions here.
   const cfg = (await store.get(CONFIG_KEY, { type: 'json' })) || {};
   const oddsKey = process.env.ODDS_API_KEY || cfg.oddsApiKey;
   const fdToken = process.env.FD_TOKEN || cfg.footballDataToken;


### PR DESCRIPTION
Both keys (oddsApiKey, footballDataToken) are now persisted in the config blob, so the temporary ?setkey=/?setfd= write path is removed.