### PR TITLE
feat(rising-shows): re-add Hidden gems + Surprise me; docs-coverage follow-ups

### DIFF
--- a/apps/arena/README.md
+++ b/apps/arena/README.md
@@ -29,6 +29,7 @@ The pure game logic (scoring, room state, location/question normalization) is sp
 | Head-to-head (H2H) | Per-room cumulative head-to-head record across rematches, plus a global pairwise H2H stats view. |
 | Profiles | Firebase Auth profiles tracking total score, games played, and wins. |
 | Post-game recap | Final scoreboard plus a side-by-side per-question / per-location recap table and detailed per-player accuracy / response-time (Trivia) or distance / region (Globe Drop) stats. |
+| Sound + haptics | WebAudio sound effects and device haptics fire on gameplay events (guess submitted, pin placed/cleared, opponent submitted, score reveal, timer low/expired, chat message, game start/end) via `js/feedback.js`. |
 
 ### Trivia
 

--- a/apps/gym-tracker/README.md
+++ b/apps/gym-tracker/README.md
@@ -49,36 +49,29 @@ A comprehensive, mobile-first workout tracking application built with vanilla Ja
 ```
 gym-tracker/
 ├── index.html                  # Main app entry point
+├── manifest.webmanifest        # PWA manifest
+├── sw.js                       # Service worker (offline support)
+├── package.json                # npm test script + metadata
+├── sitemap-exercises.xml       # Generated sitemap for the exercise directory pages
 ├── css/
-│   └── gym-tracker.css        # Main dark theme styles
+│   ├── gym-tracker.css         # Main dark theme styles
+│   ├── exercise-page.css       # Public exercise-directory page styles
+│   └── refresh.css             # Shared refresh/polish styles
 ├── js/
-│   ├── app.js                 # Main application controller
-│   ├── models/                # Data models
-│   │   ├── Program.js
-│   │   ├── WorkoutDay.js
-│   │   ├── WorkoutSession.js
-│   │   ├── WorkoutExercise.js
-│   │   ├── Set.js
-│   │   ├── Achievement.js
-│   │   └── Settings.js
-│   ├── services/              # Business logic
-│   │   ├── StorageService.js
-│   │   ├── TimerService.js
-│   │   ├── AnalyticsService.js
-│   │   └── AchievementService.js
-│   ├── utils/                 # Helper functions
-│   │   └── helpers.js
-│   └── views/                 # View controllers
-│       ├── home-view.js
-│       ├── programs-view.js
-│       ├── workout-view.js
-│       ├── history-view.js
-│       ├── exercises-view.js
-│       ├── calendar-view.js
-│       ├── achievements-view.js
-│       └── settings-view.js
-└── data/
-    └── exercises-db.js        # 500+ exercise database
+│   ├── app.js                  # Main application controller
+│   ├── models/                 # Program, WorkoutDay, WorkoutSession, WorkoutExercise,
+│   │                           #   Set, Achievement, Measurement, Settings
+│   ├── services/               # Storage, Timer, Analytics, Achievement
+│   ├── utils/                  # plate-calculator, program-schedule, pr-session, rest-cues,
+│   │                           #   session-merge, paginator, event-bus, dark-select, helpers, ...
+│   └── views/                  # home, programs, workout, history, exercises, calendar,
+│                               #   achievements, insights, measurements, settings, paused-banner
+├── data/
+│   ├── exercises-db.js         # 500+ exercise database (JS module)
+│   └── exercises-db.json       # Same data as JSON (for the page generator)
+├── exercises/                  # Generated static exercise-directory pages (gitignored)
+├── scripts/                    # Static-page + sitemap generators (build-exercise-pages.cjs, ...)
+└── tests/                      # node:test unit suites
 ```
 
 ### Data Models
@@ -315,24 +308,3 @@ Built with:
 ## License
 
 Copyright © 2024 Shevato LLC
