### PR TITLE
feat(rising-shows): per-shape hub pages with cross-links from show pages and sitemap

### DIFF
--- a/apps/rising-shows/README.md
+++ b/apps/rising-shows/README.md
@@ -62,11 +62,13 @@ A season can match more than one shape — the card shows all of them.
 
 `scripts/build-show-pages.js` (run via `npm run build:rising-shows:pages`, and on
 every Netlify deploy through `npm run build:site`) renders one static HTML page per
-series under `apps/rising-shows/shows/` plus an A-Z index and `sitemap-shows.xml`.
+series under `apps/rising-shows/shows/` plus an A-Z index, 13 per-shape hub pages, and
+`sitemap-shows.xml`.
 These are gitignored build artifacts, derived from `data.json` (which the build downloads from the `rising-shows-data` release first).
 
 `sitemap-shows.xml` is deliberately curated: it lists only the top 2,000 series by
-IMDb vote count (`SITEMAP_LIMIT` in `build-show-pages.js`), not all ~34k. Every page
+IMDb vote count (`SITEMAP_LIMIT` in `build-show-pages.js`), not all ~34k, plus the
+A-Z index and the 13 shape hubs (2,014 URLs in total). Every page
 is still built and reachable through the A-Z index; the sitemap just focuses Google's
 crawl budget on shows with real search demand instead of parking the long tail in
 "Discovered - currently not indexed" (GSC, 2026-07). After the page builders run,
@@ -82,6 +84,18 @@ Each page (`scripts/render-show-page.js`) emits:
   `#season-N` anchor.
 - Open Graph and Twitter card meta, including `og:image:alt` and `twitter:label`/`data`
   pairs that carry the dominant shape and average episode rating into link previews.
+
+**Shape hubs.** `scripts/render-shape-hub.js` renders one topic landing page per shape at
+`apps/rising-shows/shows/shape/<slug>/` (13 of them: `rising`, `consistent`, `slow-burn`,
+`big-finale`, `rebound`, `front-loaded`, `declining`, `bad-finale`, `rollercoaster`,
+`mid-peak`, `u-shaped`, `saved-best-for-last`, `shape-drift`). A show appears on exactly
+one hub, the one matching its **dominant shape** (the first shape tag of its highest-rated
+season, `computeDominantShape` in `render-show-page.js`), ranked by IMDb vote count and
+capped at the top 100; the `CollectionPage` JSON-LD `ItemList` carries the first 25.
+Each hub cross-links the other 12, the A-Z index, and the shape-filtered explorer view
+(`/apps/rising-shows/#shape=<slug>`). The per-season shape badges on show pages and the
+"See all X shows" link under the recommendations point at these hubs, the A-Z index carries
+a "Browse by shape" strip, and all 13 URLs are listed in `sitemap-shows.xml`.
 
 **Sensitive (adult) posters.** Pages for titles carrying the IMDb "Adult" genre blur
 the hero poster (and any adult related-show thumbnail) behind a CSS-only click-to-reveal

