### PR TITLE
fix(seo): generated pages link /home directly instead of the redirecting /

### DIFF
--- a/apps/gym-tracker/scripts/render-exercise-index.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-index.cjs
@@ -68,7 +68,7 @@ function renderExerciseIndex(exercises, slugs, builtAt) {
 
   <main id="main" class="exercises-index">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a href="/">Shevato</a> ›
+      <a href="/home">Shevato</a> ›
       <a href="/apps/gym-tracker/">Gym Tracker</a> ›
       <span>Exercises</span>
     </nav>
@@ -172,7 +172,7 @@ function renderTaxonomyPage({ kind, key, label, exercises, slugs, builtAt }) {
 
   <main id="main" class="exercises-index">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a href="/">Shevato</a> ›
+      <a href="/home">Shevato</a> ›
       <a href="/apps/gym-tracker/">Gym Tracker</a> ›
       <a href="/apps/gym-tracker/exercises/">Exercises</a> ›
       <span>${escapeHtml(label)}</span>

--- a/apps/gym-tracker/scripts/render-exercise-page.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-page.cjs
@@ -86,7 +86,7 @@ ${jsonLd(buildExerciseSchema({ exercise, canonical, description }))}
 
   <main id="main" class="exercise-page">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a href="/">Shevato</a> ›
+      <a href="/home">Shevato</a> ›
       <a href="/apps/gym-tracker/">Gym Tracker</a> ›
       <a href="/apps/gym-tracker/exercises/">Exercises</a> ›
       <a href="/apps/gym-tracker/exercises/muscle/${escapeHtml(exercise.muscleGroup || exercise.category)}/">${escapeHtml(labelOf(exercise.muscleGroup || exercise.category))}</a> ›

--- a/apps/gym-tracker/scripts/render-footer.cjs
+++ b/apps/gym-tracker/scripts/render-footer.cjs
@@ -18,7 +18,7 @@ function renderMoreFooter() {
         <li><a href="/apps/trip-planner/"><strong>Trip Planner</strong><span> · itineraries with maps, costs and warnings</span></a></li>
       </ul>
     </nav>
-    <p class="copyright">© Shevato LLC · <a href="/">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>
+    <p class="copyright">© Shevato LLC · <a href="/home">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>
   </footer>`;
 }
 

--- a/apps/rising-shows/scripts/render-footer.js
+++ b/apps/rising-shows/scripts/render-footer.js
@@ -22,7 +22,7 @@ function renderMoreFooter() {
       <a class="tmdb-logo-link" href="https://www.themoviedb.org/" target="_blank" rel="noopener noreferrer" aria-label="The Movie Database (TMDB)"><img class="tmdb-logo" src="/apps/rising-shows/images/tmdb-logo.svg" alt="TMDB" width="108" height="14" loading="lazy"></a>
       <p>This product uses the TMDB API but is not endorsed or certified by TMDB. Streaming data powered by <a href="https://www.justwatch.com/" target="_blank" rel="noopener noreferrer">JustWatch</a>. Information courtesy of IMDb (<a href="https://www.imdb.com/" target="_blank" rel="noopener noreferrer">https://www.imdb.com</a>). Used with permission.</p>
     </div>
-    <p class="copyright">© Shevato LLC · <a href="/">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>
+    <p class="copyright">© Shevato LLC · <a href="/home">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>
   </footer>`;
 }
 

--- a/apps/rising-shows/scripts/render-show-page.js
+++ b/apps/rising-shows/scripts/render-show-page.js
@@ -171,7 +171,7 @@ ${seasonSchemas}
 
   <main id="main" class="show-page">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a href="/">Shevato</a> ›
+      <a href="/home">Shevato</a> ›
       <a href="/apps/rising-shows/">Rising Shows</a> ›
       <a href="/apps/rising-shows/shows/">All shows</a> ›
       <span>${escapeHtml(title)}</span>

--- a/apps/rising-shows/scripts/render-shows-index.js
+++ b/apps/rising-shows/scripts/render-shows-index.js
@@ -76,7 +76,7 @@ function renderShowsIndex(series, builtAt) {
 
   <main id="main" class="shows-index">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a href="/">Shevato</a> ›
+      <a href="/home">Shevato</a> ›
       <a href="/apps/rising-shows/">Rising Shows</a> ›
       <span>All shows</span>
     </nav>


### PR DESCRIPTION
## Why

Every generated Rising Shows and Gym Tracker page linked the homepage as `/`, which 301s to `/home.html` (by design, per netlify.toml). That meant crawlers took a redirect hop from all ~35k generated pages. The homepage's canonical URL is `https://shevato.com/home`, which serves a direct 200, so the templates now link it. GSC follow-up to #315; the marketing partials needed no change because their `/home.html` hrefs are rewritten to `/home` by Netlify Pretty URLs at serve time.

## Changes

All six files carry the same one-line kind of change: `href="/"` -> `href="/home"` on homepage links. Visible anchor text and layout are untouched.

### Rising Shows

- `apps/rising-shows/scripts/render-show-page.js`: breadcrumb "Shevato" link on every per-show page.
- `apps/rising-shows/scripts/render-shows-index.js`: breadcrumb "Shevato" link on the A-Z browse index.
- `apps/rising-shows/scripts/render-footer.js`: footer "shevato.com" link.

### Gym Tracker

- `apps/gym-tracker/scripts/render-exercise-page.cjs`: breadcrumb "Shevato" link on every exercise page.
- `apps/gym-tracker/scripts/render-exercise-index.cjs`: breadcrumb "Shevato" links (two occurrences: exercise index and taxonomy pages).
- `apps/gym-tracker/scripts/render-footer.cjs`: footer "shevato.com" link, kept in sync with the Rising Shows footer renderer per convention.

## Testing

- `npm test`: 1918/1918 pass.
- Full local rebuild of both apps' generated pages: sample show page and the exercise index each contain 2 `href="/home"` links and zero `href="/"` links.
- Prod `/home` confirmed returning 200 (no redirect).
- Living plan pairs for both apps updated with this round's run report; nothing flagged for human verification (href-only change, fully checkable headlessly).