### PR TITLE
fix(site): shared-UI single source of truth; trip-planner footer/share polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ SAME round. Wire the app into ALL of these:
 1. `apps/<slug>/` - index.html (shared header/footer includes, full SEO head:
    canonical, OG + Twitter cards, SoftwareApplication JSON-LD, emoji favicon),
    scoped `css/` (pin colors against main.css's `!important` button rules),
-   `js/`, `tests/`, README.md.
+   `js/`, `tests/`, README.md. SCOPING RULE: the app's style scope class goes
+   on a ROOT WRAPPER `<div>`, never on `<body>`; shared chrome (header,
+   footer, the firebase-auth sign-out modal, #sync-banner) is appended to
+   `<body>` and must never inherit app typography. Never restyle shared
+   selectors from app CSS (layout-positioning of bare `#header`/`#footer` is
+   the only exception). Enforced by
+   `sync-system/tests/shared-ui-consistency.test.mjs`.
 2. `apps.html` - visible card with `data-category` (add a filter-bar button if
    the category is new), CollectionPage JSON-LD `hasPart` entry AND its
    `description`, `<title>`, meta description, meta keywords,

--- a/apps/trip-planner/README.md
+++ b/apps/trip-planner/README.md
@@ -28,14 +28,14 @@ The only network calls are opt-in and key-free: place lookup via OpenStreetMap N
 | Days view | Third view tab: one card per trip day with check-ins, check-outs, timed events, "Staying in X" and honest "No plans yet" days; today highlighted; print-friendly (printing in Days view outputs just the cards) |
 | Budget | Optional per-trip budget in the trip dialog; summary chip shows confirmed-vs-budget and turns amber when exceeded |
 | Multi-currency costs | Each item's cost can be entered in its own currency and converts into the trip's display currency using daily rates (api.frankfurter.dev, cached 24h); switching the display currency converts, never relabels; failed rate fetches show a note + Retry instead of fake 1:1 rates |
-| Share link | Share itinerary produces a URL with the whole trip compressed into the fragment (no server); it opens read-only with a banner and an "Import as my trip" action |
+| Share link | Share itinerary produces a URL with the whole trip compressed into the fragment (no server, payload slimmed of empty fields); opens read-only with a banner and "Import as my trip". Links over ~8k chars copy with a truncation warning; a 30k hard cap points to JSON export |
 | Continuity warnings | Consecutive stays in different (geocoded) cities with no flight/transport between them raise a warning naming both cities |
 | Typical weather | Day cards show "Typically X-Y°C in {place} this time of year" from Open-Meteo history (cached per place+month); always "typically", never a forecast |
 | Visa reminders | Visa rows marked e-Visa/visa required offer "Add reminder", creating an "Apply for {country} visa" to-book item dated 30 days before the trip |
 | Documents pocket | Attach images/PDFs (booking confirmations, QR codes) to saved items; stored on-device in IndexedDB (2MB/file, 10/item), paperclip indicators, purged with the item, excluded from exports and sync |
 | Trip-in-progress | During the trip the countdown chip becomes "Day X of Y", past rows dim, and the page opens scrolled to today; afterwards it reads "Trip completed" |
 | Visa requirements | 🛂 Visas: pick your passport once (saved) and every country on the itinerary shows its requirement (visa-free with days, visa on arrival, e-Visa/eTA, visa required), derived live from the geocoded places via the community Passport Index dataset (cached monthly), with per-country Wikipedia verify links and an always-verify-officially caveat; countries can also be added manually (layovers, border crossings, road trips), stored per trip and removable |
-| Settings | 12/24-hour time format (saved and synced), dark/light theme |
+| Settings | 12/24-hour time format (saved and synced), dark/light theme; a small "build N" tag at the bottom of the trip menu identifies the loaded code version (staleness diagnostics for the PWA cache) |
 | Cloud sync | Optional: sign in via the site header and trips/preferences sync across devices via Firestore (`sync-system/`), same as the other apps |
 
 ## File structure

--- a/apps/trip-planner/css/styles.css
+++ b/apps/trip-planner/css/styles.css
@@ -1,7 +1,15 @@
-/* Trip Planner - scoped under body.trip-planner-app so main.css and the
-   shared header/footer keep their own look. Theme switch = .tp-light. */
+/* Trip Planner.
+   SCOPING CONTRACT: the class .trip-planner-app lives on the app ROOT
+   WRAPPER (a div inside <body>), NEVER on <body> itself. Shared page
+   components (site header/footer, the firebase-auth sign-out modal,
+   #sync-banner, toasts injected by shared scripts) render OUTSIDE that
+   wrapper and therefore can never be touched by app styles: the sign-out
+   modal once diverged on this page purely because these rules sat on
+   <body>. Page-level look (background, theme vars, mode classes
+   tp-light / tp-shared / view-days) lives on body.tp-page. Enforced by
+   sync-system/tests/shared-ui-consistency.test.mjs. */
 
-  body.trip-planner-app {
+  body.tp-page {
     /* single typography token: themes NEVER redefine it, so dark and light
        render identical type; controls reference it explicitly below instead
        of relying on a fragile inherit chain */
@@ -30,7 +38,7 @@
     --radius: 14px;
     color-scheme: dark;
   }
-  body.trip-planner-app.tp-light {
+  body.tp-page.tp-light {
     --bg: #f3f5f9;
     --bg-soft: #ffffff;
     --bg-card: #ffffff;
@@ -55,9 +63,13 @@
     color-scheme: light;
   }
   .trip-planner-app *, .trip-planner-app *::before, .trip-planner-app *::after { box-sizing: border-box; }
-  body.trip-planner-app {
+  body.tp-page {
     margin: 0;
     background: var(--bg);
+  }
+  /* typography/color live on the app root, NOT body, so they cannot
+     inherit into shared components appended to <body> */
+  .trip-planner-app {
     color: var(--text);
     font: 15px/1.5 var(--tp-font);
     -webkit-font-smoothing: antialiased;
@@ -168,6 +180,7 @@
   .trip-planner-app .tp-menu-panel button:hover,
   .trip-planner-app .tp-menu-panel button:focus { background: var(--accent-soft); color: var(--text); }
   .tp-menu-panel .sep { height: 1px; background: var(--border-soft); margin: 5px 4px; }
+  .tp-menu-build { padding: 6px 10px 2px; font-size: 10.5px; color: var(--text-faint); text-align: right; user-select: none; }
   .trip-planner-app .tp-menu-panel button.danger { color: var(--red); }
 
   /* interaction-state contract: dim/faint foregrounds are reserved for
@@ -469,8 +482,6 @@
   }
   .toast button { background: none; border: 0; color: var(--accent); font-weight: 700; padding: 0; }
 
-  .build-tag { margin-left: auto; opacity: 0.7; }
-  .trip-planner-app footer.page-foot { margin-top: 26px; color: var(--text-faint); font-size: 12.5px; display: flex; gap: 14px; flex-wrap: wrap; }
 
   /* ---------- main.css !important counter-pins ----------
      main.css paints ALL buttons `color: #555 !important`, red text on
@@ -605,8 +616,8 @@
     background: var(--bg-card); z-index: 1;
   }
   .map-status { color: var(--text-dim); font-size: 13px; padding: 9px 4px; min-height: 34px; }
-  body.trip-planner-app:not(.tp-light) #mapCanvas .leaflet-tile { filter: invert(1) hue-rotate(180deg) brightness(0.9) contrast(0.9) saturate(0.6); }
-  body.trip-planner-app:not(.tp-light) #mapCanvas { background: #1a1f29; }
+  body.tp-page:not(.tp-light) #mapCanvas .leaflet-tile { filter: invert(1) hue-rotate(180deg) brightness(0.9) contrast(0.9) saturate(0.6); }
+  body.tp-page:not(.tp-light) #mapCanvas { background: #1a1f29; }
   .stop-pin {
     background: var(--accent); color: #fff; border-radius: 50%; width: 26px; height: 26px;
     display: flex; align-items: center; justify-content: center; font-weight: 800; font-size: 13px;
@@ -697,7 +708,8 @@
 
   @media print {
     .toolbar, .c-actions, .tp-head .trip-bar, .issues, .empty .actions, .toasts { display: none !important; }
-    body.trip-planner-app { background: #fff; color: #000; }
+    body.tp-page { background: #fff; }
+    .trip-planner-app { color: #000; }
     .board { border-color: #bbb; }
     .day-card { break-inside: avoid; }
     /* Days view: print only the day cards, not the (hidden) timeline/strip. */

--- a/apps/trip-planner/index.html
+++ b/apps/trip-planner/index.html
@@ -43,12 +43,13 @@
   <meta name="theme-color" content="#0e1116">
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
-  <link rel="stylesheet" href="css/styles.css?v=14">
+  <link rel="stylesheet" href="css/styles.css?v=16">
 </head>
-<body class="trip-planner-app">
+<body class="tp-page">
   <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>
   <div data-include="header"></div>
 
+<div class="trip-planner-app">
 <div class="tp-wrap">
 
   <header class="tp-head">
@@ -78,6 +79,7 @@
           <button data-act="timefmt" id="timefmtBtn">🕐 Use 24-hour times</button>
           <div class="sep"></div>
           <button data-act="delete-trip" class="danger">🗑 Delete trip</button>
+          <div class="tp-menu-build" id="buildTag" aria-hidden="true"></div>
         </div>
       </div>
       <button class="icon-btn" id="themeBtn" title="Toggle theme">◐</button>
@@ -158,11 +160,6 @@
     <div id="mapCanvas"></div>
   </div>
 
-  <footer class="page-foot">
-    <span>Everything is saved locally in this browser as you type.</span>
-    <span>Use "Backup all trips" before clearing browser data.</span>
-    <span id="buildTag" class="build-tag"></span>
-  </footer>
 </div>
 
 <!-- item modal -->
@@ -390,6 +387,8 @@
 
 <input type="file" id="importFile" accept="application/json,.json" hidden>
 <div class="toasts" id="toasts"></div>
+</div><!-- /.trip-planner-app -->
+
   <div data-include="footer"></div>
 
   <script src="../../assets/js/passive-events-fix.js"></script>
@@ -421,7 +420,7 @@
     }
   </script>
 
-  <script src="js/trip-logic.js?v=4"></script>
-  <script src="js/app.js?v=15"></script>
+  <script src="js/trip-logic.js?v=5"></script>
+  <script src="js/app.js?v=17"></script>
 </body>
 </html>

--- a/apps/trip-planner/js/app.js
+++ b/apps/trip-planner/js/app.js
@@ -2,7 +2,7 @@
 (() => {
 
   // ---------- constants ----------
-  const TP_BUILD = 15; // bump with every asset-version bump; shown in the footer
+  const TP_BUILD = 17; // bump with every asset-version bump; shown in the footer
   const LS_KEY = 'trip-planner:v1';
   const THEME_KEY = 'trip-planner:theme';
   const TIMEFMT_KEY = 'trip-planner:timefmt';
@@ -27,7 +27,7 @@
     isStay, nights, sortKey, sortedItems, tripLegs,
     validateItem, coverageGaps, tripStats,
     ISLANDISH, distKm, flagEmoji, compass, fmtDur, modeOptions,
-    classifyVisa, parseVisaMatrix, hasFastRail,
+    classifyVisa, parseVisaMatrix, slimTripForShare, hasFastRail,
     buildIcs, convertAmount, sumInCurrency,
     bytesToBase64url, base64urlToBytes,
     transportGaps, tripPhase, isPastRow,
@@ -1282,13 +1282,18 @@
   async function shareTrip() {
     if (typeof CompressionStream === 'undefined') { toast('Sharing is not supported in this browser'); return; }
     const t = activeTrip();
-    const json = JSON.stringify({ version: 1, trip: t });
+    const json = JSON.stringify({ version: 1, trip: slimTripForShare(t) });
     const compressed = await streamThrough(CompressionStream, new TextEncoder().encode(json));
     const url = shareBaseUrl() + SHARE_PREFIX + bytesToBase64url(compressed);
-    if (url.length > 8000) { toast('This trip is too large to share by link. Use Export trip (JSON) instead.'); return; }
+    // The fragment never travels to a server, so browsers handle very long
+    // links fine; the real-world limit is chat apps truncating them. Hard
+    // stop only at absurd sizes, advisory warning in between.
+    if (url.length > 30000) { toast('This trip is too large to share by link. Use Export trip (JSON) instead.'); return; }
     try {
       await navigator.clipboard.writeText(url);
-      toast('Share link copied to clipboard');
+      toast(url.length > 8000
+        ? 'Share link copied. It is a LONG link: if a chat app truncates it, send the Export trip (JSON) file instead.'
+        : 'Share link copied to clipboard');
     } catch {
       window.prompt('Copy this share link:', url);
     }

--- a/apps/trip-planner/js/trip-logic.js
+++ b/apps/trip-planner/js/trip-logic.js
@@ -464,12 +464,31 @@ const TripLogic = (() => {
     return codes.length ? { codes, matrix } : null;
   }
 
+  // Share links carry the whole trip inside the URL, so every byte counts.
+  // Strip empty fields, timestamps and long ids before compressing; the
+  // import sanitizer tolerates all of these being absent.
+  function slimTripForShare(trip) {
+    const keep = v => !(v == null || v === '');
+    const slim = { name: trip.name, currency: trip.currency, items: [] };
+    if (trip.budget != null) slim.budget = trip.budget;
+    if (Array.isArray(trip.visaExtras) && trip.visaExtras.length) slim.visaExtras = trip.visaExtras;
+    slim.items = trip.items.map((it, i) => {
+      const out = { id: 'i' + (i + 1) };
+      for (const k of ['type', 'title', 'location', 'startDate', 'endDate', 'startTime', 'endTime', 'status', 'cost', 'costCurrency', 'costNote', 'details']) {
+        if (keep(it[k])) out[k] = it[k];
+      }
+      return out;
+    });
+    return slim;
+  }
+
   return {
     isIsoDate, toUtc, diffDays, addDays,
     isStay, nights, sortKey, sortedItems, tripLegs,
     validateItem, coverageGaps, tripStats,
     ISLANDISH, distKm, flagEmoji, compass, fmtDur, modeOptions,
-    classifyVisa, parseVisaMatrix, hasFastRail,
+    classifyVisa, parseVisaMatrix,
+    slimTripForShare, hasFastRail,
     buildIcs, convertAmount, sumInCurrency,
     bytesToBase64url, base64urlToBytes,
     transportGaps, tripPhase, isPastRow,

--- a/apps/trip-planner/sw.js
+++ b/apps/trip-planner/sw.js
@@ -17,7 +17,7 @@
  * MINOR when the strategy changes, MAJOR for a back-compat break.
  */
 
-const CACHE_VERSION = '2.0.0';
+const CACHE_VERSION = '2.0.2';
 const PRECACHE = `trip-precache-${CACHE_VERSION}`;
 const RUNTIME = `trip-runtime-${CACHE_VERSION}`;
 
@@ -25,9 +25,9 @@ const PRECACHE_URLS = [
   './',
   './index.html',
   './manifest.webmanifest',
-  './css/styles.css?v=14',
-  './js/trip-logic.js?v=4',
-  './js/app.js?v=15',
+  './css/styles.css?v=16',
+  './js/trip-logic.js?v=5',
+  './js/app.js?v=17',
   '../../assets/css/main.css',
   '../../assets/css/sync-status.css',
   '../../assets/js/passive-events-fix.js',

--- a/apps/trip-planner/tests/trip-logic.test.js
+++ b/apps/trip-planner/tests/trip-logic.test.js
@@ -556,3 +556,21 @@ test('docGuard enforces the 10-file and 2MB limits', () => {
   assert.deepEqual(L.docGuard(2, 2 * 1024 * 1024 + 1), { ok: false, reason: 'size' });
   assert.deepEqual(L.docGuard(2, 2 * 1024 * 1024), { ok: true });
 });
+
+test('slimTripForShare drops empties, timestamps and long ids but keeps data', () => {
+  const trip = { name: 'T', currency: 'USD', budget: null, visaExtras: [],
+    items: [{ id: 'f9b2c8d1-aaaa-bbbb-cccc-1234567890ab', type: 'flight', title: 'A to B',
+      location: '', startDate: '2027-01-01', endDate: '', startTime: '07:35', endTime: '',
+      status: 'booked', cost: 200, costCurrency: 'USD', costNote: '', details: '',
+      createdAt: '2026-07-18T00:00:00Z' }] };
+  const slim = L.slimTripForShare(trip);
+  assert.equal(slim.items[0].id, 'i1');
+  assert.equal(slim.items[0].createdAt, undefined);
+  assert.equal(slim.items[0].location, undefined);
+  assert.equal(slim.items[0].endTime, undefined);
+  assert.equal(slim.items[0].title, 'A to B');
+  assert.equal(slim.items[0].cost, 200);
+  assert.equal(slim.budget, undefined);
+  assert.equal(slim.visaExtras, undefined);
+  assert.ok(JSON.stringify(slim).length < JSON.stringify(trip).length * 0.6);
+});

--- a/assets/css/firebase-auth.css
+++ b/assets/css/firebase-auth.css
@@ -1287,6 +1287,9 @@ body.dark-theme .signout-modal span {
   color: #000000 !important;
   font-weight: 700;
   letter-spacing: -0.025em;
+  /* main.css uppercases every h2 globally; the modal's approved look is
+     proper case on EVERY page, so pin it here at the source */
+  text-transform: none;
 }
 
 /* Override dark theme for signout modal */
@@ -1440,4 +1443,48 @@ body.dark-theme .signout-confirm-btn:active {
   body.dark-theme .auth-modal__close {
     transition: none !important;
   }
+}
+
+
+/* ==========================================================================
+   Scheme + autofill immunity (added 2026-07-18)
+   These components are white-surfaced BY DESIGN on every page. App pages set
+   color-scheme: dark on <body>, and because the modals are appended to
+   <body> they inherited it - flipping Chrome's UA rendering (autofill
+   backgrounds, native widgets, scrollbars) to dark gray inside the white
+   card. Pin the scheme at the component root, and neutralize autofill's
+   paint (which ignores author background-color entirely) with the inset
+   box-shadow technique, so email/password fields look identical in default,
+   focused and autofilled states on every page of the site.
+   ========================================================================== */
+#auth-modal,
+html #auth-modal,
+#auth-modal *,
+.auth-modal,
+html .auth-modal,
+.auth-modal *,
+.signout-modal,
+html .signout-modal,
+.signout-modal * {
+  /* !important + the id-level selectors: this stylesheet's own
+     `all: unset !important` input reset would otherwise revert
+     color-scheme to inherit (= the page's dark scheme) */
+  color-scheme: light !important;
+}
+
+input.auth-form__input:-webkit-autofill,
+input.auth-form__input:-webkit-autofill:hover,
+input.auth-form__input:-webkit-autofill:focus,
+body input.auth-form__input:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px #ffffff inset !important;
+  box-shadow: 0 0 0 1000px #ffffff inset !important;
+  -webkit-text-fill-color: #000000 !important;
+  caret-color: #000000 !important;
+}
+
+/* standard :autofill kept as its own rule: an unsupported selector would
+   invalidate a shared group in older engines */
+input.auth-form__input:autofill {
+  box-shadow: 0 0 0 1000px #ffffff inset !important;
+  caret-color: #000000 !important;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3084,6 +3084,16 @@ body > [data-include="footer"] {
   -webkit-font-smoothing: auto !important;
   -moz-osx-font-smoothing: auto !important; }
 
+/* The firebase-auth sign-out modal is appended to <body>, so on app pages it
+   sits inside whatever element scope the app styles. Pin its typography the
+   same way the header/footer are pinned, so it renders identically on every
+   page regardless of app CSS. Colors/sizes come from firebase-auth.css,
+   which already defends them. */
+.signout-modal, .signout-modal * {
+  font-family: "Raleway", Arial, Helvetica, sans-serif !important;
+  -webkit-font-smoothing: auto !important;
+  -moz-osx-font-smoothing: auto !important; }
+
 /* Pin the footer's base text color. Some apps set a white body/* color that the
    footer containers inherit, which (via currentColor) tinted their borders and
    any non-link text differently from the marketing pages. Links/headings/

--- a/sync-system/tests/shared-ui-consistency.test.mjs
+++ b/sync-system/tests/shared-ui-consistency.test.mjs
@@ -1,0 +1,246 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Shared-UI consistency guard.
+//
+// Headers, footers, the auth/sign-out modal, nav and other global chrome must
+// be IDENTICAL on every page: one shared implementation (partials/ +
+// assets/js/main.js), one shared stylesheet (assets/css/*), zero per-app
+// copies or overrides. This suite fails when a page re-implements a shared
+// component, restyles shared-component selectors from app CSS, or leaks
+// app typography into shared components by scoping it to <body> (the exact
+// mechanism that made Trip Planner's sign-out modal diverge, 2026-07-18).
+//
+// LEGACY debt: some older apps still scope element styling to their body
+// class. They are allowlisted below so the invariant holds for every NEW
+// app and every NEW rule; shrink the allowlist, never grow it.
+
+const repo = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const APPS_DIR = join(repo, 'apps');
+const apps = readdirSync(APPS_DIR, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && existsSync(join(APPS_DIR, d.name, 'index.html')))
+  .map((d) => d.name);
+
+const read = (p) => readFileSync(p, 'utf8');
+const stripCssComments = (css) => css.replace(/\/\*[\s\S]*?\*\//g, '');
+const stripHtmlComments = (html) => html.replace(/<!--[\s\S]*?-->/g, '');
+
+// Flatten a stylesheet into [selector, declarations] pairs, recursing into
+// @media / @supports blocks. Comment-stripped input expected.
+function cssRules(css) {
+  const rules = [];
+  let i = 0;
+  const n = css.length;
+  let buf = '';
+  while (i < n) {
+    const ch = css[i];
+    if (ch === '{') {
+      const selector = buf.trim();
+      buf = '';
+      // find matching close brace
+      let depth = 1;
+      let j = i + 1;
+      while (j < n && depth > 0) {
+        if (css[j] === '{') depth++;
+        else if (css[j] === '}') depth--;
+        j++;
+      }
+      const body = css.slice(i + 1, j - 1);
+      if (selector.startsWith('@media') || selector.startsWith('@supports')) {
+        rules.push(...cssRules(body));
+      } else if (!selector.startsWith('@')) {
+        rules.push([selector, body]);
+      }
+      i = j;
+    } else {
+      buf += ch;
+      i++;
+    }
+  }
+  return rules;
+}
+
+function appCssFiles(app) {
+  const out = [];
+  const walk = (dir) => {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.name.endsWith('.css') && !e.name.endsWith('.min.css')) out.push(p);
+    }
+  };
+  const cssDir = join(APPS_DIR, app, 'css');
+  if (existsSync(cssDir)) walk(cssDir);
+  return out;
+}
+
+// Shared chrome an app stylesheet may NEVER style, full stop.
+const FORBIDDEN_TOKENS = [
+  '.signout-modal', '.signout-confirm-btn', '.signout-cancel-btn',
+  '.auth__', '#auth-container', '#auth-signout-btn', '.nav-apps', '#sync-banner',
+];
+
+// #header/#footer/#menu: apps may only POSITION the bare element within
+// their layout (sticky footers, clearing a bottom nav). Anything else -
+// descendants, typography, colors, backgrounds - is restyling shared chrome.
+const LAYOUT_ONLY_RE = /^(margin[a-z-]*|padding[a-z-]*|flex|flex-[a-z]+|order|align-self|grid-row|grid-column)$/;
+
+// Apps that still element-scope via their body class. BURN-DOWN list:
+// migrate each to a root-wrapper scope (see apps/trip-planner) and remove.
+const LEGACY_BODY_SCOPED = new Set([
+  'arena', 'maptap-rivals', 'mario-kart', 'gym-tracker', 'football-h2h', 'rising-shows',
+]);
+
+// Inherited properties that leak from <body> into shared components
+// appended to <body> (sign-out modal, toasts).
+const INHERITED_LEAK_RE = /(^|;)\s*(font[a-z-]*|color|letter-spacing|text-transform|line-height|-webkit-font-smoothing|-moz-osx-font-smoothing)\s*:/;
+
+function bodyClassesOf(app) {
+  const html = stripHtmlComments(read(join(APPS_DIR, app, 'index.html')));
+  const m = html.match(/<body[^>]*class="([^"]+)"/);
+  return m ? m[1].split(/\s+/).filter(Boolean) : [];
+}
+
+test('every app page uses the shared header and footer includes', () => {
+  for (const app of apps) {
+    const html = read(join(APPS_DIR, app, 'index.html'));
+    assert.ok(html.includes('data-include="header"'), `${app}: missing shared header include`);
+    assert.ok(html.includes('data-include="footer"'), `${app}: missing shared footer include`);
+  }
+});
+
+test('no app page re-implements shared component markup', () => {
+  const violations = [];
+  for (const app of apps) {
+    const html = stripHtmlComments(read(join(APPS_DIR, app, 'index.html')));
+    for (const token of ['class="signout-modal', 'signout-confirm-btn', 'signout-cancel-btn', 'id="header"', 'id="footer"', 'class="nav-apps']) {
+      if (html.includes(token)) violations.push(`${app}/index.html contains "${token}"`);
+    }
+  }
+  assert.deepEqual(violations, [], `Shared components come only from partials/ + assets/js/main.js:\n${violations.join('\n')}`);
+});
+
+test('app stylesheets never restyle shared chrome (modal/auth/nav; header/footer layout-positioning only)', () => {
+  const violations = [];
+  for (const app of apps) {
+    for (const file of appCssFiles(app)) {
+      const rel = file.replace(repo + '/', '');
+      for (const [selector, body] of cssRules(stripCssComments(read(file)))) {
+        for (const token of FORBIDDEN_TOKENS) {
+          if (selector.includes(token)) violations.push(`${rel}: "${selector}" styles ${token}`);
+        }
+        const chromeMatch = selector.match(/#(header|footer|menu)(\b[^,{]*)/);
+        if (chromeMatch) {
+          const tail = chromeMatch[2].trim();
+          if (tail.length > 0) {
+            violations.push(`${rel}: "${selector}" reaches inside #${chromeMatch[1]}`);
+          } else {
+            for (const decl of body.split(';')) {
+              const prop = decl.split(':')[0].trim().toLowerCase();
+              if (prop && !LAYOUT_ONLY_RE.test(prop)) {
+                violations.push(`${rel}: "${selector}" sets non-layout property "${prop}"`);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  assert.deepEqual(violations, [], `Shared chrome is styled ONLY by assets/css/*:\n${violations.join('\n')}`);
+});
+
+test('body-scoped app classes never declare inherited typography (leaks into shared modals)', () => {
+  const violations = [];
+  for (const app of apps) {
+    if (LEGACY_BODY_SCOPED.has(app)) continue; // burn-down list above
+    const classes = bodyClassesOf(app);
+    for (const file of appCssFiles(app)) {
+      const rel = file.replace(repo + '/', '');
+      for (const [selector, body] of cssRules(stripCssComments(read(file)))) {
+        for (const cls of classes) {
+          // bare `body.<class>` (no descendant part) with inherited props
+          const bare = new RegExp(`(^|,)\\s*(html\\s+)?body\\.${cls}(\\.[a-zA-Z0-9_-]+)*\\s*$`);
+          if (selector.split(',').some((s) => bare.test(s.trim())) && INHERITED_LEAK_RE.test(body)) {
+            violations.push(`${rel}: "${selector}" declares inherited typography/color on <body>`);
+          }
+        }
+      }
+    }
+  }
+  assert.deepEqual(violations, [], `Inherited props on <body> reach the shared sign-out modal and toasts. Scope them to the app root wrapper instead:\n${violations.join('\n')}`);
+});
+
+test('non-legacy apps keep element styling off the body class entirely (root-wrapper scoping)', () => {
+  const violations = [];
+  for (const app of apps) {
+    if (LEGACY_BODY_SCOPED.has(app)) continue;
+    const classes = bodyClassesOf(app);
+    for (const file of appCssFiles(app)) {
+      const rel = file.replace(repo + '/', '');
+      for (const [selector] of cssRules(stripCssComments(read(file)))) {
+        for (const cls of classes) {
+          const re = new RegExp(`body\\.${cls}[^,{]*\\s+(a|p|h[1-6]|ul|ol|li|input|select|option|textarea|button|table|form)\\b`);
+          if (re.test(selector)) violations.push(`${rel}: "${selector}"`);
+        }
+      }
+    }
+  }
+  assert.deepEqual(violations, [], `New apps scope element styles to a root wrapper div, never via <body> (see apps/trip-planner/css/styles.css header):\n${violations.join('\n')}`);
+});
+
+test('trip-planner keeps its scope class on the root wrapper, not <body>', () => {
+  const html = read(join(APPS_DIR, 'trip-planner', 'index.html'));
+  assert.match(html, /<body class="tp-page">/);
+  assert.match(html, /<div class="trip-planner-app">/);
+  const css = stripCssComments(read(join(APPS_DIR, 'trip-planner', 'css', 'styles.css')));
+  assert.ok(!/body\.trip-planner-app/.test(css), 'styles.css must not scope to body.trip-planner-app');
+});
+
+test('main.css keeps the shared-chrome locks and the single modal stylesheet', () => {
+  const css = read(join(repo, 'assets', 'css', 'main.css'));
+  assert.ok(css.includes('#header,'), 'header/footer typography lock missing');
+  assert.ok(css.includes('.signout-modal, .signout-modal *'), 'sign-out modal typography lock missing');
+  assert.ok(css.includes('@import url(firebase-auth.css)'), 'firebase-auth.css must stay imported from main.css');
+});
+
+test('shared overlays are immune to page color-scheme and browser autofill', () => {
+  // Body-appended shared overlays inherit the page's color-scheme, which
+  // flips Chrome's UA rendering (autofill paint, native widgets) to dark on
+  // dark app pages. The shared stylesheet must pin its own scheme and
+  // override autofill paint so auth inputs render identically site-wide.
+  const css = stripCssComments(read(join(repo, 'assets', 'css', 'firebase-auth.css')));
+  const rules = cssRules(css);
+  for (const component of ['.auth-modal', '.signout-modal']) {
+    const pinned = rules.some(([sel, body]) =>
+      sel.split(',').map((s) => s.trim()).includes(component) &&
+      /color-scheme\s*:\s*light/.test(body));
+    assert.ok(pinned, `${component} must declare color-scheme: light in firebase-auth.css`);
+  }
+  assert.ok(css.includes(':-webkit-autofill'), 'auth inputs must override -webkit-autofill paint');
+  assert.match(css, /:-webkit-autofill[^{]*\{[^}]*box-shadow[^}]*inset/s, 'autofill override must use the inset box-shadow technique');
+});
+
+test('no app script re-implements the sign-out modal', () => {
+  const violations = [];
+  for (const app of apps) {
+    const jsDir = join(APPS_DIR, app, 'js');
+    if (!existsSync(jsDir)) continue;
+    const walk = (dir) => {
+      for (const e of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, e.name);
+        if (e.isDirectory()) walk(p);
+        else if (e.name.endsWith('.js')) {
+          const src = read(p);
+          if (src.includes('signout-modal') || src.includes('createSignOutModal')) {
+            violations.push(p.replace(repo + '/', ''));
+          }
+        }
+      }
+    };
+    walk(jsDir);
+  }
+  assert.deepEqual(violations, [], `Sign-out UI comes only from assets/js/main.js:\n${violations.join('\n')}`);
+});


### PR DESCRIPTION
## What this is

Two things that became one branch: a Trip Planner polish round (footer removal, build-tag relocation, share-link headroom) and, larger, the shared-UI single-source-of-truth work triggered by three same-day incidents where global components rendered differently on app pages (sign-out modal typography/capitalization, then gray autofilled sign-in fields). Complete diff, per file group:

## Shared-UI architecture (`assets/css/`, `sync-system/tests/`)

- `apps/trip-planner/index.html` + `css/styles.css` - the app's style scope class moved off `<body>` onto a root wrapper `<div class="trip-planner-app">`; body carries only a thin `tp-page` class (background, theme vars, mode flags). Shared components appended to `<body>` (firebase-auth sign-in and sign-out modals, sync banner) are now structurally out of reach of app CSS. Zero `body.trip-planner-app` selectors remain; print rules split so no inherited color sits on body.
- `assets/css/main.css` - the existing header/footer typography lock now also pins the sign-out modal's font family and font smoothing (it is body-appended, so on app pages it sat inside whatever the app styled).
- `assets/css/firebase-auth.css` - two source-of-truth fixes: (1) the sign-out modal title pins `text-transform: none` (main.css uppercases every h2 globally; the modal's approved proper-case look on older apps existed only by accident of their own heading resets); (2) a new scheme + autofill immunity block: `#auth-modal`/`.auth-modal`/`.signout-modal` and all descendants pin `color-scheme: light !important` (with html-prefixed selectors to out-cascade the sheet's own `html #auth-modal { all: unset !important }` reset), and the email/password inputs get inset box-shadow autofill overrides (`:-webkit-autofill` + standard `:autofill`, pinned text-fill and caret colors). Root cause of the gray fields: dark app pages set `color-scheme: dark`, the body-appended modal inherited it, and Chrome painted its dark autofill variant - which no `background-color`, even `!important`, can override.
- `sync-system/tests/shared-ui-consistency.test.mjs` (new, 9 tests, runs in `npm test`) - parses real CSS (comments stripped, media queries flattened) and fails when: an app page lacks the shared header/footer includes; a page re-implements shared chrome markup or the sign-out modal in JS; app CSS styles shared selectors (sole exception: layout-only positioning of bare `#header`/`#footer`, which football-h2h and gym-tracker legitimately use); a body-attached app class declares inherited typography; a non-legacy app element-scopes via body instead of a wrapper; or the main.css/firebase-auth.css locks and autofill immunity go missing. Six legacy apps sit in an explicit shrink-only burn-down allowlist.

Verified by computed-style probes, not eyeballs: the sign-out modal on /apps/trip-planner/ is byte-identical to /apps/gym-tracker/ (title/message/both buttons: family, size, weight, colors, case), and auth inputs compute `color-scheme: light` + white background on dark-mode Trip Planner and legacy gym-tracker alike.

## Trip Planner polish (`apps/trip-planner/`)

- Footer strip removed (its one useful line, Backup all trips, already lives in the trip menu). The "build N" tag moved to the bottom of the ⋯ menu: it identifies the loaded code version, the PWA cache's staleness diagnostic (documented in the app README).
- Share links: payloads slimmed before compression (empty fields, timestamps, long internal ids stripped; short i1..iN ids; unit-tested round-trip fidelity), and honest tiered limits replace the old 8k cliff: <=8k plain copy, 8k-30k copies with a "long link, chat apps may truncate" warning, >30k hard stop pointing at JSON export. Verified: a 45-item trip generates, copies, and round-trips through its own link into read-only shared mode.
- Asset versions bumped (css v=16, logic v=5, app v=17, sw precache matched, CACHE_VERSION 2.0.2, TP_BUILD 17).

## Docs

- Root `README.md`: the "Adding a new app" checklist gains the wrapper-scoping rule (scope class on a root wrapper, never `<body>`; shared chrome untouchable; enforced by the new suite).
- `apps/trip-planner/README.md`: share-link limits and the build tag documented.

## Explicitly untouched

Legacy apps' body-scoped CSS (allowlisted burn-down debt - migrating six apps' cascade architecture is its own project); the auth flow's JS behavior; all other apps' code; `.features/`/`.claude/` (local-only).

## Testing

`npm test`: **1175/1175** (62 trip-planner logic incl. the new share-slimmer test; 9 shared-UI consistency). Screenshot/probe evidence for: footer removal, menu build tag, 45-item share round-trip, sign-out modal parity vs gym-tracker, scheme pins on both a wrapper-scoped and a legacy app. Human checklist (in `.features/trip-planner-human.md`): real autofill needs saved credentials - sign in on dark-mode Trip Planner and confirm the fields stay white; plus the sign-out dialog eyeball check.
