### PR TITLE
feat(trip-planner): five visual improvements + exchange-rate fetch timeout

### DIFF
--- a/apps/trip-planner/css/styles.css
+++ b/apps/trip-planner/css/styles.css
@@ -241,6 +241,20 @@
   }
   .toolbar input[type="search"] { min-width: 140px; flex: 1 1 auto; max-width: 460px; margin-right: auto; }
   .toolbar input[type="search"]::placeholder { color: var(--text-faint); }
+  /* a fixed magnifier inside the field's left edge, the same absolutely-placed
+     prefix trick .cost-prefix uses for the "$"; the wrapper carries the flex
+     sizing the input used to, so the search row still grows and wraps as before */
+  .tb-filters .search-wrap {
+    position: relative; display: flex;
+    flex: 1 1 auto; min-width: 140px; max-width: 460px; margin-right: auto;
+  }
+  .trip-planner-app .tb-filters .search-wrap input[type="search"] {
+    width: 100%; flex: 1 1 auto; min-width: 0; max-width: none; margin: 0; padding-left: 32px;
+  }
+  .tb-search-ico {
+    position: absolute; left: 11px; top: 50%; transform: translateY(-50%);
+    color: var(--text-faint); pointer-events: none;
+  }
   .toolbar .view-switch { background: var(--bg-soft); }
 
   /* ---------- issues ---------- */
@@ -959,6 +973,15 @@
     display: flex; gap: 12px; align-items: center; animation: pop .18s ease-out;
   }
   .toast button { background: none; border: 0; color: var(--accent); font-weight: 700; padding: 0; }
+  /* genuine failures only: a red edge, a red-soft tint and the same "!" badge
+     .pl-err::before carries, so an error toast is never mistaken for the neutral
+     confirmations (Undo, "Copied ...") that share the .toast base. */
+  .toast.toast-error { background: var(--red-soft); border-color: var(--red); }
+  .toast.toast-error::before {
+    content: '!'; flex: none; width: 16px; height: 16px; border-radius: 50%;
+    background: var(--red); color: var(--bg-card); font-size: 11px; font-weight: 800; line-height: 1;
+    display: inline-flex; align-items: center; justify-content: center;
+  }
 
 
   /* ---------- main.css !important counter-pins ----------
@@ -998,6 +1021,37 @@
   .trip-planner-app .seg > button.on:active { color: var(--seg-on-fg) !important; }
   .trip-planner-app .seg > button.on:hover:active { background-color: var(--accent-soft); }
   .trip-planner-app .seg > button:hover:active { background-color: var(--gray-soft); }
+  /* the item-type picker: the selected tile tints with the SAME token that
+     type's cards and rows use (see .tp-t-*), so choosing Stay reads purple and
+     Activity green rather than a generic accent-blue for every type. The #id
+     outranks the .seg pins above, including their !important colour, so a small
+     per-type set is all it takes. Flight is deliberately absent: it already IS
+     the accent blue the base .on state paints. */
+  #typePicker button[data-type="stay"].on {
+    background: var(--purple-soft);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--purple) 42%, transparent);
+    color: color-mix(in srgb, var(--purple) 55%, var(--text)) !important;
+  }
+  #typePicker button[data-type="transport"].on {
+    background: var(--cyan-soft);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cyan) 42%, transparent);
+    color: color-mix(in srgb, var(--cyan) 60%, var(--text)) !important;
+  }
+  #typePicker button[data-type="activity"].on {
+    background: var(--green-soft);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--green) 42%, transparent);
+    color: color-mix(in srgb, var(--green) 55%, var(--text)) !important;
+  }
+  #typePicker button[data-type="local"].on {
+    background: var(--gray-soft);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-dim) 42%, transparent);
+    color: var(--text) !important;
+  }
+  #typePicker button[data-type="note"].on {
+    background: var(--gray-soft);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-faint) 45%, transparent);
+    color: var(--text) !important;
+  }
   /* the secondary footer action: quieter than the primary, still readable */
   .trip-planner-app .modal-foot .btn.ghost { color: var(--text-dim) !important; }
   .trip-planner-app .modal-foot .btn.ghost:hover { color: var(--text) !important; }
