### PR TITLE
fix(site): reword the privacy page and correct its password-reset claim

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -85,34 +85,34 @@
       <section class="hero" aria-labelledby="privacy-hero-title">
         <span class="eyebrow">Privacy</span>
         <h1 id="privacy-hero-title">What we do with your data.</h1>
-        <p class="lede">This page describes what the code on shevato.com actually does. Everything below was written by reading the source, not by adapting a template. Where the site does something you might not expect, it is stated here rather than left out.</p>
+        <p class="lede">A plain-language rundown of what happens to your data on shevato.com: what stays in your browser, what syncs when you sign in, and which outside services see anything at all.</p>
       </section>
 
       <article class="about-shell">
 
-        <p><strong>Last reviewed:</strong> 20 July 2026. <!-- TODO(owner): update this date whenever the behaviour described below changes. --></p>
+        <p><strong>Last reviewed:</strong> 22 July 2026. <!-- TODO(owner): update this date whenever the behaviour described below changes. --></p>
 
         <h2>The short version</h2>
 
-        <p>Every app on this site keeps your data in your own browser and works fully without an account. If you never sign in, nothing you enter into an app is sent to us. Signing in is optional and exists for one reason: to copy a specific, listed set of your data between your devices.</p>
+        <p>Every app on this site keeps your data in your own browser and works fully without an account. If you never sign in, nothing you enter into an app is sent to us. Signing in is optional and does exactly one thing: it copies a specific, listed set of your data between your devices.</p>
 
-        <p>The exceptions are worth reading, because they are real. The Trip Planner assistant and the venue-ratings lookup send trip contents to Google when you use them. Arena is a multiplayer game, so the things you do there are visible to the people you play with. Details on both are below.</p>
+        <p>There are two real exceptions. The Trip Planner assistant and the venue-ratings lookup send trip contents to Google when you use them, and Arena is a multiplayer game, so what you do there is visible to the people you play with. Both are covered in detail below.</p>
 
         <h2>What stays on your device</h2>
 
         <p>Each app stores its working data in your browser's <code>localStorage</code>, under keys scoped to that app. This includes your Mario Kart races and player names, your Football H2H games, your Gym Tracker programs, sessions, settings and body measurements, your Rising Shows watched list, your MapTap Rivals rivals and games, and your Trip Planner trips and items.</p>
 
-        <p>The Trip Planner also stores files you attach to a trip (booking confirmations, tickets, vouchers) as blobs in an IndexedDB database named <code>trip-planner-docs</code>. Those files never leave your device: they are not part of any export, not part of any share link, and not part of sync. The app says so in its own attachment dialog, and that claim is accurate.</p>
+        <p>The Trip Planner also stores files you attach to a trip (booking confirmations, tickets, vouchers) as blobs in an IndexedDB database named <code>trip-planner-docs</code>. Those files never leave your device: they aren't included in exports, share links, or sync.</p>
 
-        <p>Clearing your browser's site data for shevato.com removes all of it. If you are not signed in, there is no other copy.</p>
+        <p>Clearing your browser's site data for shevato.com removes all of it. If you're not signed in, there is no other copy.</p>
 
         <h2>Accounts and sync</h2>
 
         <p>You can create an account with an email address and a password. Authentication is handled by Firebase Authentication, a Google service, which is what stores your email address and password credential.</p>
 
-        <p>While you are signed in on an app page, that app's data is copied to Google Cloud Firestore at the path <code>users/&lt;your account id&gt;/apps/&lt;app namespace&gt;</code>, and changes flow both ways so your devices stay in step. The security rules restrict every document under <code>users/&lt;your account id&gt;</code> to that account alone.</p>
+        <p>While you're signed in on an app page, that app's data is copied to Google Cloud Firestore at the path <code>users/&lt;your account id&gt;/apps/&lt;app namespace&gt;</code>, and changes flow both ways so your devices stay in step. The security rules restrict every document under <code>users/&lt;your account id&gt;</code> to that account alone.</p>
 
-        <p>Sync is not a blanket upload. Each app has an explicit list of storage keys that are allowed to sync, and only those are copied:</p>
+        <p>Sync isn't a blanket upload. Each app has an explicit list of storage keys allowed to sync, and only those are copied:</p>
 
         <div class="skill-rows">
           <div class="skill-row">