--- a/apps/rising-shows/css/show-page.css
+++ b/apps/rising-shows/css/show-page.css
@@ -369,6 +369,44 @@ a.shape-badge:hover {
 .shows-list .muted { color: var(--muted); font-size: 13px; }
 
 .index-footer { margin-top: 28px; color: var(--muted); font-size: 14px; }
+.index-footer a { color: var(--accent); }
+
+/* --- Per-shape hubs (/shows/shape/<slug>/) --- */
+.shape-nav {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  margin: 18px 0 26px; padding: 12px 16px;
+  background: var(--panel); border-radius: 10px; border: 1px solid var(--border);
+}
+.shape-nav-label {
+  font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--muted); margin-right: 4px;
+}
+.shape-nav a, .shape-nav-current {
+  display: inline-block; padding: 4px 12px; border-radius: 999px;
+  text-decoration: none; font-size: 14px;
+  background: var(--bg-2); color: var(--text);
+}
+.shape-nav a:hover { background: var(--shape); color: var(--shape-text); }
+.shape-nav-current { background: var(--shape); color: var(--shape-text); font-weight: 600; }
+.shape-nav a.shape-nav-all { color: var(--accent); }
+
+.shape-hub .hub-hero { margin-bottom: 4px; }
+.shape-hub .hub-hero h1 { margin: 0 0 8px; font-size: clamp(28px, 4vw, 36px); }
+.shape-hub .lede { color: var(--muted); margin: 0 0 16px; max-width: 70ch; }
+
+.rank-list { list-style: none; margin: 0; padding: 0; }
+.rank-list li { border-bottom: 1px solid var(--border); }
+.rank-row {
+  display: grid; grid-template-columns: 44px 1fr auto; align-items: baseline;
+  gap: 12px; padding: 10px 8px; text-decoration: none; color: var(--text);
+  border-radius: 8px;
+}
+.rank-row:hover { background: var(--bg-2); color: var(--text); }
+.rank-row:hover .rank-title { color: var(--accent); }
+.rank-num { color: var(--muted); font-variant-numeric: tabular-nums; font-size: 14px; }
+.rank-title { font-weight: 500; }
+.rank-title .muted { color: var(--muted); font-weight: 400; font-size: 13px; }
+.rank-stats { color: var(--muted); font-size: 13px; white-space: nowrap; }
 
 /* --- Freshness line --- */
 .hero-freshness {
@@ -527,4 +565,7 @@ body:has(.sticky-cta-banner:not([hidden])) .back-to-top:hover:active {
   .sticky-cta-title { font-size: 13px; }
   .page-nav { display: none; }
   .page-header { padding: 10px 16px; }
+  .rank-row { grid-template-columns: 30px 1fr; row-gap: 2px; padding: 10px 6px; }
+  .rank-stats { grid-column: 2; white-space: normal; }
+  .shape-nav { padding: 12px; }
 }

--- a/apps/rising-shows/scripts/build-show-pages.js
+++ b/apps/rising-shows/scripts/build-show-pages.js
@@ -10,8 +10,9 @@ const fs = require('fs');
 const path = require('path');
 
 const { showPath } = require('./slugify.js');
-const { renderShowPage, shapeToSlug } = require('./render-show-page.js');
+const { renderShowPage, computeDominantShape } = require('./render-show-page.js');
 const { renderShowsIndex } = require('./render-shows-index.js');
+const { renderShapeHub, selectHubShows, SHAPE_SLUGS } = require('./render-shape-hub.js');
 const { renderShowsSitemap, selectSitemapSeries } = require('./render-sitemap.js');
 
 const ROOT = path.join(__dirname, '..');
@@ -86,8 +87,19 @@ function main() {
     path.join(SHOWS_DIR, 'index.html'),
     renderShowsIndex(series.map(toIndexEntry), data.builtAt),
   );
+
+  // Per-shape topic hubs. Safe to nest inside SHOWS_DIR: show directories
+  // always end in -tt<digits>, so "shape" can never collide with one.
+  for (const slug of SHAPE_SLUGS) {
+    const dir = path.join(SHOWS_DIR, 'shape', slug);
+    fs.mkdirSync(dir, { recursive: true });
+    const hubShows = selectHubShows(series, slug);
+    fs.writeFileSync(path.join(dir, 'index.html'), renderShapeHub(slug, hubShows, data.builtAt));
+    console.log(`[build-show-pages] shape hub /${slug}/ · ${hubShows.length} shows`);
+  }
+
   const sitemapSeries = selectSitemapSeries(series, SITEMAP_LIMIT);
-  fs.writeFileSync(SITEMAP_FILE, renderShowsSitemap(sitemapSeries.map(toIndexEntry), data.builtAt));
+  fs.writeFileSync(SITEMAP_FILE, renderShowsSitemap(sitemapSeries.map(toIndexEntry), data.builtAt, SHAPE_SLUGS));
   console.log(`[build-show-pages] sitemap curated to top ${sitemapSeries.length} of ${series.length} series by votes; the rest stay crawlable via the A-Z index`);
 
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);
@@ -149,21 +161,6 @@ function fillIfEmpty(target, src, keys) {
 
 function toIndexEntry(s) {
   return { seriesId: s.seriesId, title: s.title, year: s.year };
-}
-
-// Pick the shape from the season with the highest seriesVotes (all seasons
-// in a series share the same seriesVotes, so break ties by avgRating).
-// Returns null when the show has no shape classifications at all.
-function computeDominantShape(show) {
-  let bestSeason = null;
-  for (const s of show.seasons) {
-    if (!s.shapes || s.shapes.length === 0) continue;
-    if (!bestSeason) { bestSeason = s; continue; }
-    if (s.avgRating > bestSeason.avgRating) bestSeason = s;
-  }
-  if (!bestSeason) return { dominantShape: null, dominantShapeSlug: null };
-  const shape = bestSeason.shapes[0];
-  return { dominantShape: shape, dominantShapeSlug: shapeToSlug(shape) };
 }
 
 // Build an inverted index: shape slug → array of series objects sorted by

--- a/apps/rising-shows/scripts/render-shape-hub.js
+++ b/apps/rising-shows/scripts/render-shape-hub.js
@@ -1,0 +1,224 @@
+'use strict';
+
+const { showPath } = require('./slugify.js');
+const {
+  escapeHtml,
+  SITE,
+  SHAPE_LABELS,
+  SHAPE_DESCS,
+  computeDominantShape,
+  computeOverallAvgRating,
+  jsonLd,
+} = require('./render-show-page.js');
+const { renderMoreFooter } = require('./render-footer.js');
+
+// Every shape a season can carry, in the app's chip order (the last two are
+// series-level tags). One static hub page is generated per entry.
+const SHAPE_SLUGS = [
+  'rising',
+  'consistent',
+  'slow-burn',
+  'big-finale',
+  'rebound',
+  'front-loaded',
+  'declining',
+  'bad-finale',
+  'rollercoaster',
+  'mid-peak',
+  'u-shaped',
+  'saved-best-for-last',
+  'shape-drift',
+];
+
+// Visible ranking depth. The ItemList in JSON-LD stops earlier so the
+// structured-data payload stays small.
+const HUB_LIMIT = 100;
+const HUB_SCHEMA_LIMIT = 25;
+
+function hubPath(slug) {
+  return `/apps/rising-shows/shows/shape/${slug}/`;
+}
+
+// A show belongs to exactly one hub: the one matching its dominant shape, so
+// the same title never appears on two hubs. Ranked by IMDb votes descending
+// (ties broken by title for a deterministic build).
+function selectHubShows(series, slug, limit = HUB_LIMIT) {
+  return series
+    .filter((s) => computeDominantShape(s).dominantShapeSlug === slug)
+    .sort((a, b) => (b.seriesVotes || 0) - (a.seriesVotes || 0) || a.title.localeCompare(b.title))
+    .slice(0, limit);
+}
+
+// One static landing page per rating shape: a ranked list of the most-voted
+// shows whose dominant season carries that shape. These are the topic hubs the
+// per-season shape badges and the A-Z index link into.
+function renderShapeHub(slug, shows, builtAt) {
+  const label = SHAPE_LABELS[slug] || slug;
+  const desc = SHAPE_DESCS[slug] || '';
+  const canonical = `${SITE}${hubPath(slug)}`;
+  const count = shows.length;
+  const description = `The ${count} best ${label.toLowerCase()} TV shows, ranked by IMDb votes. ${desc}. Episode-by-episode ratings and season-shape analysis for every show.`;
+  const pageTitle = `Best ${label} TV shows - Rising Shows`;
+
+  const rows = shows
+    .map((s, i) => {
+      const avg = computeOverallAvgRating(s.seasons);
+      const stats = [
+        `${avg} avg episode`,
+        s.seriesVotes ? `${s.seriesVotes.toLocaleString()} votes` : null,
+      ].filter(Boolean).join(' · ');
+      return `<li>
+        <a class="rank-row" href="/apps/rising-shows/shows/${showPath(s.title, s.seriesId)}/">
+          <span class="rank-num">${i + 1}</span>
+          <span class="rank-title">${escapeHtml(s.title)}${s.year ? ` <span class="muted">(${s.year})</span>` : ''}</span>
+          <span class="rank-stats">${escapeHtml(stats)}</span>
+        </a>
+      </li>`;
+    })
+    .join('\n      ');
+
+  const otherShapes = SHAPE_SLUGS.filter((x) => x !== slug)
+    .map((x) => `<a href="${hubPath(x)}">${escapeHtml(SHAPE_LABELS[x] || x)}</a>`)
+    .join('\n      ');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(pageTitle)}</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <meta name="author" content="Shevato LLC">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="theme-color" content="#0b0d12">
+  <meta name="color-scheme" content="dark">
+  <link rel="canonical" href="${canonical}">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="${escapeHtml(pageTitle)}">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="${canonical}">
+  <meta property="og:image" content="${SITE}/images/og-card.png">
+  <meta property="og:image:alt" content="${escapeHtml(`Best ${label} TV shows on Rising Shows`)}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:site_name" content="Shevato">
+  <meta property="og:locale" content="en_US">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${escapeHtml(pageTitle)}">
+  <meta name="twitter:description" content="${escapeHtml(description)}">
+  <meta name="twitter:image" content="${SITE}/images/og-card.png">
+  <meta name="twitter:site" content="@shevato">
+
+  <!-- Breadcrumbs -->
+  <script type="application/ld+json">
+${jsonLd(buildBreadcrumbs(label, canonical))}
+  </script>
+
+  <!-- CollectionPage -->
+  <script type="application/ld+json">
+${jsonLd(buildCollectionSchema(label, canonical, description, shows))}
+  </script>
+
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📈%3C/text%3E%3C/svg%3E">
+  <link rel="stylesheet" href="/apps/rising-shows/css/show-page.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+
+  <header class="page-header">
+    <a class="brand" href="/apps/rising-shows/" aria-label="Rising Shows home">
+      <span aria-hidden="true">📈</span> Rising Shows
+    </a>
+    <div class="page-header-right">
+      <nav class="page-nav" aria-label="Primary">
+        <a href="/apps/rising-shows/">Explorer</a>
+        <a href="/apps/rising-shows/shows/">All shows</a>
+        <a href="/apps.html">More apps</a>
+      </nav>
+      <a class="header-launch-btn" href="/apps/rising-shows/">Launch app →</a>
+    </div>
+  </header>
+
+  <main id="main" class="shape-hub">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/home">Shevato</a> ›
+      <a href="/apps/rising-shows/">Rising Shows</a> ›
+      <a href="/apps/rising-shows/shows/">All shows</a> ›
+      <span>${escapeHtml(label)}</span>
+    </nav>
+
+    <header class="hub-hero">
+      <h1>Best ${escapeHtml(label)} TV shows</h1>
+      <p class="lede">${escapeHtml(label)}: ${escapeHtml(desc.toLowerCase())}. These are the ${count} most-voted shows whose highest-rated season carries that shape, each with an episode-by-episode rating page.</p>
+      <a class="primary-btn" href="/apps/rising-shows/#shape=${escapeHtml(slug)}">Filter ${escapeHtml(label)} shows in the explorer →</a>
+    </header>
+
+    <nav class="shape-nav" aria-label="Browse by shape">
+      <span class="shape-nav-label">Browse by shape</span>
+      <span class="shape-nav-current" aria-current="page">${escapeHtml(label)}</span>
+      ${otherShapes}
+      <a class="shape-nav-all" href="/apps/rising-shows/shows/">All shows A-Z</a>
+    </nav>
+
+    <ol class="rank-list">
+      ${rows}
+    </ol>
+
+    <p class="index-footer">Ranked by IMDb vote count. Refreshed ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : 'weekly'}. Source: <a href="https://datasets.imdbws.com/" rel="noopener" target="_blank">IMDb datasets</a>.</p>
+  </main>
+
+  ${renderMoreFooter()}
+  <script src="/assets/js/back-to-top.js" defer></script>
+</body>
+</html>
+`;
+}
+
+function buildBreadcrumbs(label, canonical) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE}/home.html` },
+      { '@type': 'ListItem', position: 2, name: 'Apps', item: `${SITE}/apps.html` },
+      { '@type': 'ListItem', position: 3, name: 'Rising Shows', item: `${SITE}/apps/rising-shows/` },
+      { '@type': 'ListItem', position: 4, name: 'All shows', item: `${SITE}/apps/rising-shows/shows/` },
+      { '@type': 'ListItem', position: 5, name: label, item: canonical },
+    ],
+  };
+}
+
+function buildCollectionSchema(label, canonical, description, shows) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: `Best ${label} TV shows`,
+    url: canonical,
+    description,
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'Rising Shows',
+      url: `${SITE}/apps/rising-shows/`,
+    },
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: shows.length,
+      itemListElement: shows.slice(0, HUB_SCHEMA_LIMIT).map((s, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: s.title,
+        url: `${SITE}/apps/rising-shows/shows/${showPath(s.title, s.seriesId)}/`,
+      })),
+    },
+  };
+}
+
+module.exports = { renderShapeHub, selectHubShows, hubPath, SHAPE_SLUGS, HUB_LIMIT };