-
----
-
-**Version**: 2.1.0
-**Last Updated**: 2025-01-20
-**Author**: Nikita Soifer
-
-## Recent Updates (v2.1.0)
-
-- Expanded exercise database from 210 to 500+ exercises
-- Split categories: Arms → Biceps/Triceps, Legs → Quads/Hamstrings/Calves
-- Added custom exercise creation with full integration
-- Implemented exercise reordering in program builder
-- Added previous workout data display (all sets) during workouts
-- Improved text contrast and readability throughout app
-- Replaced browser confirm dialogs with custom styled modals
-- Made workout tiles clickable for detailed views
-- Changed week start to Monday throughout the app
-- Removed difficulty field from exercises
-- Enhanced dashboard with cleaner layout
-- Added workout validation (requires at least one completed set)

--- a/apps/rising-shows/README.md
+++ b/apps/rising-shows/README.md
@@ -42,6 +42,8 @@ A season can match more than one shape — the card shows all of them.
 | Decade filter            | "80s / 90s / 00s / 10s / 20s" quick chips set the year range in one tap (synced with the advanced-drawer year inputs); "All" clears it. |
 | Language filter          | Multi-select chips for the top original languages (TMDB `original_language`).                      |
 | Streaming filter         | Multi-select chips for top US watch providers (Netflix, HBO Max, Prime …).                         |
+| Hidden gems              | A "💎 Hidden gems" quick-filter chip surfaces highly rated but under-watched shows: episode-weighted average episode rating ≥ 8.5 and under 500 IMDb votes per rated episode. Composes with every other filter, shows as a removable chip in the active-filter bar, and serializes to the hash (`fGems=on`). |
+| Surprise me / Popular pick | Two toolbar buttons for discovery. "🎲 Surprise me" opens a random show from the current filtered results; "🔥 Popular pick" opens a random show from the 50 most-voted of those results. Both do nothing when no shows match, and neither changes the URL. |
 | Episode-title search     | Searching ≥3 chars also matches against episode names - "Gray Matter" opens Breaking Bad.           |
 | Compare shows            | "+ Add to compare" on each show, then a floating button opens an overlay chart of season-trajectories for up to 5 series (persisted in localStorage). |
 | Season overlay           | In the show modal, all seasons drawn together on one chart with a legend; clicking a legend entry (the swatch or the S-number) hides/restores that season's line. |

--- a/apps/rising-shows/css/styles.css
+++ b/apps/rising-shows/css/styles.css
@@ -2919,57 +2919,8 @@ body:has(.modal:not([hidden])) .back-to-top {
   padding-right: 2.75rem;
 }
 
-/* Roll-again is anchored directly above the poster — same width, slim
-   height, square-ish corners — so it reads as part of the poster card
-   rather than a floating CTA. The shared --modal-poster-w token keeps
-   it locked to the poster on every breakpoint. */
+/* Shared token so the modal poster keeps a consistent width across breakpoints. */
 .modal-panel { --modal-poster-w: 120px; }