@@ -143,20 +143,20 @@
 
         <p>One shared preference, your light or dark theme choice, syncs across apps. Arena is not part of this system at all; it is covered separately below.</p>
 
-        <h2>What is deliberately not synced</h2>
+        <h2>What never syncs</h2>
 
-        <p>Some things stay on your device on purpose, even when you are signed in. In the Trip Planner these are: any AI provider API key you supply, your passport nationality for the visa checker, your assistant conversation history, the geocoding cache, the cached exchange rates, weather and visa data, the per-browser identifier described below, and the venue-lookup owner token. Attached documents, as noted, are also excluded.</p>
+        <p>Some things stay on your device on purpose, even when you're signed in. In the Trip Planner these are: any AI provider API key you supply, your passport nationality for the visa checker, your assistant conversation history, the geocoding cache, the cached exchange rates, weather and visa data, the per-browser identifier described below, and the venue-lookup owner token. Attached documents, as noted, are also excluded.</p>
 
-        <h2>Arena is different, and more public</h2>
+        <h2>Arena is more public</h2>
 
-        <p>Arena is a real-time multiplayer game, so it writes to shared locations rather than to your private area. If you play it, you should know the following.</p>
+        <p>Arena is a real-time multiplayer game, so it writes to shared locations rather than to your private area. If you play it, here's what that means in practice.</p>
 
         <ol class="process-steps">
           <li>
             <div>
               <h3>Your display name is published, and you choose it first</h3>
               <p>Arena asks you to choose a display name before your first multiplayer or daily game, and suggests a neutral default such as "Player 7KQD". Whatever you choose is written to shared records that any signed-in visitor can read. Your email address is never used to build that name.</p>
-              <p>This changed. Earlier versions defaulted your display name to the part of your sign-in email before the <code>@</code>, and published it the first time you played. If you played before this change and your email is name-based, your real name may already be on those shared records. Changing your name now updates the main leaderboard, but head-to-head and daily-challenge entries keep the old one until you play those modes again.</p>
+              <p>It didn't always work this way. Earlier versions defaulted your display name to the part of your sign-in email before the <code>@</code>, and published it the first time you played. If you played before this change and your email is name-based, your real name may already be on those shared records. Changing your name now updates the main leaderboard, but head-to-head and daily-challenge entries keep the old one until you play those modes again.</p>
             </div>
           </li>
           <li>
@@ -283,53 +283,53 @@
 
         <p>The app pages themselves do not load Google Analytics. Opening Mario Kart, Football H2H, Gym Tracker, MapTap Rivals, Trip Planner, Arena or the main Rising Shows app does not send anything to Analytics.</p>
 
-        <p>There is no contact form on this site; the contact page is a set of links. Nothing you type is collected there because there is nothing to type into.</p>
+        <p>There's no contact form on this site; the contact page is just a set of links, so nothing is collected there.</p>
 
         <h2>Logs and server-side records</h2>
 
         <p>The two functions we host, for the AI assistant and for venue ratings, log HTTP status codes and truncated error responses from the service upstream when something fails. They do not log your trip, your prompt or the assistant's reply.</p>
 
-        <p>Both functions apply usage limits, and to do that they count requests against a random identifier that the Trip Planner generates once per browser and stores locally. It is not derived from you or from your account, and it is not linked to either. It is, however, the one identifier about you that we hold on a server, and there is no control in the app to view, reset or clear it; clearing your browser's site data for shevato.com discards it and the app generates a fresh one. The counters it keys are kept in server-side storage and are discarded automatically when their hourly, daily or monthly window rolls over.</p>
+        <p>Both functions apply usage limits, and to do that they count requests against a random identifier that the Trip Planner generates once per browser and stores locally. It isn't derived from you or your account, and isn't linked to either. It is, though, the one identifier about you that we hold on a server, and there's no control in the app to view, reset or clear it; clearing your browser's site data for shevato.com discards it and the app generates a fresh one. The counters it keys are kept in server-side storage and are discarded automatically when their hourly, daily or monthly window rolls over.</p>
 
         <p>The venue-ratings function also keeps a small server-side configuration holding our own Google Places API key and a secret token that lets the site owner's browsers use a higher rate limit than the public one. Neither value is ever sent to your browser, and neither has anything to do with your data. If you are not the owner, your requests simply count against the public limits.</p>
 
