### PR TITLE
fix(wc-fantasy): resolve imported squads containing eliminated players

### DIFF
--- a/tools/wc-fantasy.html
+++ b/tools/wc-fantasy.html
@@ -134,6 +134,7 @@
   }
   .pos-tag { font-family: var(--mono); font-size: 0.75rem; color: var(--accent-2); }
   .own-low { color: var(--good); }
+  .out-flag { font-family: var(--mono); font-size: 0.72rem; font-weight: 800; color: var(--bad); }
   .roadmap-chip { color: var(--good); font-weight: 700; }
   .muted { color: var(--muted); }
   .filters { display: flex; gap: 0.4rem; margin-bottom: 0.7rem; flex-wrap: wrap; }
@@ -317,7 +318,7 @@
 
   // ---- state ---------------------------------------------------------------
   const S = {
-    players: null, squads: null, rounds: null,
+    players: null, playersAll: null, squads: null, rounds: null,
     teamById: {}, playersById: {},
     odds: {},            // 'homeId|awayId' -> {pH, pD, pA} vig-free
     lambdas: {},         // matchId -> {home, away}
@@ -357,6 +358,9 @@
         return r.json();
       }).then(function (d) { cacheSet(n, d); return d; });
     })).then(function (res) {
+      // Keep every player (eliminated, transferred, injured...) so an imported
+      // real squad always resolves; recommendations only draw from S.players.
+      S.playersAll = res[0];
       S.players = res[0].filter(function (p) { return p.status === 'playing'; });
       S.squads = res[1];
       S.rounds = res[2];
@@ -423,7 +427,7 @@
     S.teamById = {};
     S.squads.forEach(function (t) { S.teamById[t.id] = t; });
     S.playersById = {};
-    S.players.forEach(function (p) { S.playersById[p.id] = p; });
+    S.playersAll.forEach(function (p) { S.playersById[p.id] = p; });
     // current round: first not finished
     const now = Date.now();
     S.currentRound = 1;
@@ -575,7 +579,7 @@
     });
 
     S.proj = {};
-    S.players.forEach(function (p) { S.proj[p.id] = { byRound: {}, next: 0, horizon: 0 }; });
+    S.playersAll.forEach(function (p) { S.proj[p.id] = { byRound: {}, next: 0, horizon: 0 }; });
 
     const matchesByTeamRound = {};
     allMatches().forEach(function (x) {
@@ -633,7 +637,7 @@
 
     // horizon: remaining group rounds (or current knockout round) discounted
     const weights = [1, 0.85, 0.7];
-    S.players.forEach(function (p) {
+    S.playersAll.forEach(function (p) {
       const pr = S.proj[p.id];
       pr.next = pr.byRound[S.currentRound] || 0;
       let wsum = 0, i = 0;
@@ -793,6 +797,7 @@
   // ---- advice rendering --------------------------------------------------------
   function playerName(p) { return p.knownName || ((p.firstName ? p.firstName[0] + '. ' : '') + p.lastName); }
   function teamAbbr(p) { return (S.teamById[p.squadId] || {}).abbr || '?'; }
+  function playerOut(p) { return p.status !== 'playing'; }
 
   // Shared candidate pool: top 40 projections per position. Used by BOTH the
   // optimizer's final polish and the transfer advisor, so they can never
@@ -1034,7 +1039,7 @@
         const div = document.createElement('div');
         div.className = 'pcard' + (e.id === cap.id ? ' cap' : '');
         div.innerHTML = '<div class="pname">' + playerName(p) + '</div>' +
-          '<div class="pmeta">' + teamAbbr(p) + ' · ' + e.pts.toFixed(1) + ' xPts</div>' +
+          '<div class="pmeta">' + teamAbbr(p) + ' · ' + (playerOut(p) ? '<span class="out-flag">' + p.status.toUpperCase() + '</span>' : e.pts.toFixed(1) + ' xPts') + '</div>' +
           (e.id === cap.id ? '<span class="badge">C</span>' : e.id === vc.id ? '<span class="badge vc">VC</span>' : '');
         row.appendChild(div);
       });
@@ -1051,7 +1056,7 @@
       const div = document.createElement('div');
       div.className = 'pcard';
       div.innerHTML = '<div class="pname">' + (e.p.position === 'GK' ? 'GK: ' : (i + 1) + '. ') + playerName(e.p) + '</div>' +
-        '<div class="pmeta">' + e.p.position + ' · ' + teamAbbr(e.p) + ' · ' + e.pts.toFixed(1) + ' xPts</div>';
+        '<div class="pmeta">' + e.p.position + ' · ' + teamAbbr(e.p) + ' · ' + (playerOut(e.p) ? '<span class="out-flag">' + e.p.status.toUpperCase() + '</span>' : e.pts.toFixed(1) + ' xPts') + '</div>';
       bl.appendChild(div);
     });
 
@@ -1095,7 +1100,7 @@
         renderAll();
       });
       tr.innerHTML = '<td class="pos-tag">' + p.position + '</td>' +