--- a/apps/rising-shows/scripts/render-show-page.js
+++ b/apps/rising-shows/scripts/render-show-page.js
@@ -26,7 +26,45 @@ const SHAPE_LABELS = {
   'bad-finale': 'Bad finale',
   rollercoaster: 'Rollercoaster',
   'mid-peak': 'Mid-peak',
+  'u-shaped': 'U-shaped',
+  'saved-best-for-last': 'Saved best for last',
+  'shape-drift': 'Shape drift',
 };
+
+// One-line plain-English definition per shape, kept verbatim in sync with
+// SHAPE_DESCS in js/app.js so the static shape hubs describe a shape the
+// same way the in-app chips do.
+const SHAPE_DESCS = {
+  rising: 'Each episode at least as good as the last',
+  consistent: 'Excellent throughout, no weak link',
+  'slow-burn': 'Second half lifts off',
+  'big-finale': 'The last episode is the peak',
+  rebound: 'Dips, then comes back stronger',
+  'front-loaded': 'Strong start, weaker back half',
+  declining: 'Each episode no better than the last',
+  'bad-finale': 'Finale is the worst episode',
+  rollercoaster: 'Big swings episode to episode',
+  'mid-peak': 'Climaxes mid-season, falls after',
+  'u-shaped': 'Strong opener and finale, sag in the middle',
+  'saved-best-for-last': 'Final season is the show\'s highest-rated',
+  'shape-drift': 'Rating pattern or quality changed significantly late in the run',
+};
+
+// Pick the shape from the show's highest-rated season (all seasons in a series
+// share the same seriesVotes, so the season average is the tiebreaker). Returns
+// nulls when the show has no shape classifications at all. Drives the show
+// page's CTA/recommendations and the per-shape hub membership.
+function computeDominantShape(show) {
+  let bestSeason = null;
+  for (const s of show.seasons) {
+    if (!s.shapes || s.shapes.length === 0) continue;
+    if (!bestSeason) { bestSeason = s; continue; }
+    if (s.avgRating > bestSeason.avgRating) bestSeason = s;
+  }
+  if (!bestSeason) return { dominantShape: null, dominantShapeSlug: null };
+  const shape = bestSeason.shapes[0];
+  return { dominantShape: shape, dominantShapeSlug: shapeToSlug(shape) };
+}
 
 // --- sensitive (adult) posters ---
 // Titles carrying the IMDb "Adult" genre get their poster blurred behind a