@@ -1370,6 +1424,9 @@
   .days-box { display: none; }
   .days-box.on { display: block; }
   .days-list { display: grid; grid-template-columns: repeat(auto-fill, minmax(400px, 1fr)); gap: 12px; align-items: start; }
+  /* the empty state is the whole view, not a card: span every column so it
+     centres across the full width the way the timeline's empty state does */
+  .days-list > .empty { grid-column: 1 / -1; }
   /* the filter feedback line spans the whole grid: hiding days silently is
      what makes a search feel broken */
   .days-note {
@@ -1676,6 +1733,14 @@
     box-shadow: inset 3px 0 0 var(--row-accent, var(--text-dim)), inset 0 0 0 1px var(--border-soft);
   }
   .dc-event.is-travel .dc-title { font-weight: 600; }
+  /* a flagged item wears the SAME amber/red edge the timeline row does
+     (.tp-row.has-warn / .has-err), so a connection warning or collision reads
+     the same in either view. Placed after is-stay so a flagged stay shows the
+     warning rather than its resting purple edge; the ring survives hover too. */
+  .dc-event.has-warn .dc-item,
+  .dc-event.has-warn .dc-item:hover { box-shadow: inset 0 0 0 1.5px var(--amber); }
+  .dc-event.has-err .dc-item,
+  .dc-event.has-err .dc-item:hover { box-shadow: inset 0 0 0 1.5px var(--red); }
   /* the thread stops at the last timed row: it must not run through the
      dashed "No time set" divider */
   .dc-event:has(+ .dc-untimed)::after { display: none; }
@@ -2288,7 +2353,7 @@
        forcing the whole page into horizontal scroll */
     .tb-group { flex-wrap: wrap; }
     .tb-filters { flex-wrap: wrap; }
-    .tb-filters input[type="search"] { width: 100%; flex: 1 1 100%; min-width: 0; max-width: none; margin-right: 0; }
+    .tb-filters .search-wrap { width: 100%; flex: 1 1 100%; min-width: 0; max-width: none; margin-right: 0; }
     .tb-filters select { flex: 1 1 0; }
   }
 

--- a/apps/trip-planner/index.html
+++ b/apps/trip-planner/index.html
@@ -123,7 +123,10 @@
       <button id="viewMap">Map</button>
     </span>
     <div class="tb-group tb-filters" role="group" aria-label="Search and filters">
-    <input type="search" id="searchBox" placeholder="Search title, place, details...">
+    <span class="search-wrap">
+      <svg class="tb-search-ico" aria-hidden="true" viewBox="0 0 16 16" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><circle cx="7" cy="7" r="4.3"/><line x1="10.3" y1="10.3" x2="14" y2="14"/></svg>
+      <input type="search" id="searchBox" placeholder="Search title, place, details...">
+    </span>
     <select id="filterType" aria-label="Filter by type">
       <option value="">All types</option>
       <option value="flight">Flights</option>

--- a/apps/trip-planner/js/app.js
+++ b/apps/trip-planner/js/app.js
@@ -407,7 +407,13 @@
     if (lastRateAttempt.base === base && Date.now() - lastRateAttempt.at < 60000) return;
     lastRateAttempt = { base, at: Date.now() };
     ratesFetching = true;
-    fetch('https://api.frankfurter.dev/v1/latest?from=' + encodeURIComponent(base))
+    // Bound the request the same way the places lookup is (app.js fetchRatingBatch):
+    // without this, a hung connection leaves ratesFetching true forever and the
+    // "Fetching exchange rates..." note never clears. On abort the catch below
+    // flips ratesFailed, so the note falls back to "Could not fetch..." instead.
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 8000);
+    fetch('https://api.frankfurter.dev/v1/latest?from=' + encodeURIComponent(base), { signal: ctrl.signal })
       .then(r => { if (!r.ok) throw new Error('http ' + r.status); return r.json(); })
       .then(data => {
         if (data && data.base && data.rates) {
@@ -418,7 +424,7 @@
         }
       })
       .catch(() => { ratesFailed = true; render(); })
