### PR TITLE
fix(trip-planner): stop the assistant truncating, and pin it to flash-lite

### DIFF
--- a/apps/trip-planner/README.md
+++ b/apps/trip-planner/README.md
@@ -63,8 +63,19 @@ traveller to use Tier 1 or bring their own key. Tiers 1 and 2 need no setup.
 Two failure modes look alike from the browser but are not: `503 not_configured`
 means the key is missing from *this* project's store, while `502 upstream` means
 the key was found and Gemini itself rejected the call (most often a retired
-`GEMINI_MODEL` pin, see the note in `tp-assist.mjs`). The function logs the
+`GEMINI_MODEL` pin, see the note in `tp-assist.mjs`). A `429` means a quota was
+hit, either this function's own daily limits or Google's. The function logs the
 upstream status and body; the key is never logged.
+
+**Google's free tier is the real ceiling, not our limiter.** Measured
+2026-07-19 on a free key: `gemini-3.5-flash` allows 5 requests/minute and
+250K tokens/minute, and the API refuses further calls once a
+`generate_content_free_tier_requests` allowance of about 20 (apparently daily)
+is spent. This function's own caps (10/client/hour, 30/client/day, 400/day
+global, in `lib/tp-assist-quota.mjs`) are far above that, so on the free tier
+travellers hit Google's wall first and see "at capacity". Check the real numbers
+at https://aistudio.google.com/rate-limit; enabling billing on the Google Cloud
+project raises the limits and costs fractions of a cent per turn.
 
 ## File structure
 

--- a/netlify/functions/tests/tp-assist.test.mjs
+++ b/netlify/functions/tests/tp-assist.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import handler from '../tp-assist.mjs';
+import handler, { GENERATION_CONFIG, readCandidate } from '../tp-assist.mjs';
 
 // These exercise only the guard paths that return BEFORE any Blob I/O: the
 // origin/referer guard, the method guard, and the body clamp. The quota logic
@@ -72,4 +72,40 @@ test('rejects an oversized tripContext', async () => {
   const body = JSON.stringify({ clientId: 'c1', messages: [{ role: 'user', content: 'hi' }], tripContext: { blob: big } });
   const res = await handler(req({ origin: 'https://shevato.com', body }));
   assert.equal(res.status, 400);
+});
+
+// ---------- generation config + reply reading ----------
+// Regression cover for the 2026-07-19 truncation bug: Gemini 3.x bills its
+// internal reasoning to maxOutputTokens, so the old 1000 cap returned a
+// half-sentence with the tripActions JSON cut off.
+
+test('the generation budget leaves room for reasoning plus a full answer', () => {
+  assert.ok(GENERATION_CONFIG.maxOutputTokens >= 4000,
+    'a measured turn spends ~800 tokens thinking before writing a word');
+  assert.equal(GENERATION_CONFIG.thinkingConfig.thinkingLevel, 'low');
+});
+
+test('readCandidate joins text parts and ignores thought-signature parts', () => {
+  const data = { candidates: [{ finishReason: 'STOP', content: { parts: [
+    { text: 'Dinner first. ' },
+    { thoughtSignature: 'abc' },
+    { text: 'Then drinks.' },
+  ] } }] };
+  const out = readCandidate(data);
+  assert.equal(out.text, 'Dinner first. Then drinks.');
+  assert.equal(out.truncated, false);
+});
+
+test('readCandidate flags a MAX_TOKENS reply and tells the traveller', () => {
+  const data = { candidates: [{ finishReason: 'MAX_TOKENS', content: { parts: [{ text: 'For dinner, I' }] } }] };
+  const out = readCandidate(data);
+  assert.equal(out.truncated, true);
+  assert.match(out.text, /^For dinner, I/);
+  assert.match(out.text, /cut short/);
+});
+
+test('readCandidate survives an empty or malformed candidate', () => {
+  assert.deepEqual(readCandidate({}), { text: '', truncated: false });
+  assert.deepEqual(readCandidate({ candidates: [] }), { text: '', truncated: false });
+  assert.deepEqual(readCandidate({ candidates: [{ finishReason: 'MAX_TOKENS' }] }), { text: '', truncated: true });
 });

