### PR TITLE
feat(rising-shows): curate sitemap to top 2000 shows, stamp index lastmod at build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ shevato/
 │
 ├── images/                           # Logos, backgrounds, OG cards, and app artwork
 ├── netlify/, .netlify/               # Netlify functions and build artifacts
+├── scripts/                          # Site-level build helpers (sitemap index lastmod stamping)
 ├── sync-system/                      # localStorage ↔ Firestore sync used by the apps
 │
 ├── index.html                        # Apex shell — redirects to /home.html (noindex)
@@ -54,7 +55,7 @@ shevato/
 ├── netlify.toml                      # Netlify build, headers, and CSP-Report-Only config
 ├── firebase-config.js                # Firebase v10 modular SDK bootstrap
 ├── firestore.rules, database.rules.json
-└── package.json                      # Test runner only (no build step)
+└── package.json                      # Test + build scripts (build:site runs on every deploy)
 ```
 
 ## Apps

--- a/apps/rising-shows/README.md
+++ b/apps/rising-shows/README.md
@@ -65,6 +65,14 @@ every Netlify deploy through `npm run build:site`) renders one static HTML page 
 series under `apps/rising-shows/shows/` plus an A-Z index and `sitemap-shows.xml`.
 These are gitignored build artifacts, derived from `data.json` (which the build downloads from the `rising-shows-data` release first).
 
+`sitemap-shows.xml` is deliberately curated: it lists only the top 2,000 series by
+IMDb vote count (`SITEMAP_LIMIT` in `build-show-pages.js`), not all ~34k. Every page
+is still built and reachable through the A-Z index; the sitemap just focuses Google's
+crawl budget on shows with real search demand instead of parking the long tail in
+"Discovered - currently not indexed" (GSC, 2026-07). After the page builders run,
+`scripts/stamp-sitemap-index.mjs` (repo root) re-stamps the root `sitemap.xml`
+index's `<lastmod>` entries from the freshly generated sub-sitemaps.
+
 Each page (`scripts/render-show-page.js`) emits:
 
 - `BreadcrumbList` and `TVSeries` JSON-LD, plus one `TVSeason` block per season with

--- a/apps/rising-shows/scripts/build-show-pages.js
+++ b/apps/rising-shows/scripts/build-show-pages.js
@@ -12,13 +12,18 @@ const path = require('path');
 const { showPath } = require('./slugify.js');
 const { renderShowPage, shapeToSlug } = require('./render-show-page.js');
 const { renderShowsIndex } = require('./render-shows-index.js');
-const { renderShowsSitemap } = require('./render-sitemap.js');
+const { renderShowsSitemap, selectSitemapSeries } = require('./render-sitemap.js');
 
 const ROOT = path.join(__dirname, '..');
 const DATA_FILE = path.join(ROOT, 'data.json');
 const EXTRAS_FILE = path.join(ROOT, 'data', 'show-modal-extras.json');
 const SHOWS_DIR = path.join(ROOT, 'shows');
 const SITEMAP_FILE = path.join(ROOT, 'sitemap-shows.xml');
+
+// Only the most-voted shows go into the sitemap (all pages are still
+// built). At 2,000 the cutoff sits around 15k IMDb votes, i.e. shows
+// with real search demand. See renderShowsSitemap for the rationale.
+const SITEMAP_LIMIT = 2000;
 
 function main() {
   if (!fs.existsSync(DATA_FILE)) {
@@ -81,7 +86,9 @@ function main() {
     path.join(SHOWS_DIR, 'index.html'),
     renderShowsIndex(series.map(toIndexEntry), data.builtAt),
   );
-  fs.writeFileSync(SITEMAP_FILE, renderShowsSitemap(series.map(toIndexEntry), data.builtAt));
+  const sitemapSeries = selectSitemapSeries(series, SITEMAP_LIMIT);
+  fs.writeFileSync(SITEMAP_FILE, renderShowsSitemap(sitemapSeries.map(toIndexEntry), data.builtAt));
+  console.log(`[build-show-pages] sitemap curated to top ${sitemapSeries.length} of ${series.length} series by votes; the rest stay crawlable via the A-Z index`);
 
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);
   console.log(`[build-show-pages] wrote ${pageCount} show pages (${castCount} with cast) + index + sitemap in ${elapsed}s`);

--- a/apps/rising-shows/scripts/render-sitemap.js
+++ b/apps/rising-shows/scripts/render-sitemap.js
@@ -3,9 +3,12 @@
 const { showPath } = require('./slugify.js');
 const { SITE } = require('./render-show-page.js');
 
-// Emit a single sitemap.xml referencing every show page plus the
-// /shows/ browse index. Spec caps a sitemap at 50,000 URLs or 50 MB —
-// ~7k entries fits comfortably, so no chunking yet.
+// Emit a single sitemap.xml referencing the curated top show pages plus
+// the /shows/ browse index. Every show page is still built and served;
+// the sitemap deliberately lists only the most-voted subset so Google
+// spends its crawl budget on shows people actually search for instead
+// of parking 30k+ long-tail pages in "Discovered - currently not
+// indexed" (GSC, 2026-07). The rest stay reachable via the A-Z index.
 function renderShowsSitemap(series, builtAt) {
   const lastmod = builtAt ? new Date(builtAt).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10);
   const urls = [
@@ -32,4 +35,14 @@ ${urls.join('\n')}
 `;
 }
 
