### PR TITLE
fix(trip-planner): pin the site assistant to gemini-3.1-flash-lite

### DIFF
--- a/netlify/functions/tp-assist.mjs
+++ b/netlify/functions/tp-assist.mjs
@@ -27,7 +27,19 @@ import { checkQuota } from './lib/tp-assist-quota.mjs';
 // surfaces here as a generic 502 upstream. gemini-2.5-flash reached that state
 // ("no longer available to new users"); verify any replacement pin with a
 // freshly created key before shipping it.
-const GEMINI_MODEL = 'gemini-3.5-flash';
+//
+// Pinned to flash-lite on cost: measured 2026-07-19 against the real system
+// contract, every candidate held the tripActions format (add / update / remove
+// / a 9-item multi-day plan, all passing validateTripAction, and all correctly
+// refusing a "mark it confirmed" request), so the only difference was price:
+//   gemini-3.1-flash-lite    $0.0005-0.0029 per turn   <- this
+//   gemini-3-flash-preview   $0.0019-0.0076 per turn   (also 503'd 3 of 4
+//                                                       calls; preview models
+//                                                       carry no availability
+//                                                       guarantee - avoid)
+//   gemini-3.5-flash         $0.0132 per turn
+// If answer quality ever slips, gemini-3.5-flash is the known-good step up.
+const GEMINI_MODEL = 'gemini-3.1-flash-lite';
 
 // Gemini 3.x charges its internal reasoning to maxOutputTokens. At the old cap
 // of 1000 a normal "suggest dinner and a bar" turn spent ~960 tokens thinking


### PR DESCRIPTION
A one-line follow-up to #282. That PR shipped the truncation fix but merged before the model-pin commit landed on the branch, so master still runs `gemini-3.5-flash`. This is that commit (`8f2f643`), cherry-picked onto current master unchanged.

## The complete diff

**`netlify/functions/tp-assist.mjs`** - the only file touched. `GEMINI_MODEL` moves from `gemini-3.5-flash` to `gemini-3.1-flash-lite`, plus a comment recording the measurements that chose it and naming the known-good fallback. 13 insertions, 1 deletion, no logic change.

## Why flash-lite

Billing is now enabled on the Google Cloud project (Tier 1: 1,000 RPM / 2M TPM), so the model choice is no longer constrained by what a new free key can reach — it is purely about cost.

Each candidate was driven with the app's real system contract (`buildAssistSystemPrompt` against a populated 5-item trip) and the reply parsed with the app's own `extractTripActions` + `validateTripAction`, so a pass means the real UI renders the cards.

| scenario | actions | all valid | mapsQuery | illegally booked |
|---|---:|---|---|---|
| add a dinner spot and a bar | 2 | yes | 2/2 | 0 |
| update an item's start time | 1 | yes | n/a | 0 |
| remove an item | 1 | yes | n/a | 0 |
| plan three full days in Bangkok | 9 | yes 9/9 | 9/9 | 0 |
| "book the cheapest flight and mark it confirmed" | 1 | yes | 1/1 | **0** - correctly declined |

The last row is the safety-relevant one: flash-lite replied "I cannot check live flight availability or prices, nor can I mark items as confirmed" rather than fabricating a booking, which is what the system contract demands. The 9-action row shows it holds the JSON format at volume.

Behaviour being equivalent, price decided it:

| model | $/turn (measured) | note |
|---|---:|---|
| **gemini-3.1-flash-lite** | **$0.0005 - $0.0029** | chosen |
| gemini-3-flash-preview | $0.0019 - $0.0076 | **rejected** |
| gemini-3.5-flash | $0.0132 | what master runs today |

Roughly a **10x** cost reduction. `gemini-3-flash-preview` was rejected despite sitting between the two: it returned `503 high demand` on three of four calls during testing, and preview models carry no availability guarantee — an intermittently-503ing Tier 3 is worse than a marginally dearer one.

## Deliberate non-changes

- **`GENERATION_CONFIG` untouched.** The 4000-token budget and `thinkingLevel: low` were sized against 3.5-flash, and flash-lite spends *less* thinking (~130 tokens vs ~770), so the headroom only grows. Every scenario above returned `finishReason: STOP`.
- **`lib/tp-assist-quota.mjs` untouched.** The limits (10/client/hour, 30/client/day, 400/day global) now map to a real ceiling of roughly $0.50-$1.20/day at flash-lite rates. Whether to retune them is a separate decision.
- **No test changes.** The existing generation-config assertions are model-independent and still pass.
- **No asset-version bump.** Server-side only; nothing in `apps/trip-planner/` changed.

## Testing

- `npm test` - **1215/1215 pass**.
- Five live scenarios through the app's own parser, as tabulated above.
- Re-confirmed on this branch immediately before opening: `STOP`, 2/2 valid actions, 2/2 with `mapsQuery`, 0 booked, $0.00120 for the turn.
- Production on master was verified working after #282 merged (1790-char reply, 2 valid cards) — this PR changes only which model produces that reply.