-.modal-reroll {
-  position: absolute;
-  top: 1.75rem;            /* matches .modal-panel padding */
-  left: 1.75rem;           /* matches .modal-panel padding */
-  width: var(--modal-poster-w);
-  height: 30px;
-  z-index: 3;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
-  padding: 0 0.55rem;
-  border: 1px solid rgba(245, 197, 24, 0.55);
-  border-radius: 8px;
-  background: linear-gradient(180deg, var(--accent) 0%, #d8a912 100%);
-  color: var(--accent-ink) !important;
-  font-size: 0.78rem;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  box-shadow:
-    0 4px 14px rgba(245, 197, 24, 0.22),
-    0 0 0 1px rgba(0, 0, 0, 0.18) inset !important;
-  transition: filter 0.18s var(--ease), transform 0.08s var(--ease), box-shadow 0.18s var(--ease);
-}
-.modal-reroll:hover {
-  filter: brightness(1.06);
-  box-shadow:
-    0 6px 18px rgba(245, 197, 24, 0.32),
-    0 0 0 1px rgba(0, 0, 0, 0.18) inset !important;
-}
-.modal-reroll:active { transform: translateY(1px); }
-.modal-reroll:focus-visible {
-  outline: 2px solid #fff8d2;
-  outline-offset: 2px;
-}
-.modal-reroll[hidden] { display: none !important; }
-
-/* When Roll-again is visible (surprise pick), shift the modal header
-   down by the button's height + a small breathing gap so the poster
-   sits flush beneath it. Sibling combinator works because the reroll
-   button precedes .modal-header in DOM order. */
-.modal-reroll:not([hidden]) ~ .modal-header {
-  margin-top: calc(30px - 0.4rem);
-}
 
 .modal-header {
   display: flex;
@@ -3531,15 +3482,6 @@ body.advanced-drawer-open {
     margin-bottom: -1.5rem;
     /* Float the close button over the header — it stays reachable at
        the top of the sheet without consuming a full row of padding. */
-  }
-  .modal-reroll {
-    top: 1rem;
-    left: 1rem;
-    height: 28px;
-    font-size: 0.72rem;
-  }
-  .modal-reroll:not([hidden]) ~ .modal-header {
-    margin-top: calc(28px - 0.4rem);
   }
   .modal-header { gap: 0.85rem; }
   .modal-heading h2 { font-size: 1.35rem; line-height: 1.2; }

--- a/apps/rising-shows/index.html
+++ b/apps/rising-shows/index.html
@@ -157,6 +157,10 @@
             <button type="button" class="btn view-btn" data-view="grid" aria-pressed="true" aria-label="Grid view" title="Grid view">▦</button>
             <button type="button" class="btn view-btn" data-view="list" aria-pressed="false" aria-label="List view" title="List view">☰</button>
           </div>
+          <button type="button" class="btn" id="finderSurprise"
+                  title="Open a random show from the current results">🎲 Surprise me</button>
+          <button type="button" class="btn" id="finderPopularPick"
+                  title="Open a random popular show from the current results">🔥 Popular pick</button>
           <button type="button" class="btn shortcut-legend-btn" id="shortcutLegendBtn"
                   aria-haspopup="dialog" aria-controls="shortcutLegend" aria-expanded="false"
                   title="Keyboard shortcuts (press ?)">?</button>
@@ -198,6 +202,13 @@
               <button type="button" class="finder-chip" data-votes="10000" aria-pressed="false">10k+</button>
               <button type="button" class="finder-chip" data-votes="50000" aria-pressed="false">50k+</button>
               <button type="button" class="finder-chip" data-votes="100000" aria-pressed="false">100k+</button>
+            </div>
+          </div>
+          <div class="label-group" role="group" aria-label="Discovery">
+            <span class="label-group-name">Discovery</span>
+            <div class="finder-chips" role="group" aria-label="Hidden gems">
+              <button type="button" class="finder-chip" id="finderGemsChip" data-gems="on" aria-pressed="false"
+                      title="Highly rated but under-watched: avg episode 8.5+ and under 500 votes per episode">💎 Hidden gems</button>
             </div>
           </div>
         </div>
@@ -328,7 +339,6 @@
     <article class="modal-panel" tabindex="-1" data-back-to-top>
       <button type="button" class="btn modal-close" data-close="modal" aria-label="Close">×</button>
       <button type="button" class="btn modal-back" id="modalBack" hidden aria-label="Back to previous view" title="Back"></button>
-      <button type="button" class="btn btn-primary modal-reroll" id="modalReroll" hidden>Roll again</button>
       <div class="modal-header">
         <div class="modal-poster" id="modalPoster" aria-hidden="true"></div>
         <div class="modal-heading">

--- a/apps/rising-shows/js/app.js
+++ b/apps/rising-shows/js/app.js
@@ -214,7 +214,6 @@ const els = {
   showModalShareCard: document.getElementById('showModalShareCard'),
   modalPoster: document.getElementById('modalPoster'),
   modalWatchBtn: document.getElementById('modalWatchBtn'),
-  modalReroll: document.getElementById('modalReroll'),
   modalViewShow: document.getElementById('modalViewShow'),
   showModal: document.getElementById('showModal'),
   showModalTitle: document.getElementById('showModalTitle'),
@@ -260,10 +259,13 @@ const els = {
   finderSearch: document.getElementById('finderSearch'),
   finderSuggestions: document.getElementById('finderSearchSuggestions'),
   finderViewToggle: document.getElementById('finderViewToggle'),
+  finderSurprise: document.getElementById('finderSurprise'),
+  finderPopularPick: document.getElementById('finderPopularPick'),
   finderActiveFilterBar: document.getElementById('finderActiveFilterBar'),
   finderMinEpisodes: document.getElementById('finderMinEpisodes'),
   finderMinVotes: document.getElementById('finderMinVotes'),
   finderVotesChips: document.getElementById('finderVotesChips'),
+  finderGemsChip: document.getElementById('finderGemsChip'),
   finderMinShowRating: document.getElementById('finderMinShowRating'),
   finderMinAvgEpisode: document.getElementById('finderMinAvgEpisode'),
   finderGapDir: document.getElementById('finderGapDir'),
@@ -303,6 +305,7 @@ const finderState = {
   minGap: 0,
   minYear: null,
   maxYear: null,
+  hiddenGems: false,
   genres: new Set(),
   genresExclude: new Set(),
   languages: new Set(),
@@ -2130,7 +2133,6 @@ function openModal(m, opts = {}) {
     els.modalTvdb.hidden = true;
   }
   syncModalWatchBtn();
-  els.modalReroll.hidden = !modalState.surprise;
 
   els.modal.hidden = false;
   els.modal.setAttribute('aria-hidden', 'false');
@@ -3384,6 +3386,7 @@ function finderHasActiveFilters() {
   if (f.minGap > 0) return true;
   if (f.minYear != null) return true;
   if (f.maxYear != null) return true;
+  if (f.hiddenGems) return true;
   if (f.genres.size) return true;
   if (f.genresExclude.size) return true;
   if (f.languages.size) return true;
@@ -3410,6 +3413,7 @@ function resetFinderState() {
   finderState.minGap = 0;
   finderState.minYear = null;
   finderState.maxYear = null;
+  finderState.hiddenGems = false;
   finderState.genres = new Set();
   finderState.genresExclude = new Set();
   finderState.languages = new Set();
@@ -3444,6 +3448,9 @@ function syncFinderControls() {
   els.finderMaxYear.value = finderState.maxYear ?? '';
   for (const chip of els.finderVotesChips.querySelectorAll('.finder-chip')) {
     chip.setAttribute('aria-pressed', Number(chip.dataset.votes) === finderState.minVotes ? 'true' : 'false');
+  }
+  if (els.finderGemsChip) {
+    els.finderGemsChip.setAttribute('aria-pressed', finderState.hiddenGems ? 'true' : 'false');
   }
   for (const btn of els.finderGapDir.querySelectorAll('.finder-seg-btn')) {
     btn.setAttribute('aria-pressed', btn.dataset.dir === finderState.gapDir ? 'true' : 'false');
@@ -3607,6 +3614,17 @@ function describeFinderActiveFilters() {
   if (f.minShowRating > 0) chips.push(finderNumericChip('Min show', f.minShowRating, 'minShowRating', els.finderMinShowRating));
   if (f.minAvgEpisode > 0) chips.push(finderNumericChip('Min avg ep', f.minAvgEpisode, 'minAvgEpisode', els.finderMinAvgEpisode));
   if (f.minGap > 0) chips.push(finderNumericChip('Min gap', f.minGap, 'minGap', els.finderMinGap));
+  if (f.hiddenGems) {
+    chips.push({
+      key: 'Hidden gems',
+      value: 'On',
+      remove: () => {
+        f.hiddenGems = false;
+        if (els.finderGemsChip) els.finderGemsChip.setAttribute('aria-pressed', 'false');
+        onFinderFilterChange();
+      },
+    });
+  }
   if (f.minYear != null) chips.push(finderYearChip('Year ≥', f.minYear, 'minYear', els.finderMinYear));
   if (f.maxYear != null) chips.push(finderYearChip('Year ≤', f.maxYear, 'maxYear', els.finderMaxYear));
   if (f.sort !== 'votes' || f.sortDir !== 'desc') {
@@ -3708,6 +3726,27 @@ function bindFinder() {
     onFinderFilterChange();
   });
 
+  els.finderGemsChip.addEventListener('click', () => {
+    finderState.hiddenGems = !finderState.hiddenGems;
+    els.finderGemsChip.setAttribute('aria-pressed', finderState.hiddenGems ? 'true' : 'false');
+    onFinderFilterChange();
+  });
+
+  els.finderSurprise.addEventListener('click', () => {
+    const rows = filterAndSortFinder();
+    if (rows.length === 0) return;
+    const pick = rows[Math.floor(Math.random() * rows.length)];
+    openShowModal(pick.seriesId);
+  });
+
+  els.finderPopularPick.addEventListener('click', () => {
+    const rows = filterAndSortFinder();
+    if (rows.length === 0) return;
+    const top = rows.slice().sort((a, b) => b.votes - a.votes).slice(0, 50);
+    const pick = top[Math.floor(Math.random() * top.length)];
+    openShowModal(pick.seriesId);
+  });
+
   els.finderGapDir.addEventListener('click', (e) => {
     const btn = e.target.closest('.finder-seg-btn');
     if (!btn) return;
@@ -3804,6 +3843,7 @@ function writeFinderStateToURL() {
   if (f.minGap > 0) p.set('fMinGap', f.minGap);
   if (f.minYear != null) p.set('fMinYear', f.minYear);
   if (f.maxYear != null) p.set('fMaxYear', f.maxYear);
+  if (f.hiddenGems) p.set('fGems', 'on');
   if (f.genres.size) p.set('fg', [...f.genres].join(','));
   if (f.genresExclude.size) p.set('fxg', [...f.genresExclude].join(','));
   if (f.languages.size) p.set('fl', [...f.languages].join(','));

--- a/apps/rising-shows/scripts/finder-lib.js
+++ b/apps/rising-shows/scripts/finder-lib.js
@@ -19,11 +19,18 @@ const FINDER_DEFAULTS = {
   minGap: 0,
   minYear: null,
   maxYear: null,
+  hiddenGems: false,
   sort: 'votes',
   sortDir: 'desc',
   view: 'grid',
   page: 1,
 };
+
+// A show is a "hidden gem" when it is highly rated yet under-watched:
+// episode-weighted average episode rating >= 8.5 and fewer than 500 IMDb votes
+// per rated episode. Mirrors the old per-season hidden-gem rule.
+const HIDDEN_GEM_MIN_AVG = 8.5;
+const HIDDEN_GEM_MAX_VOTES_PER_EP = 500;
 
 // Aggregate per-season records (data.json `matches`) into one row per series.
 // `detectShapes` is the per-episode shape classifier from match.js - passed in
@@ -144,6 +151,7 @@ function parseFinderQuery(query) {
     minGap: parseFloat(p.get('fMinGap')) || 0,
     minYear: p.has('fMinYear') ? (parseInt(p.get('fMinYear'), 10) || null) : null,
     maxYear: p.has('fMaxYear') ? (parseInt(p.get('fMaxYear'), 10) || null) : null,
+    hiddenGems: p.get('fGems') === 'on',
     genres: new Set((p.get('fg') || '').split(',').filter(Boolean)),
     genresExclude: new Set((p.get('fxg') || '').split(',').filter(Boolean)),
     languages: new Set((p.get('fl') || '').split(',').filter(Boolean)),
@@ -172,6 +180,10 @@ function passesFinderFilters(s, f) {
   }
   if (f.minYear != null && (s.year == null || s.year < f.minYear)) return false;
   if (f.maxYear != null && (s.year == null || s.year > f.maxYear)) return false;
+  if (f.hiddenGems) {
+    if (s.avgEpisode < HIDDEN_GEM_MIN_AVG) return false;
+    if (s.episodes === 0 || (s.votes / s.episodes) >= HIDDEN_GEM_MAX_VOTES_PER_EP) return false;
+  }
   if (f.genres.size) {
     for (const g of f.genres) if (!s.genres.includes(g)) return false;
   }
@@ -213,6 +225,8 @@ function filterAndSortRows(rows, f) {
 
 const API = {
   FINDER_DEFAULTS,
+  HIDDEN_GEM_MIN_AVG,
+  HIDDEN_GEM_MAX_VOTES_PER_EP,
   buildShowAgg,
   parseFinderQuery,
   passesFinderFilters,

--- a/apps/rising-shows/tests/finder-lib.test.js
+++ b/apps/rising-shows/tests/finder-lib.test.js
@@ -145,6 +145,32 @@ test('passesFinderFilters applies every non-shape filter', () => {
   assert.ok(!passesFinderFilters(x, parseFinderQuery('q=yankee')));
 });
 
+test('parseFinderQuery reads the hidden-gems flag', () => {
+  assert.equal(parseFinderQuery('fGems=on').hiddenGems, true);
+  assert.equal(parseFinderQuery('fGems=off').hiddenGems, false);
+  assert.equal(parseFinderQuery('').hiddenGems, false);
+});
+
+test('passesFinderFilters hidden gems: high rating AND low votes-per-episode', () => {
+  const base = {
+    title: 'x', seriesId: 'tt', genres: [], shapes: [], gap: 0,
+    showRating: 8, year: 2020, language: 'en',
+  };
+  const on = parseFinderQuery('fGems=on');
+
+  // Qualifies: avg 8.6 (>= 8.5), 4000/10 = 400 votes/ep (< 500).
+  assert.ok(passesFinderFilters({ ...base, avgEpisode: 8.6, episodes: 10, votes: 4000 }, on));
+  // Fails the rating condition: avg 8.4 < 8.5.
+  assert.ok(!passesFinderFilters({ ...base, avgEpisode: 8.4, episodes: 10, votes: 4000 }, on));
+  // Fails the popularity condition: 6000/10 = 600 votes/ep >= 500.
+  assert.ok(!passesFinderFilters({ ...base, avgEpisode: 8.6, episodes: 10, votes: 6000 }, on));
+  // Boundaries: exactly 8.5 avg passes; exactly 500 votes/ep is excluded.
+  assert.ok(passesFinderFilters({ ...base, avgEpisode: 8.5, episodes: 10, votes: 4990 }, on));
+  assert.ok(!passesFinderFilters({ ...base, avgEpisode: 8.5, episodes: 10, votes: 5000 }, on));
+  // Flag off: an over-watched popular show passes.
+  assert.ok(passesFinderFilters({ ...base, avgEpisode: 8.6, episodes: 10, votes: 6000 }, parseFinderQuery('')));
+});
+
 test('passesShapeAnd requires every selected shape', () => {
   const row = { shapes: ['rising', 'slow-burn'] };
   assert.ok(passesShapeAnd(row, new Set()));


### PR DESCRIPTION
## Summary

Actions the three open follow-up decisions from the 2026-07-04 docs & reference coverage audit (PR #250). One is a real Rising Shows feature; two are Gym Tracker / Arena README fixes.

Derived from `git diff master...HEAD` (8 files, +118 / -111).

## Rising Shows - re-add Hidden gems + Surprise me to the finder

The show-finder-only rebrand had dropped these; this re-adds show-level versions.

- **`apps/rising-shows/scripts/finder-lib.js`** (shared with the Kometa export pipeline): added `hiddenGems: false` to `FINDER_DEFAULTS`, constants `HIDDEN_GEM_MIN_AVG = 8.5` / `HIDDEN_GEM_MAX_VOTES_PER_EP = 500` (exported on the API), `parseFinderQuery` handling of `fGems=on`, and the hidden-gems predicate in `passesFinderFilters` (excludes a show when episode-weighted avg episode rating < 8.5 OR total-votes/total-rated-episodes >= 500).
- **`apps/rising-shows/js/app.js`**: `finderState.hiddenGems` wired through `resetFinderState`, `finderHasActiveFilters`, `writeFinderStateToURL` (`fGems=on`), `syncFinderControls`, and `describeFinderActiveFilters` (removable "Hidden gems / On" chip). New handlers in `bindFinder` for the gems chip, `#finderSurprise` (random show from the filtered results), and `#finderPopularPick` (random from the top 50 by votes); both open the show modal and guard empty results. Removed the dead `els.modalReroll` ref and the `els.modalReroll.hidden` line in `openModal`.
- **`apps/rising-shows/index.html`**: added the "🎲 Surprise me" and "🔥 Popular pick" toolbar buttons next to the view toggle, and a "💎 Hidden gems" quick-filter chip in a new "Discovery" group. Removed the dead `#modalReroll` button.
- **`apps/rising-shows/css/styles.css`**: removed the now-orphaned `.modal-reroll` rules (base block + mobile media-query overrides); kept the still-used `--modal-poster-w` token.
- **`apps/rising-shows/tests/finder-lib.test.js`**: +2 tests - `fGems=on` parsing and the hidden-gems predicate (a qualifying show plus one failing each condition, at the boundaries, and flag-off).
- **`apps/rising-shows/README.md`**: re-added "Hidden gems" and "Surprise me / Popular pick" feature rows describing the new show-level behavior.

## Gym Tracker - README

- **`apps/gym-tracker/README.md`**: regenerated the "Architecture / File Structure" tree to match the real layout (it was missing ~15 load-bearing files - `Measurement.js`, the insights/measurements/paused-banner views, the full `js/utils/`, `scripts/`, `tests/`, `sw.js`, `manifest.webmanifest`, `sitemap-exercises.xml`; grouped the big dirs to resist re-drift). Dropped the stale `Version 2.1.0 / Last Updated 2025-01-20 / Recent Updates` block (the Features list is the source of truth); the README now ends at License.

## Arena - README

- **`apps/arena/README.md`**: added a "Sound + haptics" Features row documenting `js/feedback.js` (WebAudio SFX + device haptics on gameplay events - guess submitted, pin placed/cleared, opponent submitted, score reveal, timer low/expired, chat, game start/end).

## Judgment calls
- Hidden-gems thresholds mirror the old per-season rule (avg >= 8.5, < 500 votes/episode), applied at show level using fields `buildShowAgg` already carries. `500` exactly is excluded.
- The Hidden gems quick-chip carries no live count, matching its siblings (Votes, Gap) which also don't - only the mood presets show counts.
- Surprise me / Popular pick are transient actions (no URL state), consistent with a "random pick" affordance.

## Explicitly untouched
- No other apps. The three audit "report-only" items are now all actioned, so nothing is left pending from PR #250.

## Testing
- `npm test`: **1097 / 1097 pass** (was 1095; +2 finder-lib tests).
- Verified in a running finder (headless screenshot): the Surprise me / Popular pick buttons render in the toolbar; toggling Hidden gems drops the count 34,161 -> 4,033 and shows a removable "HIDDEN GEMS On" active-filter chip; the show modal opens with no reroll button. `#modalReroll`/`modal-reroll` grep returns 0 across index.html, app.js, and styles.css; CSS braces balanced.
