### PR TITLE
fix(rising-shows): stop changelog.json growing past GitHub's 100 MB push limit

### DIFF
--- a/.github/workflows/refresh-rising-shows.yml
+++ b/.github/workflows/refresh-rising-shows.yml
@@ -55,8 +55,10 @@ jobs:
       # The previous dataset is the diff baseline for change detection and
       # the changelog entry. It lives on the rolling release, not in git.
       # A missing asset (first run after the migration, manual deletion) is
-      # non-fatal: everything then counts as changed and the changelog
-      # records an initial entry.
+      # non-fatal: everything then counts as changed, but build-changelog
+      # skips the entry rather than record the whole catalogue as "added"
+      # (an initial full-catalogue entry is only written when the changelog
+      # itself is empty).
       - name: Download previous release data
         run: |
           mkdir -p /tmp/rs-prev

--- a/apps/rising-shows/DATA_README.md
+++ b/apps/rising-shows/DATA_README.md
@@ -198,6 +198,13 @@ diffs the previous `data.json` (downloaded from the
 node apps/rising-shows/scripts/build-changelog.js
 ```
 
+Without `--prev` there is no baseline (data.json is not in git, so the
+HEAD fallback finds nothing), and the script then refuses to append to
+a non-empty changelog: a baseline-less diff would record the entire
+catalogue (~65k seasons, ~5 MB) as "added", and repeated daily that
+grew changelog.json past GitHub's 100 MB push limit. An initial
+full-catalogue entry is only written when the changelog is empty.
+
 Or against explicit before/after files (useful for seeding history
 from past commits):
 

--- a/apps/rising-shows/scripts/build-changelog.js
+++ b/apps/rising-shows/scripts/build-changelog.js
@@ -201,11 +201,9 @@ function run(argv) {
   } else {
     prev = loadJsonFromGit('HEAD', relData, repoRoot);
     if (!prev) {
-      console.log('build-changelog: no prior data.json in HEAD — recording initial entry.');
+      console.log('build-changelog: no prior data.json in HEAD.');
     }
   }
-
-  const entry = diffDatasets(prev, next);
 
   let existing = null;
   if (fs.existsSync(outPath)) {
@@ -215,6 +213,19 @@ function run(argv) {
       console.warn(`build-changelog: could not parse ${outPath}: ${err.message}. Starting fresh.`);
     }
   }
+
+  // No baseline means every season in data.json would be recorded as
+  // freshly added: a multi-MB "everything is new" entry. That is only
+  // meaningful once, when the changelog itself is brand new. On an
+  // established changelog it is always a caller bug (e.g. data.json no
+  // longer lives in git, so the HEAD fallback finds nothing) and repeated
+  // daily it balloons the file past GitHub's 100 MB push limit.
+  if (!prev && existing?.updates?.length) {
+    console.warn('build-changelog: no previous data.json baseline and changelog already has entries; skipping to avoid a bogus full-catalogue entry.');
+    return 0;
+  }
+
+  const entry = diffDatasets(prev, next);
   const updated = appendEntry(existing, entry, maxEntries);
 
   fs.writeFileSync(outPath, JSON.stringify(updated, null, 2) + '\n');

--- a/apps/rising-shows/scripts/build-data.js
+++ b/apps/rising-shows/scripts/build-data.js
@@ -451,10 +451,13 @@ function loadSeasonOverviews() {
     }
   }
 
-  // Diff against the previously-committed data.json and update changelog.json
-  // so the "What's new" footer chip stays in sync. The footer guards the chip
-  // on `latest.builtAt === dataset.builtAt`, so writing a new data.json without
-  // also writing a matching changelog entry silently hides the chip.
+  // Update changelog.json so the "What's new" footer chip stays in sync. The
+  // footer guards the chip on `latest.builtAt === dataset.builtAt`, so writing
+  // a new data.json without also writing a matching changelog entry silently
+  // hides the chip. data.json no longer lives in git, so build-changelog's
+  // HEAD fallback finds no baseline here: it only writes an initial entry
+  // when the changelog is empty and skips otherwise (the refresh workflow
+  // writes the real entry via --prev against the release baseline).
   // Skip when explicitly opted out (e.g., test fixtures, dry runs).
   if (process.env.SKIP_CHANGELOG !== '1') {
     try {

--- a/apps/rising-shows/tests/build-changelog.test.js
+++ b/apps/rising-shows/tests/build-changelog.test.js
@@ -166,3 +166,73 @@ test('appendEntry handles an empty/missing changelog', () => {
   assert.equal(result.updates.length, 1);
   assert.equal(result.updates[0].builtAt, '2026-05-14T06:00:00.000Z');
 });
+
+// --- missing-baseline guard (CLI) ---
+//
+// data.json is not committed to git (it lives on the rising-shows-data
+// release), so the script's HEAD fallback never finds a baseline. On an
+// established changelog that must NOT append a full-catalogue "everything
+// added" entry; repeated daily it grew changelog.json past GitHub's 100 MB
+// push limit and broke the refresh workflow.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'build-changelog.js');
+
+function runCli(args) {
+  return execFileSync(process.execPath, [SCRIPT, ...args], { encoding: 'utf8' });
+}
+
+function tmpDataset() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rs-changelog-test-'));
+  const dataPath = path.join(dir, 'data.json');
+  fs.writeFileSync(dataPath, JSON.stringify(dataset([match('tt1', 'Alpha', 1)])));
+  return { dir, dataPath, outPath: path.join(dir, 'changelog.json') };
+}
+
+test('CLI skips when there is no baseline and the changelog already has entries', () => {
+  const { dataPath, outPath } = tmpDataset();
+  const existing = { updates: [
+    { builtAt: '2026-05-13T06:00:00.000Z', totals: { seasons: 10, delta: 0 }, added: [], removed: [] },
+  ] };
+  fs.writeFileSync(outPath, JSON.stringify(existing, null, 2) + '\n');
+  const before = fs.readFileSync(outPath, 'utf8');
+  runCli(['--new', dataPath, '--out', outPath]);
+  assert.equal(fs.readFileSync(outPath, 'utf8'), before);
+});
+
+test('CLI skips when --prev points at a missing file and the changelog has entries', () => {
+  const { dir, dataPath, outPath } = tmpDataset();
+  const existing = { updates: [
+    { builtAt: '2026-05-13T06:00:00.000Z', totals: { seasons: 10, delta: 0 }, added: [], removed: [] },
+  ] };
+  fs.writeFileSync(outPath, JSON.stringify(existing, null, 2) + '\n');
+  const before = fs.readFileSync(outPath, 'utf8');
+  runCli(['--new', dataPath, '--out', outPath, '--prev', path.join(dir, 'nope.json')]);
+  assert.equal(fs.readFileSync(outPath, 'utf8'), before);
+});
+
+test('CLI still records an initial entry when the changelog is empty', () => {
+  const { dataPath, outPath } = tmpDataset();
+  runCli(['--new', dataPath, '--out', outPath]);
+  const written = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+  assert.equal(written.updates.length, 1);
+  assert.equal(written.updates[0].added.length, 1);
+});
+
+test('CLI appends a normal diff entry when --prev exists', () => {
+  const { dir, dataPath, outPath } = tmpDataset();
+  const prevPath = path.join(dir, 'prev.json');
+  fs.writeFileSync(prevPath, JSON.stringify(dataset([])));
+  const existing = { updates: [
+    { builtAt: '2026-05-13T06:00:00.000Z', totals: { seasons: 0, delta: 0 }, added: [], removed: [] },
+  ] };
+  fs.writeFileSync(outPath, JSON.stringify(existing, null, 2) + '\n');
+  runCli(['--new', dataPath, '--out', outPath, '--prev', prevPath]);
+  const written = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+  assert.equal(written.updates.length, 2);
+  assert.equal(written.updates[0].added.length, 1);
+});


### PR DESCRIPTION
## Why

The scheduled refresh run [29635628151](https://github.com/nsoifer01/shevato/actions/runs/29635628151) failed at the push step: `changelog.json` reached 102.27 MB, over GitHub's hard 100 MB file cap, so the pre-receive hook rejected the bot branch.

Root cause: since data.json moved out of git and onto the rising-shows-data release (2026-07-07 history rewrite), `build-data.js`'s auto-invoke of `build-changelog.js` (no `--prev`) falls back to `git show HEAD:apps/rising-shows/data.json`, which now finds nothing. With a null baseline the diff records the entire catalogue (~65,700 seasons) as "added", a ~5.1 MB entry, on every build. The workflow runs `build-data.js` twice per refresh (initial + post-TMDB), so each day since Jul 8 appended a bogus full-catalogue entry alongside the legitimate small one; the second bogus entry of each day was replaced by the workflow's proper `--prev` entry via the builtAt dedupe. With the 30-entry cap filling up with 5 MB entries, master's changelog hit 97.5 MB and yesterday's run tipped it over 100 MB. The bogus entries were also user-visible garbage: the "What's new" popover would report tens of thousands of shows added daily.

## Changes (complete diff)

- `apps/rising-shows/scripts/build-changelog.js`
  - New guard in `run()`: when there is no baseline (null `prev`, whether from the git-HEAD fallback or a missing `--prev` path) and the changelog already has entries, log a warning and exit 0 without writing. An initial full-catalogue entry is still written when the changelog itself is empty (first-ever build).
  - The `no prior data.json in HEAD` log line no longer claims it is "recording initial entry" (it may now skip instead).
  - The existing-changelog load was moved above the guard; `diffDatasets` now runs only when an entry will actually be written. No behavior change beyond the guard.
- `apps/rising-shows/changelog.json`
  - Stripped the 10 bogus full-catalogue entries (each with ~65k `added` items, one per day since Jul 8) from master's 97.5 MB file. All 20 legitimate entries kept, including the latest (2026-07-17T08:30). File is now 133 KB. Judgment call: filtered on `added.length > 1000` (legit daily entries have 2-65 items, bogus ones ~65,700, no middle ground). The older duplicate pre-Jul-8 small-entry pairs (same double-invocation, back when the HEAD fallback still worked) were left alone: they are tiny, historical, and only `updates[0]` is ever rendered.
- `apps/rising-shows/scripts/build-data.js`
  - Comment-only: the auto-invoke block no longer claims to diff "against the previously-committed data.json"; it documents that the HEAD fallback finds no baseline and the workflow's `--prev` step writes the real entry. The auto-invoke itself is kept for the genuine first-build (empty changelog) case.
- `.github/workflows/refresh-rising-shows.yml`
  - Comment-only: the "Download previous release data" note now says a missing release asset leads to the changelog entry being skipped rather than an "initial entry" being recorded.
- `apps/rising-shows/tests/build-changelog.test.js`
  - 4 new CLI-level tests (temp fixtures, real subprocess): skip on no-baseline with non-empty changelog, skip when `--prev` points at a missing file, initial entry still written on empty changelog, normal diff entry appended when `--prev` exists.
- `apps/rising-shows/DATA_README.md`
  - Documents the new missing-baseline behavior in the `changelog.json` section.

Explicitly untouched: the "What's new" UI (`js/app.js`, `index.html`), the 30-entry cap, the release-upload flow, and the workflow's step logic (only a comment changed).

## Testing

- `npm test` at root: 1104/1104 pass (includes the 4 new tests).
- Verified the cleaned changelog parses, keeps 20 entries, and its latest entry is the legitimate 2026-07-17 one (28 added).
- After merge, the next scheduled run diffs against the Jul 18 release data (yesterday's upload succeeded before the push failed) and commits a normal small entry; today's diff details fold into tomorrow's entry.