### PR TITLE
feat(score-predictor): odds-gap note + backfill supplied pre-Jul-4 odds

### DIFF
--- a/netlify/functions/wc-lock-backfill.mjs
+++ b/netlify/functions/wc-lock-backfill.mjs
@@ -1,0 +1,161 @@
+// Score Predictor - one-time manual odds backfill (removed after use).
+//
+// The owner supplied pre-kickoff odds for the completed matches that had no
+// captured pick (odds leave the feed at kickoff and the cron started July 4).
+// These are written as locks so those matches show a graded pick. Keyed the
+// same way as results (normalized home|away|date) so each result attaches.
+// The cron only ADDS upcoming locks, so these persist untouched.
+
+import { getStore } from '@netlify/blobs';
+import { STORE_NAME, LOCKS_KEY } from './lib/wc-store.mjs';
+
+const MANUAL_LOCKS = {
+  "switzerland|algeria|2026-07-03": {
+    "home": 1.97,
+    "away": 4.35,
+    "commence_time": "2026-07-03T03:00:00Z",
+    "home_team": "Switzerland",
+    "away_team": "Algeria"
+  },
+  "portugal|croatia|2026-07-02": {
+    "home": 1.68,
+    "away": 5.6,
+    "commence_time": "2026-07-02T23:00:00Z",
+    "home_team": "Portugal",
+    "away_team": "Croatia"
+  },
+  "spain|austria|2026-07-02": {
+    "home": 1.35,
+    "away": 9.9,
+    "commence_time": "2026-07-02T19:00:00Z",
+    "home_team": "Spain",
+    "away_team": "Austria"
+  },
+  "usa|bosniaherzegovina|2026-07-02": {
+    "home": 1.38,
+    "away": 9.0,
+    "commence_time": "2026-07-02T00:00:00Z",
+    "home_team": "United States",
+    "away_team": "Bosnia-Herzegovina"
+  },
+  "belgium|senegal|2026-07-01": {
+    "home": 2.2,
+    "away": 3.55,
+    "commence_time": "2026-07-01T20:00:00Z",
+    "home_team": "Belgium",
+    "away_team": "Senegal"
+  },
+  "england|congodr|2026-07-01": {
+    "home": 1.28,
+    "away": 13.34,
+    "commence_time": "2026-07-01T16:00:00Z",
+    "home_team": "England",
+    "away_team": "Congo DR"
+  },
+  "mexico|ecuador|2026-07-01": {
+    "home": 2.25,
+    "away": 3.9,
+    "commence_time": "2026-07-01T02:00:00Z",
+    "home_team": "Mexico",
+    "away_team": "Ecuador"
+  },
+  "france|sweden|2026-06-30": {
+    "home": 1.3,
+    "away": 10.5,
+    "commence_time": "2026-06-30T21:00:00Z",
+    "home_team": "France",
+    "away_team": "Sweden"
+  },
+  "ivorycoast|norway|2026-06-30": {
+    "home": 3.52,
+    "away": 2.15,
+    "commence_time": "2026-06-30T17:00:00Z",
+    "home_team": "Ivory Coast",
+    "away_team": "Norway"
+  },
+  "netherlands|morocco|2026-06-30": {
+    "home": 2.15,
+    "away": 3.77,
+    "commence_time": "2026-06-30T01:00:00Z",
+    "home_team": "Netherlands",
+    "away_team": "Morocco"
+  },
+  "germany|paraguay|2026-06-29": {
+    "home": 1.37,
+    "away": 8.7,
+    "commence_time": "2026-06-29T20:30:00Z",
+    "home_team": "Germany",
+    "away_team": "Paraguay"
+  },
+  "brazil|japan|2026-06-29": {
+    "home": 1.7,
+    "away": 5.25,
+    "commence_time": "2026-06-29T17:00:00Z",
+    "home_team": "Brazil",
+    "away_team": "Japan"
+  },
+  "southafrica|canada|2026-06-28": {
+    "home": 6.0,
+    "away": 1.66,
+    "commence_time": "2026-06-28T19:00:00Z",
+    "home_team": "South Africa",
+    "away_team": "Canada"
+  },
+  "algeria|austria|2026-06-28": {
+    "home": 3.55,
+    "away": 3.67,
+    "commence_time": "2026-06-28T02:00:00Z",
+    "home_team": "Algeria",
+    "away_team": "Austria"
+  },
+  "jordan|argentina|2026-06-28": {
+    "home": 20.3,
+    "away": 1.13,
+    "commence_time": "2026-06-28T02:00:00Z",
+    "home_team": "Jordan",
+    "away_team": "Argentina"
+  },
+  "colombia|portugal|2026-06-27": {
+    "home": 3.45,
+    "away": 2.05,
+    "commence_time": "2026-06-27T23:30:00Z",
+    "home_team": "Colombia",
+    "away_team": "Portugal"
+  },
+  "congodr|uzbekistan|2026-06-27": {
+    "home": 1.7,
+    "away": 5.19,
+    "commence_time": "2026-06-27T23:30:00Z",
+    "home_team": "Congo DR",
+    "away_team": "Uzbekistan"
+  },
+  "croatia|ghana|2026-06-27": {
+    "home": 1.8,
+    "away": 5.59,
+    "commence_time": "2026-06-27T21:00:00Z",
+    "home_team": "Croatia",
+    "away_team": "Ghana"
+  },
+  "panama|england|2026-06-27": {
+    "home": 17.0,
+    "away": 1.15,
+    "commence_time": "2026-06-27T21:00:00Z",
+    "home_team": "Panama",
+    "away_team": "England"
+  },
+  "newzealand|belgium|2026-06-27": {
+    "home": 14.05,
+    "away": 1.18,
+    "commence_time": "2026-06-27T03:00:00Z",
+    "home_team": "New Zealand",
+    "away_team": "Belgium"
+  }
+};
+
+export default async function handler() {
+  const store = getStore(STORE_NAME);
+  const prev = (await store.get(LOCKS_KEY, { type: 'json' })) || {};
+  const locks = { ...(prev.locks || {}), ...MANUAL_LOCKS };
+  await store.setJSON(LOCKS_KEY, { updated: new Date().toISOString(), locks });
+  return new Response(`ok: added ${Object.keys(MANUAL_LOCKS).length}, total ${Object.keys(locks).length}`);
+}