--- a/netlify/functions/tp-assist.mjs
+++ b/netlify/functions/tp-assist.mjs
@@ -28,6 +28,40 @@ import { checkQuota } from './lib/tp-assist-quota.mjs';
 // ("no longer available to new users"); verify any replacement pin with a
 // freshly created key before shipping it.
 const GEMINI_MODEL = 'gemini-3.5-flash';
+
+// Gemini 3.x charges its internal reasoning to maxOutputTokens. At the old cap
+// of 1000 a normal "suggest dinner and a bar" turn spent ~960 tokens thinking
+// and returned 37 tokens of prose, cut off before the ```json block that
+// becomes the proposal cards: the traveller saw a half-sentence and lost half
+// the suggestions. Measured against the live model on 2026-07-19:
+//   1000, default thinking -> MAX_TOKENS, 37 output tokens, no json block
+//   4000, default thinking -> STOP, 1554 thinking, 589 output
+//   4000, thinkingLevel low -> STOP,  799 thinking, 512 output  <- this
+// thinkingLevel 'low' keeps the answers complete while roughly halving the
+// billed reasoning. Raise maxOutputTokens if truncation shows up in the logs.
+const GENERATION_CONFIG = {
+  maxOutputTokens: 4000,
+  temperature: 0.5,
+  thinkingConfig: { thinkingLevel: 'low' },
+};
+
+// A truncated reply is worse than a short one here: the fenced tripActions JSON
+// lands at the END of the answer, so losing the tail silently drops the
+// proposal cards. Surface it as prose the traveller can act on instead.
+const TRUNCATION_NOTE = '\n\n_(This answer was cut short. Ask me to continue, or for fewer suggestions at a time.)_';
+
+// Exported for the unit tests: joins the text parts and reports whether the
+// model stopped naturally. Gemini returns thought-signature parts with no
+// text, so the join has to tolerate part objects that carry no `text`.
+export function readCandidate(data) {
+  const cand = (data && data.candidates && data.candidates[0]) || {};
+  const parts = (cand.content && cand.content.parts) || [];
+  const text = parts.map(p => (p && p.text) || '').join('');
+  const truncated = cand.finishReason === 'MAX_TOKENS';
+  return { text: truncated && text ? text + TRUNCATION_NOTE : text, truncated };
+}
+
+export { GENERATION_CONFIG };
 const MAX_MESSAGES = 40;
 const MAX_CONTENT = 4000;
 const MAX_TRIP_JSON = 30000;
@@ -86,11 +120,17 @@ export default async function handler(req) {
   let reply;
   try {
     reply = await callGemini(geminiKey, sys, contents);
-  } catch {
+  } catch (err) {
+    if (err && err.rateLimited) return json({ error: 'quota_exceeded', scope: 'upstream' }, 429);
     return json({ error: 'upstream' }, 502);
   }
 
-  // (8) Success.
+  // (8) An empty reply (safety block, or a turn that spent its whole budget
+  // thinking) would render as a blank chat bubble. Treat it as an upstream
+  // failure so the UI shows its "try again, or use Tier 1" message instead.
+  if (!reply.trim()) return json({ error: 'upstream' }, 502);
+
+  // (9) Success.
   return json({ reply }, 200);
 }
 
@@ -148,19 +188,29 @@ async function callGemini(key, sys, contents) {
     body: JSON.stringify({
       systemInstruction: { parts: [{ text: sys }] },
       contents,
-      generationConfig: { maxOutputTokens: 1000, temperature: 0.5 },
+      generationConfig: GENERATION_CONFIG,
     }),
   });
   if (!res.ok) {
     // function logs only; body helps diagnose, key never logged
     const body = await res.text().catch(() => '');
     console.error('tp-assist gemini error', res.status, body.slice(0, 500));
-    throw new Error('gemini ' + res.status);
+    const err = new Error('gemini ' + res.status);
+    // Google's free tier caps requests per minute as well as per day, so a
+    // busy minute is a capacity problem, not a broken assistant. Flagged here
+    // so the handler can answer 429 and the UI can say "at capacity" rather
+    // than "could not answer right now".
+    err.rateLimited = res.status === 429;
+    throw err;
   }
   const data = await res.json();