-        <p><!-- TODO(owner): Netlify itself keeps standard access logs (including IP addresses) for the site and its functions, on Netlify's own retention schedule. Confirm the current retention window for your plan and state it here rather than leaving this vague. --></p>
+        <!-- TODO(owner): Netlify itself keeps standard access logs (including IP addresses) for the site and its functions, on Netlify's own retention schedule. Confirm the current retention window for your plan and state it here rather than leaving this vague. -->
 
         <h2>Share links</h2>
 
         <p>The Trip Planner can turn a trip into a link you can send to someone. The trip is compressed and placed after the <code>#</code> in the URL, which means it never travels to our server: everything needed to rebuild the trip is inside the link itself.</p>
 
-        <p>That has a consequence worth being explicit about. The link is compressed and encoded, <em>not encrypted</em>. Anyone who has the link can read the whole trip, including every item's details field. There is no password on it and it cannot be revoked once sent. Attached documents are not included.</p>
+        <p>One thing to keep in mind: the link is compressed and encoded, <em>not encrypted</em>. Anyone who has it can read the whole trip, including every item's details field. There's no password on it and it can't be revoked once sent. Attached documents aren't included.</p>
 
         <h2>Getting your data out, and deleting it</h2>
 
         <p>Every app keeps your data in your browser, so you can remove all local data at any time by clearing site data for shevato.com in your browser settings. The Trip Planner can also export a single trip or your whole planner as a JSON file, plus calendar and spreadsheet exports for a trip.</p>
 
-        <p>For synced data, the picture is uneven today and we would rather say so than imply otherwise:</p>
+        <p>For synced data, the picture is currently uneven:</p>
 
         <ul>
-          <li>Gym Tracker is the only app that can erase its own synced data: there is a control in its settings that deletes its Firestore copy.</li>
+          <li>Gym Tracker is the only app that can erase its own synced data: there's a control in its settings that deletes its Firestore copy.</li>
           <li>Mario Kart, Football H2H, Rising Shows, MapTap Rivals and the Trip Planner have no equivalent control. Their synced copies stay in Firestore until removed for you.</li>
-          <li>Arena's leaderboard, head-to-head and daily-challenge entries are outside that system too, and cannot be removed from within the app.</li>
-          <li>There is no self-service account deletion and no self-service password reset anywhere on the site. Both have to be done for you.</li>
-          <li>Arena's chat messages cannot be deleted by anyone, by design.</li>
+          <li>Arena's leaderboard, head-to-head and daily-challenge entries are outside that system too, and can't be removed from within the app.</li>
+          <li>There's no self-service account deletion; that has to be done for you. Password reset is self-service: the sign-in window has a "Forgot password?" link that emails you a reset link.</li>
+          <li>Arena's chat messages can't be deleted by anyone, by design.</li>
         </ul>
 
-        <p>If you want your account removed, your synced data deleted, or a password reset, email <a href="mailto:nikita@shevato.com">nikita@shevato.com</a> and it will be done manually.
+        <p>If you want your account removed or your synced data deleted, email <a href="mailto:nikita@shevato.com">nikita@shevato.com</a> and we'll take care of it manually.
         <!-- TODO(owner): state a turnaround commitment you can actually keep (for example "within 30 days"), and decide whether to build self-service deletion instead. As written, this paragraph is accurate but puts a manual obligation on you. --></p>
 
-        <p>This page describes what the code actually does. It is written to be accurate rather than to serve a formal compliance purpose, so it makes no statement about legal basis, statutory rights, where data is transferred, use by children, or how changes to this page are announced.
+        <p>One scope note: this is an informational page, not a formal legal policy. It makes no statement about legal basis, statutory rights, where data is transferred, use by children, or how changes to this page are announced.
         <!-- TODO(owner): the sentence above is deliberately scoped. Add legal basis, GDPR/CCPA rights, data-transfer locations, children's use, and a policy-change notification process if you need this page to serve a compliance purpose rather than an informational one. None of those are decisions the code can answer. --></p>
 
         <h2>Questions</h2>
 
