### PR TITLE
feat(maptap-rivals): link score numbers to the player's maptap.gg profile

### DIFF
--- a/apps/maptap-rivals/README.md
+++ b/apps/maptap-rivals/README.md
@@ -21,6 +21,7 @@ Seasons, the matrix selection, and the currently focused rival are persisted und
 | MapTap profile auto-sync | Link your MapTap profile (and a rival's username) to pull game history automatically from the public MapTap profile endpoint instead of pasting. |
 | Dashboard | A rival grid of summary cards (record, streak, averages) with an at-a-glance summary strip and a "today's predictions" card when the day's puzzle data is available. |
 | Per-rival dashboard | A focused head-to-head view: stat cards, score-over-time and win-distribution and score-differential charts (Chart.js), recent-games table with pagination, and narrative callouts. |
+| Outbound maptap.gg links | In the history and recent-games tables, dates link to that day's puzzle page (`maptap.gg/history/...`) and score numbers link to the player's profile (`maptap.gg/u/...`) when that player has a linked username. |
 | Round-by-round breakdown | Per-round (location) stats, win-rate-per-round chart, a last-10-games round heatmap, carry/choke insights, and a calendar heatmap of game history. |
 | Continent breakdown | Per-continent stats for games that carry synced geo data. |
 | Win/loss/tie + streaks | Computes wins, losses, ties, win %, current and longest streaks, biggest win/loss margins, and best/worst scores per rival. |

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -2412,6 +2412,22 @@ body.maptap-rivals-app button {
   outline: none;
 }
 
+/* Score cells: when the player has a linked maptap.gg profile the score
+   number itself links to it. Same dotted affordance as the day links, but
+   keeps the score's own (non-muted) color until hover. */
+.games-table tbody td .score-profile-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--muted);
+  padding-bottom: 1px;
+}
+.games-table tbody td .score-profile-link:hover,
+.games-table tbody td .score-profile-link:focus-visible {
+  color: var(--accent-2);
+  border-bottom: 1px solid currentColor;
+  outline: none;
+}
+
 /* History thead — a distinct, intentional legend row. Layered surface +
    bottom border lift it off the data; small-caps letterspacing matches the
    section labels elsewhere. Sticky within the table's own scroll so the

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -276,6 +276,35 @@
     const tok = maptapMonthDay(iso);
     return tok ? `https://maptap.gg/history/${tok}` : null;
   }
+  function mapTapProfileUrl(username) {
+    const u = normalizeMapTapUsername(username);
+    return u ? `https://maptap.gg/u/${encodeURIComponent(u)}` : null;
+  }
+  // Score <td> for the games/history tables. When the player has a known
+  // maptap.gg username the score number links to their profile. maptap.gg
+  // has no per-day profile anchor (its router only reads the nickname), so
+  // the profile top is the closest target; the date column's day link
+  // already covers that day's puzzle.
+  function scoreCell(played, total, roundsTitle, username, ownerPossessive) {
+    if (!played) {
+      return el('td', { style: 'font-weight:600', title: roundsTitle }, '—');
+    }
+    const url = mapTapProfileUrl(username);
+    if (!url) {
+      return el('td', { style: 'font-weight:600', title: roundsTitle }, String(total));
+    }
+    const linkTitle = (roundsTitle ? roundsTitle + ' · ' : '') +
+      `Open ${ownerPossessive} maptap.gg profile`;
+    return el('td', { style: 'font-weight:600' }, [
+      el('a', {
+        href: url,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        class: 'score-profile-link',
+        title: linkTitle,
+      }, String(total)),
+    ]);
+  }
   function mapTapDailyDataUrl(iso) {
     const tok = maptapMonthDay(iso);
     return tok ? `${MAPTAP_DAILY_URL_BASE}${tok}.js` : null;
@@ -3177,14 +3206,12 @@
       const diff = (meHere && themHere) ? (myT - theirT) : null;
       tableBody.appendChild(el('tr', { class: r ? '' : 'row-one-sided' }, [
         el('td', {}, shortDate(g.date)),
-        el('td', {
-          style: 'font-weight:600',
-          title: hasLocs(g) ? `Rounds: ${g.myScores.join(' / ')}` : (meHere ? '' : 'You didn\'t play this day'),
-        }, meHere ? String(myT) : '—'),
-        el('td', {
-          style: 'font-weight:600',
-          title: Array.isArray(g.theirScores) ? `Rounds: ${g.theirScores.join(' / ')}` : '',
-        }, themHere ? String(theirT) : '—'),
+        scoreCell(meHere, myT,
+          hasLocs(g) ? `Rounds: ${g.myScores.join(' / ')}` : (meHere ? '' : 'You didn\'t play this day'),
+          state.myMapTap, 'your'),
+        scoreCell(themHere, theirT,
+          Array.isArray(g.theirScores) ? `Rounds: ${g.theirScores.join(' / ')}` : '',
+          rival.maptapUsername, `${rival.name}'s`),
         diff === null
           ? el('td', { class: 'delta-zero', title: 'Only one side played' }, '—')
           : el('td', { class: diff > 0 ? 'delta-pos' : diff < 0 ? 'delta-neg' : 'delta-zero' },
@@ -4774,14 +4801,13 @@
       tbody.appendChild(el('tr', { class: 'history-day-row' + (r ? '' : ' row-one-sided') }, [
         dateCell,
         el('td', {}, rival ? `${rival.icon} ${rival.name}` : '—'),
-        el('td', {
-          style: 'font-weight:600',
-          title: hasLocs(g) ? `Rounds: ${g.myScores.join(' / ')}` : (meHere ? '' : 'You didn\'t play this day'),
-        }, meHere ? String(myT) : '—'),
-        el('td', {
-          style: 'font-weight:600',
-          title: Array.isArray(g.theirScores) ? `Rounds: ${g.theirScores.join(' / ')}` : '',
-        }, themHere ? String(theirT) : '—'),
+        scoreCell(meHere, myT,
+          hasLocs(g) ? `Rounds: ${g.myScores.join(' / ')}` : (meHere ? '' : 'You didn\'t play this day'),
+          state.myMapTap, 'your'),
+        scoreCell(themHere, theirT,
+          Array.isArray(g.theirScores) ? `Rounds: ${g.theirScores.join(' / ')}` : '',
+          rival ? rival.maptapUsername : null,
+          rival ? `${rival.name}'s` : 'their'),
         diff === null
           ? el('td', { class: 'delta-zero', title: 'Only one side played' }, '—')
           : el('td', { class: diff > 0 ? 'delta-pos' : diff < 0 ? 'delta-neg' : 'delta-zero' },


### PR DESCRIPTION
## What this round is

Owner request: make the score numbers in MapTap Rivals hyperlinks to the player's maptap.gg profile for that day's score. Investigation against the live site showed maptap.gg's public-profile router reads ONLY the nickname from `/u/<nickname>` (no date param, no hash anchors, no per-day DOM ids in `public-profile.js` / `game-history-complete.js`), so a day-scoped profile deep link does not exist. The shipped behavior: the score number links to the player's profile top; the existing date links keep covering that day's puzzle page.

## Complete diff, file by file (from `git diff master...HEAD`)

### apps/maptap-rivals/js/app.js
- New `mapTapProfileUrl(username)` helper next to `mapTapHistoryUrl`: normalizes via the existing `normalizeMapTapUsername` (accepts a bare username or a full `maptap.gg/u/...` URL) and returns `https://maptap.gg/u/<encodeURIComponent(username)>`, or null when empty.
- New shared `scoreCell(played, total, roundsTitle, username, ownerPossessive)` builder: renders the score `<td>` for both games tables. Not played -> plain placeholder cell (unchanged behavior); played but no username -> plain bold score with the original rounds tooltip (unchanged behavior); played with username -> `<a class="score-profile-link" target="_blank" rel="noopener noreferrer">` whose title combines the rounds breakdown with "Open <name>'s maptap.gg profile".
- `renderRival` recent-games table: the two inline score `<td>` builders replaced with `scoreCell` calls (my side uses `state.myMapTap`, rival side `rival.maptapUsername`). Tooltip strings are passed through verbatim, including the "You didn't play this day" case.
- `renderHistory` table: same replacement; the rival can be missing there (`rivalById[g.rivalId]` miss), so the username argument guards with `rival ? ... : null` and the possessive falls back to "their".

### apps/maptap-rivals/css/styles.css
- New `.score-profile-link` rules scoped under `.games-table tbody td` (applies to both `#history-table` and `#rival-games-table`): inherit color, dotted `var(--muted)` underline; on hover/focus-visible switches to `var(--accent-2)` with a solid underline. Mirrors the existing `maptap-day-link` affordance so the two link types read as one system.

### apps/maptap-rivals/README.md
- Added one feature-table row ("Outbound maptap.gg links") documenting both outbound link types (day puzzle links on dates, profile links on scores), which were previously undocumented.

## Judgment calls

- No day-scoped profile URL is emitted (e.g. `/u/name/July5` loads but the site ignores the segment); linking to something the target page silently ignores would be misleading, so the link is the plain profile URL. If maptap.gg ever adds a day anchor it is a one-line change in `mapTapProfileUrl`.
- Scores without a linked username stay plain text rather than linking to a search page, matching the existing pattern where sync affordances only appear once a username is saved.
- The rounds-breakdown tooltip is preserved on linked scores (merged into the anchor title) rather than replaced.

## Explicitly untouched

- The date/day links (`maptap-day-link`, `mapTapHistoryUrl`) in both tables and the heatmap row labels: unchanged and coexist with the new links.
- The heatmap total column, leaderboard, matrix, dashboard cards: scores there are aggregates, not per-player-per-day cells, and were left as plain text.
- The profile card's existing username link (`app.js` verified-line anchor) is unchanged; `mapTapProfileUrl` is used only by the new score cells.

## How it was tested

- `npm test`: 1100/1100 pass.
- Living plan pair `.features/maptap-rivals-{claude,human}.md` updated for this round (section 34): 13/13 checks passed in the 2026-07-06 run report, including a DOM href probe (my score -> `/u/nikita`, linked rival -> `/u/susmabit`, unlinked rival -> no anchor, one-sided day -> placeholder unlinked) and desktop 1280x800 + mobile 390x844 screenshots of both tables. Prior round (33) snapshotted to `.features/archive/maptap-rivals-{claude,human}-2026-07-06.md`.
- Live-site probe: `curl` + fetched `public-profile.js` confirmed the nickname-only routing claim above.