@@ -277,7 +315,7 @@ function renderSeasonSection(season, seriesId) {
   const shapeEntries = (season.shapes || []).map((s) => ({ label: SHAPE_LABELS[s] || s, slug: shapeToSlug(s) }));
   const shapesHtml = shapeEntries.length
     ? `<ul class="season-shapes" aria-label="Season shape classifications">${shapeEntries
-        .map((e) => `<li><a class="shape-badge" href="/apps/rising-shows/#shape=${escapeHtml(e.slug)}" target="_blank" rel="noopener">${escapeHtml(e.label)}</a></li>`)
+        .map((e) => `<li><a class="shape-badge" href="/apps/rising-shows/shows/shape/${escapeHtml(e.slug)}/">${escapeHtml(e.label)}</a></li>`)
         .join('')}</ul>`
     : '';
   const curveSvg = renderCurve(season.episodes, { width: 720, height: 220 });
@@ -346,7 +384,7 @@ function renderRelatedShows(relatedShows, dominantShape, dominantShapeSlug) {
   return `<section class="related-shows" aria-labelledby="related-heading">
     <h2 id="related-heading">Shows like this</h2>
     <div class="rec-strip">${cards}</div>
-    <p class="rec-see-all"><a href="/apps/rising-shows/#shape=${escapeHtml(dominantShapeSlug)}">See all ${escapeHtml(shapeLabel)} shows in the explorer →</a></p>
+    <p class="rec-see-all"><a href="/apps/rising-shows/shows/shape/${escapeHtml(dominantShapeSlug)}/">See all ${escapeHtml(shapeLabel)} shows →</a></p>
   </section>`;
 }
 
@@ -518,4 +556,17 @@ function escapeHtml(s) {
     .replace(/'/g, '&#39;');
 }
 
-module.exports = { renderShowPage, escapeHtml, buildDescription, shapeToSlug, SITE, buildTvSeasonSchema, renderSeasonNav };
+module.exports = {
+  renderShowPage,
+  escapeHtml,
+  buildDescription,
+  shapeToSlug,
+  SITE,
+  buildTvSeasonSchema,
+  renderSeasonNav,
+  SHAPE_LABELS,
+  SHAPE_DESCS,
+  computeDominantShape,
+  computeOverallAvgRating,
+  jsonLd,
+};

--- a/apps/rising-shows/scripts/render-shows-index.js
+++ b/apps/rising-shows/scripts/render-shows-index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const { showPath } = require('./slugify.js');
-const { escapeHtml, SITE } = require('./render-show-page.js');
+const { escapeHtml, SITE, SHAPE_LABELS } = require('./render-show-page.js');
+const { SHAPE_SLUGS, hubPath } = require('./render-shape-hub.js');
 const { renderMoreFooter } = require('./render-footer.js');
 
 // Single A-Z browse index of every show. This is the crawler's primary
@@ -85,6 +86,11 @@ function renderShowsIndex(series, builtAt) {
       <h1>All shows</h1>
       <p class="lede">Every series in Rising Shows (${sorted.length.toLocaleString()} shows). Each links to an episode-by-episode rating page with season-shape analysis.</p>
     </header>
+
+    <nav class="shape-nav" aria-label="Browse by shape">
+      <span class="shape-nav-label">Browse by shape</span>
+      ${SHAPE_SLUGS.map((slug) => `<a href="${hubPath(slug)}">${escapeHtml(SHAPE_LABELS[slug] || slug)}</a>`).join('\n      ')}
+    </nav>
 
     <nav class="alpha-jump" aria-label="Jump to letter">
       ${letters.map((l) => `<a href="#letter-${escapeHtml(l)}">${escapeHtml(l)}</a>`).join('')}

--- a/apps/rising-shows/scripts/render-sitemap.js
+++ b/apps/rising-shows/scripts/render-sitemap.js
@@ -9,7 +9,7 @@ const { SITE } = require('./render-show-page.js');
 // spends its crawl budget on shows people actually search for instead
 // of parking 30k+ long-tail pages in "Discovered - currently not
 // indexed" (GSC, 2026-07). The rest stay reachable via the A-Z index.
-function renderShowsSitemap(series, builtAt) {
+function renderShowsSitemap(series, builtAt, shapeSlugs = []) {
   const lastmod = builtAt ? new Date(builtAt).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10);
   const urls = [
     `  <url>
@@ -18,6 +18,14 @@ function renderShowsSitemap(series, builtAt) {
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>`,
+    // Per-shape hubs sit above the individual shows: they're the topic
+    // landing pages the show pages link back into.
+    ...shapeSlugs.map((slug) => `  <url>
+    <loc>${SITE}/apps/rising-shows/shows/shape/${slug}/</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>`),
     ...series.map((s) => {
       const slug = showPath(s.title, s.seriesId);
       return `  <url>

--- a/apps/rising-shows/tests/render-shape-hub.test.js
+++ b/apps/rising-shows/tests/render-shape-hub.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { renderShapeHub, selectHubShows, hubPath, SHAPE_SLUGS, HUB_LIMIT } = require('../scripts/render-shape-hub.js');
+
+function makeShow(seriesId, title, seriesVotes, shapes, avgRating = 8.0) {
+  return {
+    seriesId,
+    title,
+    year: 2010,
+    seriesVotes,
+    seasons: [
+      {
+        season: 1,
+        avgRating,
+        shapes,
+        episodes: [
+          { episode: 1, rating: avgRating, votes: 100 },
+          { episode: 2, rating: avgRating, votes: 100 },
+        ],
+      },
+    ],
+  };
+}
+
+const SERIES = [
+  makeShow('tt0001', 'Slow One', 5000, ['slow-burn'], 8.4),
+  makeShow('tt0002', 'Slow Two', 90000, ['slow-burn'], 8.1),
+  makeShow('tt0003', 'Riser', 40000, ['rising'], 9.0),
+  makeShow('tt0004', 'Shapeless', 70000, [], 7.0),
+  // Dominant shape is shapes[0] of the highest-rated season, so this show
+  // belongs to the rising hub only, never to slow-burn.
+  makeShow('tt0005', 'Multi Shape', 60000, ['rising', 'slow-burn'], 8.8),
+];
+
+test('SHAPE_SLUGS covers the 13 shapes exactly once', () => {
+  assert.equal(SHAPE_SLUGS.length, 13);
+  assert.equal(new Set(SHAPE_SLUGS).size, 13);
+});
+
+test('hubPath builds the /shows/shape/<slug>/ URL', () => {
+  assert.equal(hubPath('slow-burn'), '/apps/rising-shows/shows/shape/slow-burn/');
+});
+
+test('selectHubShows keeps only shows whose dominant shape matches', () => {
+  const picked = selectHubShows(SERIES, 'slow-burn');
+  assert.deepEqual(picked.map((s) => s.seriesId), ['tt0002', 'tt0001']);
+  // A secondary shape must not pull a show onto a second hub.
+  assert.ok(!picked.some((s) => s.seriesId === 'tt0005'));
+  assert.deepEqual(selectHubShows(SERIES, 'rising').map((s) => s.seriesId), ['tt0005', 'tt0003']);
+});
+
+test('selectHubShows orders by IMDb votes descending', () => {
+  const votes = selectHubShows(SERIES, 'slow-burn').map((s) => s.seriesVotes);
+  assert.deepEqual(votes, [...votes].sort((a, b) => b - a));
+});
+
+test('selectHubShows caps the list at 100 shows', () => {
+  const many = Array.from({ length: 250 }, (_, i) => makeShow(`tt9${i}`, `Show ${i}`, i, ['rebound']));
+  const picked = selectHubShows(many, 'rebound');
+  assert.equal(picked.length, HUB_LIMIT);
+  assert.equal(picked.length, 100);
+  assert.equal(picked[0].seriesVotes, 249);
+});
+
+test('renderShapeHub produces a valid HTML5 document', () => {
+  const html = renderShapeHub('slow-burn', selectHubShows(SERIES, 'slow-burn'), '2026-05-18T00:00:00.000Z');
+  assert.ok(html.startsWith('<!DOCTYPE html>'));
+  assert.ok(html.includes('<html lang="en">'));
+  assert.ok(html.trim().endsWith('</html>'));
+  assert.ok(html.includes('<title>Best Slow burn TV shows - Rising Shows</title>'));
+  assert.ok(html.includes('<h1>Best Slow burn TV shows</h1>'));
+});
+
+test('renderShapeHub sets exactly one canonical matching its own URL', () => {
+  const html = renderShapeHub('slow-burn', selectHubShows(SERIES, 'slow-burn'), '2026-05-18T00:00:00.000Z');
+  const canonicals = html.match(/<link rel="canonical"[^>]*>/g) || [];
+  assert.equal(canonicals.length, 1);
+  assert.equal(canonicals[0], '<link rel="canonical" href="https://shevato.com/apps/rising-shows/shows/shape/slow-burn/">');
+});
+
+test('renderShapeHub links every member show and nothing else', () => {
+  const html = renderShapeHub('slow-burn', selectHubShows(SERIES, 'slow-burn'), '2026-05-18T00:00:00.000Z');
+  const links = [...html.matchAll(/href="(\/apps\/rising-shows\/shows\/[a-z0-9-]+-tt\d+\/)"/g)].map((m) => m[1]);
+  assert.deepEqual(links, [
+    '/apps/rising-shows/shows/slow-two-tt0002/',
+    '/apps/rising-shows/shows/slow-one-tt0001/',
+  ]);
+  assert.ok(html.includes('<span class="rank-num">1</span>'));
+  assert.ok(html.includes('90,000 votes'));
+});
+
+test('renderShapeHub describes the shape and its count', () => {
+  const html = renderShapeHub('slow-burn', selectHubShows(SERIES, 'slow-burn'), '2026-05-18T00:00:00.000Z');
+  assert.ok(html.includes('second half lifts off'));
+  assert.ok(html.includes('These are the 2 most-voted shows'));
+  assert.ok(/<meta name="description" content="The 2 best slow burn TV shows/.test(html));
+});
+
+test('renderShapeHub JSON-LD blocks all parse', () => {
+  const html = renderShapeHub('slow-burn', selectHubShows(SERIES, 'slow-burn'), '2026-05-18T00:00:00.000Z');
+  const blocks = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+  assert.equal(blocks.length, 2);
+  const parsed = blocks.map((m) => JSON.parse(m[1]));
+  assert.equal(parsed[0]['@type'], 'BreadcrumbList');
+  assert.equal(parsed[0].itemListElement.at(-1).name, 'Slow burn');
+  assert.equal(parsed[1]['@type'], 'CollectionPage');
+  assert.equal(parsed[1].mainEntity.itemListElement.length, 2);
+  assert.equal(parsed[1].mainEntity.itemListElement[0].url, 'https://shevato.com/apps/rising-shows/shows/slow-two-tt0002/');
+});
+
+test('renderShapeHub caps the JSON-LD ItemList at 25 while listing all 100', () => {
+  const many = Array.from({ length: 250 }, (_, i) => makeShow(`tt9${i}`, `Show ${i}`, i, ['rebound']));
+  const shows = selectHubShows(many, 'rebound');
+  const html = renderShapeHub('rebound', shows, '2026-05-18T00:00:00.000Z');
+  const collection = JSON.parse(html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)[1]
+    .replace(/<\/?script[^>]*>/g, ''));
+  assert.equal(collection.mainEntity.numberOfItems, 100);
+  assert.equal(collection.mainEntity.itemListElement.length, 25);
+  assert.equal((html.match(/class="rank-row"/g) || []).length, 100);
+});
+
+test('renderShapeHub navigates to the other 12 hubs and the A-Z index', () => {
+  const html = renderShapeHub('slow-burn', selectHubShows(SERIES, 'slow-burn'), '2026-05-18T00:00:00.000Z');
+  const hubLinks = new Set([...html.matchAll(/href="(\/apps\/rising-shows\/shows\/shape\/[a-z-]+\/)"/g)].map((m) => m[1]));
+  assert.equal(hubLinks.size, 12);
+  assert.ok(!hubLinks.has('/apps/rising-shows/shows/shape/slow-burn/'));
+  assert.ok(html.includes('<a class="shape-nav-all" href="/apps/rising-shows/shows/">'));
+  // The explorer CTA stays on the app's conversion path.
+  assert.ok(html.includes('href="/apps/rising-shows/#shape=slow-burn"'));
+});
+
+test('renderShapeHub links the homepage as /home, never bare /', () => {
+  const html = renderShapeHub('slow-burn', selectHubShows(SERIES, 'slow-burn'), '2026-05-18T00:00:00.000Z');
+  assert.ok(html.includes('<a href="/home">Shevato</a>'));
+  assert.equal((html.match(/href="\/"/g) || []).length, 0);
+});
+
+test('renderShapeHub stamps the build date and uses no em dashes', () => {
+  const html = renderShapeHub('slow-burn', selectHubShows(SERIES, 'slow-burn'), '2026-05-18T12:34:56.000Z');
+  assert.ok(html.includes('Refreshed 2026-05-18'));
+  assert.equal(html.includes('—'), false);
+});
+
+test('renderShapeHub renders every shape slug with real labels', () => {
+  for (const slug of SHAPE_SLUGS) {
+    const html = renderShapeHub(slug, [makeShow('tt1', 'Only One', 10, [slug])], null);
+    assert.ok(html.includes(`href="/apps/rising-shows/#shape=${slug}"`), slug);
+    // A missing label would leak the raw slug into the h1.
+    assert.ok(!new RegExp(`<h1>Best ${slug} TV shows</h1>`).test(html), slug);
+    assert.ok(/<h1>Best [A-Z]/.test(html), slug);
+  }
+});

--- a/apps/rising-shows/tests/render-show-page.test.js
+++ b/apps/rising-shows/tests/render-show-page.test.js
@@ -169,6 +169,27 @@ test('renderShowPage hero-actions has three buttons: shape CTA, app-btn, IMDb li
   assert.ok(html.indexOf('class="app-btn"') < html.indexOf('class="secondary-btn"'));
 });
 
+test('renderShowPage season shape badges link the static shape hub in the same tab', () => {
+  const html = renderShowPage({ ...BREAKING_BAD, dominantShape: 'rising', dominantShapeSlug: 'rising', relatedShows: [] });
+  const badges = [...html.matchAll(/<a class="shape-badge"[^>]*>/g)].map((m) => m[0]);
+  assert.equal(badges.length, 1);
+  assert.ok(badges[0].includes('href="/apps/rising-shows/shows/shape/rising/"'));
+  // Hub links stay in the same tab, so no target/rel on the badge.
+  assert.ok(!badges[0].includes('target='));
+  assert.ok(!badges[0].includes('rel='));
+});
+
+test('renderShowPage sends "See all" to the hub but keeps the CTAs on the explorer', () => {
+  const related = [{ seriesId: 'tt0944947', title: 'Game of Thrones', year: 2011, poster: null, genres: ['Drama'], dominantShape: 'rising', dominantShapeSlug: 'rising', slug: 'game-of-thrones-tt0944947' }];
+  const html = renderShowPage({ ...BREAKING_BAD, dominantShape: 'rising', dominantShapeSlug: 'rising', relatedShows: related });
+  assert.ok(html.includes('<p class="rec-see-all"><a href="/apps/rising-shows/shows/shape/rising/">See all Rising shows'));
+  // Conversion path into the app is unchanged for both CTAs.
+  const primaryIdx = html.indexOf('class="primary-btn"');
+  assert.ok(html.slice(primaryIdx, primaryIdx + 160).includes('href="/apps/rising-shows/#shape=rising"'));
+  const stickyIdx = html.indexOf('class="primary-btn sticky-cta-btn"');
+  assert.ok(html.slice(stickyIdx, stickyIdx + 160).includes('href="/apps/rising-shows/#shape=rising"'));
+});
+
 test('renderShowPage app-btn is present even when show has no dominant shape', () => {
   const html = renderShowPage({ ...BREAKING_BAD, dominantShape: null, dominantShapeSlug: null, relatedShows: [] });
   assert.ok(html.includes('class="app-btn"'));

--- a/apps/rising-shows/tests/render-sitemap.test.js
+++ b/apps/rising-shows/tests/render-sitemap.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 
 const { renderShowsSitemap, selectSitemapSeries } = require('../scripts/render-sitemap.js');
 const { renderShowsIndex, sortTitle, firstLetter } = require('../scripts/render-shows-index.js');
+const { SHAPE_SLUGS } = require('../scripts/render-shape-hub.js');
 
 const SERIES = [
   { seriesId: 'tt0903747', title: 'Breaking Bad', year: 2008 },
@@ -23,6 +24,19 @@ test('renderShowsSitemap includes one URL per series plus the index', () => {
   const xml = renderShowsSitemap(SERIES, '2026-05-18T00:00:00.000Z');
   const locs = xml.match(/<loc>/g) || [];
   assert.equal(locs.length, SERIES.length + 1);
+});
+
+test('renderShowsSitemap adds one URL per shape hub when given the slugs', () => {
+  const xml = renderShowsSitemap(SERIES, '2026-05-18T00:00:00.000Z', SHAPE_SLUGS);
+  const locs = xml.match(/<loc>/g) || [];
+  assert.equal(locs.length, SERIES.length + 1 + SHAPE_SLUGS.length);
+  for (const slug of SHAPE_SLUGS) {
+    assert.ok(xml.includes(`<loc>https://shevato.com/apps/rising-shows/shows/shape/${slug}/</loc>`), slug);
+  }
+  // Hubs sit between the /shows/ index and the individual show pages.
+  assert.ok(xml.indexOf('/shows/shape/rising/') > xml.indexOf('<loc>https://shevato.com/apps/rising-shows/shows/</loc>'));
+  assert.ok(xml.indexOf('/shows/shape/shape-drift/') < xml.indexOf('/shows/breaking-bad-tt0903747/'));
+  assert.equal((xml.match(/<priority>0\.6<\/priority>/g) || []).length, SHAPE_SLUGS.length);
 });
 
 test('renderShowsSitemap URLs use the slug + tconst path scheme', () => {
@@ -86,4 +100,12 @@ test('renderShowsIndex emits the count and links to every series', () => {
   // "The Office" is alphabetized under O, not T
   assert.ok(html.includes('id="letter-O"'));
   assert.ok(html.includes('/apps/rising-shows/shows/the-office-tt0386676/'));
+});
+
+test('renderShowsIndex carries a browse-by-shape strip to all 13 hubs', () => {
+  const html = renderShowsIndex(SERIES, '2026-05-18T00:00:00.000Z');
+  const hubLinks = new Set([...html.matchAll(/href="(\/apps\/rising-shows\/shows\/shape\/[a-z-]+\/)"/g)].map((m) => m[1]));
+  assert.equal(hubLinks.size, SHAPE_SLUGS.length);
+  assert.ok(hubLinks.has('/apps/rising-shows/shows/shape/slow-burn/'));
+  assert.ok(html.includes('>Saved best for last<'));
 });


### PR DESCRIPTION
## Why

Follow-up to the sitemap curation round (#315/#316): the top-2,000 show pages we want indexed were only reachable via one giant A-Z index and 4 related-shows links each. This adds 13 static hub pages, one per rating-trend shape, at `/apps/rising-shows/shows/shape/<slug>/`, giving Google strong crawl paths into exactly those pages and creating real landing pages for queries like "best slow-burn shows".

## Changes

### New files

- `apps/rising-shows/scripts/render-shape-hub.js`: hub page renderer. Exports `renderShapeHub`, `selectHubShows` (shows whose dominant shape matches, top 100 by `seriesVotes` desc), `hubPath`, `SHAPE_SLUGS` (the 13 shapes), `HUB_LIMIT` (100). Each page carries: title "Best <Label> TV shows - Rising Shows", meta description, self-canonical, `index, follow` robots, og/twitter meta, visible breadcrumb (homepage link is `/home`, matching #316), h1 plus a one-line shape definition, ranked rows (position, linked show title, year, avg episode rating, votes), BreadcrumbList + CollectionPage/ItemList JSON-LD (ItemList capped at 25 to bound page weight), a "Browse by shape" nav (current shape as a non-link chip, links to the other 12 hubs and the A-Z index), a CTA into the interactive explorer (`#shape=<slug>`), and the shared footer. No poster images, keeping a 100-row SEO page light and sidestepping the adult-poster blur machinery a votes-ranked list would otherwise need.
- `apps/rising-shows/tests/render-shape-hub.test.js`: 15 tests - well-formed document, dominant-shape-only membership, votes-desc ordering, the 100 cap, canonical correctness, JSON-LD parseability, no `href="/"` links.

### Modified

- `apps/rising-shows/scripts/render-show-page.js`:
  - Season shape badges now link the hub pages same-tab (previously `#shape=` deep links into the explorer with `target="_blank"`); the recommendations "See all <Label> shows" link points at the hub too. The primary CTA button and the sticky CTA still deep-link the interactive explorer, keeping the app-conversion path.
  - Bugfix found along the way: three shapes (`u-shaped`, `saved-best-for-last`, `shape-drift`) had no entry in `SHAPE_LABELS`, so their badges rendered raw slugs. Labels added.
  - New `SHAPE_DESCS` map (one-line shape definitions, kept verbatim in sync with `js/app.js` so hubs describe shapes the same way the in-app chips do).
  - `computeDominantShape` moved here from `build-show-pages.js` (the hub renderer needs it and importing from the build script would create a require cycle); its stale comment corrected in the move - the tiebreaker is season `avgRating`, not `seriesVotes` as the old comment claimed. Behavior unchanged. Exports widened for the hub renderer and tests.
- `apps/rising-shows/scripts/build-show-pages.js`: writes the 13 hubs under `shows/shape/<slug>/` during the build (the `shows/` wipe-and-rebuild covers them; a dir literally named `shape` cannot collide with show dirs, which always end in `-tt<digits>`), imports `computeDominantShape` from its new home, passes `SHAPE_SLUGS` to the sitemap renderer.
- `apps/rising-shows/scripts/render-sitemap.js`: optional third argument emits the 13 hub URLs (priority 0.6, weekly, same lastmod) between the `/shows/` index entry and the show entries. The top-2,000 show curation is unchanged; total is now exactly 2,014 URLs.
- `apps/rising-shows/scripts/render-shows-index.js`: "Browse by shape" strip above the letter jump on the A-Z index, linking all 13 hubs.
- `apps/rising-shows/css/show-page.css`: `.shape-nav` chip strip (current-shape chip highlighted, non-link), `.rank-list`/`.rank-row` grid (44px/1fr/auto desktop, stacked 30px/1fr at mobile widths), hover tints, footer-link styling for the hubs.
- `apps/rising-shows/tests/render-sitemap.test.js`: +2 tests for the hub entries and the 2,014 count math.
- `apps/rising-shows/tests/render-show-page.test.js`: +2 tests - badges link hubs with no `target` attribute, explorer CTAs unchanged.
- `apps/rising-shows/README.md`: "Static show pages (SEO)" section documents the hubs (URL scheme, dominant-shape membership rule, 100 cap, sitemap presence) and the new 2,014 sitemap count.

## Judgment calls

- Hub membership uses the dominant shape only, so a show appears in exactly one hub; the explorer's `#shape=` filter matches any season's shape, so its counts are intentionally larger than the hub lists.
- The visible breadcrumb is "Shevato › Rising Shows › All shows › <Label>" (matching the existing generated pages, which omit "Apps"); the fuller Home > Apps chain lives in the BreadcrumbList JSON-LD.
- The `saved-best-for-last` and `shape-drift` hubs CTA to `#shape=` slugs the explorer's chip row does not currently offer; the filter still applies (owner verified on localhost), only the chip highlight is missing. Adding those two chips to the finder is deferred to a future finder round.

## Testing

- `npm test`: 1937/1937 pass (19 new).
- Full build against the local data.json (34,281 series): 13 hub dirs; 100 shows per hub except `shape-drift` at 40 (only 40 shows have it dominant); every hub has exactly one self-matching canonical, two cleanly parsing JSON-LD blocks, zero `href="/"` links, zero em dashes; sitemap at exactly 2,014 URLs; Breaking Bad page shows 9 hub-linked badges with no `target`, hub-linked "See all", and untouched explorer CTAs; A-Z index carries 13 hub links.
- Acceptance plan executed via the app pipeline: 49/51 assertions passed, 0 failed, 2 routed to the human file (real-mouse hover states, since verified by the owner along with the shape-drift/saved-best-for-last explorer CTA behavior). Screenshot-verified at desktop 1280 and mobile 390: hub pages, the A-Z shape strip, and re-pointed season badges.
- After deploy, the GSC sitemap expectation becomes 2,014 discovered URLs, superseding the 2,001 figure from #315.