-module.exports = { renderShowsSitemap };
+// Pick the `limit` series with the most IMDb votes (ties broken by
+// title so output is deterministic). Series without a vote count sort
+// last. Callers pass the full grouped-series list; the returned subset
+// is what goes into the sitemap.
+function selectSitemapSeries(series, limit) {
+  return [...series]
+    .sort((a, b) => (b.seriesVotes || 0) - (a.seriesVotes || 0) || a.title.localeCompare(b.title))
+    .slice(0, limit);
+}
+
+module.exports = { renderShowsSitemap, selectSitemapSeries };

--- a/apps/rising-shows/tests/render-sitemap.test.js
+++ b/apps/rising-shows/tests/render-sitemap.test.js
@@ -3,7 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { renderShowsSitemap } = require('../scripts/render-sitemap.js');
+const { renderShowsSitemap, selectSitemapSeries } = require('../scripts/render-sitemap.js');
 const { renderShowsIndex, sortTitle, firstLetter } = require('../scripts/render-shows-index.js');
 
 const SERIES = [
@@ -35,6 +35,35 @@ test('renderShowsSitemap URLs use the slug + tconst path scheme', () => {
 test('renderShowsSitemap stamps lastmod from builtAt', () => {
   const xml = renderShowsSitemap(SERIES, '2026-05-18T12:34:56.000Z');
   assert.ok(xml.includes('<lastmod>2026-05-18</lastmod>'));
+});
+
+test('selectSitemapSeries keeps the top-voted shows up to the limit', () => {
+  const series = [
+    { seriesId: 'tt1', title: 'Low', seriesVotes: 100 },
+    { seriesId: 'tt2', title: 'High', seriesVotes: 90000 },
+    { seriesId: 'tt3', title: 'Mid', seriesVotes: 5000 },
+  ];
+  const picked = selectSitemapSeries(series, 2);
+  assert.deepEqual(picked.map((s) => s.seriesId), ['tt2', 'tt3']);
+});
+
+test('selectSitemapSeries sorts missing vote counts last and breaks ties by title', () => {
+  const series = [
+    { seriesId: 'tt1', title: 'Zeta', seriesVotes: 500 },
+    { seriesId: 'tt2', title: 'No Votes' },
+    { seriesId: 'tt3', title: 'Alpha', seriesVotes: 500 },
+  ];
+  const picked = selectSitemapSeries(series, 3);
+  assert.deepEqual(picked.map((s) => s.title), ['Alpha', 'Zeta', 'No Votes']);
+});
+
+test('selectSitemapSeries does not mutate the input order', () => {
+  const series = [
+    { seriesId: 'tt1', title: 'B', seriesVotes: 1 },
+    { seriesId: 'tt2', title: 'A', seriesVotes: 2 },
+  ];
+  selectSitemapSeries(series, 1);
+  assert.deepEqual(series.map((s) => s.seriesId), ['tt1', 'tt2']);
 });
 
 test('sortTitle drops leading articles for alphabetization', () => {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:rising-shows": "node apps/rising-shows/scripts/build-data.js",
     "build:rising-shows:pages": "node apps/rising-shows/scripts/build-show-pages.js",
     "build:gym-tracker:pages": "node apps/gym-tracker/scripts/build-exercise-pages.cjs",
-    "build:site": "node apps/rising-shows/scripts/fetch-data.js && node apps/rising-shows/scripts/build-show-pages.js && node apps/gym-tracker/scripts/build-exercise-pages.cjs",
+    "build:site": "node apps/rising-shows/scripts/fetch-data.js && node apps/rising-shows/scripts/build-show-pages.js && node apps/gym-tracker/scripts/build-exercise-pages.cjs && node scripts/stamp-sitemap-index.mjs",
     "fetch:rising-shows-data": "node apps/rising-shows/scripts/fetch-data.js",
     "build:og-cards": "node assets/og/build-og-cards.mjs",
     "enrich:rising-shows": "node apps/rising-shows/scripts/enrich-tmdb.js",

--- a/scripts/stamp-sitemap-index.mjs
+++ b/scripts/stamp-sitemap-index.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Re-stamp the <lastmod> entries in the root sitemap.xml index from the
+// sub-sitemaps actually present on disk. Runs as the last step of
+// `npm run build:site`, after the Rising Shows and Gym Tracker page
+// builders have regenerated their sub-sitemaps, so the index always
+// advertises fresh dates instead of whatever was committed (the shows
+// entry sat at 2026-05-19 for two months while the data refreshed
+// daily - GSC had no reason to re-fetch it).
+//
+// Rule: an index entry's lastmod = the max per-URL <lastmod> inside the
+// referenced sub-sitemap. Sub-sitemaps missing from disk (e.g. the
+// generated ones, before a local build) keep their committed value.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const INDEX_FILE = path.join(ROOT, 'sitemap.xml');
+const ORIGIN = 'https://shevato.com/';
+
+// Max YYYY-MM-DD across every <lastmod> in a sitemap document, or null
+// when it carries none. Full ISO timestamps are truncated to the date.
+export function maxLastmod(xml) {
+  let max = null;
+  for (const [, value] of xml.matchAll(/<lastmod>([^<]+)<\/lastmod>/g)) {
+    const day = value.trim().slice(0, 10);
+    if (/^\d{4}-\d{2}-\d{2}$/.test(day) && (max === null || day > max)) max = day;
+  }
+  return max;
+}
+
+// Rewrite the index XML so each <sitemap> block whose <loc> appears in
+// lastmodByLoc gets that lastmod value. Blocks with unknown locs are
+// left untouched.
+export function stampSitemapIndex(indexXml, lastmodByLoc) {
+  return indexXml.replace(/<sitemap>[\s\S]*?<\/sitemap>/g, (block) => {
+    const loc = block.match(/<loc>([^<]+)<\/loc>/);
+    const lastmod = loc && lastmodByLoc[loc[1].trim()];
+    if (!lastmod) return block;
+    return block.replace(/<lastmod>[^<]*<\/lastmod>/, `<lastmod>${lastmod}</lastmod>`);
+  });
+}
+
+function main() {
+  const indexXml = fs.readFileSync(INDEX_FILE, 'utf8');
+  const lastmodByLoc = {};
+  for (const [, loc] of indexXml.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    const file = path.join(ROOT, loc.trim().slice(ORIGIN.length));
+    if (!fs.existsSync(file)) {
+      console.log(`[stamp-sitemap-index] ${loc} not on disk, keeping committed lastmod`);
+      continue;
+    }
+    const stamp = maxLastmod(fs.readFileSync(file, 'utf8'));
+    if (stamp) lastmodByLoc[loc.trim()] = stamp;
+  }
+  const stamped = stampSitemapIndex(indexXml, lastmodByLoc);
+  if (stamped === indexXml) {
+    console.log('[stamp-sitemap-index] sitemap.xml already up to date');
+    return;
+  }
+  fs.writeFileSync(INDEX_FILE, stamped);
+  for (const [loc, day] of Object.entries(lastmodByLoc)) {
+    console.log(`[stamp-sitemap-index] ${loc} -> ${day}`);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,18 +5,23 @@
     - sitemap-shows.xml      — auto-generated per-show pages for Rising Shows
     - sitemap-exercises.xml  — auto-generated per-exercise pages for Gym Tracker
   Submitting this single URL to Google Search Console covers all three.
+
+  The <lastmod> values below are placeholders: scripts/stamp-sitemap-index.mjs
+  rewrites each one at deploy time (last step of `npm run build:site`) to the
+  max per-URL <lastmod> inside that sub-sitemap, so the deployed index always
+  reflects the freshly generated files.
 -->
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>https://shevato.com/sitemap-pages.xml</loc>
-    <lastmod>2026-07-20</lastmod>
+    <lastmod>2026-07-22</lastmod>
   </sitemap>
   <sitemap>
     <loc>https://shevato.com/apps/rising-shows/sitemap-shows.xml</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-07-07</lastmod>
   </sitemap>
   <sitemap>
     <loc>https://shevato.com/apps/gym-tracker/sitemap-exercises.xml</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-07-19</lastmod>
   </sitemap>
 </sitemapindex>

--- a/sync-system/tests/stamp-sitemap-index.test.mjs
+++ b/sync-system/tests/stamp-sitemap-index.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { maxLastmod, stampSitemapIndex } from '../../scripts/stamp-sitemap-index.mjs';
+
+const SUB_SITEMAP = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://shevato.com/a</loc><lastmod>2026-06-01</lastmod></url>
+  <url><loc>https://shevato.com/b</loc><lastmod>2026-07-22</lastmod></url>
+  <url><loc>https://shevato.com/c</loc><lastmod>2026-05-18</lastmod></url>
+</urlset>`;
+
+const INDEX = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://shevato.com/sitemap-pages.xml</loc>
+    <lastmod>2026-07-20</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://shevato.com/apps/rising-shows/sitemap-shows.xml</loc>
+    <lastmod>2026-05-19</lastmod>
+  </sitemap>
+</sitemapindex>`;
+
+test('maxLastmod returns the newest date in the document', () => {
+  assert.equal(maxLastmod(SUB_SITEMAP), '2026-07-22');
+});
+
+test('maxLastmod truncates full ISO timestamps to the date', () => {
+  assert.equal(maxLastmod('<lastmod>2026-07-29T08:39:00.000Z</lastmod>'), '2026-07-29');
+});
+
+test('maxLastmod returns null when no lastmod is present', () => {
+  assert.equal(maxLastmod('<urlset><url><loc>x</loc></url></urlset>'), null);
+});
+
+test('maxLastmod ignores malformed values', () => {
+  assert.equal(maxLastmod('<lastmod>soon</lastmod><lastmod>2026-01-02</lastmod>'), '2026-01-02');
+});
+
+test('stampSitemapIndex rewrites only the entries it has stamps for', () => {
+  const out = stampSitemapIndex(INDEX, {
+    'https://shevato.com/apps/rising-shows/sitemap-shows.xml': '2026-07-29',
+  });
+  assert.ok(out.includes('<loc>https://shevato.com/apps/rising-shows/sitemap-shows.xml</loc>\n    <lastmod>2026-07-29</lastmod>'));
+  // The pages entry had no stamp and keeps its committed value.
+  assert.ok(out.includes('<loc>https://shevato.com/sitemap-pages.xml</loc>\n    <lastmod>2026-07-20</lastmod>'));
+});
+
+test('stampSitemapIndex is a no-op when the stamps already match', () => {
+  const out = stampSitemapIndex(INDEX, {
+    'https://shevato.com/sitemap-pages.xml': '2026-07-20',
+    'https://shevato.com/apps/rising-shows/sitemap-shows.xml': '2026-05-19',
+  });
+  assert.equal(out, INDEX);
+});


### PR DESCRIPTION
## Why

GSC reports tens of thousands of unindexed pages. Root cause: sitemap-shows.xml advertised all ~34.5k generated per-show pages, which Google parks under "Discovered - currently not indexed" on a small domain. Compounding it, the root sitemap.xml index carried hardcoded lastmod dates (the shows entry was frozen at 2026-05-19 while the data refreshed daily), so Google had little reason to re-fetch the sub-sitemaps.

## Changes

### Rising Shows (sitemap curation)

- `apps/rising-shows/scripts/render-sitemap.js`: new exported `selectSitemapSeries(series, limit)` - sorts by `seriesVotes` descending (missing counts last, ties broken by title for determinism, input not mutated) and takes the top `limit`. Header comment rewritten to document the curation rationale; it previously claimed "~7k entries", which was long stale.
- `apps/rising-shows/scripts/build-show-pages.js`: new `SITEMAP_LIMIT = 2000` constant; the sitemap is now rendered from `selectSitemapSeries(series, SITEMAP_LIMIT)` instead of every series. All pages are still built and served - only the sitemap contents changed; the rest stay crawlable via the A-Z browse index. A log line reports the cap ("sitemap curated to top N of M series") so the truncation is never silent.
- `apps/rising-shows/tests/render-sitemap.test.js`: 3 new tests for `selectSitemapSeries` (top-voted selection with limit, missing-votes-last plus title tie-break, no input mutation).

Judgment call: 2,000 as the limit puts the vote cutoff around 15k IMDb votes (top 1,000 would be ~33k, top 3,000 ~9k), which keeps every advertised page a show with real search demand while staying well clear of thin long-tail content.

### Site (sitemap index lastmod stamping)

- `scripts/stamp-sitemap-index.mjs` (new, first file in a new root `scripts/` dir): rewrites each `<lastmod>` in the root sitemap.xml index to the max per-URL `<lastmod>` found inside the referenced sub-sitemap on disk. Sub-sitemaps missing from disk keep their committed value. Exports pure `maxLastmod()` / `stampSitemapIndex()` helpers for testing; no-op write when nothing changed. This fixes all three entries uniformly, including sitemap-pages.xml drift (its index entry said 2026-07-20 while the newest page lastmod is 2026-07-22).
- `package.json`: `build:site` now ends with `node scripts/stamp-sitemap-index.mjs`, after both page builders, so every Netlify deploy stamps fresh dates.
- `sitemap.xml`: comment added documenting that the committed lastmod values are placeholders rewritten at deploy time; the committed values themselves updated to the current accurate dates (pages 2026-07-22, shows 2026-07-07 from the local data build, exercises 2026-07-19) via a local run of the stamp script.
- `sync-system/tests/stamp-sitemap-index.test.mjs` (new): 6 tests covering max-date selection, ISO-timestamp truncation, no-lastmod and malformed-value handling, selective stamping that leaves unmatched entries untouched, and exact no-op output when stamps already match.

### Docs

- `apps/rising-shows/README.md`: "Static show pages (SEO)" section documents the 2,000-entry curation, the rationale, and the index-stamping step.
- `README.md`: repo tree gained the `scripts/` entry; the package.json line no longer claims "no build step" (build:site has existed for a while - fixed the stale line while touching it).

## Testing

- `npm test`: 1918/1918 pass (9 new).
- Full local `build-show-pages.js` run against the complete data.json (34,281 series): all 34,281 pages still built; sitemap-shows.xml came out at 2,001 URLs (2,000 shows + browse index) headed by Breaking Bad, Game of Thrones, Stranger Things - votes-descending as intended.
- `stamp-sitemap-index.mjs` run end-to-end locally: stamped all three index entries from real sub-sitemap contents; a second run detects no change and writes nothing.
- Living plan pair updated (rising-shows + site) with this round's run report; post-deploy GSC checks (sitemap re-read shows ~2,001 discovered URLs; unindexed bucket trends down without indexed pages falling out) recorded in the rising-shows human file.