### PR TITLE
chore(trip-planner): bump asset cache-busters for PR #296

### DIFF
--- a/apps/trip-planner/index.html
+++ b/apps/trip-planner/index.html
@@ -43,7 +43,7 @@
   <meta name="theme-color" content="#0e1116">
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
-  <link rel="stylesheet" href="css/styles.css?v=28">
+  <link rel="stylesheet" href="css/styles.css?v=29">
 </head>
 <body class="tp-page">
   <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>
@@ -590,6 +590,6 @@
   </script>
 
   <script src="js/trip-logic.js?v=16"></script>
-  <script src="js/app.js?v=32"></script>
+  <script src="js/app.js?v=33"></script>
 </body>
 </html>

--- a/apps/trip-planner/sw.js
+++ b/apps/trip-planner/sw.js
@@ -17,7 +17,7 @@
  * MINOR when the strategy changes, MAJOR for a back-compat break.
  */
 
-const CACHE_VERSION = '2.1.5';
+const CACHE_VERSION = '2.1.6';
 const PRECACHE = `trip-precache-${CACHE_VERSION}`;
 const RUNTIME = `trip-runtime-${CACHE_VERSION}`;
 
@@ -25,9 +25,9 @@ const PRECACHE_URLS = [
   './',
   './index.html',
   './manifest.webmanifest',
-  './css/styles.css?v=28',
+  './css/styles.css?v=29',
   './js/trip-logic.js?v=16',
-  './js/app.js?v=32',
+  './js/app.js?v=33',
   '../../assets/css/main.css',
   '../../assets/css/sync-status.css',
   '../../assets/js/passive-events-fix.js',


### PR DESCRIPTION
Follow-up to #296. That round changed `apps/trip-planner/css/styles.css` and `apps/trip-planner/js/app.js` but left the `?v=` cache-buster query params unbumped, so returning visitors (whose browsers and service worker hold the old assets) would not see the round until the params changed. This bumps them.

## Changes

### `apps/trip-planner/index.html`
- `css/styles.css?v=28` -> `?v=29`
- `js/app.js?v=32` -> `?v=33`

### `apps/trip-planner/sw.js`
- Precache list mirrored to match: `./css/styles.css?v=29`, `./js/app.js?v=33`.
- `CACHE_VERSION` `2.1.5` -> `2.1.6` (patch bump, per the file's own rule: "bump PATCH when the precache contents change") so the old precache is dropped on activate and clients fetch the new assets.

## Deliberate non-changes
- `js/trip-logic.js?v=16` stays at v16 in both files - it was not touched in #296.
- No source/behavior changes; this is cache-busting only.

## How it was tested
- `npm test`: **1717/1717 passing**.
- Verified the `?v=` params in `index.html` and the `sw.js` precache list match exactly (v=29 / v=33 / v=16) so the service worker precaches the same URLs the page requests.
