### PR TITLE
feat(maptap-rivals): weekly/monthly records replace seasons plus prediction accuracy stats

### DIFF
--- a/apps/maptap-rivals/README.md
+++ b/apps/maptap-rivals/README.md
@@ -10,7 +10,7 @@ MapTap.gg has no built-in social layer, so this app *is* the rivalry layer. The 
 - **Games** (`maptapRivalsGames`) — one record per day you played a given rival: `{ id, rivalId, date, note, myScores[5], theirScores[5], myScore, theirScore }`. Each of MapTap's 5 rounds is a raw 0–100 score; round weights `[1, 1, 2, 3, 3]` roll up to a 0–1000 daily total. Older games stored as totals only (no per-round array) still count toward records and streaks but are skipped from per-round breakdowns.
 - **You** — your display name (`maptapRivalsMe`), icon (`maptapRivalsMyIcon`), and optional MapTap profile (`maptapRivalsMyProfile`).
 
-Seasons, the matrix selection, and the currently focused rival are persisted under their own keys. Everything is computed on demand from the games list — there are no precomputed stats in storage.
+The matrix selection and the currently focused rival are persisted under their own keys. Everything else, weekly and monthly records included, is computed on demand from the games list; there are no precomputed stats in storage.
 
 ## Features
 
@@ -19,15 +19,16 @@ Seasons, the matrix selection, and the currently focused rival are persisted und
 | Add/edit rivals | Create a named rival with an accent color and icon (and an optional MapTap username); edit or delete from a modal. |
 | Paste daily scores | A collapsible entry panel: paste your MapTap result, and a row per rival shows a live win/loss/tie preview against your score before you save the day's games. |
 | MapTap profile auto-sync | Link your MapTap profile (and a rival's username) to pull game history automatically from the public MapTap profile endpoint instead of pasting. |
-| Dashboard | A rival grid of summary cards (record, streak, averages) with an at-a-glance summary strip and a "today's predictions" card when the day's puzzle data is available. |
+| Dashboard | A rival grid of summary cards (record, streak, averages) in alphabetical order, with an at-a-glance summary strip, a current-form banner, and a "today's predictions" card when the day's puzzle data is available. |
+| Predictions accuracy | Each row of the predictions card carries the share of the field the player beats on an average day ("avg 78%", the mean of `(N - rank) / (N - 1)` over every past day at least two tracked players logged a score, so first is always 100% and last always 0% whatever the field size, ties sharing fractional rank credit and solo days excluded, with the raw average finish and day count in the tooltip) plus a "Spot-on" badge giving the share of days they finished exactly where the predictor put them ("Spot-on 83%", with the raw "5 of 6 past days" count in the tooltip). |
 | Per-rival dashboard | A focused head-to-head view: stat cards, score-over-time and win-distribution and score-differential charts (Chart.js), recent-games table with pagination, and narrative callouts. |
 | Outbound maptap.gg links | In the history and recent-games tables, dates link to that day's puzzle page (`maptap.gg/history/...`) and score numbers link to the player's profile (`maptap.gg/u/...`) when that player has a linked username. |
 | Round-by-round breakdown | Per-round (location) stats, win-rate-per-round chart, a last-10-games round heatmap, carry/choke insights, and a calendar heatmap of game history. |
 | Continent breakdown | Per-continent stats for games that carry synced geo data. |
 | Win/loss/tie + streaks | Computes wins, losses, ties, win %, current and longest streaks, biggest win/loss margins, and best/worst scores per rival. |
-| Leaderboard | A sortable table ranking every rival by win %, games, W/L/T, a blended rivalry score, average margin, current streak, and recent form. |
+| Leaderboard | A sortable table listing every rival alphabetically by default, re-rankable by win %, games, W/L/T, a blended rivalry score, average margin, current streak, and recent form. |
 | Confusion matrix | A cross-participant grid comparing you against each selected rival, and rival-vs-rival on days you played both, with selectable metrics. |
-| Rivalry seasons | Time-boxed challenges with a goal (win %, total wins, or minimum games) scoped to all rivals or one, tracked against progress. |
+| Weekly / monthly records | The game log bucketed automatically into ISO calendar weeks (Monday to Sunday) and calendar months: overall W-L-T, win %, games played, and a per-rival split for each period, newest first, with the current period marked. Weekly cards carry their ISO week number next to the date range ("#32"). Each rival row also carries the running count of periods won-lost(-tied) against them up to that period, e.g. "Gal (3-5-1)". Win percentages read green above 50, red below, neutral at exactly 50. The split sorts by win % (best first) or by name, and the period cards paginate 6 to a page. A dashboard banner shows this week's and this month's record. No setup, nothing to maintain. |
 | Full game history | Every game across all rivals in one table, filterable by rival and result (win/loss/tie), with pagination. |
 | WhatsApp import | Import paired games from a WhatsApp chat `.txt` export by mapping chat senders to rivals, with a preview before committing. |
 | Export / import / clear | Download a JSON backup, import one, or clear all logged games (rivals and settings are kept). |
@@ -44,7 +45,7 @@ python3 -m http.server 8000
 
 ## Running tests
 
-The scoring and stats core (weighted daily totals, the predicted-total reconciliation that keeps the predictions card's total equal to the sum of its per-round chips, side-presence, the MapTap paste parser, results, streaks, averages, trend/projection, and the composite rivalry score) lives in `js/stats.js` as a pure module so it can be unit-tested without a DOM or Firebase. `app.js` loads that module and binds its functions, so the tests exercise the same code the app runs.
+The scoring and stats core (weighted daily totals, the predicted-total reconciliation that keeps the predictions card's total equal to the sum of its per-round chips, side-presence, the MapTap paste parser, results, streaks, averages, trend/projection, the composite rivalry score, ISO week / calendar month bucketing for the Records view, the running per-rival period tally behind each rival row's "(won-lost-tied)" figure, the predicted-position accuracy ranking behind the predictions card's "Spot-on" badge, the fractional daily finishing positions and the field-share percentages behind its "avg" figure, and the name / win-% comparators the rival lists sort with) lives in `js/stats.js` as a pure module so it can be unit-tested without a DOM or Firebase. `app.js` loads that module and binds its functions, so the tests exercise the same code the app runs.
 
 ```sh
 npm run test:maptap

--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -985,14 +985,95 @@ body.maptap-rivals-app textarea:focus {
 }
 .pred-row-head .pred-cell { text-align: right; color: var(--muted-2); font-family: inherit; }
 .pred-row-you { background: var(--accent-soft); }
+/* Player cell: name on top, accuracy badge under it. Column layout keeps the
+   badge from eating into the Predicted / Actual / Δ columns. */
 .pred-label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.18rem;
+  min-width: 0;
   font-weight: 600;
   color: var(--text);
+  letter-spacing: -0.005em;
+}
+/* Name line: name plus the average finishing position. Wraps rather than
+   squeezing, so a long name pushes "avg 1.3" onto its own line instead of
+   eating the name down to an ellipsis stub. */
+.pred-label-line {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.1rem 0.4rem;
+  max-width: 100%;
+  min-width: 0;
+}
+.pred-label-name {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  letter-spacing: -0.005em;
 }
+
+/* Average finishing position. Plain text with a tooltip, never a control:
+   nothing here takes focus, hover or a click. */
+.pred-avg-pos {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  font-family: inherit;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  white-space: nowrap;
+  cursor: help;
+}
+.pred-avg-label { text-transform: uppercase; color: var(--muted-2); }
+.pred-avg-num {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.76rem;
+  letter-spacing: 0;
+  color: var(--text);
+}
+
+/* Historical accuracy chip: how often the predictor put this player in the
+   position they actually finished in. Absent when nothing is back-testable. */
+.pred-hit-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  max-width: 100%;
+  padding: 0.14rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-3);
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.35;
+  white-space: nowrap;
+  cursor: help;
+}
+.pred-hit-badge.is-hot {
+  border-color: rgba(74, 222, 128, 0.30);
+  background: var(--good-soft);
+  color: var(--good);
+}
+.pred-hit-num {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.66rem;
+  letter-spacing: 0;
+  color: var(--text);
+}
+.pred-hit-badge.is-hot .pred-hit-num { color: var(--good); }
 .pred-cell {
   text-align: right;
   font-variant-numeric: tabular-nums;
@@ -1062,6 +1143,10 @@ body.maptap-rivals-app textarea:focus {
    off the right edge. Tighten the minimums so all four columns fit. */
 @media (max-width: 360px) {
   .pred-row { grid-template-columns: minmax(74px, 1.1fr) repeat(3, minmax(42px, 1fr)); gap: 0.3rem; }
+  /* A bare percentage here would read as a win rate, so the word stays and
+     the chip shrinks around it instead. */
+  .pred-hit-badge { padding: 0.1rem 0.32rem; gap: 0.2rem; font-size: 0.55rem; letter-spacing: 0.03em; }
+  .pred-hit-num { font-size: 0.6rem; }
 }
 
 /* Wraps a player row + its per-round chip strip into one visual block
@@ -4267,241 +4352,520 @@ body.maptap-rivals-app select option {
   .matrix-form-dot { width: 0.55rem; height: 0.55rem; }
 }
 
-/* ---------- Seasons view ---------- */
+/* ---------- Records view ---------- */
 
-.seasons-toolbar {
+.records-toolbar {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 0.75rem;
   padding: 0.5rem 0 1rem;
 }
 
-.seasons-group {
-  margin-bottom: 1.75rem;
+.records-toolbar-title { max-width: 52ch; }
+
+.records-sub {
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
 }
 
-.seasons-group-title {
+/* Toolbar right side: the rival-sort dropdown and the Weekly | Monthly pills
+   sit together and wrap as one unit under the title on narrow screens. */
+.records-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+/* Per-rival sort control, same markup pattern as the matrix row sort. main.css
+   makes every <label> a 1rem block with a bottom margin and every <select> a
+   full-width 3.25rem-tall gray field with its own chevron, so the shell and the
+   field both pin their own box, colours and arrow. */
+.records-sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0.2rem 0.3rem 0.2rem 0.7rem;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
   font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  line-height: 1;
   color: var(--muted);
-  margin: 0 0 0.6rem;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 0.15s ease, background 0.15s ease;
 }
 
-.season-card {
+.records-sort:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
+}
+
+.records-sort:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.records-sort-label {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  user-select: none;
+  white-space: nowrap;
+}
+
+.records-sort-select {
+  appearance: none;
+  -webkit-appearance: none;
+  display: inline-block;
+  box-sizing: border-box;
+  width: auto;
+  height: 2rem;
+  margin: 0;
+  padding: 0 1.25rem 0 0.5rem;
+  border: 0;
+  border-radius: 999px;
+  background-color: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 2rem;
+  cursor: pointer;
+  outline: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 0.6rem) calc(50% - 1px),
+    calc(100% - 0.44rem) calc(50% - 1px);
+  background-size: 4px 4px;
+  background-repeat: no-repeat;
+}
+
+/* main.css rings every focused select in its red (`select:focus` outranks a
+   plain class), so kill it here: the lit ring belongs to the shell above. */
+.records-sort-select:focus,
+.records-sort-select:focus-visible {
+  border: 0;
+  box-shadow: none;
+}
+
+/* Weekly | Monthly segmented control. Sitewide main.css paints every button
+   gray (#555 !important + inset ring), red on hover, and forces a 3.25rem
+   line-height, so this control pins its own box and colours the same way
+   .pager .page-btn does. */
+.records-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.records-toggle-btn,
+.records-toggle-btn:hover {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2rem;
+  line-height: 1;
+  padding: 0 0.95rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted) !important;
+  box-shadow: none !important;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.records-toggle-btn:hover {
+  background: var(--surface-3) !important;
+  color: var(--text) !important;
+}
+
+/* main.css tints `button:hover:active` red, which outranks the :hover pin
+   above. Every pinned control in this app repeats the press colour. */
+.records-toggle-btn:hover:active { background-color: var(--surface-3); }
+.records-toggle-btn.is-active:hover:active { background-color: var(--accent-soft); }
+
+.records-toggle-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft) !important;
+}
+
+.records-toggle-btn.is-active,
+.records-toggle-btn.is-active:hover {
+  background: var(--accent-soft) !important;
+  border-color: var(--accent-strong);
+  color: var(--accent-2) !important;
+  font-weight: 700;
+}
+
+/* Period card. The left edge carries the verdict for the period: green when
+   you finished ahead, red when behind, neutral when level or undecided. */
+.record-card {
   background: var(--surface);
   border: 1px solid var(--border);
-  /* Status accent rides the left edge: green = met/on-track, amber = behind,
-     red = missed, neutral = upcoming/no signal. */
   border-left: 3px solid var(--border-strong);
   border-radius: var(--radius);
-  padding: 0.9rem 1rem;
-  margin-bottom: 0.65rem;
+  padding: 0.95rem 1.15rem 0.85rem;
+  margin-bottom: 0.75rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.16);
 }
 
-.season-card-active {
-  border-color: var(--accent-strong);
-  border-left-width: 3px;
-  background: linear-gradient(135deg, rgba(99,102,241,0.06), transparent 60%), var(--surface);
+.record-card-good { border-left-color: var(--good); }
+.record-card-bad  { border-left-color: var(--bad); }
+.record-card-even { border-left-color: var(--muted-2); }
+
+/* The current period keeps its verdict edge, so only the other three sides
+   pick up the accent ring. */
+.record-card.is-current {
+  border-top-color: var(--accent-strong);
+  border-right-color: var(--accent-strong);
+  border-bottom-color: var(--accent-strong);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.06), transparent 60%), var(--surface);
 }
 
-.season-card-good { border-left-color: var(--good); }
-.season-card-warn { border-left-color: var(--warn); }
-.season-card-bad  { border-left-color: var(--bad); }
-
-.season-card-headline {
-  font-size: 1.02rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  color: var(--text);
-  margin: 0.1rem 0 0.15rem;
-}
-.season-card-good .season-card-headline { color: var(--good); }
-.season-card-warn .season-card-headline { color: var(--warn); }
-.season-card-bad  .season-card-headline { color: var(--bad); }
-
-.season-card-past {
-  opacity: 0.85;
-}
-
-.season-card-head {
+/* Head: who the period is on the left, what it scored on the right. The two
+   number lines are right-aligned to a common edge so a column of cards reads
+   straight down. */
+.record-card-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 0.5rem;
-  margin-bottom: 0.35rem;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  padding-bottom: 0.7rem;
 }
 
-.season-card-title {
+/* Baseline, not centre, so the smaller week number sits on the same line as
+   the date range instead of floating above it. The pill has no text to share
+   a baseline with, so it re-centres itself below. */
+.record-card-title {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.5rem;
+  min-width: 0;
+}
+
+.record-card-name {
+  font-size: 1.02rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+/* ISO week number beside the date range, e.g. "#32". Deliberately quiet: the
+   dates are the card's title and this is only the calendar's name for them,
+   so it borrows the same muted annotation style as a rival row's running
+   "(3-5-1)" rather than becoming a second pill. */
+.record-week-num {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  cursor: help;
+}
+
+/* margin-left:auto keeps the numbers on the right edge even when the title
+   line is long enough to push them onto a line of their own. */
+.record-card-head-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.15rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.record-current-pill {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--accent-strong);
+  background: var(--accent-soft);
+  color: var(--accent-2);
+  font-size: 0.63rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.record-card-wlt {
+  font-size: 1.02rem;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.record-card-stats {
+  display: inline-flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  line-height: 1.3;
+}
+
+.record-stat-num {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+.record-stat-label { color: var(--muted); }
+.record-stat-sep   { color: var(--muted-2); }
+
+/* Card win %: green above 50, red below, muted at exactly 50 or when nothing
+   was decided. Plain spans, so main.css has no colour rule to fight here. */
+.record-stat-pct {
+  color: var(--muted);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.record-stat-pct.is-good { color: var(--good); }
+.record-stat-pct.is-bad  { color: var(--bad); }
+
+/* Per-rival split inside the period. Rows are separated by hairlines rather
+   than left floating in space, so the eye tracks from a name across to its
+   percentage on a wide card. */
+.record-rivals {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--border);
+  display: grid;
+}
+
+.record-rival {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 3.1rem;
+  align-items: baseline;
+  gap: 0.5rem 0.9rem;
+  padding: 0.42rem 0;
+  font-size: 0.85rem;
+  border-bottom: 1px solid rgba(37, 41, 56, 0.6);
+}
+.record-rival:last-child { border-bottom: 0; padding-bottom: 0.1rem; }
+
+.record-rival-name {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.1rem 0.4rem;
+  min-width: 0;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.record-rival-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Running "(won-lost[-tied])" count of periods against this rival. */
+.record-rival-run {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  cursor: help;
+}
+
+.record-rival-wlt {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.record-rival-pct {
+  color: var(--muted);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+.record-rival-pct.is-good { color: var(--good); }
+.record-rival-pct.is-bad  { color: var(--bad); }
+
+.records-empty { margin-top: 0.5rem; }
+
+/* Dashboard current-form banner: this week and this month at a glance, and
+   the way into the Records view. Colour pins as above (it is a button). */
+.record-dash-banner,
+.record-dash-banner:hover {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  height: auto;
+  line-height: 1.35;
+  padding: 0.7rem 0.9rem;
+  margin-bottom: 1rem;
+  text-align: left;
+  white-space: normal;
+  border: 1px solid var(--accent-strong);
+  border-left-width: 3px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.10), transparent 65%), var(--surface);
+  color: var(--text) !important;
+  box-shadow: none !important;
+  font: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.record-dash-banner:hover {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.20), transparent 65%), var(--surface-2);
+  border-color: var(--accent);
+}
+
+.record-dash-banner:hover:active { background-color: var(--surface-2); }
+
+.record-dash-banner:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft) !important;
+}
+
+.record-dash-banner-left {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem 1.5rem;
+  min-width: 0;
+}
+
+.record-dash-banner-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-2);
+  white-space: nowrap;
+}
+
+/* Two stat blocks, caption over figure, same rhythm as the summary cards
+   right below the banner. The rule separates them from the eyebrow label
+   without adding another box. */
+.record-dash-banner-lines {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 2rem;
+  padding-left: 1.25rem;
+  border-left: 1px solid var(--border-strong);
+}
+
+.record-dash-banner-line {
   display: flex;
   flex-direction: column;
   gap: 0.1rem;
 }
 
-.season-card-name {
+.record-dash-banner-period {
+  font-size: 0.66rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.record-dash-banner-figures {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+}
+
+.record-dash-banner-wlt {
   font-size: 1rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
 }
 
-.season-card-dates {
+.record-dash-banner-wlt.is-good { color: var(--good); }
+.record-dash-banner-wlt.is-bad  { color: var(--bad); }
+
+.record-dash-banner-empty {
+  font-size: 0.88rem;
+  color: var(--muted-2);
+}
+
+.record-dash-banner-pct {
   font-size: 0.78rem;
-  color: var(--muted);
+  font-weight: 700;
+  color: var(--muted-2);
+  font-variant-numeric: tabular-nums;
 }
+.record-dash-banner-pct.is-good { color: var(--good); }
+.record-dash-banner-pct.is-bad  { color: var(--bad); }
 
-.season-card-head-right {
-  display: flex;
+/* Right-hand affordance: the banner is a button, so it says where it goes. */
+.record-dash-banner-cta {
+  display: inline-flex;
   align-items: center;
   gap: 0.4rem;
   flex-shrink: 0;
-}
-
-.season-card-meta {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.55rem;
-}
-
-.season-card-meta-item {
-  font-size: 0.82rem;
-  color: var(--muted);
-}
-
-.season-card-meta-sep {
-  color: var(--muted-2);
-  font-size: 0.8rem;
-}
-
-.season-card-stats {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.55rem;
-  font-size: 0.87rem;
-}
-
-.season-stat-num {
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  color: var(--text);
-}
-
-.season-stat-label {
-  color: var(--muted);
-}
-
-.season-stat-sep {
-  color: var(--muted-2);
-}
-
-.season-stat-wld {
-  color: var(--text);
-  font-variant-numeric: tabular-nums;
-}
-
-.season-stat-pct {
+  padding: 0.3rem 0.6rem 0.3rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
   color: var(--accent-2);
-  font-weight: 600;
-}
-
-/* Progress bar */
-.season-progress-row {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  margin-bottom: 0.5rem;
-}
-
-.season-progress-label {
-  font-size: 0.78rem;
-  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 700;
   white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-  min-width: 5rem;
+  transition: border-color 0.15s ease, background 0.15s ease;
 }
 
-.season-progress-wrap {
-  flex: 1;
+.record-dash-banner:hover .record-dash-banner-cta,
+.record-dash-banner:focus-visible .record-dash-banner-cta {
+  border-color: var(--accent-strong);
+  background: var(--accent-soft);
 }
 
-.season-progress-bar {
-  height: 6px;
-  background: var(--surface-3);
-  border-radius: 999px;
-  overflow: hidden;
+.record-dash-banner-arrow {
+  font-size: 0.95rem;
+  line-height: 1;
+  color: var(--accent-2);
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
 }
 
-.season-progress-fill {
-  display: block;
-  height: 100%;
-  background: var(--accent);
-  border-radius: 999px;
-  transition: width 0.3s ease;
-}
+.record-dash-banner:hover .record-dash-banner-arrow { transform: translateX(2px); }
 
-.season-progress-fill.is-done {
-  background: var(--good);
-}
-
-/* On-track indicator */
-.season-track-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.15rem 0.55rem;
-  border-radius: 999px;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  margin-left: 0.4rem;
-}
-
-.season-track-pill.is-on-track {
-  background: var(--good-soft);
-  color: var(--good);
-}
-
-.season-track-pill.is-behind {
-  background: rgba(251, 146, 60, 0.14);
-  color: var(--warn);
-}
-
-/* Verdict pill */
-.season-verdict-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.2rem 0.6rem;
-  border-radius: 999px;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-}
-
-.season-verdict-pill.is-pass {
-  background: var(--good-soft);
-  color: var(--good);
-}
-
-.season-verdict-pill.is-fail {
-  background: var(--bad-soft);
-  color: var(--bad);
-}
-
-/* Season modal */
-.modal-panel-season { max-width: 28rem; }
-
-.season-modal-dates {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0 0.75rem;
-}
-
+/* Shared modal field controls, used by the rival and import modals. */
 .modal-field input[type="date"] {
   font-family: inherit;
 }
@@ -4524,127 +4888,19 @@ body.maptap-rivals-app select option {
   border-color: var(--accent);
 }
 
-.season-goal-fieldset {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 0.6rem 0.75rem;
-  margin: 0.85rem 0 0;
-}
-
-.season-goal-fieldset legend {
-  font-size: 0.78rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--muted);
-  padding: 0 0.3rem;
-}
-
-.season-goal-radio {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.3rem 0;
-  cursor: pointer;
-  font-size: 0.88rem;
-  color: var(--text);
-}
-
-.season-goal-radio input[type="radio"] {
-  accent-color: var(--accent);
-  flex-shrink: 0;
-}
-
-.season-goal-val {
-  width: 4.5rem;
-  height: 1.9rem;
-  padding: 0 0.45rem;
-  border: 1px solid var(--border);
-  border-radius: var(--ctrl-radius);
-  background: var(--surface);
-  color: var(--text);
-  font: inherit;
-  font-size: 0.88rem;
-  text-align: right;
-}
-
-.season-goal-val:focus {
-  outline: 2px solid var(--accent);
-  outline-offset: -1px;
-  border-color: var(--accent);
-}
-
-.season-goal-unit {
-  color: var(--muted);
-  font-size: 0.82rem;
-}
-
-.season-modal-error {
-  margin: 0.5rem 0 0;
-  font-size: 0.82rem;
-  color: var(--bad);
-}
-
-/* Dashboard active-season banner — shares the season cards' status-accent
-   language (left edge keyed to on-track/behind). */
-.season-dash-banner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.65rem 0.9rem;
-  background: linear-gradient(135deg, rgba(99,102,241,0.10), transparent 65%), var(--surface);
-  border: 1px solid var(--accent-strong);
-  border-left-width: 3px;
-  border-radius: var(--radius-sm);
-  margin-bottom: 1rem;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-}
-.season-dash-banner.is-on-track { border-left-color: var(--good); }
-.season-dash-banner.is-behind   { border-left-color: var(--warn); }
-
-.season-dash-banner:hover {
-  background: rgba(99, 102, 241, 0.22);
-}
-
-.season-dash-banner-left {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-}
-
-.season-dash-banner-name {
-  font-size: 0.78rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--muted);
-}
-
-.season-dash-banner-headline {
-  font-size: 0.95rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  color: var(--text);
-}
-
-.season-dash-banner-meta {
-  font-size: 0.78rem;
-  color: var(--accent-2);
-}
-
-.season-dash-banner-arrow {
-  font-size: 1rem;
-  color: var(--accent-2);
-  flex-shrink: 0;
-}
-
-.seasons-empty {
-  margin-top: 0.5rem;
-}
-
 @media (max-width: 600px) {
-  .season-modal-dates { grid-template-columns: 1fr; }
-  .season-card-head { flex-wrap: wrap; }
+  .records-toolbar { flex-direction: column; align-items: stretch; }
+  /* One row while both controls fit, each pinned to its own edge. */
+  .records-controls { justify-content: space-between; }
+  .record-card { padding: 0.85rem 0.9rem 0.75rem; }
+  .record-rival { grid-template-columns: minmax(0, 1fr) auto 2.8rem; gap: 0.4rem 0.6rem; }
+  /* The eyebrow label sits above the stat blocks once the banner stacks, so
+     the vertical rule between them would point nowhere. */
+  .record-dash-banner { align-items: flex-start; }
+  .record-dash-banner-left { gap: 0.45rem 1rem; }
+  .record-dash-banner-lines {
+    gap: 0.35rem 1.5rem;
+    padding-left: 0;
+    border-left: 0;
+  }
 }

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -54,7 +54,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "MapTap Rivals",
-    "description": "Daily MapTap.gg head-to-head tracker: log scores against named friends and see win/loss records, streaks, averages, score trends, round-by-round breakdowns, continent stats, per-rival dashboards, time-boxed rivalry seasons, and a calendar heatmap of daily activity.",
+    "description": "Daily MapTap.gg head-to-head tracker: log scores against named friends and see win/loss records, streaks, averages, score trends, round-by-round breakdowns, continent stats, per-rival dashboards, automatic weekly and monthly records, and a calendar heatmap of daily activity.",
     "url": "https://shevato.com/apps/maptap-rivals/",
     "applicationCategory": "GameApplication",
     "operatingSystem": "Web Browser",
@@ -73,7 +73,7 @@
       "WhatsApp chat import for paired games",
       "Full game history with filters and pagination",
       "Leaderboard across all rivals",
-      "Rivalry seasons (time-boxed challenges)",
+      "Automatic weekly and monthly head-to-head records",
       "Calendar heatmap of daily game activity per rival",
       "Data export and import"
     ],
@@ -118,8 +118,8 @@
       <button class="view-tab" data-view="matrix" role="tab" aria-selected="false">
         <span aria-hidden="true">🔀</span> Matrix
       </button>
-      <button class="view-tab" data-view="seasons" role="tab" aria-selected="false">
-        <span aria-hidden="true">🏅</span> Seasons
+      <button class="view-tab" data-view="records" role="tab" aria-selected="false">
+        <span aria-hidden="true">📈</span> Records
       </button>
       <button class="view-tab" data-view="history" role="tab" aria-selected="false">
         <span aria-hidden="true">📜</span> History
@@ -187,7 +187,7 @@
         </details>
       </section>
 
-      <div id="dash-active-season-banner" hidden></div>
+      <div id="dash-record-banner" hidden></div>
 
       <div class="dash-summary" id="dash-summary"></div>
 
@@ -407,13 +407,34 @@
       </p>
     </section>
 
-    <!-- SEASONS VIEW -->
-    <section class="view view-seasons" data-view-panel="seasons" hidden>
-      <div class="seasons-toolbar">
-        <h2 class="section-title">Rivalry Seasons</h2>
-        <button type="button" class="btn btn-primary" id="new-season-btn">+ New season</button>
+    <!-- RECORDS VIEW (automatic weekly / monthly head-to-head records) -->
+    <section class="view view-records" data-view-panel="records" hidden>
+      <div class="records-toolbar">
+        <div class="records-toolbar-title">
+          <h2 class="section-title">Records</h2>
+          <p class="records-sub">Your head-to-head record in every calendar week and month you have played. Weeks run Monday to Sunday.</p>
+        </div>
+        <div class="records-controls">
+          <label class="records-sort">
+            <span class="records-sort-label">Sort rivals</span>
+            <select id="records-sort-select" class="records-sort-select" aria-label="Sort rivals inside each period">
+              <option value="winpct">Win %</option>
+              <option value="name">Name</option>
+            </select>
+          </label>
+          <div class="records-toggle" role="group" aria-label="Record period">
+            <button type="button" class="records-toggle-btn is-active" data-records-unit="week" aria-pressed="true">Weekly</button>
+            <button type="button" class="records-toggle-btn" data-records-unit="month" aria-pressed="false">Monthly</button>
+          </div>
+        </div>
       </div>
-      <div id="seasons-body"></div>
+      <div id="records-body"></div>
+      <nav class="pagination" id="records-pagination" aria-label="Records pagination" hidden>
+        <div class="pagination-meta" id="records-pagination-meta"></div>
+        <div class="pagination-controls">
+          <div class="pager" id="records-pager"></div>
+        </div>
+      </nav>
     </section>
 
     <!-- HISTORY VIEW (all games, all rivals) -->
@@ -582,85 +603,6 @@
       <div class="modal-actions modal-actions-confirm">
         <button type="button" class="btn btn-ghost" id="clear-games-cancel" data-close="clear-games-modal">Cancel</button>
         <button type="button" class="btn btn-danger" id="clear-games-confirm">Clear games</button>
-      </div>
-    </article>
-  </div>
-
-  <!-- Delete-season confirmation modal -->
-  <div class="modal" id="delete-season-modal" role="dialog" aria-modal="true" aria-labelledby="delete-season-title" hidden>
-    <div class="modal-backdrop" data-close="delete-season-modal"></div>
-    <article class="modal-panel modal-panel-sm">
-      <button type="button" class="modal-close" data-close="delete-season-modal" aria-label="Close">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
-      </button>
-      <h2 id="delete-season-title">Delete season?</h2>
-      <p class="modal-confirm-body" id="delete-season-body"></p>
-      <div class="modal-actions modal-actions-confirm">
-        <button type="button" class="btn btn-ghost" id="delete-season-cancel" data-close="delete-season-modal">Cancel</button>
-        <button type="button" class="btn btn-danger" id="delete-season-confirm">Delete</button>
-      </div>
-    </article>
-  </div>
-
-  <!-- Season creation modal -->
-  <div class="modal" id="season-modal" role="dialog" aria-modal="true" aria-labelledby="season-modal-title" hidden>
-    <div class="modal-backdrop" data-close="season-modal"></div>
-    <article class="modal-panel modal-panel-season" data-back-to-top>
-      <button type="button" class="modal-close" data-close="season-modal" aria-label="Close">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
-      </button>
-      <h2 id="season-modal-title">New season</h2>
-
-      <label class="modal-field">
-        <span>Season name</span>
-        <input type="text" id="season-name" maxlength="60" placeholder="e.g. May Showdown" autocomplete="off">
-      </label>
-
-      <div class="season-modal-dates">
-        <label class="modal-field">
-          <span>Start date</span>
-          <input type="date" id="season-start">
-        </label>
-        <label class="modal-field">
-          <span>End date</span>
-          <input type="date" id="season-end">
-        </label>
-      </div>
-
-      <label class="modal-field">
-        <span>Target rival</span>
-        <select id="season-rival">
-          <option value="">All rivals</option>
-        </select>
-      </label>
-
-      <fieldset class="season-goal-fieldset">
-        <legend>Goal</legend>
-        <label class="season-goal-radio">
-          <input type="radio" name="season-goal-type" value="winPct" checked>
-          <span>Win % of at least</span>
-          <input type="number" id="season-goal-winpct" class="season-goal-val" min="1" max="100" value="60">
-          <span class="season-goal-unit">%</span>
-        </label>
-        <label class="season-goal-radio">
-          <input type="radio" name="season-goal-type" value="wins">
-          <span>Win at least</span>
-          <input type="number" id="season-goal-wins" class="season-goal-val" min="1" value="10">
-          <span class="season-goal-unit">games</span>
-        </label>
-        <label class="season-goal-radio">
-          <input type="radio" name="season-goal-type" value="minGames">
-          <span>Play at least</span>
-          <input type="number" id="season-goal-mingames" class="season-goal-val" min="1" value="20">
-          <span class="season-goal-unit">games</span>
-        </label>
-      </fieldset>
-
-      <p class="season-modal-error" id="season-modal-error" hidden></p>
-
-      <div class="modal-actions">
-        <button type="button" class="btn btn-ghost" data-close="season-modal">Cancel</button>
-        <button type="button" class="btn btn-primary" id="season-save-btn">Create season</button>
       </div>
     </article>
   </div>

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -36,7 +36,6 @@
     SELECTED: 'maptapRivalsSelectedRivalId',
     MATRIX_SEL: 'maptapRivalsMatrixSelection',
     MATRIX_SORT: 'maptapRivalsMatrixSort',
-    SEASONS: 'maptapRivalsSeasons',
     // Per-ISO-date cache of the day's 5 puzzle lat/lng pairs. Values are
     // stored under `KEY.DAILY_CITIES_PREFIX + isoDate`. Only coordinates
     // are persisted — never names or trivia from the daily file.
@@ -150,6 +149,10 @@
     getMyTotal, getTheirTotal, parseMapTapScore, mapTapHistoryToRounds,
     resultOf, resultLoc, stdDev, average, streaks, linearTrend, projectNext,
     rivalryScoreFromGames,
+    isoWeekId, monthId, periodRecords, runningRivalPeriodRecords, periodTallyText,
+    accumulatePositionHits,
+    accumulateFinishPositions, avgPositionColors,
+    compareNamesCI, compareWinPctDesc,
   } = window.MapTapStats;
 
   // Presentation-only labels stay here (not needed by the stats module).
@@ -195,7 +198,6 @@
   const state = {
     rivals: load(KEY.RIVALS, []),
     games: load(KEY.GAMES, []),
-    seasons: load(KEY.SEASONS, []),
     me: loadString(KEY.ME, 'Me'),
     myMapTap: loadString(KEY.MY_MAPTAP, ''),
     myIcon: loadString(KEY.MY_ICON, '🧍'),
@@ -210,7 +212,10 @@
     matrixSelection: load(KEY.MATRIX_SEL, null), // string[] of rivalIds, or null = "all"
     matrixSort: loadString(KEY.MATRIX_SORT, 'name'), // 'name' | 'win' | 'avg' row order
     matrixTab: 'record',           // overridden by URL hash on first paint
-    lbSort: 'winpct',              // sortable column key, e.g. 'winpct' | 'rivalry'
+    recordsUnit: 'week',           // Records view bucket: 'week' | 'month'
+    recordsSort: 'winpct',         // per-rival split order: 'winpct' | 'name'
+    recordsPage: 1,                // Records period-card page (in-memory only)
+    lbSort: 'rival',               // sortable column key, e.g. 'winpct' | 'rivalry'
     lbDir: 1,                      // 1 = column's natural order, -1 = reversed (toggled by re-clicking the header)
     historyFilters: { rival: 'all', result: 'all' },
     historyPage: 1,
@@ -239,7 +244,6 @@
 
   function persistRivals() { save(KEY.RIVALS, state.rivals); }
   function persistGames() { save(KEY.GAMES, state.games); }
-  function persistSeasons() { save(KEY.SEASONS, state.seasons); }
   function persistSettings() { save(KEY.SETTINGS, state.settings); }
   function persistMe() { saveString(KEY.ME, state.me); }
   function persistMyIcon() { saveString(KEY.MY_ICON, state.myIcon); }
@@ -696,7 +700,7 @@
     else if (view === 'rival') renderRival();
     else if (view === 'leaderboard') renderLeaderboard();
     else if (view === 'matrix') renderMatrix();
-    else if (view === 'seasons') renderSeasons();
+    else if (view === 'records') renderRecords();
     else if (view === 'history') renderHistory();
 
     syncUrlHash();
@@ -713,7 +717,7 @@
   //   #matrix | #matrix/<subtab>
   // We use replaceState so the URL updates silently without polluting the
   // back/forward history; hashchange handles users pasting or editing the URL.
-  const KNOWN_VIEWS = new Set(['dashboard', 'rival', 'leaderboard', 'matrix', 'seasons', 'history']);
+  const KNOWN_VIEWS = new Set(['dashboard', 'rival', 'leaderboard', 'matrix', 'records', 'history']);
 
   function viewHash() {
     if (state.view === 'matrix') {
@@ -765,6 +769,8 @@
       setView('dashboard');
       return;
     }
+    // Seasons became the automatic Records view; keep old links working.
+    if (view === 'seasons') { setView('records'); return; }
     if (KNOWN_VIEWS.has(view)) { setView(view); return; }
     setView('dashboard');
   }
@@ -888,7 +894,7 @@
     else if (state.view === 'dashboard') renderDashboard();
     else if (state.view === 'leaderboard') renderLeaderboard();
     else if (state.view === 'matrix') renderMatrix();
-    else if (state.view === 'seasons') renderSeasons();
+    else if (state.view === 'records') renderRecords();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -896,7 +902,7 @@
   function refreshRivalSelects() {
     const opts = state.rivals
       .slice()
-      .sort((a, b) => a.name.localeCompare(b.name))
+      .sort((a, b) => compareNamesCI(a.name, b.name))
       .map(r => `<option value="${r.id}">${escapeHtml(r.name)}</option>`)
       .join('');
 
@@ -950,7 +956,7 @@
     else if (state.view === 'rival') renderRival();
     else if (state.view === 'leaderboard') renderLeaderboard();
     else if (state.view === 'matrix') renderMatrix();
-    else if (state.view === 'seasons') renderSeasons();
+    else if (state.view === 'records') renderRecords();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -1061,105 +1067,11 @@
     ]);
   }
 
-  // ---------- seasons ----------
-
-  function seasonStats(season) {
-    const today = todayISO();
-    let filtered = state.games.filter(g =>
-      g.date >= season.startDate && g.date <= season.endDate
-    );
-    if (season.rivalId) filtered = filtered.filter(g => g.rivalId === season.rivalId);
-    // Season goals are about your record vs. the rival — rival-only days
-    // (they played, you didn't) shouldn't count toward gamesPlayed or W/L.
-    filtered = filtered.filter(bothPlayed);
-
-    const gamesPlayed = filtered.length;
-    let wins = 0, losses = 0, ties = 0;
-    for (const g of filtered) {
-      const r = resultOf(g);
-      if (r === 'W') wins++;
-      else if (r === 'L') losses++;
-      else ties++;
-    }
-    const decidedGames = wins + losses;
-    const winPct = decidedGames > 0 ? (wins / decidedGames) * 100 : 0;
-
-    return { gamesPlayed, wins, losses, ties, winPct };
-  }
-
-  function seasonVerdict(season, stats) {
-    const { wins, losses, gamesPlayed, winPct } = stats;
-    if (season.goalType === 'winPct') {
-      return (wins + losses) > 0 && winPct >= season.goalValue;
-    }
-    if (season.goalType === 'wins') return wins >= season.goalValue;
-    if (season.goalType === 'minGames') return gamesPlayed >= season.goalValue;
-    return false;
-  }
-
-  function seasonGoalText(season) {
-    if (season.goalType === 'winPct') return `Win ${season.goalValue}% or more`;
-    if (season.goalType === 'wins') return `Win ${season.goalValue} game${season.goalValue === 1 ? '' : 's'}`;
-    if (season.goalType === 'minGames') return `Play at least ${season.goalValue} game${season.goalValue === 1 ? '' : 's'}`;
-    return '';
-  }
-
-  function seasonCurrentStat(season, stats) {
-    if (season.goalType === 'winPct') return stats.winPct;
-    if (season.goalType === 'wins') return stats.wins;
-    if (season.goalType === 'minGames') return stats.gamesPlayed;
-    return 0;
-  }
-
-  function seasonOnTrack(season, stats) {
-    if (stats.gamesPlayed === 0) return null;
-    const today = todayISO();
-    const totalDays = daysBetween(season.startDate, season.endDate) + 1;
-    const daysDone = Math.min(totalDays, daysBetween(season.startDate, today) + 1);
-    const progress = Math.max(0, Math.min(1, daysDone / totalDays));
-
-    const current = seasonCurrentStat(season, stats);
-    if (season.goalType === 'winPct') {
-      return current >= season.goalValue;
-    }
-    const expected = season.goalValue * progress;
-    return current >= expected;
-  }
-
-  function seasonDateRange(season) {
-    return fmtDateShort(season.startDate) + ' to ' + fmtDateShort(season.endDate);
-  }
-
-  // Story-first one-liner for a season card / the dashboard banner. Always
-  // dash-free; phrasing varies by bucket and goal type.
-  function seasonHeadline(season, stats, bucket) {
-    const goalV = Number(season.goalValue);
-    if (bucket === 'upcoming') {
-      const days = Math.max(1, daysBetween(todayISO(), season.startDate));
-      return `Starts in ${days} day${days === 1 ? '' : 's'}`;
-    }
-    const cur = seasonCurrentStat(season, stats);
-    if (season.goalType === 'winPct') {
-      if ((stats.wins + stats.losses) === 0) {
-        return bucket === 'past' ? 'No decided games this season' : 'No decided games yet';
-      }
-      const pct = stats.winPct.toFixed(0);
-      if (bucket === 'past') {
-        return stats.winPct >= goalV
-          ? `Won ${pct}% vs the ${goalV}% target`
-          : `Fell short at ${pct}% vs the ${goalV}% target`;
-      }
-      return `Winning ${pct}% vs the ${goalV}% target`;
-    }
-    const noun = season.goalType === 'wins' ? 'win' : 'game';
-    const nounS = `${noun}${goalV === 1 ? '' : 's'}`;
-    if (bucket === 'past') {
-      return cur >= goalV
-        ? `Goal met: ${cur} of ${goalV} ${nounS}`
-        : `Fell short: ${cur} of ${goalV} ${nounS}`;
-    }
-    return `${cur} of ${goalV} ${nounS} so far`;
-  }
+  // ---------- weekly / monthly records ----------
+  // Records are derived, never authored: periodRecords buckets the game log
+  // into ISO weeks (Monday to Sunday) or calendar months. Only head-to-head
+  // days carry a result, so rival-only and solo days sit these out exactly
+  // the way resultOf treats them everywhere else.
 
   function rivalLabel(rivalId) {
     if (!rivalId) return 'All rivals';
@@ -1167,320 +1079,271 @@
     return r ? r.name : 'Unknown rival';
   }
 
-  function makeSeasonProgressBar(fraction, cls) {
-    const pct = Math.min(1, Math.max(0, fraction));
-    return el('div', { class: 'season-progress-wrap' }, [
-      el('div', { class: 'season-progress-bar' }, [
-        el('span', { class: 'season-progress-fill ' + (cls || ''), style: `width:${(pct * 100).toFixed(1)}%` }),
-      ]),
-    ]);
+  function currentPeriodId(unit) {
+    return unit === 'month' ? monthId(todayISO()) : isoWeekId(todayISO());
   }
 
-  function makeSeasonCard(season, bucket) {
-    const stats = seasonStats(season);
-    const isActive = bucket === 'active';
-    const isPast = bucket === 'past';
-    const isUpcoming = bucket === 'upcoming';
-
-    // Status drives the card's accent: met/on-track green, behind amber,
-    // missed red, upcoming neutral.
-    const passed = isPast ? seasonVerdict(season, stats) : null;
-    const onTrack = isActive ? seasonOnTrack(season, stats) : null;
-    const statusCls =
-      isPast ? (passed ? ' season-card-good' : ' season-card-bad')
-      : isActive ? (onTrack === null ? '' : onTrack ? ' season-card-good' : ' season-card-warn')
-      : '';
-    const card = el('article', { class: 'season-card season-card-' + bucket + statusCls });
-
-    // Header row
-    const head = el('div', { class: 'season-card-head' });
-    head.appendChild(el('div', { class: 'season-card-title' }, [
-      el('span', { class: 'season-card-name' }, season.name),
-      el('span', { class: 'season-card-dates' }, seasonDateRange(season)),
-    ]));
-    const headRight = el('div', { class: 'season-card-head-right' });
-    head.appendChild(headRight);
-
-    if (isPast) {
-      headRight.appendChild(el('span', {
-        class: 'season-verdict-pill ' + (passed ? 'is-pass' : 'is-fail'),
-      }, passed ? 'Passed' : 'Failed'));
+  // One human line per period, year included: "Aug 3 to Aug 9, 2026" or
+  // "August 2026". A week straddling New Year carries both years so the jump
+  // is obvious ("Dec 28, 2025 to Jan 3, 2026").
+  function periodTitle(rec) {
+    if (rec.unit === 'month') {
+      return new Date(rec.start + 'T00:00:00')
+        .toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
     }
+    const startYear = rec.start.slice(0, 4);
+    const endYear = rec.end.slice(0, 4);
+    return startYear === endYear
+      ? `${fmtDateShort(rec.start)} to ${fmtDateShort(rec.end)}, ${endYear}`
+      : `${fmtDateShort(rec.start)}, ${startYear} to ${fmtDateShort(rec.end)}, ${endYear}`;
+  }
 
-    if ((isActive || isUpcoming)) {
-      headRight.appendChild(el('button', {
-        type: 'button',
-        class: 'icon-btn icon-btn-danger season-delete-btn',
-        title: 'Delete season',
-        'aria-label': 'Delete season',
-        html: ICON_TRASH,
-        onclick: () => deleteSeason(season.id),
-      }));
-    }
+  // The ISO week number, read straight off the period id ('2026-W32' -> '#32')
+  // rather than recomputed, so the label can never drift from the bucket the
+  // card was built from. Monthly ids carry no week, so they get nothing.
+  function weekNumber(rec) {
+    const m = rec.unit === 'week' && /-W(\d{2})$/.exec(rec.id);
+    return m ? Number(m[1]) : null;
+  }
 
-    card.appendChild(head);
+  // "3W · 2L", plus the ties only when there were any. Same rule as the
+  // running per-rival tally, so a card never carries a column of zeroes.
+  function wltText(rec) {
+    const base = `${rec.wins}W · ${rec.losses}L`;
+    return rec.ties ? `${base} · ${rec.ties}T` : base;
+  }
 
-    // Story-first headline, then the meta line.
-    card.appendChild(el('div', { class: 'season-card-headline' },
-      seasonHeadline(season, stats, bucket)));
-    card.appendChild(el('div', { class: 'season-card-meta' }, [
-      el('span', { class: 'season-card-meta-item' }, rivalLabel(season.rivalId)),
-      el('span', { class: 'season-card-meta-sep' }, '·'),
-      el('span', { class: 'season-card-meta-item' }, seasonGoalText(season)),
+  function winPctText(rec) {
+    return rec.decided > 0 ? `${rec.winPct.toFixed(0)}% win` : 'no decided games';
+  }
+
+  // Verdict for a period: ahead, behind, or level. Empty when nothing was
+  // decided, so a week of pure ties stays neutral.
+  function recordTone(rec) {
+    if (!rec || !rec.decided) return '';
+    if (rec.wins > rec.losses) return 'good';
+    if (rec.wins < rec.losses) return 'bad';
+    return 'even';
+  }
+
+  // Green above 50%, red below, neutral at exactly 50 or with nothing
+  // decided. `wins > losses` is the same statement as `winPct > 50`, so the
+  // percentage and the card's verdict edge can never disagree.
+  function pctToneClass(rec) {
+    const tone = recordTone(rec);
+    return tone === 'good' ? ' is-good' : tone === 'bad' ? ' is-bad' : '';
+  }
+
+  // Running record against one rival, as it stood at the end of this period.
+  function periodTallyTitle(rec, name, tally) {
+    const unit = rec.unit === 'month' ? 'month' : 'week';
+    const won = `${tally.won} ${unit}${tally.won === 1 ? '' : 's'}`;
+    return `${name}: ${won} won, ${tally.lost} lost` +
+      (tally.tied ? `, ${tally.tied} tied` : '') +
+      `, counting every ${unit} you played them up to and including this one`;
+  }
+
+  function makeRecordCard(rec, isCurrent, running) {
+    const tone = recordTone(rec);
+    const week = weekNumber(rec);
+    const card = el('article', {
+      class: 'record-card' + (tone ? ' record-card-' + tone : '') +
+             (isCurrent ? ' is-current' : ''),
+    });
+
+    card.appendChild(el('div', { class: 'record-card-head' }, [
+      el('div', { class: 'record-card-title' }, [
+        el('span', { class: 'record-card-name' }, periodTitle(rec)),
+        week
+          ? el('span', {
+              class: 'record-week-num',
+              title: `ISO week ${week} of ${rec.id.slice(0, 4)}`,
+            }, `#${week}`)
+          : null,
+        isCurrent
+          ? el('span', { class: 'record-current-pill' },
+              rec.unit === 'month' ? 'This month' : 'This week')
+          : null,
+      ]),
+      el('div', { class: 'record-card-head-right' }, [
+        el('span', { class: 'record-card-wlt' }, wltText(rec)),
+        el('span', { class: 'record-card-stats' }, [
+          el('span', { class: 'record-stat-num' }, String(rec.games)),
+          el('span', { class: 'record-stat-label' }, ' game' + (rec.games === 1 ? '' : 's')),
+          el('span', { class: 'record-stat-sep' }, '·'),
+          el('span', { class: 'record-stat-pct' + pctToneClass(rec) }, winPctText(rec)),
+        ]),
+      ]),
     ]));
 