-        '<td>' + playerName(p) + '</td><td>' + teamAbbr(p) + '</td>' +
+        '<td>' + playerName(p) + (playerOut(p) ? ' <span class="out-flag">' + p.status.toUpperCase() + '</span>' : '') + '</td><td>' + teamAbbr(p) + '</td>' +
         '<td class="num">$' + p.price.toFixed(1) + 'm</td>' +
         '<td class="num' + ((p.percentSelected || 0) < 5 ? ' own-low' : '') + '">' + (p.percentSelected || 0).toFixed(1) + '</td>' +
         '<td class="num">' + S.proj[id].horizon.toFixed(1) + '</td>';
@@ -1271,7 +1276,9 @@
     if (res.error) { $('import-status').textContent = res.error; return; }
     S.mySquad = res.ids;
     localStorage.setItem(SQUAD_LS, JSON.stringify(S.mySquad));
+    const outCount = res.ids.filter(function (id) { return playerOut(S.playersById[id]); }).length;
     let msg = 'Imported 15 players. All advice now uses your real squad.';
+    if (outCount) msg = 'Imported 15 players, ' + outCount + ' of them out of the tournament (flagged in the squad table). All advice now uses your real squad.';
     if (res.captain && S.playersById[res.captain]) {
       msg += ' Your current armband: ' + playerName(S.playersById[res.captain]) +
         (res.vice && S.playersById[res.vice] ? ' (vice ' + playerName(S.playersById[res.vice]) + ')' : '') +


### PR DESCRIPTION
## Problem

Importing a real FIFA squad on the WC Fantasy Coach page silently failed once any squad member's national team was knocked out of the tournament. The page dropped every player whose `status` was not `playing` at data-load time, so eliminated players no longer resolved in `S.playersById`. The importer then found only 11 of the 15 ids, failed the 2/5/5/3 composition check, and returned an error while the page kept rendering the previously stored or auto-recommended squad. Reported with a real team where 4 of 15 players (Davies, Munoz, Bombito, L. Diaz) were on eliminated Canada/Colombia.

## Changes (single file: `tools/wc-fantasy.html`)

- **Data loading (`loadFifa`)**: the full player feed is kept as `S.playersAll` alongside the existing `S.players`, which stays filtered to `status === 'playing'`. New state field `playersAll` added to `S`.
- **Indexing (`indexData`)**: `S.playersById` is now built from `S.playersAll`, so every player id in the feed resolves (statuses in the live feed: `playing`, `eliminated`, `transferred`, `injured`, `suspended`). This is what fixes the import.
- **Projections (`computeProjections`)**: `S.proj` is zero-initialized for all of `S.playersAll`, and the horizon/next pass iterates `S.playersAll`. Non-playing players get 0 projections everywhere instead of crashing `renderSquad`, `renderPlan`, `squadScore`, and `chipPlan` on missing entries. The actual projection math still only runs over `S.players` rosters, unchanged.
- **New helper `playerOut(p)`** next to `playerName`/`teamAbbr`: true when `status !== 'playing'`.
- **Starting XI cards, bench cards, squad table rows**: players who are out of the tournament show a red status tag (e.g. `ELIMINATED`) instead of a meaningless 0.0 xPts (XI/bench) or next to their name (table).
- **CSS**: new `.out-flag` class (mono, small, `var(--bad)`), matching the existing tag conventions.
- **Import status message**: when the imported squad contains out-of-tournament players, the success message reports the count and points at the squad table flags.

## Judgment calls

- The recommendation machinery is deliberately untouched: `optimizeSquad`, `topCandidates`, `transferAdvice`, the explorer, and the squad-table replacement dropdowns all still draw candidates from the playing-only `S.players`, so an eliminated/transferred player can never be recommended as a transfer target. The change only widens id resolution and rendering.
- Eliminated players can still appear in the displayed Starting XI when the squad has too few playing players in a position (e.g. only 2 playing DEFs forces a dead DEF into a 3-at-the-back formation). That reflects reality in the FIFA game until the user makes transfers, and the red flag communicates it; the transfer advice above the XI leads with replacing exactly those players.
- `playerOut` is keyed on player `status` rather than team `isEliminated` because the live feed also marks `transferred`, `injured`, and `suspended` players, and player status was verified to be perfectly consistent with team elimination (0 mismatches across 1489 players).
- The status tag renders the raw status uppercased (`ELIMINATED`, `INJURED`, ...) rather than a generic "OUT", since the distinction is useful (an injured player may return; an eliminated one cannot).

## Explicitly untouched

- The structured and generic JSON walkers in `importSquadFromJson`, including their error messages.
- The `players` localStorage cache (it already stored the unfiltered feed, so cached data works with the new code).
- The "Starting XI" card remains the tool's recommended lineup/captain, not the user's imported FIFA lineup; the imported captain/vice are still only echoed in the import status line.
- No `.features/` doc updates: this tool has no living plan or README mention (same as the other throwaway tools under `tools/`).

## Testing

- `npm test`: all 1100 tests pass.
- Headless-Chrome DOM probe against a local server: loaded live FIFA data, pasted the exact reported team JSON, clicked Import. Verified all 15 real players render in the squad table, 4 rows flagged `ELIMINATED`, import status reports "15 players, 4 of them out of the tournament", squad cost $105.0m, and transfer advice opens with four free "DO IT" moves replacing exactly the four eliminated players.
- Screenshot-verified on desktop (1280px) and mobile (390px) viewports: flags render cleanly in XI cards, bench cards, and table rows with no overflow or layout breakage.
