### PR TITLE
fix(rising-shows): slim the finder search toolbar and center the active-filter chip x

### DIFF
--- a/apps/rising-shows/css/styles.css
+++ b/apps/rising-shows/css/styles.css
@@ -620,20 +620,23 @@ body.rising-shows-app button {
    the controls. Only shown at viewports wide enough that everything
    sits on a single line. */
 @media (min-width: 760px) {
-  /* 5-column grid: [left spacer 1fr] [search ≤600px] [right spacer 1fr]
-     [view-toggle auto] [surprise-group auto]. Matching 1fr columns
-     visually center the search; trailing auto columns keep the
-     view/surprise controls pinned to the right edge. */
+  /* 7-column grid: [left spacer 1fr] [search ≤600px] [right spacer 1fr]
+     [view-toggle] [surprise] [popular-pick] [shortcut-legend]. Matching
+     1fr columns visually center the search; trailing auto columns keep
+     the view/discover controls pinned to the right edge. The legend
+     button gets the LAST column explicitly — with fewer columns the
+     auto-placed surprise/popular buttons collide with it and push it
+     onto a second toolbar row. */
   .filter-row.primary {
     display: grid;
-    grid-template-columns: 1fr minmax(0, 600px) 1fr auto auto auto;
+    grid-template-columns: 1fr minmax(0, 600px) 1fr auto auto auto auto;
   }
   .filter-row.primary .search-cluster { grid-column: 2; }
   .filter-row.primary .view-toggle {
     position: relative;
     grid-column: 4;
   }
-  .filter-row.primary .shortcut-legend-btn { grid-column: 6; }
+  .filter-row.primary .shortcut-legend-btn { grid-column: 7; }
   .filter-row.primary .view-toggle::before {
     content: '';
     position: absolute;
@@ -690,7 +693,10 @@ body.rising-shows-app button {
   .search { flex: 1 1 240px !important; }
 }
 
-.search > label { display: block; }
+/* main.css gives every <label> a 1rem bottom margin — inside the search
+   it added ~15px of phantom height below the input, making the field
+   read taller than it is and pushing it off vertical center. */
+.search > label { display: block; margin: 0; }
 
 .search-suggestions {
   position: absolute;
@@ -866,16 +872,21 @@ body.rising-shows-app button {
    look so the surface reads as one piece, not nested boxes. Lighter and
    smaller text reads as a refined search field, not a heavy form input. */
 .filter-row.primary .search input {
+  /* Slightly shorter than the row's 32px controls — the field reads
+     sleeker while text and icon stay vertically centered by the row's
+     align-items:center (mobile: 44px - 4 = 40px, still a full tap
+     target). */
+  height: calc(var(--ctrl-h) - 4px);
   background: transparent;
   border-color: transparent;
-  padding: 0 0.8rem 0 2.15rem;
+  padding: 0 0.8rem 0 1.9rem;
   font-size: 0.82rem;
   font-weight: 400;
   border-radius: 999px;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23a4adbd' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='7'/><path d='M21 21l-4.35-4.35'/></svg>");
   background-repeat: no-repeat;
-  background-position: 0.7rem center;
-  background-size: 0.9rem 0.9rem;
+  background-position: 0.55rem center;
+  background-size: 0.85rem 0.85rem;
   transition: background-color 0.18s var(--ease), border-color 0.18s var(--ease),
               box-shadow 0.18s var(--ease);
 }
@@ -3404,7 +3415,7 @@ body.advanced-drawer-open {
   .filter-row.primary .search { flex: 1 1 100% !important; order: 1; }
   .filter-row.primary .search input {
     font-size: 16px;          /* prevents iOS auto-zoom on focus */
-    padding-left: 2.4rem;
+    padding-left: 2.15rem;
   }
   .filter-row.primary .view-toggle {
     order: 2;
@@ -4334,10 +4345,16 @@ body.advanced-drawer-open {
   justify-content: center;
   width: 18px;
   height: 18px;
+  /* Optical correction: the × glyph's ink sits ~0.5px below the circle's
+     geometric center; the asymmetric bottom padding lifts the flex-centered
+     glyph without moving the circle. */
+  padding-bottom: 1px;
+  box-sizing: border-box;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.12);
   color: var(--text);
   font-size: 0.95rem;
+  line-height: 1;
   font-weight: 700;
 }
 .active-filter-chip:hover .chip-x { background: var(--accent); color: var(--accent-ink); }


### PR DESCRIPTION
Owner-feedback design round for Rising Shows: the finder search read heavier than it should, and the active-filter chip's x looked off-center in its circle. Investigation showed the perceived search-bar bulk came from two layout defects rather than the input's own styling, both fixed here.

## Complete diff

One file changed: `apps/rising-shows/css/styles.css` (+28 / -11). Four changes:

1. **Search label margin bleed fixed** (`.search > label`). main.css's global `label { margin: 0 0 1rem 0 }` leaked into the label wrapping the finder search input, adding ~15px of phantom height below it: the search area rendered 46.7px tall for a 32px input, and the input sat ~7px above the row's visual center. The rule now zeroes the margin (with a comment documenting the bleed). This is the same main.css-collision family as prior theme-audit findings.

2. **Primary toolbar restored to a single row on desktop** (>=760px grid). The grid template had 6 columns with `.shortcut-legend-btn` pinned to column 6, written when the row had one discover button. The later-added Popular pick button auto-placed into column 6, collided with the pinned `?` button, and pushed it onto a second toolbar row, making the whole toolbar 95px tall with the `?` stranded alone at the bottom right. The template is now 7 columns with the legend at column 7 (comment updated to explain why the explicit last column matters). The toolbar now renders 41px tall with search, view toggle, Surprise me, Popular pick, and `?` all on one line.

3. **Sleeker search input** (`.filter-row.primary .search input`). New `height: calc(var(--ctrl-h) - 4px)`: 28px on desktop (row controls stay 32px; the row's align-items keeps the field dead-centered, measured 0.5px offset), 40px on mobile (still a full tap target; the 16px font that prevents iOS zoom is untouched). Left text padding 2.15rem -> 1.9rem (mobile override 2.4rem -> 2.15rem), magnifier icon 0.9rem -> 0.85rem positioned 0.7rem -> 0.55rem, so the icon-to-text gap stays proportional.

4. **Active-filter chip x optically centered** (`.chip-x`). Pixel-centroid measurement at 4x zoom showed the glyph ink 0.5px BELOW the circle's geometric center and exactly centered horizontally (not high-left as it read at 1x). Added `padding-bottom: 1px` + `box-sizing: border-box` + explicit `line-height: 1`: the flex-centered glyph lifts 0.5px and the glyph/circle bounding-box centers now match exactly on both axes. The circle itself was verified dead-center within the pill (0.00 offset) before and after.

## Explicitly untouched

- Search width, transparent rest state, hover tint, and the amber focus border + glow (verified intact after the height change: computed focus style is border rgba(245,197,24,.55) with the 3px rgba(245,197,24,.22) glow).
- Mobile toolbar ordering (Surprise/Popular above the search on phones) is pre-existing and out of scope.
- The generic `.search input` rules shared with other contexts; only the `.filter-row.primary` scope changed sizes.
- No HTML or JS changes.

## Judgment calls

- The requested "reduce height ~15-20% (from ~64px)" was based on estimated numbers (owner later confirmed). Measured reality: input 32px but 46.7px of rendered search area and a 95px toolbar. Fixing the two layout defects delivers most of the reduction honestly; the input itself dropped 4px (12.5%) rather than 20% so it stays proportional to the 32px controls beside it and keeps a 40px mobile tap target.
- For the chip x, the suggested `translateY(1px)` (downward) would have doubled the measured error, so the nudge went up 0.5px instead, via asymmetric padding rather than transform so the circle itself never moves.

## Testing

- `npm test`: 1100/1100 pass.
- Headless screenshot verification on desktop (1280px) and mobile (390px): toolbar 41px single row, input 28px/40px with icon and text vertically centered (0.5px), focus glow rendering, chip x centering re-measured at 0.00px offset on both axes in default and simulated-hover (yellow) states.
- Living plan pair `.features/rising-shows-{claude,human}.md` updated with this round (local-only files).