### PR TITLE
fix(theme): pin app styles against main.css !important collisions, third sweep

### DIFF
--- a/apps/arena/css/styles.css
+++ b/apps/arena/css/styles.css
@@ -186,6 +186,9 @@ body.brain-arena-app button {
   transform: translateY(-1px);
 }
 .btn:active { transform: translateY(0); box-shadow: none !important; }
+/* Pin off main.css's `button:hover:active { background-color: rgba(206,27,40,0.25) }`
+   red pressed flash (its 0-2-1 specificity beats the single-class rules above). */
+.btn:hover:active { background-color: var(--surface-2); }
 .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .btn:disabled, .btn[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
 
@@ -202,6 +205,8 @@ body.brain-arena-app button {
   box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.6), 0 10px 32px rgba(34, 211, 238, 0.4) !important;
   transform: translateY(-1px);
 }
+/* See .btn:hover:active note; the gradient supplies the fill here. */
+.btn-primary:hover:active { background-color: transparent; }
 
 .btn-ghost, .btn-ghost:hover {
   background: rgba(255, 255, 255, 0.03);
@@ -212,6 +217,8 @@ body.brain-arena-app button {
   background: rgba(34, 211, 238, 0.07);
   border-color: rgba(34, 211, 238, 0.35);
 }
+/* See .btn:hover:active note. */
+.btn-ghost:hover:active { background-color: rgba(34, 211, 238, 0.07); }
 
 /* ---------- Layout ---------- */
 
@@ -1350,7 +1357,11 @@ select option { background: var(--surface); color: var(--text); }
 .btn-icon-danger {
   background: transparent;
   border: 1px solid rgba(248, 113, 113, 0.4);
-  color: rgb(252, 165, 165);
+  /* `!important` + box-shadow pins off main.css's global `button` rules
+     (gray #555 text/ring, red hover/active repaint), same approach as
+     .link-btn / .room-code-copy. */
+  color: rgb(252, 165, 165) !important;
+  box-shadow: none;
   width: 28px;
   height: 28px;
   border-radius: 6px;
@@ -1362,8 +1373,10 @@ select option { background: var(--surface); color: var(--text); }
 }
 .btn-icon-danger:hover {
   background: rgba(248, 113, 113, 0.12);
-  color: rgb(254, 202, 202);
+  color: rgb(254, 202, 202) !important;
+  box-shadow: none;
 }
+.btn-icon-danger:hover:active { background: rgba(248, 113, 113, 0.12); }
 .leaderboard-table .col-admin { width: 40px; text-align: center; }
 
 .room-host-actions {
@@ -1377,16 +1390,23 @@ select option { background: var(--surface); color: var(--text); }
   font-size: 0.82rem;
   line-height: 1.1;
 }
-.btn-danger-ghost {
-  color: rgb(252, 165, 165);
+.btn-danger-ghost,
+.btn-danger-ghost:hover {
+  /* `!important` + grouped :hover so the pink survives .btn / .btn:hover's
+     own `color: var(--text) !important` counter-pins (added vs main.css). */
+  color: rgb(252, 165, 165) !important;
   border-color: rgba(248, 113, 113, 0.4);
 }
 .btn-danger-ghost:hover {
   background: rgba(248, 113, 113, 0.10);
 }
-.btn-danger {
+.btn-danger-ghost:hover:active { background-color: rgba(248, 113, 113, 0.10); }
+.btn-danger,
+.btn-danger:hover {
   background: rgb(220, 38, 38) !important;
   border-color: rgb(220, 38, 38) !important;
+  /* Grouped :hover so white beats .btn-primary:hover's
+     `color: #051b22 !important` on the confirm-modal danger variant. */
   color: white !important;
 }
 .btn-danger:hover { background: rgb(185, 28, 28) !important; }
@@ -1835,6 +1855,10 @@ select option { background: var(--surface); color: var(--text); }
 }
 .globe-drop-fab-ghost:hover .globe-drop-fab-icon { color: #fde68a; }
 .globe-drop-fab-ghost:active { transform: translateY(0); }
+/* Pin off main.css's `button:hover:active` red background flash; restate
+   the color layer of the shorthand backgrounds above. */
+.globe-drop-fab-primary:hover:active { background-color: transparent; }
+.globe-drop-fab-ghost:hover:active { background-color: rgba(20, 11, 4, 0.55); }
 
 @media (max-width: 540px) {
   .globe-drop-fab-stack { top: 0.5rem; right: 0.5rem; gap: 0.35rem; }
@@ -2918,7 +2942,7 @@ select option { background: var(--surface); color: var(--text); }
 /* Wikipedia escape hatch — small pill below the reveal so players can
    read more about the location regardless of whether the inline trivia
    fetch returned anything. */
-.globe-drop-reveal-wiki {
+.globe-drop-reveal .globe-drop-reveal-wiki {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -2933,9 +2957,10 @@ select option { background: var(--surface); color: var(--text); }
   text-decoration: none;
   transition: background 0.18s ease, border-color 0.18s ease;
 }
-.globe-drop-reveal-wiki:hover {
+.globe-drop-reveal .globe-drop-reveal-wiki:hover {
   background: rgba(34, 211, 238, 0.16);
   border-color: rgba(34, 211, 238, 0.45);
+  text-decoration: none;
 }
 
 /* Pin styling is now handled by globe.gl's pointColor() (no DOM nodes
@@ -3051,6 +3076,10 @@ select option { background: var(--surface); color: var(--text); }
   border: 1px solid var(--border-strong);
   border-radius: 12px;
   color: var(--text) !important;
+  /* Base box-shadow + :hover color pins off main.css's global `button`
+     rules (gray #555 ring, `button:hover { color: #ce1b28 !important }`
+     which outranks the single-class pin above). */
+  box-shadow: none;
   font: inherit;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s, transform 0.05s, box-shadow 0.15s;
@@ -3060,7 +3089,9 @@ select option { background: var(--surface); color: var(--text); }
   background: var(--surface-3);
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-soft);
+  color: var(--text) !important;
 }
+.pick-cat-btn:hover:active { background-color: var(--surface-3); }
 .pick-cat-btn:active { transform: translateY(1px); }
 .pick-cat-btn:disabled {
   opacity: 0.55;
@@ -3219,6 +3250,10 @@ select option { background: var(--surface); color: var(--text); }
   border: 1px solid var(--border-strong);
   border-radius: 12px;
   color: var(--text) !important;
+  /* Base box-shadow + :hover color pins off main.css's global `button`
+     rules (gray #555 ring, `button:hover { color: #ce1b28 !important }`
+     which outranks the single-class pin above). */
+  box-shadow: none;
   font: inherit;
   font-size: 1rem;
   text-align: left;
@@ -3230,7 +3265,11 @@ select option { background: var(--surface); color: var(--text); }
   background: var(--surface-3);
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-soft);
+  color: var(--text) !important;
 }
+/* Pin off main.css's `button:hover:active` red background flash. */
+.answer-btn:hover:active { background-color: var(--surface-3); }
+.answer-btn.is-picked:hover:active { background-color: var(--accent-soft); }
 .answer-btn:active { transform: translateY(1px); }
 .answer-btn:disabled { cursor: default; }
 

--- a/apps/football-h2h/css/football-h2h.css
+++ b/apps/football-h2h/css/football-h2h.css
@@ -1469,8 +1469,13 @@
     box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
 }
 
-.modal-btn-primary:hover {
+.modal-btn-primary:hover,
+.modal-btn-primary:hover:active {
     background: linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%);
+    /* color re-pinned: the sitewide theme trap's `button:hover
+       { color: #ce1b28 !important }` (main.css) outspecifies the base
+       `.modal-btn-primary` pin, so hover/press text silently went red. */
+    color: white !important;
     transform: translateY(-2px);
     box-shadow: 0 6px 16px rgba(139, 92, 246, 0.4);
 }
@@ -1478,6 +1483,9 @@
 .modal-btn-secondary {
     background: #374151;
     color: #cbd5e0 !important;
+    /* Kill the theme trap's inset ring (gray #555 at rest, red #ce1b28 on
+       hover) — this button already carries a real border. */
+    box-shadow: none !important;
     border: 1px solid #4a5568;
     padding: 0.75rem 1.75rem;
     border-radius: 0.5rem;
@@ -1492,7 +1500,11 @@
     line-height: 1;
 }
 
-.modal-btn-secondary:hover {
+.modal-btn-secondary:hover,
+.modal-btn-secondary:hover:active {
+    /* :hover:active included so the theme trap's press state
+       (`button:hover:active { background-color: rgba(206,27,40,0.25) }`,
+       specificity (0,2,1)) can't tint the pressed button red. */
     background: #4a5568;
     border-color: #5a6678;
     color: #e2e8f0 !important;
@@ -1502,6 +1514,10 @@
 .modal-btn-danger {
     background: #ef4444;
     color: white !important;
+    /* Kill the theme trap's inset ring (gray #555 at rest, red #ce1b28 on
+       hover) — the red fill is the affordance, no ring wanted. Press bg is
+       already protected by mario-kart-overrides' `.modal-btn-danger:hover:active`. */
+    box-shadow: none !important;
     border: none;
     padding: 0.75rem 1.5rem;
     border-radius: 0.5rem;

--- a/apps/football-h2h/css/refresh.css
+++ b/apps/football-h2h/css/refresh.css
@@ -1070,6 +1070,21 @@ body.football-h2h-tracker .matchup-select {
     cursor: pointer;
 }
 
+/* Pagination buttons: the shared mario-kart-overrides.css pins color and
+   background against the sitewide theme trap, but not box-shadow, so
+   main.css `button { box-shadow: inset 0 0 0 1px #555555 }` painted a gray
+   inner ring on every non-active pagination button. Pin flat at rest and
+   restore pagination.css's intended indigo hover lift across hover/press.
+   The active-page ring (`body.theme .pagination-btn.active` in
+   mario-kart-overrides, !important at higher specificity) still wins. */
+body.football-h2h-tracker .pagination-btn {
+    box-shadow: none !important;
+}
+body.football-h2h-tracker .pagination-btn:hover:not(:disabled),
+body.football-h2h-tracker .pagination-btn:hover:active:not(:disabled) {
+    box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3) !important;
+}
+
 /* Dark theme for the shared pagination rows-per-page select (the shared
    assets/css/pagination.css hardcodes a white background) */
 body.football-h2h-tracker .pagination-size select {

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -3030,3 +3030,108 @@ body.gym-tracker .achievement-category-header:hover {
 body.gym-tracker .achievement-bulk-btn {
     box-shadow: none !important;
 }
+
+/* ---- 2026-07 theme-collision audit additions ----------------------------
+   Computed-style probes (base / :hover / :hover:active simulated across all
+   stylesheets, transitions disabled) surfaced the remaining <button>s that
+   main.css still bleeds into. Two flavors:
+   1. box-shadow / color forced with !important by main.css: counter-pin the
+      intended value with !important, then re-pin any focus ring the widget
+      sets itself (our blanket `box-shadow: none !important` would eat it).
+   2. the :hover:active red press-tint (plain rule, specificity (0,2,1)):
+      defeated by out-specifying with plain body.gym-tracker-scoped rules
+      mirroring each control's own hover background, per the NOTE above. */
+
+/* Set-completion toggle (active workout): borderless pill track, so the
+   red hover ring paints inside it and the press-tint fills it. */
+body.gym-tracker .set-toggle,
+body.gym-tracker .set-toggle:hover,
+body.gym-tracker .set-toggle:hover:active {
+    box-shadow: none !important;
+    /* No visible glyphs today (the knob icon pins its own colors), but the
+       forced gray/red would surface on any future text/icon addition. */
+    color: var(--text-primary) !important;
+}
+body.gym-tracker .set-toggle:focus-visible {
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.45) !important;
+}
+body.gym-tracker .set-toggle[aria-pressed="true"]:focus-visible {
+    box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.45) !important;
+}
+body.gym-tracker .set-toggle:hover:active {
+    background: var(--bg-hover) padding-box;
+}
+body.gym-tracker .set-toggle[aria-pressed="true"]:hover:active {
+    background: var(--accent-success) padding-box;
+}
+
+/* Program-modal weekday chips: they use a real 1px border, so the leaked
+   inset ring double-strokes them gray and turns red on hover. */
+body.gym-tracker .schedule-day-chip,
+body.gym-tracker .schedule-day-chip:hover,
+body.gym-tracker .schedule-day-chip:hover:active {
+    box-shadow: none !important;
+}
+body.gym-tracker .schedule-day-chip:focus-visible {
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.35) !important;
+}
+body.gym-tracker .schedule-day-chip:hover:active {
+    background: var(--bg-hover);
+}
+body.gym-tracker .schedule-day-chip.is-on:hover:active {
+    background: #1d4ed8;
+}
+
+/* Desktop workout FAB and mobile More-menu rows: their labels/icons are
+   saved by child pins (`body.gym-tracker span { color: white }` etc.), but
+   the buttons' own declared colors are silently forced gray/red. Pin them
+   so nothing depends on that masking. */
+body.gym-tracker .workout-fab,
+body.gym-tracker .workout-fab:hover,
+body.gym-tracker .workout-fab:hover:active {
+    color: #ffffff !important;
+}
+body.gym-tracker .workout-fab:hover:active {
+    background: linear-gradient(135deg, var(--accent-primary), #1d4ed8);
+}
+body.gym-tracker .workout-fab--resume:hover:active {
+    background: linear-gradient(135deg, #22c55e, #16a34a);
+}
+body.gym-tracker .more-item,
+body.gym-tracker .more-item:hover,
+body.gym-tracker .more-item:hover:active {
+    color: var(--gt-text) !important;
+}
+
+/* Press-tint counters for controls whose base background sits below the
+   (0,2,1) main.css rule: mirror each control's own hover background.
+   (.calendar-day.selected keeps its own !important gradient; .empty cells
+   are pointer-events: none, so neither can tint.) */
+body.gym-tracker .calendar-day:hover:active {
+    background: var(--bg-elevated);
+}
+body.gym-tracker .calendar-day.future:hover:active {
+    background: var(--bg-card);
+}
+body.gym-tracker .calendar-day.has-workout:hover:active {
+    background: linear-gradient(135deg, rgba(91, 155, 255, 0.25) 0%, rgba(91, 155, 255, 0.4) 100%);
+}
+body.gym-tracker .dark-select-trigger:hover:active {
+    background: var(--bg-hover);
+}
+body.gym-tracker .dark-calendar-trigger:hover:active {
+    background: var(--bg-elevated);
+}
+body.gym-tracker .achievement-category-header:hover:active {
+    background: var(--bg-elevated);
+}
+body.gym-tracker .achievement-bulk-btn:hover:active {
+    background: rgba(91, 155, 255, 0.2);
+}
+body.gym-tracker .btn-save-settings:hover:active {
+    background: var(--gradient-primary);
+}
+body.gym-tracker .btn-remove-set:hover:active,
+body.gym-tracker .btn-add-set--extra:hover:active {
+    background: var(--bg-hover);
+}

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -114,6 +114,18 @@ body.maptap-rivals-app button {
   color: var(--text);
 }
 
+/* Focus baseline. main.css paints every text input/select/textarea focus
+   with the theme red (`:focus { border-color:#ce1b28; box-shadow:0 0 0 1px
+   #ce1b28 }`). Neutralize it app-wide here; this rule sits EARLY on purpose
+   so the specific focus styles further down (profile input, modal fields,
+   history filters, paste textareas) win their ties by order. */
+body.maptap-rivals-app input:focus,
+body.maptap-rivals-app select:focus,
+body.maptap-rivals-app textarea:focus {
+  border-color: var(--accent);
+  box-shadow: none;
+}
+
 /* ---------- Buttons ----------
    main.css line ~322 has `button:hover { color: #ce1b28 !important }`.
    We force our colors with !important so the site's red link hover loses. */
@@ -146,6 +158,10 @@ body.maptap-rivals-app button {
   box-shadow: none !important;
 }
 .btn:active { transform: translateY(1px); }
+/* Pressed: main.css `button:hover:active { background-color: rgba(206,27,40,.25) }`
+   would flash the theme red; keep the hover surface instead. Variant press
+   pins below (same specificity) win by order. */
+.btn:hover:active { background-color: var(--surface-2); }
 .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .btn:disabled, .btn[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
 /* Defeat `.btn { display: inline-flex }` overriding UA `[hidden] { display: none }`. */
@@ -158,12 +174,16 @@ body.maptap-rivals-app button {
   font-weight: 600;
 }
 .btn-primary:hover { filter: brightness(1.1); }
+/* Gradient is opaque; pin the color layer so the red press tint can't sit
+   underneath it. */
+.btn-primary:hover:active { background-color: transparent; }
 
 .btn-ghost, .btn-ghost:hover {
   background: var(--surface-2);
   color: var(--text) !important;
 }
 .btn-ghost:hover { background: var(--surface-3); }
+.btn-ghost:hover:active { background-color: var(--surface-3); }
 
 .btn-danger, .btn-danger:hover {
   background: var(--bad);
@@ -172,6 +192,7 @@ body.maptap-rivals-app button {
   font-weight: 600;
 }
 .btn-danger:hover { filter: brightness(1.05); }
+.btn-danger:hover:active { background-color: var(--bad); }
 
 /* Ghost variant for destructive actions — subtle until hovered. */
 .btn-danger-ghost,
@@ -184,6 +205,7 @@ body.maptap-rivals-app button {
   background: var(--bad-soft);
   border-color: rgba(248, 113, 113, 0.45);
 }
+.btn-danger-ghost:hover:active { background-color: var(--bad-soft); }
 
 /* ---------- Layout ---------- */
 
@@ -242,6 +264,9 @@ body.maptap-rivals-app button {
   transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 .view-tab:hover { background: var(--surface-2); border-color: var(--border-strong); }
+/* Pressed: defeat main.css red press tint; .is-active:hover below outranks
+   this by order for the active tab. */
+.view-tab:hover:active { background-color: var(--surface-2); }
 .view-tab.is-active,
 .view-tab.is-active:hover {
   background: var(--accent-soft);
@@ -1082,7 +1107,11 @@ body.maptap-rivals-app button {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface-2);
-  color: var(--muted);
+  /* !important pins: main.css paints every button gray (#555 !important +
+     inset ring) and red on hover (#ce1b28 !important + red ring + red
+     press tint). */
+  color: var(--muted) !important;
+  box-shadow: none !important;
   font: inherit;
   cursor: pointer;
   display: flex;
@@ -1097,15 +1126,17 @@ body.maptap-rivals-app button {
 .pred-day-tab:hover {
   border-color: var(--border-strong);
   background: var(--surface-3);
-  color: var(--text);
+  color: var(--text) !important;
+  box-shadow: none !important;
   transform: translateY(-1px);
 }
 .pred-day-tab:active { transform: translateY(0); }
+.pred-day-tab:hover:active { background-color: var(--surface-3); }
 
 /* Today (when not the selected day): subtle accent text so the current
    day is locatable at a glance. (The little dot marker was removed —
    owner request; the accent-colored text and "Today" label suffice.) */
-.pred-day-tab.is-today { color: var(--text); }
+.pred-day-tab.is-today { color: var(--text) !important; }
 .pred-day-tab.is-today .pred-day-tab-num { color: var(--accent-2); }
 
 /* Selected day: the centrepiece. Larger pill via scale, accent gradient
@@ -1117,12 +1148,14 @@ body.maptap-rivals-app button {
       rgba(99, 102, 241, 0.06) 100%),
     linear-gradient(180deg, var(--surface-3), var(--surface-2));
   border-color: var(--accent);
-  color: var(--accent-2);
+  color: var(--accent-2) !important;
   transform: translateY(-2px) scale(1.06);
+  /* !important so the base `box-shadow: none !important` pin above doesn't
+     strip the selected-day glow. */
   box-shadow:
     inset 0 1px 0 0 rgba(255, 255, 255, 0.08),
     0 0 0 1px rgba(99, 102, 241, 0.35),
-    0 8px 22px -8px rgba(99, 102, 241, 0.55);
+    0 8px 22px -8px rgba(99, 102, 241, 0.55) !important;
 }
 .pred-day-tab.is-active:hover { transform: translateY(-2px) scale(1.06); }
 .pred-day-tab.is-active::after {
@@ -1379,6 +1412,9 @@ body.maptap-rivals-app button {
   color: var(--text) !important;
   box-shadow: none !important;
 }
+/* Pressed: defeat main.css red press tint; .is-revealed:hover below wins
+   its tie by order. */
+.pred-loc-btn:hover:active { background-color: var(--surface-3); }
 .pred-loc-btn:focus-visible {
   outline: 2px solid var(--accent-2);
   outline-offset: 2px;
@@ -1512,7 +1548,10 @@ body.maptap-rivals-app button {
   padding: 0;
   border: 0;
   background: transparent;
-  color: var(--muted);
+  /* !important pins vs main.css gray/red button theme (color + inset ring
+     + press tint). */
+  color: var(--muted) !important;
+  box-shadow: none !important;
   cursor: pointer;
   border-radius: 6px;
   display: inline-flex;
@@ -1523,13 +1562,16 @@ body.maptap-rivals-app button {
 .rival-card-edit:hover,
 .rival-card-sync:hover {
   background: rgba(255, 255, 255, 0.06);
-  color: var(--text);
+  color: var(--text) !important;
+  box-shadow: none !important;
 }
+.rival-card-edit:hover:active,
+.rival-card-sync:hover:active { background-color: rgba(255, 255, 255, 0.06); }
 .rival-card-edit:focus-visible,
 .rival-card-sync:focus-visible {
   outline: none;
   background: rgba(255, 255, 255, 0.06);
-  box-shadow: 0 0 0 2px var(--accent-soft);
+  box-shadow: 0 0 0 2px var(--accent-soft) !important;
 }
 .rival-card-edit svg,
 .rival-card-sync svg {
@@ -1538,7 +1580,7 @@ body.maptap-rivals-app button {
   display: block;
 }
 .rival-card-sync[disabled] { opacity: 0.45; cursor: not-allowed; }
-.rival-card-sync.is-loading { color: var(--accent-2); animation: spin 0.9s linear infinite; }
+.rival-card-sync.is-loading { color: var(--accent-2) !important; animation: spin 0.9s linear infinite; }
 @keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
 
 .rival-sync-status {
@@ -2634,7 +2676,11 @@ body.maptap-rivals-app button {
   padding: 0;
   border: 1px solid var(--border-strong);
   background: var(--surface-2);
-  color: var(--muted);
+  /* !important pins vs main.css gray/red button theme (color + inset ring
+     + press tint); every color/box-shadow in this icon-btn family carries
+     one for the same reason. */
+  color: var(--muted) !important;
+  box-shadow: none !important;
   cursor: pointer;
   border-radius: 6px;
   display: inline-flex;
@@ -2648,23 +2694,25 @@ body.maptap-rivals-app button {
 .icon-btn:hover {
   background: var(--surface-3);
   border-color: var(--border-strong);
-  color: var(--text);
+  color: var(--text) !important;
+  box-shadow: none !important;
 }
+.icon-btn:hover:active { background-color: var(--surface-3); }
 .icon-btn:focus-visible {
   outline: none;
   background: var(--surface-3);
-  color: var(--text);
-  box-shadow: 0 0 0 2px var(--accent-soft);
+  color: var(--text) !important;
+  box-shadow: 0 0 0 2px var(--accent-soft) !important;
 }
 /* Row hover lifts the action affordance a touch further. */
 tr:hover .icon-btn,
 tr:focus-within .icon-btn {
   border-color: var(--border-strong);
-  color: var(--text);
+  color: var(--text) !important;
 }
 /* Danger keeps a persistent red tint so destructive intent reads at rest. */
 .icon-btn-danger {
-  color: var(--bad);
+  color: var(--bad) !important;
   border-color: rgba(248, 113, 113, 0.28);
   background: rgba(248, 113, 113, 0.07);
 }
@@ -2673,15 +2721,16 @@ tr:hover .icon-btn-danger,
 tr:focus-within .icon-btn-danger {
   background: rgba(248, 113, 113, 0.16);
   border-color: rgba(248, 113, 113, 0.45);
-  color: var(--bad);
+  color: var(--bad) !important;
 }
+.icon-btn-danger:hover:active { background-color: rgba(248, 113, 113, 0.16); }
 .icon-btn-danger:focus-visible {
   background: rgba(248, 113, 113, 0.16);
-  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.3);
+  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.3) !important;
 }
 /* Share leans into the indigo accent. */
 .icon-btn-share {
-  color: var(--accent-2);
+  color: var(--accent-2) !important;
   border-color: rgba(99, 102, 241, 0.28);
   background: rgba(99, 102, 241, 0.07);
 }
@@ -2690,11 +2739,12 @@ tr:hover .icon-btn-share,
 tr:focus-within .icon-btn-share {
   background: rgba(99, 102, 241, 0.16);
   border-color: rgba(99, 102, 241, 0.45);
-  color: var(--accent-2);
+  color: var(--accent-2) !important;
 }
+.icon-btn-share:hover:active { background-color: rgba(99, 102, 241, 0.16); }
 .icon-btn-share:focus-visible {
   background: rgba(99, 102, 241, 0.16);
-  box-shadow: 0 0 0 2px var(--accent-soft);
+  box-shadow: 0 0 0 2px var(--accent-soft) !important;
 }
 
 /* Floating clipboard-confirmation pill — bottom center, doesn't affect layout. */
@@ -3188,6 +3238,8 @@ body.maptap-rivals-app select option {
   color: var(--text) !important;
 }
 .settings-btn:active { transform: translateY(0.5px); }
+/* Pressed: defeat main.css red press tint (danger pin below wins by order). */
+.settings-btn:hover:active { background-color: rgba(255, 255, 255, 0.045); }
 .settings-btn:focus-visible {
   outline: none;
   border-color: var(--accent);
@@ -3212,6 +3264,7 @@ body.maptap-rivals-app select option {
   background: rgba(248, 113, 113, 0.09);
   color: var(--bad) !important;
 }
+.settings-btn-danger:hover:active { background-color: rgba(248, 113, 113, 0.09); }
 .settings-btn-danger:focus-visible {
   border-color: var(--bad);
   box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.18) !important;
@@ -3291,6 +3344,8 @@ body.maptap-rivals-app select option {
   border: 0;
   background: transparent;
   color: var(--muted) !important;
+  /* main.css paints buttons with a gray/red inset ring + red press tint. */
+  box-shadow: none !important;
   font-size: 0;
   cursor: pointer;
   line-height: 1;
@@ -3303,10 +3358,11 @@ body.maptap-rivals-app select option {
   background: rgba(255, 255, 255, 0.06);
   color: var(--text) !important;
 }
+.modal-close:hover:active { background-color: rgba(255, 255, 255, 0.06); }
 .modal-close:focus-visible {
   outline: none;
   background: rgba(255, 255, 255, 0.06);
-  box-shadow: 0 0 0 2px var(--accent-soft);
+  box-shadow: 0 0 0 2px var(--accent-soft) !important;
 }
 .modal-close svg {
   width: 13px;
@@ -3401,10 +3457,19 @@ body.maptap-rivals-app select option {
   cursor: pointer;
   border: 0;
   padding: 0;
+  /* color pinned (no visible text) purely so main.css's gray/red button
+     text theme can't leak into computed styles. */
+  color: var(--text) !important;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
   transition: transform 0.15s ease, box-shadow 0.18s ease;
 }
-.color-swatch:hover { transform: scale(1.12); }
+.color-swatch:hover {
+  transform: scale(1.12);
+  color: var(--text) !important;
+  /* re-state the notch ring so main.css `button:hover` can't swap in its
+     red inset ring (.is-selected below wins its tie by order). */
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
 .color-swatch:focus-visible {
   outline: none;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25), 0 0 0 3px var(--accent-soft);
@@ -3426,6 +3491,10 @@ body.maptap-rivals-app select option {
   cursor: pointer;
   background: rgba(255, 255, 255, 0.025);
   border: 1px solid var(--border);
+  /* !important pins vs main.css gray/red button theme (color + inset ring
+     + press tint). */
+  color: var(--text) !important;
+  box-shadow: none !important;
   font-size: 0.98rem;
   line-height: 1;
   padding: 0;
@@ -3434,18 +3503,21 @@ body.maptap-rivals-app select option {
 .icon-swatch:hover {
   background: var(--surface-3);
   border-color: var(--border-strong);
+  color: var(--text) !important;
+  box-shadow: none !important;
   transform: translateY(-1px);
 }
+.icon-swatch:hover:active { background-color: var(--surface-3); }
 .icon-swatch:focus-visible {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: 0 0 0 3px var(--accent-soft) !important;
 }
 .icon-swatch.is-selected,
 .icon-swatch.is-selected:hover {
   background: var(--accent-soft);
   border-color: var(--accent);
-  color: var(--accent-2);
+  color: var(--accent-2) !important;
   transform: none;
 }
 
@@ -3472,6 +3544,8 @@ body.maptap-rivals-app select option {
   transition: background 0.15s ease, border-color 0.15s ease;
 }
 .my-icon-btn:hover { background: var(--surface-3); border-color: var(--border-strong); }
+/* Pressed: defeat main.css red press tint. */
+.my-icon-btn:hover:active { background-color: var(--surface-3); }
 .my-icon-btn:focus-visible {
   outline: none;
   border-color: var(--accent);
@@ -3504,16 +3578,21 @@ body.maptap-rivals-app select option {
   cursor: pointer;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--border);
+  /* !important pins vs main.css gray/red button theme (color + inset ring
+     + press tint). */
+  color: var(--text) !important;
+  box-shadow: none !important;
   font-size: 0.98rem;
   line-height: 1;
   padding: 0;
   transition: background 0.12s ease, border-color 0.12s ease;
 }
-.my-icon-swatch:hover  { background: var(--surface-3); border-color: var(--border-strong); }
+.my-icon-swatch:hover  { background: var(--surface-3); border-color: var(--border-strong); color: var(--text) !important; }
+.my-icon-swatch:hover:active { background-color: var(--surface-3); }
 .my-icon-swatch:focus-visible {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: 0 0 0 3px var(--accent-soft) !important;
 }
 .my-icon-swatch.is-selected,
 .my-icon-swatch.is-selected:hover {
@@ -3849,6 +3928,8 @@ body.maptap-rivals-app select option {
   border-radius: 999px;
   background: var(--surface-2);
   color: #fff !important;
+  /* main.css paints buttons with a gray/red inset ring + red press tint. */
+  box-shadow: none !important;
   opacity: 1;
   font: inherit;
   font-size: 0.85rem;
@@ -3857,6 +3938,7 @@ body.maptap-rivals-app select option {
   transition: transform 0.1s, background 0.15s, border-color 0.15s, color 0.15s;
 }
 .matrix-chip:hover { transform: translateY(-1px); color: #fff !important; }
+.matrix-chip:hover:active { background-color: var(--surface-2); }
 .matrix-chip.is-on { color: #fff !important; font-weight: 600; }
 
 .matrix-wrap {
@@ -4063,6 +4145,8 @@ body.maptap-rivals-app select option {
   border-radius: 999px;
   background: transparent;
   color: #fff !important;
+  /* main.css paints buttons with a gray/red inset ring + red press tint. */
+  box-shadow: none !important;
   font: inherit;
   font-size: 0.85rem;
   font-weight: 500;
@@ -4073,6 +4157,9 @@ body.maptap-rivals-app select option {
   background: var(--surface-2);
   color: #fff !important;
 }
+/* Pressed: defeat main.css red press tint; .is-active:hover below wins its
+   tie by order. */
+.matrix-subtab:hover:active { background-color: var(--surface-2); }
 .matrix-subtab.is-active,
 .matrix-subtab.is-active:hover {
   background: var(--accent-soft);

--- a/apps/mario-kart/css/course-picker.css
+++ b/apps/mario-kart/css/course-picker.css
@@ -206,6 +206,21 @@
     cursor: pointer;
 }
 
+/* Counter-pin against the main.css button trap (`button{color:#555!important}`,
+   `:hover{color:#ce1b28!important}`, `:hover:active{background:rgba(206,27,40,0.25)}`).
+   Without this, every course-row press flashes the site-red wash and the row
+   button's own color chain goes gray/red. Row highlight is owned by .cp-row,
+   so the button stays transparent across base / hover / pressed. */
+.course-picker .cp-course,
+.cp-modal .cp-course,
+.course-picker .cp-course:hover,
+.cp-modal .cp-course:hover,
+.course-picker .cp-course:hover:active,
+.cp-modal .cp-course:hover:active {
+    background: transparent !important;
+    color: var(--mk-text, #f1f3f8) !important;
+}
+
 /* Line 1: name (hero) + inline NEW badge — one unified line, no layout shift. */
 .course-picker .cp-line1 { display: flex; align-items: center; gap: 7px; min-width: 0; }
 .course-picker .cp-name {
@@ -271,6 +286,11 @@
 .course-picker .cp-row.cp-active .cp-fav { opacity: 1; }
 .course-picker .cp-fav:hover { color: var(--mk-text, #f1f3f8) !important; opacity: 1; }
 .course-picker .cp-fav.is-fav { color: #f59e0b !important; opacity: 1; }
+/* Pin the pressed state: defeat main.css `button:hover:active` red wash. */
+.course-picker .cp-fav:hover:active,
+.cp-modal .cp-fav:hover:active {
+    background: transparent !important;
+}
 
 .course-picker .cp-noresult {
     padding: 22px 12px;
@@ -370,6 +390,12 @@
     transition: background 0.1s ease, color 0.1s ease;
 }
 .cp-modal .cp-filter:hover { color: var(--mk-text, #f1f3f8) !important; }
+/* Pin the pressed state: defeat main.css `button:hover:active` red wash.
+   `.cp-filter.is-on` (0,3,0) already outranks the trap; the inactive chip
+   (0,2,0) does not, so pin its surface here. */
+.cp-modal .cp-filter:hover:active {
+    background: var(--mk-surface-3, #232836) !important;
+}
 .cp-modal .cp-filter:focus-visible { outline: 2px solid var(--mk-accent, #818cf8); outline-offset: 2px; }
 .cp-modal .cp-filter.is-on {
     color: #fff !important;
@@ -404,6 +430,10 @@
     border: none; border-radius: 999px; cursor: pointer;
 }
 .cp-modal .cp-rs-chip:hover { color: var(--mk-text, #f1f3f8) !important; }
+/* Pin the pressed state: defeat main.css `button:hover:active` red wash. */
+.cp-modal .cp-rs-chip:hover:active {
+    background: var(--mk-surface-3, #232836) !important;
+}
 
 /* ---- Clear (x) inside the search field ---- */
 .cp-modal .cp-search-clear { width: 22px; height: 22px; }
@@ -498,6 +528,10 @@
     border: 1px solid transparent; border-radius: 8px;
 }
 .cp-modal .cp-preview-fav:hover { color: var(--mk-text, #f1f3f8) !important; }
+/* Pin the pressed state: defeat main.css `button:hover:active` red wash. */
+.cp-modal .cp-preview-fav:hover:active {
+    background: var(--mk-surface-3, #232836) !important;
+}
 .cp-modal .cp-preview-fav.is-fav { color: #f59e0b !important; background: rgba(245, 158, 11, 0.10); border-color: rgba(245, 158, 11, 0.35); }
 .cp-modal .cp-preview-select {
     display: block; width: 100%; padding: 9px;
@@ -508,7 +542,12 @@
     transition: filter 0.1s ease;
 }
 .cp-modal .cp-preview-select:hover { filter: brightness(1.1); }
+/* Pin the pressed state: defeat main.css `button:hover:active` red wash. */
+.cp-modal .cp-preview-select:hover:active {
+    background: var(--mk-accent-strong, #6366f1) !important;
+}
 .cp-modal .cp-preview-select.is-selected { color: var(--mk-good, #34d399) !important; background: rgba(52, 211, 153, 0.12); }
+.cp-modal .cp-preview-select.is-selected:hover:active { background: rgba(52, 211, 153, 0.12) !important; }
 
 /* ---- Footer keyboard legend: barely there ---- */
 .cp-modal .cp-modal-foot {

--- a/apps/mario-kart/css/mario-kart-overrides.css
+++ b/apps/mario-kart/css/mario-kart-overrides.css
@@ -176,6 +176,24 @@ body.theme .pagination-btn.active:hover:not(:disabled) {
     line-height: 1;
 }
 
+/* Hover/pressed pins for the primary/secondary modal buttons. The base rules
+   below pin white text, but main.css `button:hover { color:#ce1b28 !important }`
+   (higher specificity) turned the labels red on hover, and
+   `button:hover:active { background: rgba(206,27,40,0.25) }` washed the fill
+   red on press. Pin both states to the buttons' own colors, mirroring the
+   .modal-btn-danger block further down. */
+.modal-btn-primary:hover,
+.modal-btn-primary:hover:active {
+    background: #8b5cf6 !important;
+    color: white !important;
+}
+
+.modal-btn-secondary:hover,
+.modal-btn-secondary:hover:active {
+    background: var(--modal-secondary-bg, #4a5568) !important;
+    color: white !important;
+}
+
 .modal-btn-secondary {
     background: var(--modal-secondary-bg, #4a5568);
     color: white !important;

--- a/apps/mario-kart/css/sidebar.css
+++ b/apps/mario-kart/css/sidebar.css
@@ -584,6 +584,12 @@ body.theme .sidebar-overlay {
     box-shadow: var(--shadow-md);
 }
 
+/* Pin the pressed state: main.css `button:hover:active` layers its red wash
+   (rgba(206,27,40,0.25)) behind the gradient; keep the button on its own fill. */
+.sidebar .custom-date-range button:hover:active {
+    background: var(--primary-gradient) !important;
+}
+
 /* Custom Date Error Message in Sidebar */
 .sidebar #custom-date-error {
     margin-top: 8px;
@@ -1198,6 +1204,17 @@ body.theme .sidebar-cancel-race:hover {
 
 .position-picker-toggle:active {
     transform: translateY(0);
+}
+
+/* White glyph pinned against the site-wide button trap in main.css
+   (`button { color:#555 !important }`, `:hover { color:#ce1b28 !important }`).
+   The visible glyph lives in .picker-icon (pinned white by the body.theme rule
+   below), but the button's own color chain went gray at rest and site-red on
+   hover/press; pin base/hover/active together so the trap can never surface. */
+body.mario-kart-app .position-picker-toggle,
+body.mario-kart-app .position-picker-toggle:hover,
+body.mario-kart-app .position-picker-toggle:hover:active {
+    color: white !important;
 }
 
 .picker-icon {

--- a/apps/rising-shows/css/kometa.css
+++ b/apps/rising-shows/css/kometa.css
@@ -356,6 +356,10 @@
   background: rgba(255, 255, 255, 0.05);
   box-shadow: none;
 }
+/* main.css `button:hover:active` (0,2,1) flashes a translucent red press
+   background; pin the press to the hover surface. Kept above the
+   .is-active rules so an active tab's own press styling still wins. */
+.kometa-output-tab:hover:active { background: rgba(255, 255, 255, 0.05); }
 .kometa-output-tab.is-active {
   background: rgba(245, 197, 24, 0.18);
   color: var(--accent-warm) !important;

--- a/apps/rising-shows/css/styles.css
+++ b/apps/rising-shows/css/styles.css
@@ -347,6 +347,34 @@ body.rising-shows-app button {
   border-color: var(--good);
 }
 
+/* ---------- Press-state background counter-pins ----------
+   main.css ~line 328 has `button:hover:active { background-color:
+   rgba(206, 27, 40, 0.25) }`, the site's translucent red press flash.
+   That selector (0,2,1) outweighs our single-class :hover rules (0,2,0),
+   so every button pins its press background explicitly at (0,3,0)+. Each
+   value repeats the control's own hover background: a press keeps the
+   hover surface, and the :active transform rules stay the only visible
+   press feedback. */
+.btn:hover:active { background-color: var(--surface-2); }
+.btn-primary:hover:active { background-color: transparent; }
+.view-btn:hover:active { background-color: var(--surface-3); }
+.view-btn[aria-pressed="true"]:hover:active { background-color: var(--accent); }
+.modal-close:hover:active,
+.modal-back:hover:active { background-color: rgba(255, 255, 255, 0.16); }
+.watch-btn.is-watched:hover:active,
+.compare-btn.is-in-compare:hover:active { background-color: var(--good); }
+.watch-toggle:hover:active { background-color: rgba(0, 0, 0, 0.75); }
+.watch-toggle[aria-pressed="true"]:hover:active { background-color: var(--good); }
+.shape-chip:hover:active { background-color: rgba(245, 197, 24, 0.06); }
+.shape-chip[aria-pressed="true"]:hover:active { background-color: rgba(245, 197, 24, 0.12); }
+.mood-chip:hover:active { background-color: rgba(245, 197, 24, 0.06); }
+.mood-chip[aria-pressed="true"]:hover:active { background-color: rgba(245, 197, 24, 0.12); }
+.advanced-reset:hover:active { background-color: rgba(248, 113, 113, 0.2); }
+.whats-new-chip:hover:active { background-color: rgba(245, 197, 24, 0.14); }
+.shortcut-legend-btn:hover:active { background-color: var(--accent); }
+.poster-reveal:hover:active { background-color: rgba(7, 9, 15, 0.22); }
+.active-filter-chip:hover:active { background-color: var(--accent-soft); }
+
 /* ---------- Page layout ---------- */
 
 .page {
@@ -1463,6 +1491,9 @@ body.rising-shows-app button {
   padding: 0;
   border: 0;
   background: transparent;
+  /* Pin away main.css's gray/red 1px inset button ring, which otherwise
+     frames the whole poster. */
+  box-shadow: none !important;
   line-height: 1;
   cursor: pointer;
   font: inherit;
@@ -2289,7 +2320,15 @@ button.shape-tag.is-clickable:hover {
 }
 .compare-fab[hidden] { display: none; }
 .compare-fab:hover,
-.compare-fab:hover:active { color: #1a1300 !important; background: var(--accent); }
+.compare-fab:hover:active {
+  color: #1a1300 !important;
+  background: var(--accent);
+  /* Repeat the base shadow: main.css `button:hover` otherwise swaps the
+     FAB's lift for its red 1px inset ring. */
+  box-shadow:
+    0 10px 24px rgba(0, 0, 0, 0.45),
+    0 2px 8px rgba(245, 197, 24, 0.35);
+}
 .compare-fab:hover { transform: translateY(-1px); }
 .compare-fab-icon { font-size: 1.05rem; }
 .compare-fab-count {
@@ -4319,7 +4358,10 @@ body.advanced-drawer-open {
   border-radius: 999px;
   border: 1px solid var(--border-strong);
   background: var(--surface-2);
-  color: var(--text);
+  /* !important twins defeat main.css `button { color: #555 !important;
+     box-shadow: inset 0 0 0 1px #555 }` and its red hover variants. */
+  color: var(--text) !important;
+  box-shadow: none !important;
   font-size: 0.88rem;
   cursor: pointer;
   line-height: 1;
@@ -4327,6 +4369,8 @@ body.advanced-drawer-open {
 .active-filter-chip:hover {
   border-color: var(--accent-strong);
   background: var(--accent-soft);
+  color: var(--text) !important;
+  box-shadow: none !important;
 }
 .active-filter-chip .chip-key {
   color: var(--accent);
@@ -4447,7 +4491,10 @@ body.advanced-drawer-open {
 .shortcut-legend-btn:hover,
 .shortcut-legend-btn[aria-expanded="true"] {
   background: var(--accent);
-  color: var(--accent-ink);
+  /* !important: the button also carries .btn, whose `color: var(--text)
+     !important` counter-pin (itself needed against main.css) would
+     otherwise leave light text on the yellow hover surface. */
+  color: var(--accent-ink) !important;
   border-color: var(--accent);
 }
 .shortcut-legend {
@@ -4862,6 +4909,9 @@ body.advanced-drawer-open {
   background: var(--surface-2) !important;
   color: var(--muted) !important;
   border: 1px solid var(--border) !important;
+  /* main.css buttons carry `box-shadow: inset 0 0 0 1px #555` (red on
+     hover); without a pin these pills render that stray inner ring. */
+  box-shadow: none !important;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
@@ -4870,6 +4920,7 @@ body.advanced-drawer-open {
   background: var(--surface-3) !important;
   color: var(--text) !important;
   border-color: var(--border-strong) !important;
+  box-shadow: none !important;
 }
 
 .finder-chip[aria-pressed="true"],

--- a/apps/trip-planner/css/styles.css
+++ b/apps/trip-planner/css/styles.css
@@ -519,7 +519,10 @@
   .trip-planner-app .visa-remind:hover { color: var(--accent) !important; }
   .trip-planner-app .doc-remove { color: var(--text-faint) !important; }
   .trip-planner-app .doc-remove:hover { color: var(--red) !important; }
-  .trip-planner-app .rates-retry { color: var(--accent) !important; }
+  .trip-planner-app .rates-retry,
+  .trip-planner-app .rates-retry:hover { color: var(--accent) !important; }
+  .trip-planner-app .toast button,
+  .trip-planner-app .toast button:hover { color: var(--accent) !important; }
   .trip-planner-app button:disabled { color: var(--text-faint) !important; }
   /* main.css also flashes rgba-red backgrounds on :hover:active */
   .trip-planner-app button:hover:active { background-color: transparent; }
@@ -530,6 +533,14 @@
   .trip-planner-app .tp-menu-panel button:hover:active { background-color: var(--accent-soft); }
   .trip-planner-app .view-switch button.on:hover:active,
   .trip-planner-app .type-picker button.on:hover:active { background-color: var(--accent); }
+  /* ...and a 1px red inset ring on every button hover, a red hover
+     background on .primary buttons, and a red focus ring on text fields
+     (none of those are !important, so specificity pins suffice) */
+  .trip-planner-app button:hover { box-shadow: none; }
+  .trip-planner-app .btn.primary:hover { background-color: var(--accent); }
+  .trip-planner-app input:focus,
+  .trip-planner-app select:focus,
+  .trip-planner-app textarea:focus { box-shadow: none; }
 
   /* ---------- view switch ---------- */
   .view-switch {

--- a/apps/trip-planner/index.html
+++ b/apps/trip-planner/index.html
@@ -43,7 +43,7 @@
   <meta name="theme-color" content="#0e1116">
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
-  <link rel="stylesheet" href="css/styles.css?v=16">
+  <link rel="stylesheet" href="css/styles.css?v=17">
 </head>
 <body class="tp-page">
   <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>
@@ -421,6 +421,6 @@
   </script>
 
   <script src="js/trip-logic.js?v=5"></script>
-  <script src="js/app.js?v=17"></script>
+  <script src="js/app.js?v=18"></script>
 </body>
 </html>

--- a/apps/trip-planner/js/app.js
+++ b/apps/trip-planner/js/app.js
@@ -2,7 +2,7 @@
 (() => {
 
   // ---------- constants ----------
-  const TP_BUILD = 17; // bump with every asset-version bump; shown in the footer
+  const TP_BUILD = 18; // bump with every asset-version bump; shown in the footer
   const LS_KEY = 'trip-planner:v1';
   const THEME_KEY = 'trip-planner:theme';
   const TIMEFMT_KEY = 'trip-planner:timefmt';

--- a/apps/trip-planner/sw.js
+++ b/apps/trip-planner/sw.js
@@ -17,7 +17,7 @@
  * MINOR when the strategy changes, MAJOR for a back-compat break.
  */
 
-const CACHE_VERSION = '2.0.2';
+const CACHE_VERSION = '2.0.3';
 const PRECACHE = `trip-precache-${CACHE_VERSION}`;
 const RUNTIME = `trip-runtime-${CACHE_VERSION}`;
 
@@ -25,9 +25,9 @@ const PRECACHE_URLS = [
   './',
   './index.html',
   './manifest.webmanifest',
-  './css/styles.css?v=16',
+  './css/styles.css?v=17',
   './js/trip-logic.js?v=5',
-  './js/app.js?v=17',
+  './js/app.js?v=18',
   '../../assets/css/main.css',
   '../../assets/css/sync-status.css',
   '../../assets/js/passive-events-fix.js',


### PR DESCRIPTION
Third sitewide theme-collision sweep (after #187, #194). Every page linking `assets/css/main.css` was probed with rendered computed styles in headless Chrome (never CSS source) in default, hover, pressed, and focus states at 1280x900 and 390x844, using selector-rewrite simulation (`:hover`/`:active`/`:focus` re-emitted as marker classes), transitions disabled during measurement, and canary controls validating each probe run. Trap signatures flagged: text `rgb(85,85,85)`, text `rgb(206,27,40)`, gray/red inset rings, pressed `rgba(206,27,40,0.25)` washes, focus `border-color rgb(206,27,40)`. Full audit report archived at `.features/archive/theme-collision-audit-2026-07-18.md` (local).

## Changes by app (complete diff)

### Arena
- `apps/arena/css/styles.css` (+48/-5)
  - `.btn` / `.btn-primary` / `.btn-ghost`: `:hover:active` background pins (red press wash on every room control, chat Send, settings, ready, rematch, share, confirm dialogs).
  - `.btn-icon-danger` (admin leaderboard remove): color and shadow pins across base/hover, press pin (was gray base, red hover).
  - `.btn-danger-ghost` (End game, Decline): base+hover pinned to intended pink; it was rendering the default text color, eaten by the app's own earlier `.btn` counter-pins. `.btn-danger` (confirm modal): white text pinned on hover (was computing the primary button's dark teal).
  - `.globe-drop-fab-primary/-ghost`: press background pins (red wash visible through the semi-transparent ghost FAB).
  - `.pick-cat-btn` / `.answer-btn` (incl. `.is-picked`): gray ring removed, hover color and press background pinned (trivia answers had gray rings and went red on hover/press).
  - `.globe-drop-reveal-wiki` base+hover selectors bumped to `.globe-drop-reveal .globe-drop-reveal-wiki` so its declared cyan beats the app's generic `body.brain-arena-app a` rule (it rendered violet), plus `text-decoration: none` on hover (the generic underline also outranked it). This one is an app-internal specificity fix surfaced by the audit, owner-approved.

### Football H2H
- `apps/football-h2h/css/refresh.css` (+15)
  - `.pagination-btn`: `box-shadow: none !important` (gray ring showed through; prior round pinned color/bg but not shadow) plus hover/press re-pin of the intended indigo lift shadow.
- `apps/football-h2h/css/football-h2h.css` (+20/-2)
  - `.modal-btn-primary` (session-summary Copy): white text pinned on hover and press (went red).
  - `.modal-btn-secondary` (Close/Cancel): gray/red rings removed, press keeps its own `#4a5568` instead of the red wash.
  - `.modal-btn-danger` (Delete): gray/red ring removed from its red fill; press already protected by the existing `#b91c1c` pin.

### Gym Tracker
- `apps/gym-tracker/css/refresh.css` (+105), appended to the existing THEME-COLLISION GUARDS section
  - `.set-toggle` (active-workout W/F pills): full pin set (was gray text, red hover ring, red press).
  - `.schedule-day-chip` (program modal Mon-Sun): gray/red double ring removed, press pinned, focus ring re-pinned.
  - `.workout-fab` and `.more-item`: color pins across states. These looked correct in prod only because a span-level rule masked the defeated button color; pinned properly to remove the fragile masking.
  - Press-wash counters for `.calendar-day` (+`.future`/`.has-workout`), `.dark-select-trigger`, `.dark-calendar-trigger`, `.achievement-category-header`, `.achievement-bulk-btn`, `.btn-save-settings`, `.btn-remove-set`, `.btn-add-set--extra`.

### MapTap Rivals
- `apps/maptap-rivals/css/styles.css` (+113/-26), widest exposure of any app
  - App-wide focus baseline (`body.maptap-rivals-app input/select/textarea:focus`) pinning the app accent, placed early so specific focus styles still win by order; kills red focus borders/halos on the name input, page-size selects, matrix sort, WhatsApp sender select, profile-prompt input, paste textareas, and modal fields.
  - Press-wash counters for the `.btn` family, view tabs, settings buttons, modal close, matrix chips/subtabs, prediction day/location tabs, icon buttons, swatches, rival-card edit/sync.
  - Gray/red text and ring pins on `.icon-btn`/`-danger`/`-share`, `.icon-swatch`, `.my-icon-swatch`, `.color-swatch`, `.rival-card-edit/-sync`, `.pred-day-tab` (incl. `tr:hover` row-lift and `.is-loading`/`.is-selected` variants; focus rings promoted to `!important` so the blanket shadow removal cannot eat them).
  - Ordering discipline: every press pin sits before its `.is-active`/`.is-selected`/`-danger` sibling so state variants keep winning equal-specificity ties.

### Mario Kart
- `apps/mario-kart/css/course-picker.css` (+39)
  - `.cp-course` (every course row, inline + modal scopes): was gray text with red hover/press flash; pinned to `--mk-text` with transparent base.
  - Press pins for `.cp-filter` chips, `.cp-fav` stars, `.cp-rs-chip` recent-search chips, `.cp-preview-fav`, `.cp-preview-select` (incl. `.is-selected`).
- `apps/mario-kart/css/mario-kart-overrides.css` (+18)
  - `.modal-btn-primary` / `.modal-btn-secondary` (Save Changes, Restore Data, Cancel): hover and press pinned to their own fills with white text (went red), mirroring the existing `.modal-btn-danger` block. Judgment call: hover pins the base fill with no darkening because the app never defined hover shades for these two; no new colors were invented.
- `apps/mario-kart/css/sidebar.css` (+17)
  - Custom date-range Apply: press pin (wash currently invisible behind its opaque gradient; pinned for correctness).
  - `.position-picker-toggle`: white pinned across states (button color was gray/red; only the glyph was saved by a child pin).

### Rising Shows
- `apps/rising-shows/css/styles.css` (+57/-4)
  - New press-state counter-pin block: one `:hover:active` background per control repeating its hover surface (mood chips, view toggle, Surprise/Popular pick/legend/reset, all modal close/back, share, watch, compare, related-more toggle, whats-new chip, shape chips, watch toggle, poster reveal, active-filter chip). Note: `.watch-toggle` is currently unreferenced CSS; pinned for consistency with its siblings.
  - `.finder-seg-btn` / `.finder-chip` (incl. Hidden gems): gray/red inset rings removed.
  - `.active-filter-chip`: text color and ring pinned (its non-important color lost to main.css).
  - `.compare-fab`: hover/press re-state the two-layer lift shadow (hover collapsed it to a red ring).
  - `.shortcut-legend-btn`: hover/expanded ink pinned to `--accent-ink` (was rendering light text on the yellow hover, a casualty of the app's own `.btn` counter-pin).
  - `.poster-reveal` (sensitive-poster overlay): gray/red ring removed.
- `apps/rising-shows/css/kometa.css` (+4)
  - `.kometa-output-tab:hover:active` background pin, placed before the `.is-active` rules so active-tab styling still wins (file tabs and copy/download buttons flashed red on press).

### Trip Planner
- `apps/trip-planner/css/styles.css` (+10/-3). The PR #277 pin round held everywhere (no gray text, no red press flash); four misses fixed:
  - `button:hover { box-shadow: none }` app-scope pin: every non-primary button got a red inset ring on hover (main.css `(0,1,1)` beat the app's zero-specificity `:where()` reset).
  - `.btn.primary:hover` background pinned to `var(--accent)`: every primary outside the toolbar hovered theme-red (only the toolbar was saved by specificity). Preserves the intended brightness(1.08) hover effect.
  - `input/select/textarea:focus { box-shadow: none }`: the search box showed the theme's red focus ring.
  - Toast Undo and rates-retry hover: accent color restored; both were casualties of the app's own PR #277 blanket button pin, not of main.css directly.
- `apps/trip-planner/index.html` (+2/-2), `apps/trip-planner/js/app.js` (+1/-1), `apps/trip-planner/sw.js` (+3/-3): cache chain bumped per the app's convention (styles.css v16 to v17, app.js v17 to v18 / TP_BUILD 18, service-worker CACHE_VERSION 2.0.2 to 2.0.3 with precache URLs updated). Hard-reload once after deploy to pick up the new service worker.

## Explicitly untouched
- `assets/css/main.css` and all shared partials/chrome (#header, #footer, #menu, sign-out modal, back-to-top): the gray/red theme is intentional there and out of scope by design.
- Root site pages (home, apps, work, about, contact, moadon-alef, 404, index): audited clean at both viewports; existing pins in `site.css` and `moadon-alef-theme.css` verified against rendered output. Zero changes.
- Gym Tracker exercise pages (500+) and Rising Shows show pages: do not link main.css, not exposed.
- Gym Tracker `.toggle-switch` checkboxes and kometa native checkboxes/radios/range slider: compute the trap colors but are `opacity:0` overlays or `appearance:auto` widgets where nothing rendered is affected; left unpinned to keep the diff minimal.
- App-internal reds (Mario Kart achievements/danger, H2H loss cards, trip-planner danger/gap tokens): the apps' own palettes, not the theme red.
- Leaflet map chrome in trip-planner: styled by Leaflet's own stylesheet, no collision.
- `apps/trip-planner/js/app.js:5` stale comment ("shown in the footer") noticed but left; docs-only nit unrelated to this sweep.

## Judgment calls
- Press-state backgrounds reuse each control's hover surface where the app defines no distinct pressed shade (MapTap Rivals app-wide, several Gym Tracker controls). On touch devices this shows a brief hover-tint during tap where the base surface previously stayed; matches the pattern already used by pinned controls in the repo. Owner reviewed and kept.
- Mario Kart modal primary/secondary hover pins the base fill (no invented darkening); owner reviewed and kept.
- Rising Shows `.whats-new-chip` press and `.poster-reveal` ring fixes are CSS-derivation-verified (their states are unreachable in a fresh headless profile); identical pin pattern to the measured fixes.
- Living `.features/` plan pairs were not modified: per the convention established by the 2026-06-13/14 audits, a cross-app audit round ships as a self-contained dated report (now in `.features/archive/theme-collision-audit-2026-07-18.md`), not as per-app plan rounds.

## Testing
- `npm test`: 1175/1175 pass on the final tree (and after each app's fixes during the audit).
- Every fix re-verified with the identical computed-style probe after a cache-busted reload: zero trap flags across all apps at both viewports (trip-planner additionally verified in dark theme; arena's 7 residual desktop flags are a `display:none` mobile-only toggle that is fully pinned where it actually renders).
- Before/after screenshot evidence with in-page computed-value banners was reviewed during the audit and cleaned up before commit per the ship convention; the archived report retains all proof values (computed rgb() before/after per element).
