### PR TITLE
fix(trip-planner): keep Reagan National first for a Washington airport search

### DIFF
--- a/apps/trip-planner/js/trip-logic.js
+++ b/apps/trip-planner/js/trip-logic.js
@@ -862,6 +862,12 @@ const TripLogic = (() => {
   //     Santiago CL/CU, Victoria SC/CA. Those ask "which CITY did you mean",
   //     which is a question the row's own country line answers on screen, and
   //     picking a winner here would just be guessing at the traveller.
+  //   - Washington DCA/IAD: OWNER DECISION, do not "fix" this by adding IAD.
+  //     Dulles is the intercontinental gateway, but Reagan National is inside
+  //     the city, carries comparable domestic traffic, and is what its city
+  //     field says it is. So "washington" answers DCA on the plain city match
+  //     and Dulles lists second, which is where an unpromoted NAME_PREFIX hit
+  //     puts it.
   const PRIMARY_HUBS = new Map([
     ['AMM', 'Amman'],          // Queen Alia, over Marka (ADJ)
     ['BKK', 'Bangkok'],        // Suvarnabhumi, over Don Mueang (DMK)
@@ -900,12 +906,6 @@ const TripLogic = (() => {
     ['PVG', 'Shanghai'],       // Pudong, over Hongqiao (SHA)
     ['IKA', 'Tehran'],         // Imam Khomeini, over the domestic Mehrabad (THR)
     ['TFS', 'Tenerife'],       // South, which is where the flights land, over North (TFN)
-    ['IAD', 'Washington'],     // Dulles, over Reagan National (DCA). The closest call
-                               //   in this list - DCA is inside the city and carries
-                               //   comparable domestic traffic - but Dulles is the
-                               //   intercontinental gateway and DCA's perimeter rule
-                               //   keeps long-haul off it, so it is the likelier
-                               //   answer when someone is building an itinerary.
   ]);
 
   // Below this a query is not naming a place, it is two letters on the way to

--- a/apps/trip-planner/tests/trip-logic.test.js
+++ b/apps/trip-planner/tests/trip-logic.test.js
@@ -5439,7 +5439,20 @@ test('naming a metro finds its gateway even when the data files it elsewhere', (
   // partial typing gets there too, so the promotion is not an exact-match trick
   assert.equal(top('mil'), 'MXP');
   assert.equal(top('buch'), 'OTP');
-  assert.equal(top('washi'), 'IAD');
+  assert.equal(top('dall'), 'DFW');
+});
+
+test('Washington answers DCA, not Dulles (owner decision)', () => {
+  // Dulles is the intercontinental gateway, but Reagan National is inside the
+  // city and is what its city field says it is. IAD is deliberately absent
+  // from PRIMARY_HUBS so no metro promotion fires and the plain city match
+  // wins. Pinned because the "obvious" change is to add IAD back.
+  const rows = L.airportIndex(require('../data/airports.json'));
+  assert.ok(!L.PRIMARY_HUBS.has('IAD'));
+  assert.deepEqual(L.searchAirports('washington', rows, 3).map(a => a.iata), ['DCA', 'IAD', 'BWI']);
+  // Dulles is still perfectly reachable by its own name and code
+  assert.equal(L.searchAirports('dulles', rows, 3).map(a => a.iata)[0], 'IAD');
+  assert.equal(L.searchAirports('iad', rows, 3).map(a => a.iata)[0], 'IAD');
 });
 
 test('the promotion needs the METRO name, not any prefix of the airport name', () => {
@@ -5496,7 +5509,6 @@ test('the shipped data still ranks the real multi-airport metros correctly', () 
   // suburb, and a smaller airport inside the city limits was beating it
   assert.equal(top('bucharest'), 'OTP');   // was BBU (Baneasa)
   assert.equal(top('dallas'), 'DFW');      // was DAL (Love Field)
-  assert.equal(top('washington'), 'IAD');  // was DCA
   assert.equal(top('manchester'), 'MAN');  // was MHT (New Hampshire)
   // and the ones it merely confirms
   assert.equal(top('paris'), 'CDG');


### PR DESCRIPTION
Follow-up to #305, which merged before this landed.

You asked for Reagan National first when searching "washington". Done by dropping the `IAD` entry from `PRIMARY_HUBS`, so no metro promotion fires for Washington and the plain city match wins.

## Result

| Query | Before | After |
|---|---|---|
| `washington` | IAD, DCA, BWI | **DCA, IAD, BWI** |
| `dulles` | IAD | IAD (unchanged) |
| `iad` | IAD | IAD (unchanged) |

Dulles is still one row down and still reachable directly by name or code — the promotion only ever decided *ordering*, never whether a row appeared.

## Files

- **`js/trip-logic.js`** — removes the `['IAD', 'Washington']` entry (36 hubs → 35). The reasoning moves up into the list's "deliberately NOT here" block, alongside Chengdu and the cross-country namesakes, worded as `OWNER DECISION, do not "fix" this by adding IAD` so the next reader doesn't helpfully re-add it.
- **`tests/trip-logic.test.js`** — new test `Washington answers DCA, not Dulles (owner decision)` pins the full `['DCA', 'IAD', 'BWI']` order, asserts `IAD` is absent from the hub list, and asserts Dulles is still reachable by name and code. Two existing assertions that expected IAD were retargeted to `dall`/`DFW`, which exercise the same metro-promotion path.

## Explicitly untouched

The promotion mechanism itself is unchanged, as are the other three metros it fixed — `bucharest` → OTP, `dallas` → DFW, `manchester` → MAN all still verified. No data rebuild: `data/airports.json` is untouched, since this was never a data problem.

## Testing

`npm test` → **1839/1839** (was 1838; net +1 from the new test replacing nothing). Verified in-browser against the shipped data at 900×300: the dropdown for "washington" returns Washington (DCA), Dulles (IAD), Baltimore (BWI) in that order, and `TripLogic.PRIMARY_HUBS` reports 35 entries with no IAD.