-      .finally(() => { ratesFetching = false; });
+      .finally(() => { clearTimeout(timer); ratesFetching = false; });
   }
 
   // Converted money totals in the trip currency. Returns confirmed/planned as
@@ -802,6 +808,17 @@
     render();
   }
 
+  // item id -> highest issue severity ('error' beats 'warn'). Both the timeline
+  // and the day view colour their rows from this same map, so a flagged item
+  // reads the same in either view.
+  function buildIssueById(issues) {
+    const map = {};
+    for (const iss of issues) for (const id of iss.ids) {
+      map[id] = map[id] === 'error' ? 'error' : iss.level;
+    }
+    return map;
+  }
+
   function renderBoard(trip, issues) {
     const board = $('#board');
     const items = sortedItems(trip);
@@ -833,10 +850,7 @@
       return;
     }
 
-    const issueById = {};
-    for (const iss of issues) for (const id of iss.ids) {
-      issueById[id] = issueById[id] === 'error' ? 'error' : iss.level;
-    }
+    const issueById = buildIssueById(issues);
     const gaps = issues.filter(i => i.gap).map(i => i.gap);
     const st = tripStats(trip);
     const phase = (st.start && st.end) ? tripPhase(st.start, st.end, todayIso()) : { phase: 'before' };
@@ -1196,9 +1210,11 @@
     return `<span class="dc-cost${refund}">${est}${moneyHtml(trip, amount, digits, 'item')}</span>`;
   }
 