-    if (isUpcoming) return card;
-
-    // Stats row
-    const wld = `${stats.wins}W · ${stats.losses}L · ${stats.ties}T`;
-    const winPctStr = (stats.wins + stats.losses) > 0
-      ? stats.winPct.toFixed(0) + '% win'
-      : 'no decided games';
-
-    card.appendChild(el('div', { class: 'season-card-stats' }, [
-      el('span', { class: 'season-stat-num' }, String(stats.gamesPlayed)),
-      el('span', { class: 'season-stat-label' }, ' game' + (stats.gamesPlayed === 1 ? '' : 's')),
-      el('span', { class: 'season-stat-sep' }, '·'),
-      el('span', { class: 'season-stat-wld' }, wld),
-      el('span', { class: 'season-stat-sep' }, '·'),
-      el('span', { class: 'season-stat-pct' }, winPctStr),
-    ]));
-
-    // Progress toward goal. Guard the divisor: a persisted/imported season
-    // with goalValue 0 or non-numeric must not yield width:NaN%.
-    const goalV = Number(season.goalValue);
-    const goalSafe = Number.isFinite(goalV) && goalV > 0;
-    const currentVal = seasonCurrentStat(season, stats);
-    let progressFraction = 0;
-    if (goalSafe) {
-      progressFraction = (season.goalType === 'winPct' ? stats.winPct : currentVal) / goalV;
-    }
-
-    const progressLabel = season.goalType === 'winPct'
-      ? `${stats.winPct.toFixed(0)}% / ${goalSafe ? goalV : '?'}%`
-      : `${currentVal} / ${goalSafe ? goalV : '?'}`;
-
-    const barCls = progressFraction >= 1 ? 'is-done' : '';
-    card.appendChild(el('div', { class: 'season-progress-row' }, [
-      el('span', { class: 'season-progress-label' }, progressLabel),
-      makeSeasonProgressBar(progressFraction, barCls),
-    ]));
-
-    // On-track indicator (active only)
-    if (isActive && onTrack !== null) {
-      card.appendChild(el('div', {
-        class: 'season-track-pill ' + (onTrack ? 'is-on-track' : 'is-behind'),
-      }, onTrack ? 'On track' : 'Behind'));
-    }
+    // Per-rival split. Best win % first by default so the period's strongest
+    // and weakest matchups read straight off the card; the toolbar control
+    // switches every card to plain ABC, which also breaks win-% ties.
+    const byName = (a, b) => compareNamesCI(rivalLabel(a.rivalId), rivalLabel(b.rivalId));
+    const order = state.recordsSort === 'name'
+      ? byName
+      : (a, b) => compareWinPctDesc(a, b) || byName(a, b);
+    const rivals = el('ul', { class: 'record-rivals' });
+    rec.byRival
+      .slice()
+      .sort(order)
+      .forEach(r => {
+        const name = rivalLabel(r.rivalId);
+        const tally = running ? running[r.rivalId] : null;
+        rivals.appendChild(el('li', { class: 'record-rival' }, [
+          el('span', { class: 'record-rival-name' }, [
+            el('span', { class: 'record-rival-label' }, name),
+            tally
+              ? el('span', {
+                  class: 'record-rival-run',
+                  title: periodTallyTitle(rec, name, tally),
+                }, `(${periodTallyText(tally)})`)
+              : null,
+          ]),
+          el('span', { class: 'record-rival-wlt' }, wltText(r)),
+          el('span', { class: 'record-rival-pct' + pctToneClass(r) },
+            r.decided > 0 ? `${r.winPct.toFixed(0)}%` : '-'),
+        ]));
+      });
+    card.appendChild(rivals);
 
     return card;
   }
 