--- a/tools/score-predictor-v2.html
+++ b/tools/score-predictor-v2.html
@@ -216,7 +216,7 @@
     margin-left: 0.4rem; text-transform: uppercase; letter-spacing: 0.05em;
   }
 
-  /* Model scoreboard — Points vs Exact, head to head */
+  /* Model scoreboard - Points vs Exact, head to head */
   .wc-summary {
     background: var(--surface); border: 1px solid var(--border);
     border-radius: var(--radius); padding: 1rem 1.1rem 1.1rem; margin-bottom: 1rem;
@@ -297,6 +297,11 @@
 
   /* Completed matches sit in their own block below the upcoming table */
   details.wc-done { margin: 1.25rem 0 0; }
+  .wc-done-note {
+    color: var(--muted); font-size: 0.82rem; line-height: 1.5;
+    margin: 0.5rem 0 0.9rem; max-width: 46rem;
+  }
+  .wc-done-note b { color: var(--muted-2); font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em; font-size: 0.75rem; }
   details.wc-done > summary { color: var(--muted); font-size: 0.95rem; font-weight: 600; }
 
   @media (max-width: 540px) {
@@ -341,6 +346,7 @@
 
       <details class="wc-done" id="wc-done" hidden>
         <summary id="wc-done-summary">Completed matches</summary>
+        <p class="wc-done-note">Rows marked <b>result only</b> show the 90-minute score but no pick: their odds were never captured before kickoff (odds leave the feed once a match starts). This is limited to some of the earliest group-stage games; everything more recent has a pick.</p>
         <div class="bands-table-wrap">
           <table class="bands-table wc-table">
             <thead>
@@ -355,7 +361,8 @@
         <summary>How this works</summary>
         <div class="wc-collapse-body">
           <p class="section-sub">Upcoming and played matches use median 1X2 odds from The Odds API, scored under both models. Once a match kicks off its odds and picks lock and never change; only future matches update when you Load or Refresh. Your key is stored in this browser only, never in this file. Odds are cached for 6 hours; Refresh refetches odds plus final scores (about 3 credits) and the scoreboard builds up over time.</p>
-          <p class="section-sub">Both the odds (frozen before each kickoff) and the final scores are collected server-side every hour, so the full table and scoreboard rebuild themselves even on a brand-new browser and even if this tab was never open during a match. Your own key is still only needed to pull fresh odds for matches you want to watch live. Scores are the feed's final result: for group-stage matches that is the 90-minute score, so a 1-1 group game counts as 1-1 in both models. Knockout games that go to extra time would include those goals, since the feed exposes no regulation-only split.</p>
+          <p class="section-sub">Both the odds (frozen before each kickoff) and the scores are collected server-side every hour, so the full table and scoreboard rebuild themselves even on a brand-new browser and even if this tab was never open during a match. Your own key is still only needed to pull fresh odds for matches you want to watch live. Every score is the 90-minute (regulation) result: for a knockout that goes to extra time or penalties, only the score after 90 minutes counts, so a game that is 1-1 after 90 counts as 1-1 in both models regardless of what happens later.</p>
+          <p class="section-sub">A match shows a pick only if its odds were frozen before kickoff, because odds vanish from the feed the moment a match starts. Automatic server collection began on July 4, and earlier odds were captured where they were still available, so a match with no captured odds appears as "result only": the 90-minute score is shown, but there is no pick to grade and it is left out of the model scoreboard. This is limited to some of the earliest group-stage games; everything more recent is predicted, and every match from July 4 onward is captured automatically.</p>
           <p class="section-sub">Both columns are scored in your points (3 exact, 2 outcome, 0 otherwise), so a 1-1 pick on a 2-2 result earns 2 in either column. The models differ only in how they choose a pick: the Points model picks the score that maximizes expected points, so it leans toward the most likely outcome, while the Exact model chases the single most likely exact scoreline. An Exact pick still earns 2 whenever its outcome is right; the difference is that the Points model is optimizing for the points you actually score, so it should come out ahead over a full tournament. Use Points for your entries; the Exact column is just a sanity check, and any single match can go either way.</p>
         </div>
       </details>


### PR DESCRIPTION
Adds an in-tool explanation of 'result only' rows (score, no pick) and corrects stale knockout copy (scores are 90-minute). Adds a one-time function that writes 20 owner-supplied pre-kickoff odds as locks so those completed matches grade; keyed like the results so each attaches. Function removed after it runs.