-  function dayEventHtml(ev, trip) {
+  function dayEventHtml(ev, trip, issueById) {
     const it = ev.item;
     const look = rowLook(it);
+    const issueLevel = issueById && issueById[it.id];
+    const issueCls = issueLevel === 'error' ? ' has-err' : (issueLevel === 'warn' ? ' has-warn' : '');
     const isStayRow = ev.kind === 'checkin' || ev.kind === 'checkout';
     const tag = ev.kind === 'checkin' ? 'Check in' : (ev.kind === 'checkout' ? 'Check out' : '');
     // A check-out row names the place you are leaving; the location line would
@@ -1244,7 +1260,7 @@
     // day), so they share one line rather than one slot.
     const tags = (tag ? `<span class="dc-tag">${tag}</span>` : '')
       + (cancelled ? '<span class="dc-tag is-cancelled">Cancelled</span>' : '');
-    return `<div class="dc-event ${look.cls}${travelCls}${isStayRow ? ' is-stay' : ''} ${sm.cls} ${cancelled ? 'is-cancelled' : ''}">
+    return `<div class="dc-event ${look.cls}${travelCls}${isStayRow ? ' is-stay' : ''}${issueCls} ${sm.cls} ${cancelled ? 'is-cancelled' : ''}">
       <div class="dc-rail">
         <span class="dc-dot" role="img" aria-label="${esc(sm.label)}" title="${esc(sm.label)}"></span>
         ${when ? `<span class="dc-when">${when}</span>` : ''}
@@ -1284,11 +1300,11 @@
   // belongs to a stay that began earlier, so it is not "an event on this day".
   const dayClearCount = card => card.events.filter(ev => ev.kind !== 'checkout').length + card.untimed.length;
 
-  function dayCardHtml(card, isToday, trip) {
+  function dayCardHtml(card, isToday, trip, issueById) {
     const parts = [];
-    if (card.events.length) parts.push(card.events.map(ev => dayEventHtml(ev, trip)).join(''));
+    if (card.events.length) parts.push(card.events.map(ev => dayEventHtml(ev, trip, issueById)).join(''));
     if (card.untimed.length) {
-      parts.push(`<div class="dc-untimed"><span class="dc-untimed-label">No time set</span>${card.untimed.map(ev => dayEventHtml(ev, trip)).join('')}</div>`);
+      parts.push(`<div class="dc-untimed"><span class="dc-untimed-label">No time set</span>${card.untimed.map(ev => dayEventHtml(ev, trip, issueById)).join('')}</div>`);
     }
     // A day with nothing on it still has a bed if a stay spans it, and saying
     // "No plans yet" there would be false (see emptyDayNote).
@@ -1496,9 +1512,15 @@
     const box = $('#daysList');
     const all = dayCards(trip);
     if (!all.length) {
-      box.innerHTML = `<div class="empty" style="padding:40px 24px"><p>Add items with dates and a day-by-day plan appears here.</p></div>`;
+      box.innerHTML = `
+        <div class="empty">
+          <div class="big">📅</div>
+          <h2>No day-by-day plan yet</h2>
+          <p>Add items with dates and a day-by-day plan appears here.</p>
+        </div>`;
       return;
     }
+    const issueById = buildIssueById(computeIssues(trip));
     const st = tripStats(trip);
     const phase = (st.start && st.end) ? tripPhase(st.start, st.end, todayIso()) : { phase: 'before' };
     const today = todayIso();
@@ -1539,7 +1561,7 @@
     const wx = '<div class="days-note days-wx">Temperatures are typical for that month across the last '
       + WEATHER_YEARS + ' years of records, not a forecast. Weather data by '
       + '<a href="https://open-meteo.com/" target="_blank" rel="noopener">Open-Meteo</a> (CC BY 4.0).</div>';
-    box.innerHTML = note + cards.map(c => dayCardHtml(c, phase.phase === 'during' && c.date === today, trip)).join('') + wx;
+    box.innerHTML = note + cards.map(c => dayCardHtml(c, phase.phase === 'during' && c.date === today, trip, issueById)).join('') + wx;
     // Same one batched lookup as the timeline: paints from the shared session
     // cache instantly, so switching into the days view never refetches a key the
     // board already resolved.
@@ -2235,7 +2257,7 @@
         const stored = save(); render();
         if (stored) reportImportDrops(`Imported ${added} trip${added === 1 ? '' : 's'}`, drops);
       } catch (err) {
-        toast(`Import failed: ${err.message}`);
+        toastError(`Import failed: ${err.message}`);
       }
     };
     reader.readAsText(file);
@@ -2350,7 +2372,7 @@
   }
 
   async function shareTrip() {
-    if (typeof CompressionStream === 'undefined') { toast('Sharing is not supported in this browser'); return; }
+    if (typeof CompressionStream === 'undefined') { toastError('Sharing is not supported in this browser'); return; }
     const t = activeTrip();
     const json = JSON.stringify({ version: 1, trip: slimTripForShare(t) });
     const compressed = await streamThrough(CompressionStream, new TextEncoder().encode(json));
@@ -2358,7 +2380,7 @@
     // The fragment never travels to a server, so browsers handle very long
     // links fine; the real-world limit is chat apps truncating them. Hard
     // stop only at absurd sizes, advisory warning in between.
-    if (url.length > 30000) { toast('This trip is too large to share by link. Use Export trip (JSON) instead.'); return; }
+    if (url.length > 30000) { toastError('This trip is too large to share by link. Use Export trip (JSON) instead.'); return; }
     try {
       await navigator.clipboard.writeText(url);
       toast(url.length > 8000
@@ -2370,7 +2392,7 @@
   }
 
   async function decodeShare(hash) {
-    if (typeof DecompressionStream === 'undefined') { toast('Sharing is not supported in this browser'); return null; }
+    if (typeof DecompressionStream === 'undefined') { toastError('Sharing is not supported in this browser'); return null; }
     try {
       const bytes = base64urlToBytes(hash.slice(SHARE_PREFIX.length));
       const out = await streamThrough(DecompressionStream, bytes);
@@ -2378,7 +2400,7 @@
       const trip = parsed && parsed.trip;
       if (!trip || !Array.isArray(trip.items)) throw new Error('bad payload');
       return trip;
-    } catch { toast('This share link could not be opened'); return null; }
+    } catch { toastError('This share link could not be opened'); return null; }
   }
 
   async function enterSharedMode() {
@@ -2750,8 +2772,11 @@
     box.classList.toggle('is-blank', state === 'blank');
     box.style.setProperty('--map-progress', typeof pct === 'number' ? Math.round(pct) + '%' : '0%');
   }
-  function mapFailed(msg) {
-    $('#mapStatus').textContent = msg;
+  // Same polished empty block the timeline and days views use, so a map with
+  // nothing to draw reads as a considered state rather than a broken card. The
+  // icon distinguishes the reason at a glance (no places / offline / not found).
+  function mapFailed(icon, heading, msg) {
+    $('#mapStatus').innerHTML = `<div class="empty"><div class="big">${icon}</div><h2>${esc(heading)}</h2><p>${esc(msg)}</p></div>`;
     setMapState('blank');
   }
 
@@ -2762,14 +2787,14 @@
     const stops = mapStops(trip);
     if (!stops.length) {
       if (mapInstance) { mapInstance.remove(); mapInstance = null; }
-      mapFailed('Add items with a "Place" (Tokyo, Kyoto, ...) and they will show up here as a route.');
+      mapFailed('🗺️', 'No places to map yet', 'Add items with a "Place" (Tokyo, Kyoto, ...) and they will show up here as a route.');
       return;
     }
-    if (!navigator.onLine) { mapFailed('The map needs an internet connection (tiles + place lookup).'); return; }
+    if (!navigator.onLine) { mapFailed('📡', 'The map is offline', 'The map needs an internet connection (tiles + place lookup).'); return; }
     setMapState('loading', 0);
     status.textContent = 'Loading map...';
     const ok = await ensureLeaflet();
-    if (!ok) { mapFailed('Could not load the map library (offline?). The timeline is unaffected.'); return; }
+    if (!ok) { mapFailed('📡', 'The map could not load', 'Could not load the map library (offline?). The timeline is unaffected.'); return; }
     if (token !== mapRunToken) return;
 
     const located = [], failed = [];
@@ -2781,7 +2806,7 @@
       if (hit.ok) located.push({ ...stops[i], ...hit });
       else failed.push(stops[i].name);
     }
-    if (!located.length) { mapFailed(`Could not locate: ${failed.join(', ')}. Try more specific place names (add the country).`); return; }
+    if (!located.length) { mapFailed('📍', 'Could not find those places', `Could not locate: ${failed.join(', ')}. Try more specific place names (add the country).`); return; }
     setMapState('ready');
 
     if (mapInstance) { mapInstance.remove(); mapInstance = null; }
@@ -4415,15 +4440,18 @@
   }
 
   let lastDeleted = null;
-  function toast(msg, undoFn) {
+  function toast(msg, undoFn, opts) {
     const box = $('#toasts');
     const el = document.createElement('div');
-    el.className = 'toast';
+    el.className = 'toast' + (opts && opts.error ? ' toast-error' : '');
     el.innerHTML = `<span>${esc(msg)}</span>${undoFn ? '<button type="button">Undo</button>' : ''}`;
     if (undoFn) el.querySelector('button').addEventListener('click', () => { undoFn(); el.remove(); });
     box.appendChild(el);
     setTimeout(() => { el.style.opacity = '0'; el.style.transition = 'opacity .4s'; setTimeout(() => el.remove(), 450); }, undoFn ? 6000 : 2600);
   }
+  // Genuine failures (a bad import, a share link that will not open) route here
+  // so they read as errors, not the neutral confirmations Undo toasts use.
+  function toastError(msg) { toast(msg, null, { error: true }); }
 
   // ---------- events ----------
   $('#addBtn').addEventListener('click', () => openItemModal(null));


### PR DESCRIPTION
A visual-polish round for Trip Planner (5 improvements, all within the app's existing design tokens), plus one behavioral bugfix found during live testing. No data-model changes. Derived from `git diff master...HEAD`.

## Changed files

### `apps/trip-planner/js/app.js` (+80/-28)
- **Empty states unified (item 1).** `renderDays` now emits the shared `.empty` block (📅 icon + `<h2>No day-by-day plan yet</h2>` + body) instead of a bare inline-styled fragment. `mapFailed(msg)` became `mapFailed(icon, heading, msg)` and writes the same `.empty` block into `#mapStatus`; its three call sites pass distinct icons/headings: 🗺️ "No places to map yet", 📡 "The map is offline" / "The map could not load", 📍 "Could not find those places". Triggers and message wording are unchanged.
- **Days-view warning colors (item 2).** New `buildIssueById(issues)` helper (extracted from the inline loop `renderBoard` already used, so Timeline and Days share one severity map). `renderDays` builds it from `computeIssues(trip)` and threads it through `dayCardHtml(..., issueById)` -> `dayEventHtml(ev, trip, issueById)`, which appends `has-warn`/`has-err` to the `.dc-event`.
- **Error toasts (item 3).** `toast(msg, undoFn)` -> `toast(msg, undoFn, opts)`; when `opts.error` it adds class `toast-error`. New `toastError(msg)` helper. Five genuine-failure call sites routed through it: import failed, share unsupported, share too-large, decode-share unsupported, share-link could-not-open. Routine/undo toasts untouched (same timing, stacking, animation).
- **Rates fetch timeout (bugfix, item 6).** The Frankfurter exchange-rate fetch in `ensureRates` had no timeout, so a hung connection left `ratesFetching` true forever and the "Fetching exchange rates..." note never cleared. Added an 8s `AbortController` (mirroring the places lookup's abort); on abort the existing `.catch` sets `ratesFailed` and re-renders, so the note falls back to the already-present "Could not fetch exchange rates..." message. `clearTimeout` added to `.finally`.

### `apps/trip-planner/css/styles.css` (+67/-3)
- `.tb-filters .search-wrap` + `.tb-search-ico` (item 4): the magnifier's absolute positioning and the wrapper flex sizing; the ≤560px phone rule now targets `.search-wrap` instead of the raw input so full-width wrapping still works.
- `.toast.toast-error` + `::before` (item 3): red border, `--red-soft` bg, cloned "!" badge from `.pl-err::before`.
- `#typePicker button[data-type="X"].on` for stay/transport/activity/local/note (item 5): each tints with its own `--*-soft` token + accent hairline + a readable label color `!important` (the `#id` outranks the shared `.seg > button.on` pin). No rule for flight, by design.
- `.dc-event.has-warn/.has-err .dc-item` (+ `:hover`) (item 2): amber/red inset ring, placed after `.is-stay` so a flagged stay shows the warning rather than its resting purple edge.
- `.days-list > .empty { grid-column: 1 / -1 }` (item 1): centers the days empty state full-width.

### `apps/trip-planner/index.html` (+5/-1)
- `#searchBox` wrapped in `<span class="search-wrap">` with an inline monochrome `<svg class="tb-search-ico">` (stroke `currentColor`, so it takes `--text-faint`; SVG rather than emoji so the color applies).

## Deliberate non-changes
- **Flight type-picker tile** left on the base `--accent` blue (its row-accent already is that blue).
- **Cache-buster `?v=` params** in `index.html` (`styles.css?v=28`, `app.js?v=32`) intentionally NOT bumped in these commits - flagging for the merge step, since both files changed and returning visitors need the bump to see the new assets.
- **Routine/success/undo toasts, tp-places quota, geocoder, and all data-model/logic** untouched.

## Judgment calls
- The rates-timeout fix is a **functional** bugfix riding on a visual branch; kept together because it was found and fixed during this round's live testing and is a small, self-contained robustness fix. Documented as "Part D: Bugfixes found along the way" in the plan.
- Local and Note both tint `--gray-soft` (identical value, per spec's "neutral gray" for both); they stay distinguishable by icon/label.

## How it was tested
- `npm test`: **1717/1717 passing**.
- Plan pair `.features/trip-planner-{claude,human}.md` (gitignored/local): the visual round ran **55/55 checks, 0 failed, 0 unverified** across desktop 1280 + mobile 390 (app-test-runner); section 6 adds 5/5 source-grep checks for the rates fix. Prior round archived to `.features/archive/trip-planner-{claude,human}-2026-07-24.md`.
- Two items need a real browser (routed to the human plan): hover-persistence of the Days-view warning ring, and the real-offline flip of the map/rates notes.