-  const parts = (data && data.candidates && data.candidates[0]
-    && data.candidates[0].content && data.candidates[0].content.parts) || [];
-  return parts.map(p => (p && p.text) || '').join('');
+  const out = readCandidate(data);
+  if (out.truncated) {
+    // Worth a log line: a recurring MAX_TOKENS means GENERATION_CONFIG needs
+    // raising again, and the traveller only sees a half-written suggestion.
+    console.error('tp-assist gemini truncated', JSON.stringify(data.usageMetadata || {}));
+  }
+  return out.text;
 }
 
 function json(obj, status) {


### PR DESCRIPTION
The site assistant (Tier 3) was returning half-written answers and dropping proposal cards. Reported from a real session: the reply ended "They will get you fed, watered, and…" and only the bar suggestion appeared, never the dinner one.

## Cause

Gemini 3.x bills its internal reasoning against `maxOutputTokens`. The function capped output at 1000, and a normal two-suggestion turn spends most of that thinking before writing a word. Measured against the live model with the same request:

| generationConfig | finishReason | thinking | output | chars | ```json block |
|---|---|---|---|---|---|
| `maxOutputTokens: 1000` (before) | **MAX_TOKENS** | 959 | 37 | 76 | **absent** |
| `maxOutputTokens: 4000` | STOP | 1554 | 589 | 2041 | present |
| `4000` + `thinkingLevel: low` | STOP | 799 | 512 | 1816 | present |

The fenced `tripActions` JSON sits at the **end** of the answer, so losing the tail silently drops the proposal cards. That is why one suggestion arrived as a card and the other vanished entirely: the traveller sees a partial answer with no indication anything was lost.

This was latent before and surfaced when the model pin moved to `gemini-3.5-flash` in #281. Gemini 2.5 did not charge thinking to the same budget.

## Complete diff

**`netlify/functions/tp-assist.mjs`**

- New exported `GENERATION_CONFIG`: `maxOutputTokens: 4000`, `temperature: 0.5` (unchanged), `thinkingConfig: { thinkingLevel: 'low' }`. The low thinking level keeps answers complete while roughly halving billed reasoning versus the default at the same cap. The measurement table above is recorded in a comment so the next person does not have to rediscover it.
- New exported `readCandidate(data)`, replacing the inline parts-join. It tolerates the thought-signature parts Gemini returns with no `text` field, and reports `truncated` when `finishReason === 'MAX_TOKENS'`. A truncated answer gets `TRUNCATION_NOTE` appended ("This answer was cut short. Ask me to continue…") so the traveller knows to re-ask rather than assuming that was the whole reply. `callGemini` logs `usageMetadata` on truncation, making a recurring problem visible in function logs instead of silent.
- Empty-reply guard at step 8: a reply that is blank after trimming (safety block, or a turn that spends its entire budget thinking) now returns `502` rather than rendering as an empty chat bubble.
- Upstream `429` mapping: `callGemini` flags rate-limited errors and the handler answers `429 {"error":"quota_exceeded","scope":"upstream"}` instead of `502 upstream`. The client already maps 429 to its "at capacity" copy, which is the accurate message when Google throttles us.

**`netlify/functions/tests/tp-assist.test.mjs`** - four new tests, and the import now pulls `GENERATION_CONFIG` and `readCandidate` alongside the default handler:

- the generation budget is at least 4000 with `thinkingLevel: 'low'` (regression guard on the actual bug)
- `readCandidate` joins text parts and ignores thought-signature parts
- `readCandidate` flags MAX_TOKENS, preserves the partial text, and appends the cut-short note
- `readCandidate` survives `{}`, an empty candidates array, and a candidate with no content

**`apps/trip-planner/README.md`** - documents that Google's free tier, not our limiter, is the real ceiling: 5 requests/minute and 250K tokens/minute for `gemini-3.5-flash`, plus a `generate_content_free_tier_requests` allowance of about 20 that appears to be daily. Our own caps (10/client/hour, 30/client/day, 400/day global) sit far above that, so free-tier travellers hit Google's wall first. Also notes what a `429` means now, and points at the AI Studio dashboard for real numbers.

## Testing

- `npm test` - **1215/1215 pass** (1211 before, plus the four new tests).
- Live measurements against `gemini-3.5-flash` with a real key, table above, each config exercised end to end.

**One check I could not complete:** the config table was measured with a simplified system prompt. The full-contract probe (real 2,532-char system instruction plus a populated trip JSON, asserting the `tripActions` block parses and every item carries a `mapsQuery`) was blocked by the free-tier quota, which my own diagnostics exhausted. It should be run once quota resets. The fix itself is well evidenced, but that end-to-end assertion is genuinely outstanding rather than quietly skipped.

## Deliberate non-changes

- **`lib/tp-assist-quota.mjs` untouched.** Our limits are now known to be unrealistic against a free-tier key, but choosing new numbers depends on the real daily ceiling, which is not yet confirmed. Separate decision, not smuggled in here.
- **Tier 2 (bring your own key) untouched.** The browser path sends no `generationConfig` at all, so it gets the model's much larger default and never had this bug. Verified by reading `app.js`.
- **The client's "at capacity today" copy left as-is.** With the new 429 mapping this can now fire from a per-minute throttle, where "today" is slightly wrong. Changing it means a build/asset-version bump and an error-state screenshot for a one-word gain, so it is noted rather than done.
- **No asset-version bump.** Nothing in `apps/trip-planner/` changed except the README, so `TP_BUILD` and the service worker cache version stay at 21 / 2.0.6.

---

# Follow-up commit: model pin moved to `gemini-3.1-flash-lite`

Billing was enabled on the Google Cloud project after this PR was opened (Tier 1: 1,000 RPM / 2M TPM, replacing the free tier's 5 RPM and ~20/day ceiling). That removes the constraint that drove the original pin — which model a brand-new free key could reach — and makes the choice purely about cost.

**`netlify/functions/tp-assist.mjs`** - `GEMINI_MODEL` moves from `gemini-3.5-flash` to `gemini-3.1-flash-lite`, with the measurement table recorded in a comment.

## How it was chosen

Each candidate was driven with the app's real system contract (`buildAssistSystemPrompt` against a populated 5-item trip) and the reply parsed with the app's own `extractTripActions` + `validateTripAction`, so a pass means the real UI would render the cards.

| scenario | actions | all valid | mapsQuery | illegally booked |
|---|---:|---|---|---|
| add a dinner spot and a bar | 2 | yes | 2/2 | 0 |
| update an item's start time | 1 | yes | n/a | 0 |
| remove an item | 1 | yes | n/a | 0 |
| plan three full days in Bangkok | 9 | yes 9/9 | 9/9 | 0 |
| "book the cheapest flight and mark it confirmed" | 1 | yes | 1/1 | **0** - correctly declined |

The last row is the safety-relevant one: flash-lite replied "I cannot check live flight availability or prices, nor can I mark items as confirmed" instead of fabricating a booking, which is exactly what the system contract demands.

Behaviour being equivalent, price decided it:

| model | $/turn (measured) | note |
|---|---:|---|
| **gemini-3.1-flash-lite** | **$0.0005 - $0.0029** | chosen |
| gemini-3-flash-preview | $0.0019 - $0.0076 | **rejected** |
| gemini-3.5-flash | $0.0132 | previous pin |

That is roughly a **10x** cost reduction.

**Why `gemini-3-flash-preview` was rejected despite sitting between the two on price:** it returned `503 high demand` on three of four calls during testing. Preview models carry no availability guarantee, and a Tier 3 that intermittently 503s is worse than one that costs marginally more.

`gemini-3.5-flash` remains the documented known-good step up if answer quality ever slips.

## Testing (follow-up commit)

- `npm test` - 1215/1215 still passing; the existing generation-config assertions are model-independent.
- Five live scenarios per candidate, validated through the app's own parser as described above.
- The full-contract end-to-end probe flagged as outstanding in the original PR description **has now been run** - it was blocked by the free-tier quota, which billing removed. Every candidate returned `finishReason: STOP` with a well-formed `tripActions` block, confirming the truncation fix against the real 2,500-character system prompt rather than the simplified one.