-        <p>If something here does not match what you observe, that is a bug and we want to hear about it. Email <a href="mailto:nikita@shevato.com">nikita@shevato.com</a>.</p>
+        <p>If something here doesn't match what the site actually does, we want to know. Email <a href="mailto:nikita@shevato.com">nikita@shevato.com</a>.</p>
 
       </article>
 
       <section class="cta-banner">
         <h3>Something here look wrong?</h3>
-        <p>If you spot a gap between what this page says and what the site does, tell us and we will fix one or the other.</p>
+        <p>If what this page says and what the site does ever disagree, tell us and we'll fix it.</p>
         <a href="contact.html" class="cta-button"><span class="icon fa-envelope" aria-hidden="true"></span>Get in touch</a>
       </section>
 

--- a/sitemap-pages.xml
+++ b/sitemap-pages.xml
@@ -31,7 +31,7 @@
 
   <url>
     <loc>https://shevato.com/privacy</loc>
-    <lastmod>2026-07-20</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>


### PR DESCRIPTION
## What this PR contains

Complete diff: 2 files, 27 insertions, 27 deletions.

### privacy.html (site)

Tone-only rewrite requested by the owner ("make it sound less robotic/cringy, or remove it"). The page was kept, not removed: it is the only disclosure of Arena's permanent public chat, the unencrypted share links, and the third-party service list, and it is already wired into the footer, both sitemaps, and an OG card. Every factual claim was preserved except one, which had gone stale (see bugfix below).

Copy changes:
- Removed the self-referential meta-commentary: "Everything below was written by reading the source, not by adapting a template", "The app says so in its own attachment dialog, and that claim is accurate", "we would rather say so than imply otherwise", "The exceptions are worth reading, because they are real", "Nothing you type is collected there because there is nothing to type into", "that is a bug and we want to hear about it", "That has a consequence worth being explicit about", "This changed."
- Added natural contractions throughout (isn't, you're, there's, can't); the hero lede, short version, sync, Arena, share-links, logs, deletion, questions, and CTA-banner sections were all reworded.
- Renamed two headings: "Arena is different, and more public" is now "Arena is more public"; "What is deliberately not synced" is now "What never syncs". Neither heading had an id, and nothing links to them by anchor.
- Removed an empty `<p>` that only wrapped the Netlify-logs `TODO(owner)` comment (the comment itself is kept, now outside any element).
- Bumped the visible "Last reviewed" date to 22 July 2026, per that section's own TODO instruction to update it when the described behavior changes.

Bugfix found along the way:
- The deletion section claimed "no self-service password reset anywhere on the site. Both have to be done for you." That was true when the page was written (2026-07-20) but went stale two days later when 4cdf5fb added a "Forgot password?" link to the sign-in modal. The bullet now correctly says password reset is self-service, and the manual-email paragraph now covers only account removal and synced-data deletion.

Explicitly untouched:
- All four `TODO(owner)` HTML comments (last-reviewed reminder, Netlify log retention, deletion turnaround, legal scaffolding) are content decisions and remain as invisible notes.
- All `<head>` metadata: title, meta description, OG/Twitter tags, JSON-LD, canonical. Still accurate after the rewrite.
- Page structure, class names, scripts, and every factual claim other than the stale password-reset one.

### sitemap-pages.xml (site)

- `lastmod` for `https://shevato.com/privacy` bumped from 2026-07-20 to 2026-07-22 to match the content change. No other entries touched.

## Judgment calls

- Kept the page rather than removing it (the owner offered both options); reasons above.
- The password-reset spam problem discussed in the same session is deliberately NOT addressed here: the fix is a Firebase console sender-domain change plus Netlify DNS records, which is owner-only configuration, not repo code.
- The living `.features/site-{claude,human}.md` plan pair and `.features/account-recovery-ops.md` were updated for this round (run report appended, stale quotes of the old wording reconciled), but those files are gitignored by design and therefore not part of this diff.

## How it was tested

- `npm test`: 1673/1673 pass after every edit.
- Screenshot-verified with headless Chrome on desktop (1280px: top, scrolled-to-bottom, and deletion section) and mobile (390px: top and deletion section): new copy renders as written, no layout issues, no TODO comments visible. Evidence dir was deleted at ship per convention.