-  function deleteSeason(id) {
-    const season = state.seasons.find(s => s.id === id);
-    if (!season) return;
-    openDeleteSeasonModal(season);
+  // Six period cards a page. Switching bucket or rival order rewrites what
+  // every card says, so both send the reader back to the newest page.
+  const RECORDS_PAGE_SIZE = 6;
+
+  function setRecordsUnit(unit) {
+    if (state.recordsUnit === unit) return;
+    state.recordsUnit = unit;
+    state.recordsPage = 1;
+    renderRecords();
   }
 
-  // Delete-season confirmation modal — same pattern as the delete-game and
-  // clear-games modals: Cancel gets initial focus; backdrop/X/Escape close
-  // without deleting; focus returns to the trigger afterwards.
-  function openDeleteSeasonModal(season) {
-    const modal = $('#delete-season-modal');
-    $('#delete-season-body').textContent =
-      `${season.name} (${seasonDateRange(season)}). This cannot be undone.`;
-    state.pendingDeleteSeasonId = season.id;
-    state.deleteSeasonLastFocus = document.activeElement;
-    modal.hidden = false;
-    setTimeout(() => $('#delete-season-cancel').focus(), 30);
+  function setRecordsSort(sort) {
+    if (state.recordsSort === sort) return;
+    state.recordsSort = sort;
+    state.recordsPage = 1;
+    renderRecords();
   }
 
-  function closeDeleteSeasonModal() {
-    $('#delete-season-modal').hidden = true;
-    state.pendingDeleteSeasonId = null;
-    const prev = state.deleteSeasonLastFocus;
-    state.deleteSeasonLastFocus = null;
-    if (prev && document.body.contains(prev)) setTimeout(() => prev.focus(), 0);
-  }
-
-  function confirmDeleteSeason() {
-    const id = state.pendingDeleteSeasonId;
-    closeDeleteSeasonModal();
-    if (!id) return;
-    state.seasons = state.seasons.filter(s => s.id !== id);
-    persistSeasons();
-    renderSeasons();
-    renderActiveSeasonBanner();
-    if (state.view === 'dashboard') renderDashboard();
-  }
-
-  function renderSeasons() {
-    const body = $('#seasons-body');
+  function renderRecords() {
+    const body = $('#records-body');
     if (!body) return;
     body.innerHTML = '';
 
-    const today = todayISO();
-
-    if (state.seasons.length === 0) {
-      body.appendChild(el('div', { class: 'empty-state seasons-empty' }, [
-        el('p', {}, 'No seasons yet. Create your first season to start tracking a time-boxed challenge.'),
-        el('button', { type: 'button', class: 'btn btn-ghost', style: 'margin-top:.75rem', onclick: openSeasonModal }, '+ Create your first season'),
-      ]));
-      return;
-    }
-
-    const active = state.seasons.filter(s => s.startDate <= today && s.endDate >= today);
-    const upcoming = state.seasons.filter(s => s.startDate > today);
-    const past = state.seasons.filter(s => s.endDate < today);
-
-    function makeGroup(title, items, bucket) {
-      if (!items.length) return null;
-      const section = el('section', { class: 'seasons-group' });
-      section.appendChild(el('h3', { class: 'seasons-group-title' }, title));
-      items.forEach(s => section.appendChild(makeSeasonCard(s, bucket)));
-      return section;
-    }
-
-    const activeSection = makeGroup('Active', active, 'active');
-    const upcomingSection = makeGroup('Upcoming', upcoming, 'upcoming');
-    const pastSection = makeGroup('Past', past, 'past');
-
-    if (activeSection) body.appendChild(activeSection);
-    if (upcomingSection) body.appendChild(upcomingSection);
-    if (pastSection) body.appendChild(pastSection);
-  }
-
-  // ---------- season modal ----------
-  function openSeasonModal() {
-    const modal = $('#season-modal');
-    const nameInput = $('#season-name');
-    const startInput = $('#season-start');
-    const endInput = $('#season-end');
-    const rivalSelect = $('#season-rival');
-    const errorEl = $('#season-modal-error');
-
-    // Populate rival dropdown
-    rivalSelect.innerHTML = '<option value="">All rivals</option>';
-    state.rivals
-      .slice()
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .forEach(r => {
-        rivalSelect.appendChild(el('option', { value: r.id }, r.name));
-      });
-
-    // Defaults
-    const today = todayISO();
-    nameInput.value = '';
-    startInput.value = today;
-    endInput.value = addDaysISO(today, 30);
-    rivalSelect.value = '';
-    document.querySelector('input[name="season-goal-type"][value="winPct"]').checked = true;
-    errorEl.hidden = true;
-    errorEl.textContent = '';
-
-    modal.hidden = false;
-    setTimeout(() => nameInput.focus(), 30);
-  }
-
-  function closeSeasonModal() {
-    $('#season-modal').hidden = true;
-  }
-
-  function saveSeasonFromModal() {
-    const name = $('#season-name').value.trim();
-    const startDate = $('#season-start').value;
-    const endDate = $('#season-end').value;
-    const rivalId = $('#season-rival').value || null;
-    const goalType = document.querySelector('input[name="season-goal-type"]:checked')?.value;
-    const errorEl = $('#season-modal-error');
-
-    const goalValInput = {
-      winPct: $('#season-goal-winpct'),
-      wins: $('#season-goal-wins'),
-      minGames: $('#season-goal-mingames'),
-    }[goalType];
-    const goalValue = goalValInput ? Number(goalValInput.value) : 0;
-
-    errorEl.hidden = true;
-
-    if (!name) {
-      errorEl.textContent = 'Season name is required.';
-      errorEl.hidden = false;
-      $('#season-name').focus();
-      return;
-    }
-    if (!startDate || !endDate) {
-      errorEl.textContent = 'Start and end dates are required.';
-      errorEl.hidden = false;
-      return;
-    }
-    if (startDate > endDate) {
-      errorEl.textContent = 'Start date must be on or before end date.';
-      errorEl.hidden = false;
-      return;
-    }
-    if (!goalValue || goalValue <= 0) {
-      errorEl.textContent = 'Goal value must be greater than 0.';
-      errorEl.hidden = false;
-      return;
-    }
-    if (goalType === 'winPct' && goalValue > 100) {
-      errorEl.textContent = 'Win % goal must be between 1 and 100.';
-      errorEl.hidden = false;
-      return;
-    }
-
-    state.seasons.push({
-      id: uid(),
-      name,
-      rivalId,
-      startDate,
-      endDate,
-      goalType,
-      goalValue,
-      createdAt: Date.now(),
+    const unit = state.recordsUnit;
+    $$('.records-toggle-btn').forEach(btn => {
+      const active = btn.dataset.recordsUnit === unit;
+      btn.classList.toggle('is-active', active);
+      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
     });
-    persistSeasons();
-    closeSeasonModal();
-    renderSeasons();
-    if (state.view === 'dashboard') renderDashboard();
+    const sortSelect = $('#records-sort-select');
+    if (sortSelect) sortSelect.value = state.recordsSort;
+
+    const records = periodRecords(state.games, unit);
+    if (!records.length) {
+      body.appendChild(el('div', { class: 'empty-state records-empty' }, [
+        el('p', {}, `No head-to-head games yet. Log a day against a rival and your ${unit === 'month' ? 'monthly' : 'weekly'} record shows up here on its own.`),
+      ]));
+      renderRecordsPagination(1);
+      return;
+    }
+
+    const totalPages = Math.max(1, Math.ceil(records.length / RECORDS_PAGE_SIZE));
+    if (state.recordsPage > totalPages) state.recordsPage = totalPages;
+    if (state.recordsPage < 1) state.recordsPage = 1;
+    const startIdx = (state.recordsPage - 1) * RECORDS_PAGE_SIZE;
+
+    // Every card needs the running per-rival tally as it stood at the end of
+    // its own period, so the replay runs over the full history once, not per
+    // visible page.
+    const running = runningRivalPeriodRecords(records);
+    const currentId = currentPeriodId(unit);
+    records
+      .slice(startIdx, startIdx + RECORDS_PAGE_SIZE)
+      .forEach(rec => body.appendChild(
+        makeRecordCard(rec, rec.id === currentId, running[rec.id])));
+
+    renderRecordsPagination(totalPages);
   }
 
-  // Dashboard active-season banner
-  function renderActiveSeasonBanner() {
-    const wrap = $('#dash-active-season-banner');
+  // Prev / Next plus "Page X of Y", built from the same .pagination shell and
+  // colour-pinned .page-btn styling the history footer uses. One page of
+  // periods needs no controls at all, so the whole nav goes away.
+  function renderRecordsPagination(totalPages) {
+    const nav = $('#records-pagination');
+    if (!nav) return;
+    if (totalPages <= 1) { nav.hidden = true; return; }
+    nav.hidden = false;
+    $('#records-pagination-meta').textContent = `Page ${state.recordsPage} of ${totalPages}`;
+
+    const pager = $('#records-pager');
+    pager.innerHTML = '';
+    pager.hidden = false;
+    const go = (n) => { state.recordsPage = n; renderRecords(); };
+    pager.appendChild(pageButton('Prev', state.recordsPage - 1, state.recordsPage <= 1, go));
+    pager.appendChild(pageButton('Next', state.recordsPage + 1, state.recordsPage >= totalPages, go));
+  }
+
+  // Dashboard current-form banner: this week's and this month's overall record,
+  // and a way into the full Records view.
+  function makeBannerLine(label, rec) {
+    const tone = recordTone(rec);
+    return el('span', { class: 'record-dash-banner-line' }, [
+      el('span', { class: 'record-dash-banner-period' }, label),
+      el('span', { class: 'record-dash-banner-figures' }, [
+        rec
+          ? el('span', { class: 'record-dash-banner-wlt' + (tone ? ' is-' + tone : '') },
+              wltText(rec))
+          : el('span', { class: 'record-dash-banner-empty' }, 'No games yet'),
+        rec && rec.decided > 0
+          ? el('span', { class: 'record-dash-banner-pct' + pctToneClass(rec) },
+              `${rec.winPct.toFixed(0)}%`)
+          : null,
+      ]),
+    ]);
+  }
+
+  function renderRecordBanner() {
+    const wrap = $('#dash-record-banner');
     if (!wrap) return;
     wrap.innerHTML = '';
-    const today = todayISO();
-    const active = state.seasons.filter(s => s.startDate <= today && s.endDate >= today);
-    if (!active.length) { wrap.hidden = true; return; }
 
-    const season = active[0];
-    const stats = seasonStats(season);
-    // Inclusive count — on the season's final day this reads "1 day left",
-    // not "0 days left" (the old off-by-one).
-    const daysLeft = Math.max(0, daysBetween(today, season.endDate) + 1);
-    const onTrack = seasonOnTrack(season, stats);
-    const trackText = onTrack === null ? '' : (onTrack ? ' · On track' : ' · Behind');
-    const statusCls = onTrack === null ? '' : (onTrack ? ' is-on-track' : ' is-behind');
+    const weeks = periodRecords(state.games, 'week');
+    if (!weeks.length) { wrap.hidden = true; return; }
+
+    const today = todayISO();
+    const week = weeks.find(w => w.id === isoWeekId(today));
+    const month = periodRecords(state.games, 'month').find(m => m.id === monthId(today));
 
     wrap.hidden = false;
-    const banner = el('div', { class: 'season-dash-banner' + statusCls, onclick: () => setView('seasons') }, [
-      el('div', { class: 'season-dash-banner-left' }, [
-        el('span', { class: 'season-dash-banner-name' }, season.name + ' is active'),
-        el('span', { class: 'season-dash-banner-headline' }, seasonHeadline(season, stats, 'active')),
-        el('span', { class: 'season-dash-banner-meta' }, `${daysLeft} day${daysLeft === 1 ? '' : 's'} left${trackText}`),
+    wrap.appendChild(el('button', {
+      type: 'button',
+      class: 'record-dash-banner',
+      'aria-label': 'Open the Records view',
+      onclick: () => setView('records'),
+    }, [
+      el('span', { class: 'record-dash-banner-left' }, [
+        el('span', { class: 'record-dash-banner-label' }, 'Current form'),
+        el('span', { class: 'record-dash-banner-lines' }, [
+          makeBannerLine('This week', week),
+          makeBannerLine('This month', month),
+        ]),
       ]),
-      el('span', { class: 'season-dash-banner-arrow' }, '→'),
-    ]);
-    wrap.appendChild(banner);
+      el('span', { class: 'record-dash-banner-cta' }, [
+        el('span', { class: 'record-dash-banner-cta-text' }, 'All records'),
+        el('span', { class: 'record-dash-banner-arrow', 'aria-hidden': 'true' }, '→'),
+      ]),
+    ]));
   }
 
   // ---------- dashboard view ----------
   function renderDashboard() {
     renderProfileCard();
     renderPasteSection();
-    renderActiveSeasonBanner();
+    renderRecordBanner();
     renderDashSummary();
     renderTodaysPredictions();
     renderRivalGrid();
@@ -1540,6 +1403,204 @@
       scores: Array.isArray(g.theirScores) ? g.theirScores : null,
       total:  Array.isArray(g.theirScores) ? getTheirTotal(g) : null,
     };
+  }
+
+  // ---------- predicted-position accuracy ----------
+  // How often the predictor put a player in the position they actually
+  // finished in, as "hits / eligible days". Back-testing re-runs the
+  // predictor for each past day with asOfISO set to that day, so a day's
+  // prediction only ever sees rounds older than itself.
+  //
+  // A day is eligible for a player when its 5 puzzle cities are known, the
+  // player has enough pre-cutoff history to be predicted, and the player
+  // actually played. Paste-imported days carry no cities and are eligible
+  // for nobody, which is why a player can have a prediction today and still
+  // show no badge.
+  //
+  // The whole pass is O(days x players x history) haversine work, so it is
+  // memoized twice: per (player, date) inside a pass, and per game-log
+  // fingerprint across renders. The day cap keeps the cost linear as the
+  // history grows instead of quadratic.
+  const POSITION_HIT_MAX_DAYS = 180;
+  const MY_PLAYER_KEY = '@me';
+  const positionHitCache = { signature: null, records: null, preds: new Map() };
+
+  // Fingerprint of everything the back-test reads. MapTap syncs backfill
+  // existing games in place, so counting the score arrays matters as much
+  // as the game count; todayISO keeps the window honest past midnight.
+  function predictionHistorySignature() {
+    let games = 0, withCities = 0, withMine = 0, withTheirs = 0, latest = '';
+    for (const g of state.games) {
+      games++;
+      if (Array.isArray(g.cities)) withCities++;
+      if (Array.isArray(g.myScores)) withMine++;
+      if (Array.isArray(g.theirScores)) withTheirs++;
+      if (g.date > latest) latest = g.date;
+    }
+    return [games, withCities, withMine, withTheirs, latest,
+            state.rivals.map(r => r.id).join(','), todayISO()].join('|');
+  }
+
+  // A past day's 5 puzzle cities: synced games carry them inline, and the
+  // daily-cities cache covers days whose games were logged without them.
+  function citiesForPastDay(iso, fromGames) {
+    const inline = fromGames.get(iso);
+    if (inline) return inline;
+    try {
+      const cached = JSON.parse(localStorage.getItem(KEY.DAILY_CITIES_PREFIX + iso) || 'null');
+      if (cached && Array.isArray(cached.cities) && cached.cities.length === N_LOCS) {
+        return cached.cities;
+      }
+    } catch (_) { /* corrupted cache entry: treat the day as unknown */ }
+    return null;
+  }
+
+  function memoPredictedTotal(playerKey, iso, rounds, cities) {
+    const cacheKey = playerKey + '|' + iso;
+    if (positionHitCache.preds.has(cacheKey)) return positionHitCache.preds.get(cacheKey);
+    const pred = predictRoundsForPlayer(rounds, cities, iso);
+    const total = pred ? predTotalFromScores(pred.scores) : null;
+    positionHitCache.preds.set(cacheKey, total);
+    return total;
+  }
+
+  function computePositionHitRecords() {
+    const today = todayISO();
+    const citiesByDate = new Map();
+    const dates = new Set();
+    for (const g of state.games) {
+      if (!g.date || g.date >= today) continue;
+      dates.add(g.date);
+      if (!citiesByDate.has(g.date) &&
+          Array.isArray(g.cities) && g.cities.length === N_LOCS) {
+        citiesByDate.set(g.date, g.cities);
+      }
+    }
+
+    const players = [{
+      key: MY_PLAYER_KEY,
+      name: state.me || 'You',
+      rounds: myProfileRounds(),
+      actualTotal: iso => actualScoresForDay(iso).mineTotal,
+    }];
+    state.rivals.forEach(r => players.push({
+      key: r.id,
+      name: r.name,
+      rounds: rivalRounds(r.id),
+      actualTotal: iso => actualScoresForRivalDay(r.id, iso).total,
+    }));
+
+    const days = [];
+    for (const iso of Array.from(dates).sort().slice(-POSITION_HIT_MAX_DAYS)) {
+      const cities = citiesForPastDay(iso, citiesByDate);
+      if (!cities) continue;
+      const entries = [];
+      for (const player of players) {
+        const predictedTotal = memoPredictedTotal(player.key, iso, player.rounds, cities);
+        if (predictedTotal == null) continue;
+        entries.push({
+          key: player.key,
+          name: player.name,
+          predictedTotal,
+          actualTotal: player.actualTotal(iso),
+        });
+      }
+      if (entries.length) days.push(entries);
+    }
+    return accumulatePositionHits(days);
+  }
+
+  function positionHitRecords() {
+    const signature = predictionHistorySignature();
+    if (positionHitCache.signature !== signature) {
+      positionHitCache.signature = signature;
+      positionHitCache.preds.clear();
+      positionHitCache.records = computePositionHitRecords();
+    }
+    return positionHitCache.records;
+  }
+
+  // Compact accuracy badge for a prediction row. A player with no eligible
+  // day gets no badge at all rather than a meaningless "0%". The chip shows
+  // the rate because that is what compares across players with different
+  // amounts of history; the raw hits-of-days count lives in the tooltip.
+  function makeHitBadge(record) {
+    if (!record || !record.eligible) return null;
+    const pct = Math.round((record.hits / record.eligible) * 100);
+    const title = `Finished in the predicted position on ${record.hits} of ` +
+      `${record.eligible} past day${record.eligible === 1 ? '' : 's'} with a prediction ` +
+      `(${pct}%)`;
+    const hot = record.hits * 2 >= record.eligible;
+    return el('span', {
+      class: 'pred-hit-badge' + (hot ? ' is-hot' : ''),
+      title,
+      'aria-label': title,
+    }, [
+      el('span', { class: 'pred-hit-label' }, 'Spot-on'),
+      el('span', { class: 'pred-hit-num' }, `${pct}%`),
+    ]);
+  }
+
+  // ---------- average finishing position ----------
+  // Where a player usually lands on a day, by actual daily total, across every
+  // past day at least two tracked players logged a score. Solo days award no
+  // position, and this needs nothing but totals, so paste-imported days count
+  // exactly like synced ones (unlike the Spot-on record above, which needs the
+  // day's cities). Cheap enough to recompute per game-log fingerprint.
+  const finishPositionCache = { signature: null, records: null };
+
+  function computeFinishPositionRecords() {
+    const today = todayISO();
+    const live = new Set(state.rivals.map(r => r.id));
+    const byDate = new Map();
+    for (const g of state.games) {
+      if (!g.date || g.date >= today || !live.has(g.rivalId)) continue;
+      let day = byDate.get(g.date);
+      if (!day) { day = new Map(); byDate.set(g.date, day); }
+      // Your own scores repeat across every rival you played that day, so the
+      // first game carrying them settles your total for the day.
+      if (iPlayed(g) && !day.has(MY_PLAYER_KEY)) day.set(MY_PLAYER_KEY, getMyTotal(g));
+      if (theyPlayed(g)) day.set(g.rivalId, getTheirTotal(g));
+    }
+
+    const days = [];
+    byDate.forEach(day => {
+      const entries = [];
+      day.forEach((total, key) => entries.push({ key, total }));
+      days.push(entries);
+    });
+    return accumulateFinishPositions(days);
+  }
+
+  function finishPositionRecords() {
+    const signature = predictionHistorySignature();
+    if (finishPositionCache.signature !== signature) {
+      finishPositionCache.signature = signature;
+      finishPositionCache.records = computeFinishPositionRecords();
+    }
+    return finishPositionCache.records;
+  }
+
+  // Share of the field a player beats on an average day, beside their name.
+  // Plain text with a tooltip, never a control. A percentage rather than the
+  // raw position because a position is only readable next to the field size
+  // it came from; the raw average finish stays in the tooltip. A player with
+  // no qualifying day gets nothing. `color` ranks the number against the other
+  // rows on screen (green highest, red lowest) and is null when there is
+  // nothing to rank it against.
+  function makeAvgPosition(record, color) {
+    if (!record || !record.days) return null;
+    const pct = Math.round(record.share * 100);
+    const title = `Beats ${pct}% of the field on an average day. ` +
+      `Average finish ${record.avg.toFixed(1)} across ${record.days} ` +
+      `day${record.days === 1 ? '' : 's'}.`;
+    return el('span', { class: 'pred-avg-pos', title, 'aria-label': title }, [
+      el('span', { class: 'pred-avg-label' }, 'avg'),
+      el('span', {
+        class: 'pred-avg-num',
+        style: color ? `color:${color};` : null,
+      }, `${pct}%`),
+    ]);
   }
 
   // SVG icon helpers — tiny stroke glyphs used as score-cell adornments
@@ -1613,10 +1674,16 @@
     ]);
   }
 
-  function makePredictionRow({ label, predictedScores, actualScores, predictedTotal, actualTotal, isYou, accentColor }) {
+  function makePredictionRow({ label, predictedScores, actualScores, predictedTotal, actualTotal, isYou, accentColor, hitRecord, avgPosition, avgColor }) {
     const cls = ['pred-row'];
     if (isYou) cls.push('pred-row-you');
-    const cells = [el('div', { class: 'pred-label' }, label)];
+    const cells = [el('div', { class: 'pred-label' }, [
+      el('span', { class: 'pred-label-line' }, [
+        el('span', { class: 'pred-label-name' }, label),
+        makeAvgPosition(avgPosition, avgColor),
+      ]),
+      makeHitBadge(hitRecord),
+    ])];
     cells.push(el('div', { class: 'pred-cell pred-predicted' },
       predictedTotal != null ? String(predictedTotal) : '—'));
     cells.push(el('div', { class: 'pred-cell pred-actual' },
@@ -1798,6 +1865,8 @@
     // players who already played rank first by actual score, everyone
     // else follows by predicted score (actual is the #1 sort key,
     // predicted the #2). Name is the final tie-break.
+    const hitRecords = positionHitRecords();
+    const avgPositions = finishPositionRecords();
     const rows = [];
     rows.push({
       label: `${state.myIcon || '🧍'} ${state.me || 'You'}`,
@@ -1808,6 +1877,8 @@
       actualTotal:     myActuals.mineTotal,
       isYou: true,
       accentColor: 'var(--accent-2)',
+      hitRecord: hitRecords[MY_PLAYER_KEY] || null,
+      avgPosition: avgPositions[MY_PLAYER_KEY] || null,
     });
 
     let predictedCount = myPred ? 1 : 0;
@@ -1825,17 +1896,27 @@
         actualTotal:     act.total,
         isYou: false,
         accentColor: r.color,
+        hitRecord: hitRecords[r.id] || null,
+        avgPosition: avgPositions[r.id] || null,
       });
     });
+
+    // Rank the field-share percentages against each other. The ramp anchors
+    // green at its lowest input, so the shares go in negated: the biggest
+    // share becomes the smallest number and takes the green end. Scoped to the
+    // rows on screen, so it recomputes whenever the day or roster changes.
+    const avgColors = avgPositionColors(
+      rows.map(r => (r.avgPosition ? -r.avgPosition.share : null)));
+    rows.forEach((r, i) => { r.avgColor = avgColors[i]; });
 
     rows.sort((a, b) => {
       const aPlayed = a.actualTotal != null, bPlayed = b.actualTotal != null;
       if (aPlayed !== bPlayed) return aPlayed ? -1 : 1;
       if (aPlayed) return (b.actualTotal - a.actualTotal) ||
                           ((b.predictedTotal ?? -1) - (a.predictedTotal ?? -1)) ||
-                          a.sortName.localeCompare(b.sortName);
+                          compareNamesCI(a.sortName, b.sortName);
       return ((b.predictedTotal ?? -1) - (a.predictedTotal ?? -1)) ||
-             a.sortName.localeCompare(b.sortName);
+             compareNamesCI(a.sortName, b.sortName);
     });
     rows.forEach(r => body.appendChild(makePredictionRow(r)));
 
@@ -1890,7 +1971,7 @@
 
     state.rivals
       .slice()
-      .sort((a, b) => a.name.localeCompare(b.name))
+      .sort((a, b) => compareNamesCI(a.name, b.name))
       .forEach(r => wrap.appendChild(makePasteRivalRow(r)));
 
     // Restore "mine" textarea from preserved state
@@ -2215,11 +2296,11 @@
     }
 
     // Refresh the dashboard tiles + summary so saved games land immediately.
-    // The active-season banner counts these games too — without this it
-    // showed stale progress until the next full dashboard render.
+    // The current-form banner counts these games too. Without this it showed
+    // a stale record until the next full dashboard render.
     renderDashSummary();
     renderRivalGrid();
-    renderActiveSeasonBanner();
+    renderRecordBanner();
   }
 
   function renderDashSummary() {
@@ -2528,13 +2609,9 @@
   function renderRivalGrid() {
     const grid = $('#rival-grid');
     grid.innerHTML = '';
-    const sorted = state.rivals.slice().sort((a, b) => {
-      // Most-played rivalries first; ties broken alphabetically.
-      const sa = rivalSummary(a);
-      const sb = rivalSummary(b);
-      if (sb.total !== sa.total) return sb.total - sa.total;
-      return a.name.localeCompare(b.name);
-    });
+    // Alphabetical, case-insensitive: every rival list outside the Records
+    // view reads ABC, so a card sits in the same place whatever the week did.
+    const sorted = state.rivals.slice().sort((a, b) => compareNamesCI(a.name, b.name));
 
     sorted.forEach(r => grid.appendChild(makeRivalCard(rivalSummary(r))));
 
@@ -2982,9 +3059,12 @@
           renderRival();
         },
       });
-      state.rivals.forEach(r => {
-        switcher.appendChild(el('option', { value: r.id, selected: r.id === rival.id || undefined }, r.name));
-      });
+      state.rivals
+        .slice()
+        .sort((a, b) => compareNamesCI(a.name, b.name))
+        .forEach(r => {
+          switcher.appendChild(el('option', { value: r.id, selected: r.id === rival.id || undefined }, r.name));
+        });
       actions.appendChild(switcher);
     }
     const syncBtn = el('button', {
@@ -4072,7 +4152,7 @@
     // Comparator per sortable column. Numeric columns sort descending;
     // "rival" sorts A→Z. Ties fall back to games played, then name.
     const LB_SORTS = {
-      rival:   (a, b) => a.rival.name.localeCompare(b.rival.name),
+      rival:   (a, b) => compareNamesCI(a.rival.name, b.rival.name),
       games:   (a, b) => b.total - a.total,
       wins:    (a, b) => b.wins - a.wins,
       losses:  (a, b) => b.losses - a.losses,
@@ -4089,9 +4169,9 @@
     // state.lbDir to -1, which reverses just the primary key; the games/name
     // tie-breakers stay stable so equal rows keep a predictable order.
     const dir = state.lbDir === -1 ? -1 : 1;
-    const cmp = LB_SORTS[state.lbSort] || LB_SORTS.winpct;
+    const cmp = LB_SORTS[state.lbSort] || LB_SORTS.rival;
     summaries.sort((a, b) =>
-      dir * cmp(a, b) || b.total - a.total || a.rival.name.localeCompare(b.rival.name));
+      dir * cmp(a, b) || b.total - a.total || compareNamesCI(a.rival.name, b.rival.name));
 
     // Update sort-active state on the column headers. aria-sort reflects the
     // actual direction (the ::after caret follows aria-sort in CSS), so the
@@ -4458,7 +4538,7 @@
     if (!state.rivals.length) return;
     state.rivals
       .slice()
-      .sort((a, b) => a.name.localeCompare(b.name))
+      .sort((a, b) => compareNamesCI(a.name, b.name))
       .forEach(r => {
         const selected = isMatrixRivalSelected(r.id);
         const chip = el('button', {
@@ -4562,12 +4642,12 @@
 
     const sortKey = state.matrixSort || 'name';
     const sortedRivalParts = rivalParts.slice().sort((a, b) => {
-      if (sortKey === 'win') return winRateOf(b) - winRateOf(a) || a.label.localeCompare(b.label);
+      if (sortKey === 'win') return winRateOf(b) - winRateOf(a) || compareNamesCI(a.label, b.label);
       if (sortKey === 'avg') {
         const av = avgFor(a), bv = avgFor(b);
-        return (bv == null ? -Infinity : bv) - (av == null ? -Infinity : av) || a.label.localeCompare(b.label);
+        return (bv == null ? -Infinity : bv) - (av == null ? -Infinity : av) || compareNamesCI(a.label, b.label);
       }
-      return a.label.localeCompare(b.label);
+      return compareNamesCI(a.label, b.label);
     });
     const participants = [you, ...sortedRivalParts];
 
@@ -5494,7 +5574,7 @@
       else if (state.view === 'rival') renderRival();
       else if (state.view === 'leaderboard') renderLeaderboard();
       else if (state.view === 'matrix') renderMatrix();
-      else if (state.view === 'seasons') renderSeasons();
+      else if (state.view === 'records') renderRecords();
       else if (state.view === 'history') renderHistory();
     } catch (err) {
       setRivalSyncStatus(rivalId, 'err', err.message || 'sync failed');
@@ -5725,7 +5805,7 @@
       sel.appendChild(el('option', { value: 'skip' }, 'Skip'));
       sel.appendChild(el('option', { value: 'me' }, 'Me'));
       // existing rivals
-      state.rivals.slice().sort((a, b) => a.name.localeCompare(b.name)).forEach(r => {
+      state.rivals.slice().sort((a, b) => compareNamesCI(a.name, b.name)).forEach(r => {
         sel.appendChild(el('option', { value: 'rival:' + r.id }, `Rival: ${r.name}`));
       });
       // new rival from sender's name
@@ -5947,7 +6027,7 @@
     else if (state.view === 'rival') renderRival();
     else if (state.view === 'leaderboard') renderLeaderboard();
     else if (state.view === 'matrix') renderMatrix();
-    else if (state.view === 'seasons') renderSeasons();
+    else if (state.view === 'records') renderRecords();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -5989,7 +6069,7 @@
     else if (state.view === 'rival') renderRival();
     else if (state.view === 'leaderboard') renderLeaderboard();
     else if (state.view === 'matrix') renderMatrix();
-    else if (state.view === 'seasons') renderSeasons();
+    else if (state.view === 'records') renderRecords();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -6036,7 +6116,7 @@
         else if (state.view === 'rival') renderRival();
         else if (state.view === 'leaderboard') renderLeaderboard();
         else if (state.view === 'matrix') renderMatrix();
-        else if (state.view === 'seasons') renderSeasons();
+        else if (state.view === 'records') renderRecords();
         else if (state.view === 'history') renderHistory();
       } catch (e) {
         alert('Could not parse backup file.');
@@ -6057,7 +6137,6 @@
     if (!e.key) return;
     if (e.key === KEY.RIVALS) state.rivals = load(KEY.RIVALS, []);
     else if (e.key === KEY.GAMES) state.games = load(KEY.GAMES, []);
-    else if (e.key === KEY.SEASONS) state.seasons = load(KEY.SEASONS, []);
     else if (e.key === KEY.ME) {
       state.me = loadString(KEY.ME, 'Me');
       const me = $('#my-name'); if (me) me.value = state.me;
@@ -6080,7 +6159,7 @@
     else if (state.view === 'rival') renderRival();
     else if (state.view === 'leaderboard') renderLeaderboard();
     else if (state.view === 'matrix') renderMatrix();
-    else if (state.view === 'seasons') renderSeasons();
+    else if (state.view === 'records') renderRecords();
     else if (state.view === 'history') renderHistory();
   }
 
@@ -6102,15 +6181,15 @@
     $('#add-rival-btn').addEventListener('click', () => openRivalModal(null));
     $('#dash-empty-add-btn').addEventListener('click', () => openRivalModal(null));
 
-    // Seasons
-    $('#new-season-btn').addEventListener('click', openSeasonModal);
-    $('#season-modal').querySelectorAll('[data-close="season-modal"]').forEach(node => {
-      node.addEventListener('click', closeSeasonModal);
+    // Records period toggle + per-rival sort
+    $$('.records-toggle-btn').forEach(btn => {
+      btn.addEventListener('click', () => setRecordsUnit(btn.dataset.recordsUnit));
     });
-    $('#season-save-btn').addEventListener('click', saveSeasonFromModal);
-    $('#season-name').addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') { e.preventDefault(); saveSeasonFromModal(); }
-    });
+    const recordsSortSelect = $('#records-sort-select');
+    if (recordsSortSelect) {
+      recordsSortSelect.value = state.recordsSort;
+      recordsSortSelect.addEventListener('change', (e) => setRecordsSort(e.target.value));
+    }
 
     // Rival modal close — scoped to #rival-modal so it doesn't also fire
     // for clicks on the WhatsApp import modal.
@@ -6132,20 +6211,13 @@
       node.addEventListener('click', closeClearGamesModal);
     });
     $('#clear-games-confirm').addEventListener('click', confirmClearGames);
-    // Delete-season confirmation modal
-    $('#delete-season-modal').querySelectorAll('[data-close="delete-season-modal"]').forEach(node => {
-      node.addEventListener('click', closeDeleteSeasonModal);
-    });
-    $('#delete-season-confirm').addEventListener('click', confirmDeleteSeason);
 
     document.addEventListener('keydown', (e) => {
       if (e.key !== 'Escape') return;
       if (!$('#wa-modal').hidden) closeWhatsAppModal();
       else if (!$('#delete-game-modal').hidden) closeDeleteGameModal();
       else if (!$('#clear-games-modal').hidden) closeClearGamesModal();
-      else if (!$('#delete-season-modal').hidden) closeDeleteSeasonModal();
       else if (!$('#rival-modal').hidden) closeRivalModal();
-      else if (!$('#season-modal').hidden) closeSeasonModal();
     });
 
     // settings strip

--- a/apps/maptap-rivals/js/stats.js
+++ b/apps/maptap-rivals/js/stats.js
@@ -299,6 +299,364 @@
     return volume * 50 * (recencyWinRate + recencyMarginRate);
   }
 
+  // ---------- calendar period bucketing ----------
+  // Every helper below works off the 'YYYY-MM-DD' string through Date.UTC so
+  // the bucket never depends on the browser's timezone. `new Date('2026-08-02')`
+  // parses as UTC midnight and then reports the *previous* day from getDate()
+  // west of Greenwich, which would misfile a Monday game into the prior week.
+
+  const DAY_MS = 86400000;
+
+  function parseDateISO(iso) {
+    if (typeof iso !== 'string') return null;
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+    if (!m) return null;
+    const year = Number(m[1]), month = Number(m[2]), day = Number(m[3]);
+    const ms = Date.UTC(year, month - 1, day);
+    const back = new Date(ms);
+    // Rejects impossible dates that Date.UTC silently rolls over (2026-02-30).
+    if (back.getUTCFullYear() !== year || back.getUTCMonth() !== month - 1 ||
+        back.getUTCDate() !== day) return null;
+    return { year, month, day, ms };
+  }
+
+  function isoFromMs(ms) { return new Date(ms).toISOString().slice(0, 10); }
+
+  // Monday of the ISO week containing `iso`.
+  function isoWeekStart(iso) {
+    const p = parseDateISO(iso);
+    if (!p) return null;
+    const back = (new Date(p.ms).getUTCDay() + 6) % 7; // Mon = 0 ... Sun = 6
+    return isoFromMs(p.ms - back * DAY_MS);
+  }
+
+  // Sunday of the ISO week containing `iso`.
+  function isoWeekEnd(iso) {
+    const start = isoWeekStart(iso);
+    return start ? isoFromMs(parseDateISO(start).ms + 6 * DAY_MS) : null;
+  }
+
+  // ISO-8601 week id, 'YYYY-Www'. The week-numbering year is the year of that
+  // week's Thursday, so 2021-01-01 (a Friday) belongs to '2020-W53'.
+  function isoWeekId(iso) {
+    const start = isoWeekStart(iso);
+    if (!start) return null;
+    const thursdayMs = parseDateISO(start).ms + 3 * DAY_MS;
+    const year = new Date(thursdayMs).getUTCFullYear();
+    const week = Math.floor((thursdayMs - Date.UTC(year, 0, 1)) / (7 * DAY_MS)) + 1;
+    return `${year}-W${String(week).padStart(2, '0')}`;
+  }
+
+  function monthId(iso) {
+    const p = parseDateISO(iso);
+    return p ? iso.slice(0, 7) : null;
+  }
+
+  function monthStart(iso) {
+    const p = parseDateISO(iso);
+    return p ? isoFromMs(Date.UTC(p.year, p.month - 1, 1)) : null;
+  }
+
+  // Day 0 of the following month is the last day of this one.
+  function monthEnd(iso) {
+    const p = parseDateISO(iso);
+    return p ? isoFromMs(Date.UTC(p.year, p.month, 0)) : null;
+  }
+
+  // { id, start, end } for the calendar week or month holding `iso`.
+  function periodBounds(iso, unit) {
+    if (unit === 'month') {
+      const id = monthId(iso);
+      return id ? { id, start: monthStart(iso), end: monthEnd(iso) } : null;
+    }
+    const id = isoWeekId(iso);
+    return id ? { id, start: isoWeekStart(iso), end: isoWeekEnd(iso) } : null;
+  }
+
+  function blankRecord() {
+    return { games: 0, wins: 0, losses: 0, ties: 0, decided: 0, winPct: 0 };
+  }
+
+  function tallyRecord(rec, result) {
+    rec.games += 1;
+    if (result === 'W') rec.wins += 1;
+    else if (result === 'L') rec.losses += 1;
+    else rec.ties += 1;
+  }
+
+  // Win % counts decided games only, matching how the app has always read a
+  // W/L record: a week of nothing but ties is "no decided games", not 0%.
+  function finishRecord(rec) {
+    rec.decided = rec.wins + rec.losses;
+    rec.winPct = rec.decided > 0 ? (rec.wins / rec.decided) * 100 : 0;
+    return rec;
+  }
+
+  // Bucket the game log into calendar weeks ('week') or months ('month').
+  // Only head-to-head days count: rival-only and solo days carry no W/L
+  // semantics, exactly like resultOf treats them. Returns newest period
+  // first; `byRival` is each rival's record inside that period, biggest
+  // sample first with the rival id as a stable tie-break.
+  function periodRecords(games, unit) {
+    const byPeriod = new Map();
+    for (const g of Array.isArray(games) ? games : []) {
+      if (!g || !bothPlayed(g)) continue;
+      const bounds = periodBounds(g.date, unit);
+      if (!bounds) continue;
+      let period = byPeriod.get(bounds.id);
+      if (!period) {
+        period = Object.assign({ id: bounds.id, unit: unit === 'month' ? 'month' : 'week',
+                                 start: bounds.start, end: bounds.end,
+                                 rivals: new Map() }, blankRecord());
+        byPeriod.set(bounds.id, period);
+      }
+      const result = resultOf(g);
+      tallyRecord(period, result);
+      let rival = period.rivals.get(g.rivalId);
+      if (!rival) {
+        rival = Object.assign({ rivalId: g.rivalId }, blankRecord());
+        period.rivals.set(g.rivalId, rival);
+      }
+      tallyRecord(rival, result);
+    }
+
+    return Array.from(byPeriod.values())
+      .map(period => {
+        const byRival = Array.from(period.rivals.values())
+          .map(finishRecord)
+          .sort((a, b) => b.games - a.games ||
+                          String(a.rivalId).localeCompare(String(b.rivalId)));
+        delete period.rivals;
+        period.byRival = byRival;
+        return finishRecord(period);
+      })
+      .sort((a, b) => b.start.localeCompare(a.start));
+  }
+
+  // ---------- running period record vs one rival ----------
+
+  // Which way one period went against one rival: you out-won them, they
+  // out-won you, or you split it. Ties inside the period never decide it, so
+  // a period of nothing but ties is a tied period. A period you never played
+  // that rival in is not a period at all, and returns null.
+  function periodOutcomeVsRival(rivalRecord) {
+    if (!rivalRecord || !rivalRecord.games) return null;
+    if (rivalRecord.wins > rivalRecord.losses) return 'won';
+    if (rivalRecord.wins < rivalRecord.losses) return 'lost';
+    return 'tied';
+  }
+
+  // Periods won / lost / tied against each rival, replayed oldest period
+  // first and snapshotted at every period, so a card can show the record as
+  // it stood at the end of its own period ("Gal (63-54-1)"). Takes the
+  // periodRecords() output in any order and returns
+  // { [periodId]: { [rivalId]: { won, lost, tied } } }; a rival absent from a
+  // period keeps the tally it already had, it does not reset or disappear.
+  function runningRivalPeriodRecords(periods) {
+    const ordered = (Array.isArray(periods) ? periods : [])
+      .filter(p => p && p.id)
+      .slice()
+      .sort((a, b) => String(a.start).localeCompare(String(b.start)));
+    const running = new Map();
+    const out = {};
+    for (const period of ordered) {
+      for (const rivalRecord of period.byRival || []) {
+        const outcome = periodOutcomeVsRival(rivalRecord);
+        if (!outcome) continue;
+        let tally = running.get(rivalRecord.rivalId);
+        if (!tally) {
+          tally = { won: 0, lost: 0, tied: 0 };
+          running.set(rivalRecord.rivalId, tally);
+        }
+        tally[outcome] += 1;
+      }
+      const snapshot = {};
+      running.forEach((tally, rivalId) => {
+        snapshot[rivalId] = Object.assign({}, tally);
+      });
+      out[period.id] = snapshot;
+    }
+    return out;
+  }
+
+  // "9-8" until a period is drawn, "63-54-1" after: the tied component only
+  // shows up once there is one to show.
+  function periodTallyText(tally) {
+    if (!tally) return '';
+    return tally.tied
+      ? `${tally.won}-${tally.lost}-${tally.tied}`
+      : `${tally.won}-${tally.lost}`;
+  }
+
+  // ---------- predicted-position accuracy ----------
+  // Entries are one day's players: { key, name, predictedTotal, actualTotal }.
+  // `key` identifies the player (rival id, or a sentinel for the user) and
+  // `actualTotal` is null when that player did not play the day.
+
+  // Player keys ordered by `scoreKey` descending, name as the tie-break, so
+  // the index in the returned array is the player's rank for that day. This
+  // mirrors the Today's-predictions leaderboard sort.
+  function rankByScore(entries, scoreKey) {
+    return (Array.isArray(entries) ? entries : [])
+      .filter(e => e && Number.isFinite(e[scoreKey]))
+      .slice()
+      .sort((a, b) => b[scoreKey] - a[scoreKey] ||
+                      String(a.name || '').localeCompare(String(b.name || '')))
+      .map(e => e.key);
+  }
+
+  // Which players hit their predicted finishing position on this day.
+  // Both rankings are taken over the same set: players with a computable
+  // prediction who actually played. A predicted player who sat the day out
+  // holds no predicted slot, so he cannot make the players ranked below him
+  // structurally unable to hit.
+  // Players without a prediction, or who sat the day out, are absent from
+  // the result and so count toward nobody's eligible days.
+  function positionHitsForDay(entries) {
+    const played = (Array.isArray(entries) ? entries : [])
+      .filter(e => e && Number.isFinite(e.predictedTotal) && Number.isFinite(e.actualTotal));
+    const predictedOrder = rankByScore(played, 'predictedTotal');
+    const actualOrder = rankByScore(played, 'actualTotal');
+    const out = {};
+    for (const entry of played) {
+      out[entry.key] = predictedOrder.indexOf(entry.key) === actualOrder.indexOf(entry.key);
+    }
+    return out;
+  }
+
+  // Accumulate per-player { hits, eligible } over a list of days, each day
+  // being its own entries array. Players with no eligible day are absent
+  // from the result, which is what lets the UI skip the badge entirely
+  // instead of rendering a meaningless "0/0".
+  function accumulatePositionHits(days) {
+    const out = {};
+    for (const entries of Array.isArray(days) ? days : []) {
+      const hits = positionHitsForDay(entries);
+      for (const key of Object.keys(hits)) {
+        if (!out[key]) out[key] = { hits: 0, eligible: 0 };
+        out[key].eligible += 1;
+        if (hits[key]) out[key].hits += 1;
+      }
+    }
+    return out;
+  }
+
+  // ---------- daily finishing positions ----------
+  // Entries are one day's players: { key, total }, where a non-finite total
+  // means that player did not play. Position is 1-based over the players who
+  // did play, ranked by actual daily total, so paste-imported days (no cities,
+  // no prediction) count exactly like synced ones.
+  //
+  // Equal totals share the mean of the ranks they span: two players tied for
+  // first are both 1.5, never an arbitrary first and second decided by name.
+  // A day with fewer than two players yields nothing at all - finishing first
+  // out of one is not a position, it is just showing up.
+  function finishPositionsForDay(entries) {
+    const played = (Array.isArray(entries) ? entries : [])
+      .filter(e => e && Number.isFinite(e.total));
+    if (played.length < 2) return {};
+    const ordered = played.slice().sort((a, b) => b.total - a.total);
+    const out = {};
+    let i = 0;
+    while (i < ordered.length) {
+      let j = i;
+      while (j + 1 < ordered.length && ordered[j + 1].total === ordered[i].total) j++;
+      const shared = ((i + 1) + (j + 1)) / 2;
+      for (let k = i; k <= j; k++) out[ordered[k].key] = shared;
+      i = j + 1;
+    }
+    return out;
+  }
+
+  // Share of the field a player beat on a day: (N - R) / (N - 1) for their
+  // fractional rank R among the N players who played. First is always 1 and
+  // last is always 0 whatever N is, so being last of three reads exactly as
+  // badly as being last of ten - which raw positions cannot express, since
+  // "3rd" flatters a small field and punishes a big one. A day where everyone
+  // ties lands the whole field on 0.5.
+  function fieldSharesForDay(entries) {
+    const positions = finishPositionsForDay(entries);
+    const keys = Object.keys(positions);
+    const n = keys.length;
+    const out = {};
+    for (const key of keys) out[key] = (n - positions[key]) / (n - 1);
+    return out;
+  }
+
+  // Accumulate per-player { days, sum, avg, shareSum, share } over a list of
+  // days, each day being its own entries array. `share` is the headline figure
+  // (mean daily share of the field beaten, 0..1); `avg` is the mean raw
+  // finishing position, kept for the tooltip. Players with no qualifying day
+  // are absent from the result, which is what lets the UI skip the figure
+  // instead of rendering a meaningless "avg 0%".
+  function accumulateFinishPositions(days) {
+    const out = {};
+    for (const entries of Array.isArray(days) ? days : []) {
+      const positions = finishPositionsForDay(entries);
+      const shares = fieldSharesForDay(entries);
+      for (const key of Object.keys(positions)) {
+        if (!out[key]) out[key] = { days: 0, sum: 0, avg: 0, shareSum: 0, share: 0 };
+        out[key].days += 1;
+        out[key].sum += positions[key];
+        out[key].shareSum += shares[key];
+      }
+    }
+    for (const key of Object.keys(out)) {
+      out[key].avg = out[key].sum / out[key].days;
+      out[key].share = out[key].shareSum / out[key].days;
+    }
+    return out;
+  }
+
+  // Comparative color for a set of figures shown side by side. The lowest
+  // value anchors green, the highest anchors red, so a caller whose metric is
+  // better-when-higher (the field-share percentage) negates its values before
+  // passing them in; everything between is a linear RGB blend through a yellow
+  // midpoint: the lower half of the range walks green -> yellow, the upper
+  // half yellow -> red. Fewer than two averages, or a set where every average
+  // is identical, has nothing to compare against and yields null throughout so
+  // the caller keeps its neutral color instead of inventing a ranking.
+  const AVG_POS_RAMP = [[74, 222, 128], [250, 204, 21], [248, 113, 113]];
+
+  function avgPositionColor(t) {
+    const c = Math.min(1, Math.max(0, t));
+    const leg = c <= 0.5 ? 0 : 1;
+    const from = AVG_POS_RAMP[leg];
+    const to = AVG_POS_RAMP[leg + 1];
+    const local = (c - leg * 0.5) / 0.5;
+    const ch = i => Math.round(from[i] + (to[i] - from[i]) * local);
+    return `rgb(${ch(0)}, ${ch(1)}, ${ch(2)})`;
+  }
+
+  function avgPositionColors(values) {
+    const list = Array.isArray(values) ? values : [];
+    const nums = list.filter(v => Number.isFinite(v));
+    if (nums.length < 2) return list.map(() => null);
+    const min = Math.min(...nums);
+    const max = Math.max(...nums);
+    if (max === min) return list.map(() => null);
+    return list.map(v => Number.isFinite(v) ? avgPositionColor((v - min) / (max - min)) : null);
+  }
+
+  // ---------- ordering ----------
+  // Case-insensitive name order, used by every rival list outside the Records
+  // view. Names differing only in case fall back to the raw comparison so the
+  // order stays stable instead of flipping between renders.
+  function compareNamesCI(a, b) {
+    const as = String(a == null ? '' : a);
+    const bs = String(b == null ? '' : b);
+    return as.toLowerCase().localeCompare(bs.toLowerCase()) || as.localeCompare(bs);
+  }
+
+  // Best win % first, for the Records per-rival split. A record with nothing
+  // decided (all ties, or no games) has no win % to rank on and sorts below a
+  // genuine 0% rather than sharing the bottom with it.
+  function compareWinPctDesc(a, b) {
+    const av = a && a.decided > 0 ? a.winPct : -1;
+    const bv = b && b.decided > 0 ? b.winPct : -1;
+    return bv - av;
+  }
+
   const api = {
     // constants
     N_LOCS, WEIGHTS, MAX_RAW, MONTHS,
@@ -310,6 +668,17 @@
     // results / aggregates
     resultOf, resultLoc, stdDev, average, streaks, linearTrend, projectNext,
     rivalryScoreFromGames,
+    // calendar periods
+    parseDateISO, isoWeekStart, isoWeekEnd, isoWeekId,
+    monthId, monthStart, monthEnd, periodBounds, periodRecords,
+    periodOutcomeVsRival, runningRivalPeriodRecords, periodTallyText,
+    // predicted-position accuracy
+    rankByScore, positionHitsForDay, accumulatePositionHits,
+    // finishing positions
+    finishPositionsForDay, fieldSharesForDay, accumulateFinishPositions,
+    avgPositionColor, avgPositionColors,
+    // ordering
+    compareNamesCI, compareWinPctDesc,
   };
 
   if (typeof module !== 'undefined' && module.exports) {

--- a/apps/maptap-rivals/tests/stats.test.js
+++ b/apps/maptap-rivals/tests/stats.test.js
@@ -13,6 +13,13 @@ const {
   getMyTotal, getTheirTotal, parseMapTapScore, mapTapHistoryToRounds,
   resultOf, resultLoc, stdDev, average, streaks, linearTrend, projectNext,
   rivalryScoreFromGames,
+  parseDateISO, isoWeekStart, isoWeekEnd, isoWeekId,
+  monthId, monthStart, monthEnd, periodBounds, periodRecords,
+  periodOutcomeVsRival, runningRivalPeriodRecords, periodTallyText,
+  rankByScore, positionHitsForDay, accumulatePositionHits,
+  finishPositionsForDay, fieldSharesForDay, accumulateFinishPositions,
+  avgPositionColor, avgPositionColors,
+  compareNamesCI, compareWinPctDesc,
 } = require('../js/stats.js');
 
 // Helpers: a totals-only game where both sides played, and a rival-only day.
@@ -426,4 +433,752 @@ test('predTotalFromScores: malformed input returns null (distinct from a 0 total
   assert.equal(predTotalFromScores([1, 2, 3]), null);
   assert.equal(predTotalFromScores('nope'), null);
   assert.equal(predTotalFromScores(null), null);
+});
+
+// --- parseDateISO ----------------------------------------------------------
+
+test('parseDateISO: reads the parts off the string, not a local-time Date', () => {
+  assert.deepEqual(parseDateISO('2026-08-02'),
+    { year: 2026, month: 8, day: 2, ms: Date.UTC(2026, 7, 2) });
+});
+
+test('parseDateISO: rejects malformed and impossible dates', () => {
+  assert.equal(parseDateISO('2026-2-2'), null);      // needs zero padding
+  assert.equal(parseDateISO('2026-02-30'), null);    // would roll over to Mar 2
+  assert.equal(parseDateISO('2026-13-01'), null);
+  assert.equal(parseDateISO('not a date'), null);
+  assert.equal(parseDateISO(null), null);
+  assert.equal(parseDateISO(20260802), null);
+});
+
+// --- ISO week bucketing ----------------------------------------------------
+// Weeks run Monday to Sunday, so the boundary cases that matter are a Sunday
+// (last day of its week, not the first) and the turn of the year.
+
+test('isoWeekStart / isoWeekEnd: Monday opens the week, Sunday closes it', () => {
+  assert.equal(isoWeekStart('2026-07-27'), '2026-07-27'); // Monday is its own start
+  assert.equal(isoWeekEnd('2026-07-27'), '2026-08-02');
+});
+
+test('isoWeekStart: a Sunday lands in the Monday-started week that precedes it', () => {
+  // 2026-08-02 is a Sunday; the naive "week starts Sunday" bucketing would
+  // open a new week here and split the Mon-Sat games away from it.
+  assert.equal(isoWeekStart('2026-08-02'), '2026-07-27');
+  assert.equal(isoWeekEnd('2026-08-02'), '2026-08-02');
+  assert.equal(isoWeekId('2026-08-02'), isoWeekId('2026-07-27'));
+});
+
+test('isoWeekStart: the next Monday opens a fresh week', () => {
+  assert.equal(isoWeekStart('2026-08-03'), '2026-08-03');
+  assert.notEqual(isoWeekId('2026-08-03'), isoWeekId('2026-08-02'));
+});
+
+test('isoWeekId: week-numbering year follows the week Thursday across new year', () => {
+  assert.equal(isoWeekId('2021-01-01'), '2020-W53'); // Friday, still 2020's week 53
+  assert.equal(isoWeekId('2020-12-28'), '2020-W53'); // same week, previous year
+  assert.equal(isoWeekId('2019-12-30'), '2020-W01'); // Monday, already 2020's week 1
+  assert.equal(isoWeekId('2026-01-01'), '2026-W01'); // Thursday opens week 1
+});
+
+test('isoWeekId: pads the week number to two digits so ids sort as text', () => {
+  assert.equal(isoWeekId('2026-03-05'), '2026-W10');
+  assert.equal(isoWeekId('2026-02-26'), '2026-W09');
+  assert.ok(isoWeekId('2026-02-26') < isoWeekId('2026-03-05'));
+});
+
+test('isoWeekId: the bucket does not move with the host timezone', () => {
+  // The browser is not pinned to UTC the way this test file is. Date math on
+  // the string must give the same week in Los Angeles as in Kiritimati.
+  const original = process.env.TZ;
+  try {
+    process.env.TZ = 'America/Los_Angeles';
+    assert.equal(isoWeekId('2026-08-03'), '2026-W32');
+    assert.equal(isoWeekStart('2026-08-03'), '2026-08-03');
+    assert.equal(monthId('2026-08-01'), '2026-08');
+    process.env.TZ = 'Pacific/Kiritimati';
+    assert.equal(isoWeekId('2026-08-03'), '2026-W32');
+    assert.equal(isoWeekStart('2026-08-03'), '2026-08-03');
+    assert.equal(monthId('2026-08-01'), '2026-08');
+  } finally {
+    process.env.TZ = original;
+  }
+});
+
+test('isoWeek helpers: malformed dates yield null instead of a garbage bucket', () => {
+  assert.equal(isoWeekId('nope'), null);
+  assert.equal(isoWeekStart(''), null);
+  assert.equal(isoWeekEnd(undefined), null);
+});
+
+// --- month bucketing -------------------------------------------------------
+
+test('monthId / monthStart / monthEnd: calendar month bounds', () => {
+  assert.equal(monthId('2026-08-02'), '2026-08');
+  assert.equal(monthStart('2026-08-02'), '2026-08-01');
+  assert.equal(monthEnd('2026-08-02'), '2026-08-31');
+  assert.equal(monthEnd('2026-06-15'), '2026-06-30');
+  assert.equal(monthEnd('2026-12-31'), '2026-12-31');
+});
+
+test('monthEnd: leap years get February 29', () => {
+  assert.equal(monthEnd('2024-02-10'), '2024-02-29');
+  assert.equal(monthEnd('2026-02-10'), '2026-02-28');
+});
+
+test('month helpers: malformed dates yield null', () => {
+  assert.equal(monthId('2026-8'), null);
+  assert.equal(monthStart('nope'), null);
+  assert.equal(monthEnd(null), null);
+});
+
+// --- periodBounds ----------------------------------------------------------
+
+test('periodBounds: picks the week or the month for the same date', () => {
+  assert.deepEqual(periodBounds('2026-08-01', 'week'),
+    { id: '2026-W31', start: '2026-07-27', end: '2026-08-02' });
+  assert.deepEqual(periodBounds('2026-08-01', 'month'),
+    { id: '2026-08', start: '2026-08-01', end: '2026-08-31' });
+});
+
+test('periodBounds: anything other than "month" buckets by week', () => {
+  assert.equal(periodBounds('2026-08-01', 'week').id, '2026-W31');
+  assert.equal(periodBounds('2026-08-01', undefined).id, '2026-W31');
+});
+
+// --- periodRecords ---------------------------------------------------------
+// A log spanning two ISO weeks and two months, two rivals, one tie, plus the
+// two kinds of one-sided day the sync can produce. Hand-computed below.
+const recordLog = [
+  { rivalId: 'a', date: '2026-07-22', myScore: 600, theirScore: 500 }, // W  week30 / Jul
+  { rivalId: 'b', date: '2026-07-22', myScore: 600, theirScore: 700 }, // L  week30 / Jul
+  { rivalId: 'a', date: '2026-07-24', myScore: 500, theirScore: 500 }, // T  week30 / Jul
+  { rivalId: 'a', date: '2026-07-31', myScore: 700, theirScore: 400 }, // W  week31 / Jul
+  { rivalId: 'b', date: '2026-08-01', myScore: 300, theirScore: 900 }, // L  week31 / Aug
+  { rivalId: 'a', date: '2026-08-02', theirScore: 800 },               // rival-only day
+  { rivalId: 'b', date: '2026-07-29', myScore: 750 },                  // solo day
+];
+
+test('periodRecords: weekly buckets are newest first with the Sunday game in the Monday week', () => {
+  const weeks = periodRecords(recordLog, 'week');
+  assert.deepEqual(weeks.map(w => w.id), ['2026-W31', '2026-W30']);
+  assert.equal(weeks[0].start, '2026-07-27');
+  assert.equal(weeks[0].end, '2026-08-02');
+  assert.equal(weeks[0].unit, 'week');
+});
+
+test('periodRecords: overall W-L-T and win % per week match the hand count', () => {
+  const [w31, w30] = periodRecords(recordLog, 'week');
+  // Week 31: Jul 31 win, Aug 1 loss. The Aug 2 rival-only day counts for nobody.
+  assert.deepEqual(
+    { games: w31.games, wins: w31.wins, losses: w31.losses, ties: w31.ties },
+    { games: 2, wins: 1, losses: 1, ties: 0 });
+  assert.equal(w31.decided, 2);
+  assert.equal(w31.winPct, 50);
+  // Week 30: win, loss, tie. Win % counts decided games only, so 1 of 2.
+  assert.deepEqual(
+    { games: w30.games, wins: w30.wins, losses: w30.losses, ties: w30.ties },
+    { games: 3, wins: 1, losses: 1, ties: 1 });
+  assert.equal(w30.decided, 2);
+  assert.equal(w30.winPct, 50);
+});
+
+test('periodRecords: per-rival breakdown splits the week, biggest sample first', () => {
+  const [, w30] = periodRecords(recordLog, 'week');
+  assert.deepEqual(w30.byRival.map(r => r.rivalId), ['a', 'b']);
+  assert.deepEqual(
+    { games: w30.byRival[0].games, wins: w30.byRival[0].wins, ties: w30.byRival[0].ties },
+    { games: 2, wins: 1, ties: 1 });
+  assert.equal(w30.byRival[0].winPct, 100); // 1 win, 0 losses, the tie is undecided
+  assert.deepEqual(
+    { games: w30.byRival[1].games, losses: w30.byRival[1].losses },
+    { games: 1, losses: 1 });
+  assert.equal(w30.byRival[1].winPct, 0);
+});
+
+test('periodRecords: monthly buckets split the week that straddles the month end', () => {
+  const months = periodRecords(recordLog, 'month');
+  assert.deepEqual(months.map(m => m.id), ['2026-08', '2026-07']);
+  assert.equal(months[0].unit, 'month');
+  assert.equal(months[0].start, '2026-08-01');
+  assert.equal(months[0].end, '2026-08-31');
+  // August so far: only the Aug 1 loss (Aug 2 is rival-only).
+  assert.deepEqual(
+    { games: months[0].games, wins: months[0].wins, losses: months[0].losses },
+    { games: 1, wins: 0, losses: 1 });
+  // July: two wins, one loss, one tie across both rivals.
+  assert.deepEqual(
+    { games: months[1].games, wins: months[1].wins, losses: months[1].losses, ties: months[1].ties },
+    { games: 4, wins: 2, losses: 1, ties: 1 });
+  assert.equal(months[1].decided, 3);
+  closeTo(months[1].winPct, (2 / 3) * 100, 1e-9);
+});
+
+test('periodRecords: one-sided days never create a period of their own', () => {
+  const oneSided = [
+    { rivalId: 'a', date: '2026-05-04', theirScore: 800 },
+    { rivalId: 'b', date: '2026-05-05', myScore: 700 },
+  ];
+  assert.deepEqual(periodRecords(oneSided, 'week'), []);
+  assert.deepEqual(periodRecords(oneSided, 'month'), []);
+});
+
+test('periodRecords: a period of nothing but ties reports no decided games', () => {
+  const allTies = [
+    { rivalId: 'a', date: '2026-05-04', myScore: 500, theirScore: 500 },
+    { rivalId: 'a', date: '2026-05-05', myScore: 600, theirScore: 600 },
+  ];
+  const [week] = periodRecords(allTies, 'week');
+  assert.equal(week.games, 2);
+  assert.equal(week.ties, 2);
+  assert.equal(week.decided, 0);
+  assert.equal(week.winPct, 0);
+});
+
+test('periodRecords: legacy totals-only games and round arrays bucket alike', () => {
+  const mixed = [
+    { rivalId: 'a', date: '2026-05-04', myScore: 500, theirScore: 400 },
+    { rivalId: 'a', date: '2026-05-05', myScores: [80, 80, 80, 80, 80], theirScores: [10, 10, 10, 10, 10] },
+  ];
+  const [week] = periodRecords(mixed, 'week');
+  assert.equal(week.games, 2);
+  assert.equal(week.wins, 2);
+});
+
+test('periodRecords: undated or malformed games are skipped, not bucketed', () => {
+  const dirty = [
+    { rivalId: 'a', date: 'whenever', myScore: 500, theirScore: 400 },
+    { rivalId: 'a', myScore: 500, theirScore: 400 },
+    null,
+    { rivalId: 'a', date: '2026-05-04', myScore: 500, theirScore: 400 },
+  ];
+  const weeks = periodRecords(dirty, 'week');
+  assert.equal(weeks.length, 1);
+  assert.equal(weeks[0].games, 1);
+});
+
+test('periodRecords: no games at all yields an empty list', () => {
+  assert.deepEqual(periodRecords([], 'week'), []);
+  assert.deepEqual(periodRecords(null, 'month'), []);
+});
+
+// --- periodOutcomeVsRival / runningRivalPeriodRecords ----------------------
+// Three consecutive ISO weeks inside one month, two rivals. Hand-computed:
+//   week Jun 8:  a W,W -> won      b L    -> lost
+//   week Jun 15: a L,L -> lost     b absent
+//   week Jun 22: a W,L -> tied     b W    -> won
+// So over the whole month a is 3W-3L (tied) and b is 1W-1L (tied), which is
+// what makes the monthly tallies differ from the weekly ones.
+const runLog = [
+  { rivalId: 'a', date: '2026-06-08', myScore: 600, theirScore: 500 },
+  { rivalId: 'a', date: '2026-06-09', myScore: 600, theirScore: 500 },
+  { rivalId: 'b', date: '2026-06-10', myScore: 400, theirScore: 500 },
+  { rivalId: 'a', date: '2026-06-15', myScore: 400, theirScore: 500 },
+  { rivalId: 'a', date: '2026-06-16', myScore: 400, theirScore: 500 },
+  { rivalId: 'a', date: '2026-06-22', myScore: 600, theirScore: 500 },
+  { rivalId: 'a', date: '2026-06-23', myScore: 400, theirScore: 500 },
+  { rivalId: 'b', date: '2026-06-24', myScore: 600, theirScore: 500 },
+];
+
+test('periodOutcomeVsRival: the W/L balance decides the period, ties do not', () => {
+  assert.equal(periodOutcomeVsRival({ games: 3, wins: 2, losses: 1, ties: 0 }), 'won');
+  assert.equal(periodOutcomeVsRival({ games: 3, wins: 1, losses: 2, ties: 0 }), 'lost');
+  assert.equal(periodOutcomeVsRival({ games: 4, wins: 2, losses: 2, ties: 0 }), 'tied');
+  // A period of nothing but ties is still a period you played: it is drawn.
+  assert.equal(periodOutcomeVsRival({ games: 2, wins: 0, losses: 0, ties: 2 }), 'tied');
+  // Never played in that period, so it counts for nothing.
+  assert.equal(periodOutcomeVsRival({ games: 0, wins: 0, losses: 0, ties: 0 }), null);
+  assert.equal(periodOutcomeVsRival(null), null);
+});
+
+test('runningRivalPeriodRecords: weekly tallies accumulate oldest to newest', () => {
+  const running = runningRivalPeriodRecords(periodRecords(runLog, 'week'));
+  assert.deepEqual(running['2026-W24'], {
+    a: { won: 1, lost: 0, tied: 0 },
+    b: { won: 0, lost: 1, tied: 0 },
+  });
+  assert.deepEqual(running['2026-W25'], {
+    a: { won: 1, lost: 1, tied: 0 },
+    b: { won: 0, lost: 1, tied: 0 }, // not played that week, tally untouched
+  });
+  assert.deepEqual(running['2026-W26'], {
+    a: { won: 1, lost: 1, tied: 1 },
+    b: { won: 1, lost: 1, tied: 0 },
+  });
+});
+
+test('runningRivalPeriodRecords: monthly counts months, not weeks', () => {
+  const running = runningRivalPeriodRecords(periodRecords(runLog, 'month'));
+  assert.deepEqual(running['2026-06'], {
+    a: { won: 0, lost: 0, tied: 1 },
+    b: { won: 0, lost: 0, tied: 1 },
+  });
+});
+
+test('runningRivalPeriodRecords: input order does not matter, snapshots are independent', () => {
+  const weeks = periodRecords(runLog, 'week');            // newest first
+  const fromNewest = runningRivalPeriodRecords(weeks);
+  const fromOldest = runningRivalPeriodRecords(weeks.slice().reverse());
+  assert.deepEqual(fromNewest, fromOldest);
+  // Mutating one period's snapshot must not bleed into the next period's.
+  fromNewest['2026-W24'].a.won = 99;
+  assert.equal(fromNewest['2026-W26'].a.won, 1);
+});
+
+test('runningRivalPeriodRecords: nothing to replay yields nothing', () => {
+  assert.deepEqual(runningRivalPeriodRecords([]), {});
+  assert.deepEqual(runningRivalPeriodRecords(null), {});
+});
+
+test('periodTallyText: the tied component only renders once it is nonzero', () => {
+  assert.equal(periodTallyText({ won: 9, lost: 8, tied: 0 }), '9-8');
+  assert.equal(periodTallyText({ won: 63, lost: 54, tied: 1 }), '63-54-1');
+  assert.equal(periodTallyText({ won: 0, lost: 0, tied: 0 }), '0-0');
+  assert.equal(periodTallyText(null), '');
+});
+
+// --- rankByScore -----------------------------------------------------------
+
+test('rankByScore: highest score first, name breaks the tie', () => {
+  const entries = [
+    { key: 'z', name: 'Zed', predictedTotal: 500 },
+    { key: 'a', name: 'Ann', predictedTotal: 500 },
+    { key: 'm', name: 'Moe', predictedTotal: 900 },
+  ];
+  assert.deepEqual(rankByScore(entries, 'predictedTotal'), ['m', 'a', 'z']);
+});
+
+test('rankByScore: entries without a usable score drop out of the ranking', () => {
+  const entries = [
+    { key: 'a', name: 'Ann', predictedTotal: 500, actualTotal: null },
+    { key: 'b', name: 'Bob', predictedTotal: 400, actualTotal: 600 },
+  ];
+  assert.deepEqual(rankByScore(entries, 'actualTotal'), ['b']);
+});
+
+test('rankByScore: does not mutate the caller array', () => {
+  const entries = [
+    { key: 'a', name: 'Ann', predictedTotal: 100 },
+    { key: 'b', name: 'Bob', predictedTotal: 900 },
+  ];
+  rankByScore(entries, 'predictedTotal');
+  assert.deepEqual(entries.map(e => e.key), ['a', 'b']);
+});
+
+// --- positionHitsForDay ----------------------------------------------------
+
+test('positionHitsForDay: a hit is finishing exactly where you were predicted', () => {
+  const day = [
+    { key: 'a', name: 'Ann', predictedTotal: 900, actualTotal: 800 },
+    { key: 'b', name: 'Bob', predictedTotal: 700, actualTotal: 850 },
+    { key: 'c', name: 'Cid', predictedTotal: 500, actualTotal: 400 },
+  ];
+  // Predicted a, b, c. Actual b (850), a (800), c (400): only c held its spot.
+  assert.deepEqual(positionHitsForDay(day), { a: false, b: false, c: true });
+});
+
+test('positionHitsForDay: ties in the actual scores fall back to name order', () => {
+  const day = [
+    { key: 'a', name: 'Ann', predictedTotal: 900, actualTotal: 600 },
+    { key: 'z', name: 'Zed', predictedTotal: 700, actualTotal: 600 },
+  ];
+  // Equal actuals: Ann sorts first by name and so keeps her predicted spot.
+  assert.deepEqual(positionHitsForDay(day), { a: true, z: true });
+});
+
+test('positionHitsForDay: a player with no prediction is invisible to the ranking', () => {
+  const day = [
+    { key: 'a', name: 'Ann', predictedTotal: 900, actualTotal: 800 },
+    { key: 'b', name: 'Bob', predictedTotal: 700, actualTotal: 850 },
+    { key: 'c', name: 'Cid', predictedTotal: 500, actualTotal: 400 },
+    // Newcomer with a synced score but not enough history to be predicted.
+    { key: 'd', name: 'Dee', predictedTotal: null, actualTotal: 1000 },
+  ];
+  const hits = positionHitsForDay(day);
+  assert.equal('d' in hits, false);
+  // Dee's 1000 must not push everyone down a rank.
+  assert.deepEqual(hits, { a: false, b: false, c: true });
+});
+
+test('positionHitsForDay: a predicted player who sat out is not eligible', () => {
+  const day = [
+    { key: 'a', name: 'Ann', predictedTotal: 900, actualTotal: 800 },
+    { key: 'b', name: 'Bob', predictedTotal: 700, actualTotal: null },
+    { key: 'c', name: 'Cid', predictedTotal: 500, actualTotal: 400 },
+  ];
+  const hits = positionHitsForDay(day);
+  assert.equal('b' in hits, false);
+  // Both rankings cover only Ann and Cid, so each one keeps its predicted spot.
+  assert.deepEqual(hits, { a: true, c: true });
+});
+
+test('positionHitsForDay: an absent player does not shift the ranks of those who played', () => {
+  const withAbsentee = [
+    { key: 'a', name: 'Ann', predictedTotal: 900, actualTotal: 800 },
+    // Predicted to finish second but never played: holds no rank slot.
+    { key: 'b', name: 'Bob', predictedTotal: 700, actualTotal: null },
+    { key: 'c', name: 'Cid', predictedTotal: 500, actualTotal: 400 },
+    { key: 'd', name: 'Dee', predictedTotal: 300, actualTotal: 200 },
+  ];
+  const sameDayWithoutHim = withAbsentee.filter(e => e.key !== 'b');
+  // Cid and Dee, predicted third and fourth, can still hit their real
+  // positions (first and second among the three who showed up) - the whole
+  // point of ranking predictions over the players who actually played.
+  assert.deepEqual(positionHitsForDay(withAbsentee), { a: true, c: true, d: true });
+  assert.deepEqual(positionHitsForDay(withAbsentee), positionHitsForDay(sameDayWithoutHim));
+});
+
+test('positionHitsForDay: a lone player who played always hits', () => {
+  assert.deepEqual(
+    positionHitsForDay([{ key: 'a', name: 'Ann', predictedTotal: 400, actualTotal: 900 }]),
+    { a: true });
+});
+
+test('positionHitsForDay: a day nobody played produces no eligible players', () => {
+  assert.deepEqual(positionHitsForDay([
+    { key: 'a', name: 'Ann', predictedTotal: 900, actualTotal: null },
+    { key: 'b', name: 'Bob', predictedTotal: 700, actualTotal: null },
+  ]), {});
+  assert.deepEqual(positionHitsForDay([]), {});
+});
+
+// --- accumulatePositionHits ------------------------------------------------
+
+test('accumulatePositionHits: counts hits and eligible days per player', () => {
+  const days = [
+    [ // both hold their spots
+      { key: 'a', name: 'Ann', predictedTotal: 900, actualTotal: 800 },
+      { key: 'b', name: 'Bob', predictedTotal: 700, actualTotal: 600 },
+    ],
+    [ // Bob upsets Ann
+      { key: 'a', name: 'Ann', predictedTotal: 900, actualTotal: 500 },
+      { key: 'b', name: 'Bob', predictedTotal: 700, actualTotal: 950 },
+    ],
+    [ // Ann alone: eligible for her, not for Bob
+      { key: 'a', name: 'Ann', predictedTotal: 900, actualTotal: 800 },
+      { key: 'b', name: 'Bob', predictedTotal: 700, actualTotal: null },
+    ],
+  ];
+  assert.deepEqual(accumulatePositionHits(days), {
+    a: { hits: 2, eligible: 3 },
+    b: { hits: 1, eligible: 2 },
+  });
+});
+
+test('accumulatePositionHits: days without any prediction contribute nothing', () => {
+  const days = [
+    [{ key: 'a', name: 'Ann', predictedTotal: null, actualTotal: 800 }],
+    [],
+  ];
+  assert.deepEqual(accumulatePositionHits(days), {});
+});
+
+test('accumulatePositionHits: no history at all yields no records (never 0/0)', () => {
+  assert.deepEqual(accumulatePositionHits([]), {});
+  assert.deepEqual(accumulatePositionHits(null), {});
+});
+
+// --- finishPositionsForDay -------------------------------------------------
+
+test('finishPositionsForDay: highest daily total finishes first', () => {
+  assert.deepEqual(finishPositionsForDay([
+    { key: 'a', total: 700 },
+    { key: 'b', total: 900 },
+    { key: 'c', total: 500 },
+  ]), { b: 1, a: 2, c: 3 });
+});
+
+test('finishPositionsForDay: tied totals share the mean of the ranks they span', () => {
+  // Two tied firsts split ranks 1 and 2, so the podium reads 1.5, 1.5, 3
+  // instead of handing one of them first place on a name coin-flip.
+  assert.deepEqual(finishPositionsForDay([
+    { key: 'zoe', total: 900 },
+    { key: 'ann', total: 900 },
+    { key: 'bob', total: 400 },
+  ]), { zoe: 1.5, ann: 1.5, bob: 3 });
+});
+
+test('finishPositionsForDay: a three-way tie for second averages ranks 2, 3 and 4', () => {
+  assert.deepEqual(finishPositionsForDay([
+    { key: 'a', total: 900 },
+    { key: 'b', total: 600 },
+    { key: 'c', total: 600 },
+    { key: 'd', total: 600 },
+  ]), { a: 1, b: 3, c: 3, d: 3 });
+});
+
+test('finishPositionsForDay: everyone tied shares one position', () => {
+  assert.deepEqual(finishPositionsForDay([
+    { key: 'a', total: 500 },
+    { key: 'b', total: 500 },
+  ]), { a: 1.5, b: 1.5 });
+});
+
+test('finishPositionsForDay: a solo day has no position to award', () => {
+  // Position is a claim about the other players; with nobody else there is
+  // nothing to claim, so the day must not inflate anyone's average to 1.0.
+  assert.deepEqual(finishPositionsForDay([{ key: 'a', total: 900 }]), {});
+  assert.deepEqual(finishPositionsForDay([]), {});
+  assert.deepEqual(finishPositionsForDay(null), {});
+});
+
+test('finishPositionsForDay: players who did not play are not ranked', () => {
+  assert.deepEqual(finishPositionsForDay([
+    { key: 'a', total: 900 },
+    { key: 'b', total: null },
+    { key: 'c', total: 300 },
+  ]), { a: 1, c: 2 });
+  // Only one of the three actually played: still a solo day.
+  assert.deepEqual(finishPositionsForDay([
+    { key: 'a', total: 900 },
+    { key: 'b', total: null },
+    { key: 'c', total: undefined },
+  ]), {});
+});
+
+test('finishPositionsForDay: does not mutate the caller array', () => {
+  const day = [{ key: 'a', total: 100 }, { key: 'b', total: 900 }];
+  finishPositionsForDay(day);
+  assert.deepEqual(day.map(e => e.key), ['a', 'b']);
+});
+
+// --- fieldSharesForDay -----------------------------------------------------
+
+test('fieldSharesForDay: first beats the whole field, last beats none of it', () => {
+  assert.deepEqual(fieldSharesForDay([
+    { key: 'a', total: 700 },
+    { key: 'b', total: 900 },
+    { key: 'c', total: 500 },
+  ]), { b: 1, a: 0.5, c: 0 });
+});
+
+test('fieldSharesForDay: finishing last is 0% whatever the field size', () => {
+  // The whole point of the metric: last of three is not a better day than
+  // last of ten just because the number 3 is smaller than the number 10.
+  const last3 = fieldSharesForDay([
+    { key: 'a', total: 900 }, { key: 'b', total: 800 }, { key: 'z', total: 100 },
+  ]);
+  const last4 = fieldSharesForDay([
+    { key: 'a', total: 900 }, { key: 'b', total: 800 },
+    { key: 'c', total: 700 }, { key: 'z', total: 100 },
+  ]);
+  const last10 = fieldSharesForDay(
+    Array.from({ length: 9 }, (_, i) => ({ key: `p${i}`, total: 900 - i * 10 }))
+      .concat([{ key: 'z', total: 100 }]));
+  assert.equal(last3.z, 0);
+  assert.equal(last4.z, 0);
+  assert.equal(last10.z, 0);
+  // And first is 1 across the same three field sizes.
+  assert.equal(last3.a, 1);
+  assert.equal(last4.a, 1);
+  assert.equal(last10.p0, 1);
+});
+
+test('fieldSharesForDay: a two-player day is all or nothing', () => {
+  assert.deepEqual(fieldSharesForDay([
+    { key: 'a', total: 900 },
+    { key: 'b', total: 500 },
+  ]), { a: 1, b: 0 });
+});
+
+test('fieldSharesForDay: tied players split the credit their ranks span', () => {
+  // Two tied firsts of three share rank 1.5, so each beat (3 - 1.5) / 2 of
+  // the field: three quarters, not the full field and not half of it.
+  closeTo(fieldSharesForDay([
+    { key: 'zoe', total: 900 },
+    { key: 'ann', total: 900 },
+    { key: 'bob', total: 400 },
+  ]).zoe, 0.75);
+  // Everyone tied means nobody beat anybody: dead centre.
+  assert.deepEqual(fieldSharesForDay([
+    { key: 'a', total: 500 },
+    { key: 'b', total: 500 },
+  ]), { a: 0.5, b: 0.5 });
+  const allTied = fieldSharesForDay([
+    { key: 'a', total: 500 }, { key: 'b', total: 500 }, { key: 'c', total: 500 },
+  ]);
+  closeTo(allTied.a, 0.5);
+  closeTo(allTied.c, 0.5);
+});
+
+test('fieldSharesForDay: a solo day awards no share', () => {
+  assert.deepEqual(fieldSharesForDay([{ key: 'a', total: 900 }]), {});
+  assert.deepEqual(fieldSharesForDay([
+    { key: 'a', total: 900 }, { key: 'b', total: null },
+  ]), {});
+  assert.deepEqual(fieldSharesForDay([]), {});
+  assert.deepEqual(fieldSharesForDay(null), {});
+});
+
+// --- accumulateFinishPositions ---------------------------------------------
+
+test('accumulateFinishPositions: averages the qualifying days only', () => {
+  const days = [
+    [{ key: 'a', total: 900 }, { key: 'b', total: 500 }],   // a 1st, b 2nd
+    [{ key: 'a', total: 400 }, { key: 'b', total: 800 }],   // a 2nd, b 1st
+    [{ key: 'a', total: 700 }, { key: 'b', total: 700 }],   // both 1.5
+    [{ key: 'a', total: 650 }],                             // solo: excluded
+  ];
+  const out = accumulateFinishPositions(days);
+  assert.equal(out.a.days, 3);
+  assert.equal(out.b.days, 3);
+  closeTo(out.a.avg, (1 + 2 + 1.5) / 3);
+  closeTo(out.b.avg, (2 + 1 + 1.5) / 3);
+  // Same three days as shares of the field beaten: won, lost, drew.
+  closeTo(out.a.share, (1 + 0 + 0.5) / 3);
+  closeTo(out.b.share, (0 + 1 + 0.5) / 3);
+});
+
+test('accumulateFinishPositions: the share is field-size proof, the average is not', () => {
+  // Two days finishing dead last, one in a field of three and one in a field
+  // of four. The raw average finish drifts to 3.5 purely because the second
+  // field was bigger; the share stays at 0 because last is last.
+  const out = accumulateFinishPositions([
+    [{ key: 'a', total: 900 }, { key: 'b', total: 800 }, { key: 'z', total: 100 }],
+    [{ key: 'a', total: 900 }, { key: 'b', total: 800 },
+     { key: 'c', total: 700 }, { key: 'z', total: 100 }],
+  ]);
+  assert.equal(out.z.days, 2);
+  closeTo(out.z.avg, 3.5);
+  assert.equal(out.z.share, 0);
+  // The player who won both is 100% both times, again regardless of N.
+  closeTo(out.a.avg, 1);
+  assert.equal(out.a.share, 1);
+});
+
+test('accumulateFinishPositions: a day you sat out is nobody else\'s problem', () => {
+  const days = [
+    [{ key: 'a', total: 900 }, { key: 'b', total: 500 }, { key: 'c', total: 100 }],
+    [{ key: 'a', total: 900 }, { key: 'b', total: null }, { key: 'c', total: 100 }],
+  ];
+  const out = accumulateFinishPositions(days);
+  assert.equal(out.b.days, 1);
+  closeTo(out.b.avg, 2);
+  closeTo(out.b.share, 0.5);
+  // With b away, c is second on day two, so c averages (3 + 2) / 2.
+  assert.equal(out.c.days, 2);
+  closeTo(out.c.avg, 2.5);
+  // c was last on both days though, so the share does not reward the smaller
+  // field the way the raw position does.
+  assert.equal(out.c.share, 0);
+});
+
+test('accumulateFinishPositions: a player with no qualifying day is absent', () => {
+  const out = accumulateFinishPositions([
+    [{ key: 'a', total: 900 }, { key: 'b', total: 500 }],
+    [{ key: 'c', total: 900 }],
+  ]);
+  assert.equal('c' in out, false);
+  assert.deepEqual(Object.keys(out).sort(), ['a', 'b']);
+});
+
+// --- avgPositionColor / avgPositionColors ----------------------------------
+
+test('avgPositionColor: the ramp ends and midpoint are the app tone colors', () => {
+  assert.equal(avgPositionColor(0), 'rgb(74, 222, 128)');
+  assert.equal(avgPositionColor(0.5), 'rgb(250, 204, 21)');
+  assert.equal(avgPositionColor(1), 'rgb(248, 113, 113)');
+});
+
+test('avgPositionColor: each half is a straight blend between its two anchors', () => {
+  assert.equal(avgPositionColor(0.25), 'rgb(162, 213, 75)');
+  assert.equal(avgPositionColor(0.75), 'rgb(249, 159, 67)');
+  // Out-of-range input clamps rather than running off the end of the ramp.
+  assert.equal(avgPositionColor(-2), avgPositionColor(0));
+  assert.equal(avgPositionColor(9), avgPositionColor(1));
+});
+
+test('avgPositionColor: hue only ever walks green -> yellow -> red', () => {
+  // The point of the ramp is that a reader sees one gradient, not a set of
+  // unrelated colors, so hue must fall monotonically from green to red with
+  // no detour through blue.
+  const hueOf = (t) => {
+    const [r, g, b] = avgPositionColor(t).match(/\d+/g).map(Number);
+    const max = Math.max(r, g, b), min = Math.min(r, g, b);
+    if (max === min) return 0;
+    const h = max === r ? (g - b) / (max - min)
+            : max === g ? 2 + (b - r) / (max - min)
+                        : 4 + (r - g) / (max - min);
+    return ((h * 60) % 360 + 360) % 360;
+  };
+  let prev = hueOf(0);
+  assert.ok(prev > 130 && prev < 150, `green end hue was ${prev}`);
+  for (let i = 1; i <= 40; i++) {
+    const h = hueOf(i / 40);
+    assert.ok(h < prev, `hue rose at step ${i}: ${prev} -> ${h}`);
+    prev = h;
+  }
+  assert.equal(prev, 0);
+});
+
+test('avgPositionColors: lowest input is green, highest is red, middles interpolate', () => {
+  // The card feeds negated field shares, so the biggest share (1) arrives as
+  // the smallest number and must take the green end.
+  const out = avgPositionColors([-1, -0.75, -0.5, 0]);
+  assert.equal(out[0], 'rgb(74, 222, 128)');
+  assert.equal(out[3], 'rgb(248, 113, 113)');
+  assert.equal(out[1], avgPositionColor(0.25));
+  assert.equal(out[2], avgPositionColor(0.5));
+});
+
+test('avgPositionColors: rows without a figure keep their slot and stay null', () => {
+  const out = avgPositionColors([-0.8, null, -0.2, undefined]);
+  assert.deepEqual(out, ['rgb(74, 222, 128)', null, 'rgb(248, 113, 113)', null]);
+});
+
+test('avgPositionColors: nothing to compare against means no ramp at all', () => {
+  // One player with a figure has no better or worse to be measured against,
+  // and identical figures are not a ranking, so both stay neutral.
+  assert.deepEqual(avgPositionColors([-0.5, null, null]), [null, null, null]);
+  assert.deepEqual(avgPositionColors([-0.5, -0.5, -0.5]), [null, null, null]);
+  assert.deepEqual(avgPositionColors([]), []);
+});
+
+test('accumulateFinishPositions: no history at all yields no records', () => {
+  assert.deepEqual(accumulateFinishPositions([]), {});
+  assert.deepEqual(accumulateFinishPositions(null), {});
+  assert.deepEqual(accumulateFinishPositions([[], [{ key: 'a', total: 700 }]]), {});
+});
+
+// --- compareNamesCI --------------------------------------------------------
+
+test('compareNamesCI: sorts ABC regardless of case', () => {
+  const names = ['Zoe', 'ann', 'Bob', 'charlie'];
+  assert.deepEqual(names.slice().sort(compareNamesCI), ['ann', 'Bob', 'charlie', 'Zoe']);
+  // A plain code-unit sort buries every lowercase name under the capitals,
+  // which is exactly the ordering the rival lists must not fall back to.
+  assert.deepEqual(names.slice().sort(), ['Bob', 'Zoe', 'ann', 'charlie']);
+});
+
+test('compareNamesCI: names differing only in case keep a stable order', () => {
+  assert.ok(compareNamesCI('bob', 'Bob') !== 0);
+  assert.equal(compareNamesCI('bob', 'Bob'), -compareNamesCI('Bob', 'bob'));
+});
+
+test('compareNamesCI: identical names compare equal, missing names sort first', () => {
+  assert.equal(compareNamesCI('Ann', 'Ann'), 0);
+  assert.ok(compareNamesCI(null, 'Ann') < 0);
+  assert.ok(compareNamesCI(undefined, '') === 0);
+});
+
+// --- compareWinPctDesc -----------------------------------------------------
+
+test('compareWinPctDesc: best win % first', () => {
+  const recs = [
+    { rivalId: 'a', decided: 4, winPct: 50 },
+    { rivalId: 'b', decided: 3, winPct: 100 },
+    { rivalId: 'c', decided: 5, winPct: 20 },
+  ];
+  assert.deepEqual(recs.slice().sort(compareWinPctDesc).map(r => r.rivalId), ['b', 'a', 'c']);
+});
+
+test('compareWinPctDesc: a record with nothing decided sorts below a real 0%', () => {
+  const allTies = { rivalId: 'ties', decided: 0, winPct: 0 };
+  const allLosses = { rivalId: 'losses', decided: 3, winPct: 0 };
+  assert.ok(compareWinPctDesc(allTies, allLosses) > 0);
+  assert.deepEqual([allTies, allLosses].sort(compareWinPctDesc).map(r => r.rivalId),
+    ['losses', 'ties']);
+});
+
+test('compareWinPctDesc: equal win % is left to the caller tie-break', () => {
+  assert.equal(compareWinPctDesc({ decided: 2, winPct: 50 }, { decided: 6, winPct: 50 }), 0);
 });


### PR DESCRIPTION
## Summary

Replaces the Seasons feature in MapTap Rivals with automatic weekly/monthly Records, and adds prediction accuracy stats (a "Spot-on" hit percentage and a field-share AVG stat) to the Today's predictions card, plus records sorting/pagination and an alphabetical-ordering sweep across the app.

## Changes by file (apps/maptap-rivals)

### index.html
- Seasons tab, view panel, create modal, and delete modal removed; SEO meta description and JSON-LD featureList updated to describe records instead of seasons.
- New Records tab and view: Weekly | Monthly toggle, "Sort rivals" control (`#records-sort-select`, Win % / Name), pagination nav (`#records-pagination`, mirrors the history pagination markup), `#records-body`.
- Dashboard: `#dash-active-season-banner` replaced by `#dash-record-banner` ("Current form").

### js/app.js
- Entire seasons block removed: `KEY.SEASONS`, `state.seasons`, `persistSeasons`, `seasonStats` and all helper/CRUD/modal code, event wiring, Escape handling, storage-event branch, and every view-dispatch mention. Existing `maptapRivalsSeasons` localStorage data is never read or deleted (no user data loss); seasons remain absent from export/import as before.
- Records rendering: period cards with W-L-T, games, win %, per-rival splits sorted by win % (default) or name, running per-rival period tallies next to each name ("Emmett (9-8)", tie component only when nonzero, explanatory title attribute), human week titles ("Aug 3 to Aug 9, 2026", both years when a week straddles New Year) with a muted "#32" ISO week number, "This week"/"This month" pill, 6-per-page pagination with page clamp and reset on unit/sort change, empty state. Legacy `#seasons` hash opens the Records view; `#records` is the canonical deep link; `records` added to `KNOWN_VIEWS`.
- Dashboard "Current form" banner: this week's and this month's record with tone-colored win %, rendered as a real button linking to Records.
- Prediction accuracy engine: memoized back-test (capped at the 180 most recent eligible days to keep first paint fast) computing per-player predicted-position hit records; days without known cities (paste/WhatsApp imports) are excluded without affecting anyone's counts. The Spot-on badge renders "Spot-on N%" with the raw "X of Y" figures in both title and aria-label. Both the predicted and the actual ranking for a day are computed over the same set: players with a computable prediction who actually played that day (owner decision), so a predicted-but-absent player cannot block others from hitting.
- AVG field-share stat per prediction row: "AVG 78%" is the share of the field the player beats on an average day, computed as (N - R) / (N - 1) per day with fractional tie credit, solo days excluded. Field-size-proof: last place is 0% whether 3 or 10 played. Raw average finish and day count are in the title/aria. The number is colored on a comparative green-yellow-red ramp across the displayed rows (highest share green, lowest red, neutral when equal or fewer than two values).
- Alphabetical (case-insensitive) ordering applied to: the history rival filter, dashboard paste rows, dashboard rivalry cards (was most-played-first), the Rival tab switcher dropdown (was insertion order), the leaderboard default sort column plus its global tie-break (all columns remain clickable), the matrix chip list and matrix row tie-breaks, the WhatsApp sender-mapping dropdown, and the predictions-card name tie-break.

### js/stats.js
New pure, DOM-free helpers, all exported and unit tested:
- Calendar bucketing and aggregation: `parseDateISO`, `isoWeekStart`, `isoWeekEnd`, `isoWeekId`, `monthId`, `monthStart`, `monthEnd`, `periodBounds`, `periodRecords`. All date math goes through `Date.UTC` on the date string to avoid local-timezone misfiling.
- Predicted-position hits: `rankByScore`, `positionHitsForDay` (same-set played-only rule), `accumulatePositionHits`.
- Finishing positions and field shares: `finishPositionsForDay` (fractional tie positions), `fieldSharesForDay`, `accumulateFinishPositions` (carries both the field share and the raw average position).
- Running per-rival period tallies: `periodOutcomeVsRival`, `runningRivalPeriodRecords` (order-agnostic, snapshot-isolated), `periodTallyText`.
- Ordering and color: `compareNamesCI`, `compareWinPctDesc` (undecided ranks below a genuine 0%), `avgPositionColor`, `avgPositionColors` (piecewise-linear green/yellow/red interpolation).

### css/styles.css
- Seasons styles replaced by Records styles: cards with verdict-colored left edge, right-aligned stat column, hairline-separated rival rows, running-tally and week-number annotations, current-period pill, toggle, sort control, and pagination. The shared `.modal-field input[type="date"]` / `.modal-field select` rules that other modals rely on were preserved.
- Win % tone classes (green above 50, red below, neutral at 50/undecided) on card, rival, and banner percentages.
- Dashboard banner: stat blocks, vertical rule, CTA with hover/focus states.
- Prediction rows: `.pred-label-line` (name + AVG), `.pred-avg-pos` typography, `.pred-hit-badge` percentage form; at 360px and below the Spot-on label is kept visible so a bare percentage cannot be misread as a win rate.
- Every new interactive control pins its own color/background/hover/focus against the sitewide main.css `!important` button and select rules (including the red `select:focus` ring).

### tests/stats.test.js
71 new tests covering: ISO week bucketing (Sunday landing in the Monday-started week, year boundary), month bucketing, W-L-T aggregation with rival-only and solo days, position-hit ranking (name tie-breaks, an absent player not shifting the ranks of those who played, lone-player-always-hits, nobody-played), field shares (fractional ties, two-player all-or-nothing days, solo-day exclusion, explicit field-size invariance: last of 3 equals last of 4 equals 0), running per-rival tallies (skipped periods carrying tallies forward, monthly vs weekly counting, order independence, snapshot isolation, tally formatting), the name and win-% comparators, and the color-ramp interpolation including neutral edge cases.

### README.md
Feature table and data-model notes updated: records (with sorting, pagination, running tallies, win-% coloring) instead of seasons, the prediction accuracy stats and their formulas, alphabetical ordering, and the expanded stats.js test coverage.

## Judgment calls
- Spot-on rankings compare only players who actually played that day (owner decision after review; prevents absentees from structurally blocking lower-predicted players).
- The AVG stat is the field-share percentage rather than the raw average position (owner decision; raw averages are biased by daily field size). The raw figure remains available on hover.
- Leaderboard default sort is Rival A-Z per the "alphabetical everywhere outside Records" instruction; every column stays clickable and the win-% default is a one-line revert if preferred.
- Records unit/sort/page state is in-memory only; the view opens on Weekly / Win % / page 1 each visit (no new storage keys).
- The prediction back-test is capped at the 180 most recent eligible days; cost is quadratic in history length and runs on first dashboard paint.
- "0T" is dropped from every W-L-T figure (ties shown only when nonzero), matching the running-tally convention.

## Testing
- `npm test`: 2009 pass, 0 fail (maptap suite 125; 71 tests added on a 1938 baseline).
- Living acceptance plan pair (`.features/maptap-rivals-claude.md` / `-human.md`, local): three runs; the final consolidated run verified 150 of 152 assertions (85 passed of the 99 in scope that run, 0 failed, 2 unverifiable by tooling: reading the browser console headlessly and before/after screenshot pairs).
- All new surfaces screenshot-verified at 1280 and 390 (plus 340 for the prediction rows), including computed-rgb checks for every tone color against the app's tokens.
