### PR TITLE
feat(gym-tracker): round 8 - progression visibility, faster logging, smarter planning

### DIFF
--- a/apps/gym-tracker/README.md
+++ b/apps/gym-tracker/README.md
@@ -18,7 +18,12 @@ A comprehensive, mobile-first workout tracking application built with vanilla Ja
 - **Custom Exercises**: Create and manage your own custom exercises
 - **Workout History**: Complete history of all workouts with detailed stats, numbered pagination, and clickable workout details; each exercise in the session detail shows a small inline strength-trend chart of its top-set weight over recent sessions, plus any per-exercise notes you logged
 - **Progress Tracking**: View previous workout data (all sets) during current workout for progression
+- **Progression Suggestions**: When the last two sessions of an exercise hit every set's rep target at the same weight, the next workout pre-fills a bumped weight (equipment-appropriate increment) and explains itself with a "+X suggested" badge on the first planned row; tapping the badge reveals the two sessions it is based on and a "Use last weight" control that puts the literal last-session weight back. Missing your reps shows "Missed target - repeat weight" instead, and two consecutive misses at the same weight suggest a 5-10% deload. Per-set rep ranges are respected (each set is judged against its own target)
+- **Weight/Rep Steppers**: One-tap minus/plus buttons flank every planned row's weight and reps inputs; weight steps by the exercise's increment, reps by 1 (floored at 0), without raising the phone keyboard, and plate hints plus the "same as last time" chip stay live
+- **In-Workout Exercise Swap**: A swap button on each exercise header substitutes a different exercise for THIS session only (searchable picker pre-filtered to the same category); the saved program is never touched, swapping with logged sets asks for confirmation, and the substitute's sets count toward its own history and PRs
+- **Warm-Up Ramp**: Barbell and trap-bar exercises whose working weight meets a configurable threshold show a collapsed warm-up strip above set 1 (empty bar, then percentage steps rounded to loadable plates) with one-tap ticks; warm-ups never count toward set completion, volume, or PRs
 - **Body Measurements**: A dedicated Measurements view (its own nav entry) to log body measurements over time via an add-measurement modal, with a trends grid showing one tile per tracked metric (latest value, 30-day delta, and an inline sparkline) above the editable history list; included in the welcome tour
+- **Measurement Goals**: Each trend tile takes an optional target value and direction (increase or decrease); a tile with a goal shows a progress bar and "N% to goal" under its sparkline, measured from the earliest logged value, and clearing the goal removes the bar without touching history
 - **Calendar View**: Visual representation of workout days with progress indicators (first day of week is configurable, Sunday or Monday)
 - **Program Scheduling**: Assign weekdays to a program; the days show on the program tiles, as markers on the calendar, and as a compact day-pill week strip at the top of the workout screen where tapping a day shows that day's scheduled workout below the pills and highlights the matching program card
 - **Welcome Tour**: A single scrollable onboarding modal that explains the core features, with quick links into Programs, Workout, Calendar, and Settings; replayable any time from Settings
@@ -30,10 +35,10 @@ A comprehensive, mobile-first workout tracking application built with vanilla Ja
 - Weekly workout tracking (respects the configured first day of week)
 - Exercise frequency analysis
 - Personal records tracking (max weight, reps, volume per exercise)
-- Workout history with filtering and sorting
+- Workout history with filtering and sorting, including a program filter (All Programs plus each saved program) that combines with the sort and date-range controls
 - Clickable workout cards for detailed views
 - Exercise history with best set tracking
-- Insights view: a 4-week volume-by-muscle-group breakdown and a 12-month consistency heatmap
+- Insights view: a 4-week volume-by-muscle-group breakdown, a "Not trained recently" list (muscle groups in your programs with no volume for 14 days, never-trained first), and a 12-month consistency heatmap
 
 ### ⚙️ Settings & Customization
 
@@ -44,10 +49,11 @@ A comprehensive, mobile-first workout tracking application built with vanilla Ja
 - Configurable rest timer
 - Separate sound and vibration toggles, plus the seconds-left thresholds for the first warning sound and the countdown
 - Plate calculator configuration (bar weight and the comma-separated list of available plate sizes, with a live preview)
+- Warm-up ramp configuration (enable toggle, kg and lb thresholds, and the three ramp rows' percentages and reps; saved as you change them)
 - Post-workout metrics (heart rate, calories)
 - Dark theme optimized for gym use with improved text contrast
 - Custom styled confirmation modals throughout app
-- Data export/import (JSON)
+- Data export/import (JSON), plus a per-set CSV export for spreadsheets
 - Cloud sync via Firebase with SSO authentication
 - Destructive actions, each behind a confirmation modal: "Clear All Data" (wipes every local program, workout, achievement, custom exercise, and setting) and "Delete cloud data" (removes the synced copy)
 
@@ -188,6 +194,7 @@ Designed for gym environments with low lighting:
 - Complete data backup
 - Transfer between devices
 - Export downloads a dated JSON file (`gym-tracker-data-YYYY-MM-DD.json`); import reads a JSON file you pick
+- CSV export: one row per completed set (date, program, exercise, set number, weight, reps, duration, volume, unit) as `gym-tracker-sets-YYYY-MM-DD.csv`, RFC-4180 escaped; exporting with no workouts shows a toast instead of an empty file
 
 ## User Workflow
 

--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -10381,3 +10381,542 @@ button.calendar-day {
 .program-modal-workout-actions .btn-ghost:focus-visible {
     box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
 }
+
+/* =========================================================================
+   IN-WORKOUT ROUND: progression badges, one-tap steppers, warm-up ramp,
+   exercise swap (Items 1, 2, 3, 6).
+
+   Every control below pins its own color/background with !important: the
+   sitewide assets/css/main.css paints `button { color: #555 !important }`
+   plus a red hover, and these classes are new so no existing gym-tracker
+   pin covers them. refresh.css does not target them either, so this block
+   (loaded after main.css) is the single source of truth for their look.
+   ========================================================================= */
+
+/* ---- Item 2: one-tap weight/rep steppers ------------------------------- */
+.gt-stepper-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.gt-stepper {
+    position: relative;
+    flex-shrink: 0;
+    width: 34px;
+    height: 40px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: var(--bg-elevated) !important;
+    color: var(--text-secondary) !important;
+    font-size: 0.72rem;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+    transition: background var(--transition-fast), border-color var(--transition-fast),
+                color var(--transition-fast);
+}
+
+.gt-stepper i { color: inherit !important; }
+
+.gt-stepper:hover {
+    background: var(--bg-hover) !important;
+    border-color: var(--border-light);
+    color: var(--text-primary) !important;
+}
+
+.gt-stepper:active {
+    background: var(--bg-hover) !important;
+    color: var(--accent-primary) !important;
+}
+
+.gt-stepper:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
+}
+
+/* ---- Item 1: progression badge + reveal panel -------------------------- */
+/* Both sit on their own line inside the wrapping .set-row flex container,
+   the same placement the restore chip uses. Full-width strip (not a pill):
+   a flex item with basis 100% is sized by the basis, and a half-width pill
+   floating under the inputs reads as debris. */
+.gt-progress-badge,
+.gt-progress-label {
+    flex: 0 0 100%;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    max-width: 100%;
+    margin-top: 0.15rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    font-size: 0.68rem;
+    font-weight: 700;
+    line-height: 1.3;
+    letter-spacing: 0.01em;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.gt-progress-badge {
+    cursor: pointer;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+    transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.gt-progress-badge i,
+.gt-progress-label i { color: inherit !important; font-size: 0.66rem; }
+
+.gt-progress-badge--bump {
+    background: rgba(52, 211, 153, 0.12) !important;
+    border-color: rgba(52, 211, 153, 0.35);
+    color: var(--accent-success) !important;
+}
+
+.gt-progress-badge--bump:hover,
+.gt-progress-badge--bump:focus-visible {
+    background: rgba(52, 211, 153, 0.2) !important;
+    color: var(--accent-success) !important;
+}
+
+.gt-progress-badge--deload {
+    background: rgba(251, 191, 36, 0.12) !important;
+    border-color: rgba(251, 191, 36, 0.35);
+    color: var(--accent-warning) !important;
+}
+
+.gt-progress-badge--deload:hover,
+.gt-progress-badge--deload:focus-visible {
+    background: rgba(251, 191, 36, 0.2) !important;
+    color: var(--accent-warning) !important;
+}
+
+.gt-progress-badge:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
+}
+
+/* Regression label: informational only, never tappable. */
+.gt-progress-label--miss {
+    background: rgba(251, 191, 36, 0.1);
+    border-color: rgba(251, 191, 36, 0.28);
+    color: var(--accent-warning);
+}
+
+.gt-progress-detail {
+    flex: 0 0 100%;
+    margin-top: 0.25rem;
+    padding: 0.4rem 0.5rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+}
+
+.gt-progress-detail[hidden] { display: none; }
+
+.gt-progress-history {
+    list-style: none;
+    margin: 0 0 0.35rem 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.gt-progress-history-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.6rem;
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.gt-progress-history-date { color: var(--text-muted); }
+.gt-progress-history-sets { color: var(--text-secondary); font-weight: 600; }
+
+.gt-progress-uselast {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    min-height: 32px;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-sm);
+    background: var(--bg-elevated) !important;
+    color: var(--text-secondary) !important;
+    font-size: 0.7rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.gt-progress-uselast i { color: inherit !important; font-size: 0.66rem; }
+
+.gt-progress-uselast:hover,
+.gt-progress-uselast:focus-visible {
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
+    border-color: var(--accent-primary);
+}
+
+.gt-progress-uselast:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
+}
+
+/* ---- Item 6: warm-up ramp strip ---------------------------------------- */
+/* Deliberately unlike a set row: amber dashed rail, no set numbers, no pill
+   toggle. Nothing in here is a logged set. */
+.gt-warmup {
+    margin: 0 0 0.4rem 0;
+    border: 1px dashed rgba(251, 191, 36, 0.35);
+    border-left-width: 3px;
+    border-left-style: solid;
+    border-left-color: rgba(251, 191, 36, 0.5);
+    border-radius: var(--radius-sm);
+    background: rgba(251, 191, 36, 0.04);
+}
+
+.gt-warmup-toggle {
+    width: 100%;
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.55rem;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent !important;
+    color: var(--accent-warning) !important;
+    font-size: 0.74rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-align: left;
+    cursor: pointer;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.gt-warmup-toggle i { color: inherit !important; font-size: 0.72rem; }
+
+.gt-warmup-toggle:hover,
+.gt-warmup-toggle:focus-visible {
+    background: rgba(251, 191, 36, 0.08) !important;
+    color: var(--accent-warning) !important;
+}
+
+.gt-warmup-toggle:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.35) !important;
+}
+
+.gt-warmup-title { flex: 1; text-transform: uppercase; }
+
+.gt-warmup-count {
+    color: var(--text-muted);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+.gt-warmup-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 0.55rem 0.45rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.gt-warmup-list[hidden] { display: none; }
+
+.gt-warmup-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 40px;
+    padding: 0.25rem 0.4rem;
+    border: 1px dashed var(--border-light);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.gt-warmup-row--done {
+    border-style: solid;
+    border-color: rgba(52, 211, 153, 0.3);
+    background: rgba(52, 211, 153, 0.06);
+}
+
+.gt-warmup-pct {
+    flex-shrink: 0;
+    min-width: 34px;
+    color: var(--accent-warning);
+    font-size: 0.68rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+.gt-warmup-load {
+    flex: 1;
+    min-width: 0;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+.gt-warmup-row--done .gt-warmup-load {
+    color: var(--text-muted);
+    text-decoration: line-through;
+}
+
+.gt-warmup-done {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    min-height: 32px;
+    padding: 0.25rem 0.55rem;
+    border: 1px solid var(--border-light);
+    border-radius: 999px;
+    background: var(--bg-elevated) !important;
+    color: var(--text-secondary) !important;
+    font-size: 0.68rem;
+    font-weight: 700;
+    cursor: pointer;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+    transition: background var(--transition-fast), color var(--transition-fast),
+                border-color var(--transition-fast);
+}
+
+.gt-warmup-done i { color: inherit !important; font-size: 0.62rem; }
+
+.gt-warmup-done:hover,
+.gt-warmup-done:focus-visible {
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
+    border-color: var(--accent-success);
+}
+
+.gt-warmup-done[aria-pressed="true"] {
+    background: rgba(52, 211, 153, 0.16) !important;
+    border-color: var(--accent-success);
+    color: var(--accent-success) !important;
+}
+
+.gt-warmup-done:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.35) !important;
+}
+
+/* ---- Item 3: in-workout exercise swap ---------------------------------- */
+.swap-exercise-subtitle {
+    margin: 0 0 var(--spacing-md) 0;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.swap-exercise-subtitle strong { color: var(--text-primary); }
+
+/* ---- Touch targets: every new control clears 44x44 on phones ----------- */
+/* The steppers keep a compact visible box so the [− weight +] × [− reps +]
+   line still fits; the tap area is grown OUTWARD (away from the input) with
+   a pseudo-element so it never steals taps meant for the number field. */
+@media (max-width: 480px) {
+    .gt-stepper {
+        width: 36px;
+        height: 44px;
+    }
+
+    .gt-stepper::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 44px;
+    }
+
+    .gt-stepper--minus::before { right: 0; }
+    .gt-stepper--plus::before { left: 0; }
+
+    /* At 375px a [- weight +] x [- reps +] line cannot hold four 44px targets,
+       so the reps group wraps under the weight group. Stacked, the "x" would
+       dangle at the end of the first line, so it is dropped and the inputs get
+       the freed width instead (a 3-digit weight like 102.5 must not clip). */
+    .set-row-planned .set-row-x { display: none; }
+    .set-row-inputs input { width: 80px; }
+
+    .gt-swap-toggle::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 44px;
+        height: 44px;
+        transform: translate(-50%, -50%);
+    }
+
+    .gt-swap-toggle { position: relative; }
+
+    /* Grow the strip to a real 44px-high tap target. Height (not an overlapping
+       pseudo-element) so it never steals taps from the inputs above it. */
+    .gt-progress-badge,
+    .gt-progress-label {
+        min-height: 44px;
+        padding: 0.4rem 0.6rem;
+        white-space: normal;
+    }
+
+    .gt-progress-uselast,
+    .gt-warmup-done {
+        min-height: 44px;
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+    }
+
+    .gt-warmup-toggle { min-height: 44px; }
+}
+
+/* =========================================================================
+   Insights "Not trained recently" (Item 4) + History program filter (Item 5)
+   ========================================================================= */
+
+/* Amber rail, not the azure of the volume bars: this list is a gap report,
+   not a measurement. Rows are informational only, nothing is tappable. */
+.insights-stale-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 6px;
+}
+
+.insights-stale-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.75rem;
+    padding: 0.5rem 0.7rem;
+    border: 1px solid rgba(251, 191, 36, 0.25);
+    border-left: 3px solid rgba(251, 191, 36, 0.55);
+    border-radius: var(--radius-sm);
+    background: rgba(251, 191, 36, 0.05);
+}
+
+.insights-stale-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.insights-stale-since {
+    font-size: 0.78rem;
+    color: var(--accent-warning);
+    font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 600px) {
+    .insights-stale-row { padding: 0.45rem 0.55rem; }
+    .insights-stale-label { font-size: 0.8rem; }
+    .insights-stale-since { font-size: 0.72rem; }
+}
+
+/* Program filter: same icon + DarkSelect shape as the sort control, but it
+   stays left-aligned so the sort keeps its margin-left:auto slot. */
+.history-program-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 200px;
+}
+
+.history-program-icon {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    flex-shrink: 0;
+}
+
+.history-program-wrap .dark-select {
+    width: auto;
+    min-width: 180px;
+    flex: 1;
+}
+
+/* The trigger and its options are <button>s: pin their colors so the sitewide
+   main.css `button { color:#555 !important }` (and its red hover) can't repaint
+   this control. */
+.history-program-wrap .dark-select-trigger {
+    height: 36px !important;
+    padding: 0 0.85rem !important;
+    font-size: 0.85rem !important;
+    font-weight: 500 !important;
+    line-height: 1 !important;
+    font-family: inherit !important;
+    gap: 0.55rem;
+    background: var(--bg-elevated) !important;
+    color: var(--text-primary) !important;
+}
+
+.history-program-wrap .dark-select-trigger:hover {
+    background: var(--bg-hover) !important;
+    color: var(--text-primary) !important;
+}
+
+/* "All Programs" is a real selection, not an empty placeholder, so it reads
+   at full strength like the sort control beside it. */
+.history-program-wrap .dark-select.is-placeholder .dark-select-label {
+    color: var(--text-primary);
+}
+
+.history-program-wrap .dark-select-trigger .dark-select-chevron {
+    font-size: 0.7rem !important;
+}
+
+.history-program-wrap .dark-select.is-open .dark-select-trigger {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-color: var(--accent-primary);
+    background: var(--bg-hover) !important;
+    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.22);
+}
+
+.history-program-wrap .dark-select-popup {
+    top: calc(100% - 1px);
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-top: 1px solid var(--accent-primary);
+    padding: 0.35rem;
+    max-height: 260px;
+    overflow-y: auto;
+}
+
+.history-program-wrap .dark-select-option {
+    color: var(--text-primary) !important;
+}
+
+.history-program-wrap .dark-select-option.selected {
+    color: var(--accent-primary) !important;
+}
+
+@media (max-width: 520px) {
+    .history-program-wrap,
+    .history-program-wrap .dark-select {
+        width: 100%;
+        min-width: 0;
+    }
+
+    /* Full 44px tap target on phones. */
+    .history-program-wrap .dark-select-trigger { height: 44px !important; }
+    .history-program-wrap .dark-select-option { min-height: 44px; }
+}

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -3135,3 +3135,109 @@ body.gym-tracker .btn-remove-set:hover:active,
 body.gym-tracker .btn-add-set--extra:hover:active {
     background: var(--bg-hover);
 }
+
+/* ==================================================================
+   Warm-up ramp configuration (Settings) + measurement goal targets
+   (Measurements). Styles for controls added with those two features.
+   ================================================================== */
+
+/* ---- Settings: warm-up ramp rows ---- */
+body.gym-tracker .warmup-ramp {
+    display: grid;
+    gap: 8px;
+}
+body.gym-tracker .warmup-ramp-row {
+    display: grid;
+    grid-template-columns: 4.5rem 1fr 1fr;
+    align-items: end;
+    gap: 8px;
+    background: var(--gt-surface-2);
+    border: 1px solid var(--gt-border);
+    border-radius: var(--gt-radius-sm);
+    padding: 0.6rem 0.7rem;
+}
+body.gym-tracker .warmup-ramp-num {
+    color: var(--gt-muted);
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-bottom: 0.7rem;
+}
+body.gym-tracker .warmup-ramp-field {
+    display: grid;
+    gap: 4px;
+}
+body.gym-tracker .settings-form .setting-item .warmup-ramp-field input[type="number"] {
+    padding: 0.5rem 0.6rem;
+    min-height: 44px;
+}
+
+/* ---- Measurements: goal progress bar under the sparkline ---- */
+body.gym-tracker .measurement-goal {
+    display: grid;
+    gap: 4px;
+    margin-top: 6px;
+}
+body.gym-tracker .measurement-goal-track {
+    height: 6px;
+    border-radius: var(--gt-radius-pill);
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+}
+body.gym-tracker .measurement-goal-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: var(--gt-accent-grad);
+}
+body.gym-tracker .measurement-goal-pct {
+    color: var(--gt-muted);
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+}
+
+/* ---- Measurements: per-tile goal button ----
+   A new control, so it pins its own colors against the sitewide
+   main.css `button { color: #555 !important }` plus the red press tint. */
+body.gym-tracker .measurement-goal-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 36px;
+    margin-top: 8px;
+    padding: 0.35rem 0.6rem;
+    border: 1px solid var(--gt-border);
+    border-radius: var(--gt-radius-sm);
+    box-shadow: none;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0;
+    text-transform: none;
+}
+body.gym-tracker .measurement-goal-btn,
+body.gym-tracker .measurement-goal-btn:hover,
+body.gym-tracker .measurement-goal-btn:hover:active {
+    color: var(--gt-text) !important;
+}
+body.gym-tracker .measurement-goal-btn,
+body.gym-tracker .measurement-goal-btn:hover:active {
+    background: var(--gt-surface-2);
+}
+body.gym-tracker .measurement-goal-btn:hover {
+    background: var(--gt-surface-3);
+    border-color: var(--gt-border-strong);
+    color: var(--gt-accent) !important;
+}
+body.gym-tracker .measurement-goal-btn:focus-visible {
+    box-shadow: 0 0 0 3px var(--gt-accent-ring);
+}
+
+@media (max-width: 640px) {
+    body.gym-tracker .measurement-goal-btn { min-height: 44px; }
+    body.gym-tracker .warmup-ramp-row { grid-template-columns: 1fr 1fr; }
+    body.gym-tracker .warmup-ramp-num {
+        grid-column: 1 / -1;
+        padding-bottom: 0;
+    }
+}

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -540,6 +540,75 @@
                         </div>
                     </div>
 
+                    <!-- Item 3: in-workout exercise swap picker. Session-only:
+                         picking a replacement rewrites the live session entry,
+                         never the saved program. Lives inside #workout-view so
+                         wireWorkoutActions' delegation reaches its cards. -->
+                    <div id="swap-exercise-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="swap-exercise-title">
+                        <div class="modal-content large" data-back-to-top>
+                            <div class="modal-header">
+                                <h2 id="swap-exercise-title">Swap Exercise</h2>
+                                <button class="modal-close" aria-label="Close">&times;</button>
+                            </div>
+                            <div class="modal-body">
+                                <p class="swap-exercise-subtitle">
+                                    Replacing <strong id="swap-exercise-current"></strong> for this workout only.
+                                </p>
+                                <div class="exercise-picker-search">
+                                    <div class="search-input-wrapper">
+                                        <i class="fas fa-search search-icon"></i>
+                                        <input type="text" id="swap-exercise-search" placeholder="Search exercises by name or muscle group...">
+                                    </div>
+                                    <div class="exercise-filters">
+                                        <select id="swap-exercise-category-filter" aria-label="Filter by category">
+                                            <option value="">All Categories</option>
+                                            <option value="chest">Chest</option>
+                                            <option value="back">Back</option>
+                                            <option value="shoulders">Shoulders</option>
+                                            <option value="biceps">Biceps</option>
+                                            <option value="triceps">Triceps</option>
+                                            <option value="forearms">Forearms</option>
+                                            <option value="quads">Quads</option>
+                                            <option value="hamstrings">Hamstrings</option>
+                                            <option value="glutes">Glutes</option>
+                                            <option value="calves">Calves</option>
+                                            <option value="core">Core</option>
+                                            <option value="abs">Abs</option>
+                                            <option value="obliques">Obliques</option>
+                                            <option value="traps">Traps</option>
+                                            <option value="neck">Neck</option>
+                                            <option value="full-body">Full Body</option>
+                                            <option value="cardio">Cardio</option>
+                                        </select>
+                                        <select id="swap-exercise-equipment-filter" aria-label="Filter by equipment">
+                                            <option value="">All Equipment</option>
+                                            <option value="barbell">Barbell</option>
+                                            <option value="dumbbell">Dumbbell</option>
+                                            <option value="cable">Cable</option>
+                                            <option value="machine">Machine</option>
+                                            <option value="bodyweight">Bodyweight</option>
+                                            <option value="kettlebell">Kettlebell</option>
+                                            <option value="resistance-band">Resistance Band</option>
+                                            <option value="plate">Plate</option>
+                                            <option value="trap-bar">Trap Bar</option>
+                                            <option value="medicine-ball">Medicine Ball</option>
+                                            <option value="battle-ropes">Battle Ropes</option>
+                                            <option value="ab-wheel">Ab Wheel</option>
+                                            <option value="sled">Sled</option>
+                                            <option value="tire">Tire</option>
+                                            <option value="gripper">Gripper</option>
+                                            <option value="towel">Towel</option>
+                                            <option value="various">Various</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div id="swap-exercise-list" class="exercise-grid">
+                                    <!-- Will be populated by JS -->
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Finish Workout Modal -->
                     <div id="finish-workout-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="finish-workout-title">
                         <div class="modal-content finish-workout-modal-content" data-back-to-top>
@@ -640,6 +709,12 @@
                     <button type="button" class="history-clear-btn" id="clear-filters-btn" disabled aria-disabled="true">
                         <i class="fas fa-xmark"></i> Clear
                     </button>
+                    <div class="history-program-wrap">
+                        <i class="fas fa-layer-group history-program-icon" aria-hidden="true"></i>
+                        <select id="history-program">
+                            <option value="">All Programs</option>
+                        </select>
+                    </div>
                     <div class="history-sort-wrap">
                         <i class="fas fa-arrow-down-wide-short history-sort-icon" aria-hidden="true"></i>
                         <select id="history-sort">
@@ -932,6 +1007,13 @@
                     </div>
                     <div class="insights-volume-grid" id="insights-volume-grid"></div>
                 </section>
+                <section class="section" id="insights-stale-section" hidden>
+                    <div class="section-header">
+                        <h2>Not trained recently</h2>
+                        <span class="section-caption" id="insights-stale-caption"></span>
+                    </div>
+                    <ul class="insights-stale-list" id="insights-stale-list"></ul>
+                </section>
                 <section class="section" id="insights-heatmap-section" hidden>
                     <div class="section-header">
                         <h2>Workout heatmap</h2>
@@ -1038,6 +1120,36 @@
                                 <div class="form-actions">
                                     <button type="button" class="btn btn-ghost modal-close">Cancel</button>
                                     <button type="submit" class="btn btn-primary">Save</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Goal modal (per trend tile) -->
+                <div id="measurement-goal-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="measurement-goal-modal-title">
+                    <div class="modal-content small" data-back-to-top>
+                        <div class="modal-header">
+                            <h2 id="measurement-goal-modal-title">Set goal</h2>
+                            <button class="modal-close" aria-label="Close">&times;</button>
+                        </div>
+                        <div class="modal-body">
+                            <form id="measurement-goal-form" novalidate>
+                                <div class="form-group">
+                                    <label for="goal-target">Target <small id="goal-target-unit"></small></label>
+                                    <input type="number" id="goal-target" step="0.1" min="0" placeholder="e.g. 75">
+                                </div>
+                                <div class="form-group">
+                                    <label for="goal-direction">Direction</label>
+                                    <select id="goal-direction">
+                                        <option value="decrease">Decrease to target</option>
+                                        <option value="increase">Increase to target</option>
+                                    </select>
+                                </div>
+                                <div class="form-actions">
+                                    <button type="button" class="btn btn-ghost" id="goal-clear-btn">Clear goal</button>
+                                    <button type="button" class="btn btn-ghost modal-close">Cancel</button>
+                                    <button type="submit" class="btn btn-primary">Save goal</button>
                                 </div>
                             </form>
                         </div>
@@ -1199,6 +1311,70 @@
 
                     <section class="settings-section">
                         <header class="settings-section-header">
+                            <i class="fas fa-fire settings-section-icon"></i>
+                            <div>
+                                <h2>Warm-up ramp</h2>
+                                <p class="settings-section-sub">Suggested ramp sets before a heavy working set. Saved as you edit.</p>
+                            </div>
+                        </header>
+                        <div class="setting-item setting-item-toggle">
+                            <label for="warmup-enabled" class="setting-toggle-label">Suggest warm-up sets</label>
+                            <label class="toggle-switch" aria-label="Warm-up suggestions toggle">
+                                <input type="checkbox" id="warmup-enabled">
+                                <span class="toggle-slider" aria-hidden="true"></span>
+                            </label>
+                        </div>
+                        <div class="setting-item">
+                            <label for="warmup-threshold-kg">Threshold <small>(kg)</small></label>
+                            <input type="number" id="warmup-threshold-kg" min="1" step="0.5" inputmode="decimal" placeholder="40">
+                        </div>
+                        <div class="setting-item">
+                            <label for="warmup-threshold-lb">Threshold <small>(lb)</small></label>
+                            <input type="number" id="warmup-threshold-lb" min="1" step="0.5" inputmode="decimal" placeholder="90">
+                        </div>
+                        <div class="setting-item setting-item-stack">
+                            <label>Ramp sets <small>(percent of the working weight, 0 = empty bar)</small></label>
+                            <div class="warmup-ramp" id="warmup-ramp">
+                                <div class="warmup-ramp-row" data-ramp-index="0">
+                                    <span class="warmup-ramp-num">Set 1</span>
+                                    <div class="warmup-ramp-field">
+                                        <label for="warmup-pct-0">Percent</label>
+                                        <input type="number" id="warmup-pct-0" class="warmup-ramp-pct" data-ramp-index="0" min="0" max="100" step="1" inputmode="numeric" placeholder="0">
+                                    </div>
+                                    <div class="warmup-ramp-field">
+                                        <label for="warmup-reps-0">Reps</label>
+                                        <input type="number" id="warmup-reps-0" class="warmup-ramp-reps" data-ramp-index="0" min="1" max="30" step="1" inputmode="numeric" placeholder="8">
+                                    </div>
+                                </div>
+                                <div class="warmup-ramp-row" data-ramp-index="1">
+                                    <span class="warmup-ramp-num">Set 2</span>
+                                    <div class="warmup-ramp-field">
+                                        <label for="warmup-pct-1">Percent</label>
+                                        <input type="number" id="warmup-pct-1" class="warmup-ramp-pct" data-ramp-index="1" min="0" max="100" step="1" inputmode="numeric" placeholder="50">
+                                    </div>
+                                    <div class="warmup-ramp-field">
+                                        <label for="warmup-reps-1">Reps</label>
+                                        <input type="number" id="warmup-reps-1" class="warmup-ramp-reps" data-ramp-index="1" min="1" max="30" step="1" inputmode="numeric" placeholder="5">
+                                    </div>
+                                </div>
+                                <div class="warmup-ramp-row" data-ramp-index="2">
+                                    <span class="warmup-ramp-num">Set 3</span>
+                                    <div class="warmup-ramp-field">
+                                        <label for="warmup-pct-2">Percent</label>
+                                        <input type="number" id="warmup-pct-2" class="warmup-ramp-pct" data-ramp-index="2" min="0" max="100" step="1" inputmode="numeric" placeholder="75">
+                                    </div>
+                                    <div class="warmup-ramp-field">
+                                        <label for="warmup-reps-2">Reps</label>
+                                        <input type="number" id="warmup-reps-2" class="warmup-ramp-reps" data-ramp-index="2" min="1" max="30" step="1" inputmode="numeric" placeholder="3">
+                                    </div>
+                                </div>
+                            </div>
+                            <p class="settings-help-text">Warm-ups are suggested when the working weight is at or above the threshold for your current unit.</p>
+                        </div>
+                    </section>
+
+                    <section class="settings-section">
+                        <header class="settings-section-header">
                             <i class="fas fa-database settings-section-icon"></i>
                             <div>
                                 <h2>Data Management</h2>
@@ -1208,6 +1384,9 @@
                         <div class="setting-actions">
                             <button type="button" class="btn btn-secondary" id="export-data-btn">
                                 <i class="fas fa-download"></i> Export Data
+                            </button>
+                            <button type="button" class="btn btn-secondary" id="export-csv-btn">
+                                <i class="fas fa-file-csv"></i> Export CSV
                             </button>
                             <button type="button" class="btn btn-secondary" id="import-data-btn">
                                 <i class="fas fa-upload"></i> Import Data

--- a/apps/gym-tracker/js/services/AnalyticsService.js
+++ b/apps/gym-tracker/js/services/AnalyticsService.js
@@ -261,6 +261,83 @@ export class AnalyticsService {
     }
 
     /**
+     * Item 4: latest date (local YYYY-MM-DD) on which each muscle category
+     * logged any volume. Categories that were never trained are absent from
+     * the map. Category lookup matches getVolumeByCategoryInRange, so an
+     * exercise missing from the catalog buckets into 'other'.
+     */
+    static getLastTrainedByCategory(sessions, exerciseDatabase) {
+        const byId = new Map((exerciseDatabase || []).map(e => [e.id, e]));
+        const out = new Map();
+        (sessions || []).forEach(s => {
+            if (!s.date) return;
+            (s.exercises || []).forEach(ex => {
+                const data = byId.get(ex.exerciseId);
+                const category = (data && data.category) || 'other';
+                const vol = (ex.sets || []).reduce(
+                    (sum, set) => sum + ((set.weight || 0) * (set.reps || 0)) + (set.duration || 0),
+                    0,
+                );
+                if (vol <= 0) return;
+                const prev = out.get(category);
+                if (!prev || s.date > prev) out.set(category, s.date);
+            });
+        });
+        return out;
+    }
+
+    /**
+     * Item 4: muscle categories the user has PROGRAMMED but has not trained
+     * inside the trailing `days` window. Saved programs are the statement of
+     * intent, so a category that appears in no program is never reported.
+     *
+     * Returns [{ category, lastDate, daysSince }] where a never-trained
+     * category carries `lastDate: null` / `daysSince: null`. Sorted
+     * never-trained first, then longest-neglected first, then by name.
+     */
+    static getStaleProgramCategories(programs, sessions, exerciseDatabase, { days = 14, today = new Date() } = {}) {
+        const byId = new Map((exerciseDatabase || []).map(e => [e.id, e]));
+        const programmed = new Set();
+        (programs || []).forEach(p => {
+            (p.exercises || []).forEach(ex => {
+                const data = byId.get(ex.exerciseId);
+                programmed.add((data && data.category) || 'other');
+            });
+        });
+        if (programmed.size === 0) return [];
+
+        const end = new Date(today);
+        end.setHours(0, 0, 0, 0);
+        const windowStart = new Date(end);
+        windowStart.setDate(windowStart.getDate() - days);
+        const endExclusive = new Date(end);
+        endExclusive.setDate(endExclusive.getDate() + 1); // inclusive of today
+
+        const recent = new Set(
+            this.getVolumeByCategoryInRange(sessions || [], exerciseDatabase, windowStart, endExclusive)
+                .map(t => t.category),
+        );
+        const lastTrained = this.getLastTrainedByCategory(sessions || [], exerciseDatabase);
+
+        const out = [];
+        programmed.forEach(category => {
+            if (recent.has(category)) return;
+            const lastDate = lastTrained.get(category) || null;
+            const daysSince = lastDate
+                ? Math.round((end - this.toLocalDate(lastDate)) / 86400000)
+                : null;
+            out.push({ category, lastDate, daysSince });
+        });
+
+        return out.sort((a, b) => {
+            const av = a.daysSince == null ? Infinity : a.daysSince;
+            const bv = b.daysSince == null ? Infinity : b.daysSince;
+            if (av !== bv) return bv - av;
+            return a.category.localeCompare(b.category);
+        });
+    }
+
+    /**
      * Get muscle group distribution
      */
     static getMuscleGroupDistribution(sessions, exerciseDatabase) {

--- a/apps/gym-tracker/js/services/StorageService.js
+++ b/apps/gym-tracker/js/services/StorageService.js
@@ -17,7 +17,9 @@ export class StorageService {
             CUSTOM_EXERCISES: 'gymTrackerCustomExercises',
             ACTIVE_WORKOUT: 'gymTrackerActiveWorkout',
             ONBOARDING_SEEN: 'gymTrackerOnboardingSeen',
-            MEASUREMENTS: 'gymTrackerMeasurements'
+            MEASUREMENTS: 'gymTrackerMeasurements',
+            MEASUREMENT_GOALS: 'gymTrackerMeasurementGoals',
+            WARMUP_SETTINGS: 'gymTrackerWarmupSettings'
         };
     }
 

--- a/apps/gym-tracker/js/utils/helpers.js
+++ b/apps/gym-tracker/js/utils/helpers.js
@@ -277,6 +277,110 @@ export function downloadJSON(data, filename) {
 }
 
 /**
+ * Download a text file (CSV export). Mirrors downloadJSON: a Blob object
+ * URL, so the download works fully offline with no network round-trip.
+ */
+export function downloadText(text, filename, mimeType = 'text/plain') {
+    const blob = new Blob([text], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+/**
+ * Escape a single CSV field per RFC 4180: quote it when it contains a
+ * comma, a double quote, CR or LF, and double up any embedded quotes.
+ * null / undefined become an empty field.
+ */
+export function escapeCsvField(value) {
+    const s = value === null || value === undefined ? '' : String(value);
+    if (/[",\r\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+    return s;
+}
+
+/** Column order of the per-set CSV export. */
+export const SETS_CSV_HEADER = [
+    'date', 'program', 'exercise', 'setNumber',
+    'weight', 'reps', 'duration', 'volume', 'unit',
+];
+
+/**
+ * Flatten every COMPLETED set across all sessions into a per-set CSV.
+ *
+ * One row per completed set. Timed sets (duration > 0) report seconds in
+ * `duration` and leave weight/reps empty; rep sets report weight + reps and
+ * leave duration empty. `volume` mirrors the app's Set.volume rule (duration
+ * for timed sets, weight × reps otherwise). `unit` is the session's temporary
+ * unit when it has one, else the account unit.
+ *
+ * Returns { csv, rowCount } so callers can tell "nothing logged yet" from
+ * "header plus rows" without re-walking the data.
+ */
+export function buildSetsCsv(sessions, defaultUnit = 'kg') {
+    const lines = [SETS_CSV_HEADER.join(',')];
+
+    (sessions || []).forEach((session) => {
+        const unit = session.sessionUnit || defaultUnit;
+        (session.exercises || []).forEach((exercise) => {
+            (exercise.sets || []).forEach((set, index) => {
+                if (!set.completed) return;
+                const duration = Number(set.duration) || 0;
+                const weight = Number(set.weight) || 0;
+                const reps = Number(set.reps) || 0;
+                const timed = duration > 0;
+                // Prefer the stable user-facing slot; legacy sets without one
+                // fall back to array position, same as the render layer.
+                const setNumber = set.slot != null ? Number(set.slot) + 1 : index + 1;
+                lines.push([
+                    session.date,
+                    session.workoutDayName,
+                    exercise.exerciseName,
+                    setNumber,
+                    timed ? '' : weight,
+                    timed ? '' : reps,
+                    timed ? duration : '',
+                    timed ? duration : weight * reps,
+                    unit,
+                ].map(escapeCsvField).join(','));
+            });
+        });
+    });
+
+    return { csv: lines.join('\r\n'), rowCount: lines.length - 1 };
+}
+
+/**
+ * Progress toward a measurement goal as an integer percent, clamped 0-100.
+ *
+ * `baseline` is the earliest logged value for the metric, `current` the
+ * latest. A 'decrease' goal fills as the value drops toward the target; an
+ * 'increase' goal fills as it rises. When the baseline already sits at or
+ * past the target there is no span to travel, so the result is simply 100
+ * (target met) or 0. Returns null when any input is not a finite number.
+ */
+export function computeGoalProgress(baseline, current, goal) {
+    // Number(null) is 0, so blanks are rejected before coercion.
+    const toNumber = (v) => (v === null || v === undefined || v === '' ? NaN : Number(v));
+    const from = toNumber(baseline);
+    const now = toNumber(current);
+    const target = toNumber(goal?.target);
+    if (!Number.isFinite(from) || !Number.isFinite(now) || !Number.isFinite(target)) return null;
+
+    const decrease = goal.direction === 'decrease';
+    const span = decrease ? from - target : target - from;
+    const moved = decrease ? from - now : now - from;
+    if (span <= 0) {
+        return (decrease ? now <= target : now >= target) ? 100 : 0;
+    }
+    return Math.max(0, Math.min(100, Math.round((moved / span) * 100)));
+}
+
+/**
  * Show toast notification.
  *
  * Accepts either `showToast(message, type, duration)` or

--- a/apps/gym-tracker/js/utils/progression.js
+++ b/apps/gym-tracker/js/utils/progression.js
@@ -1,0 +1,105 @@
+/**
+ * Progressive-overload decision helpers (Item 1) - pure.
+ *
+ * The workout view pre-fills a planned row from the last session. Three
+ * outcomes are possible, and the lifter must be able to SEE which one applied:
+ *
+ *   'bump'   the last two sessions both hit every set's target reps at the
+ *            same weight -> suggest last weight + increment.
+ *   'repeat' the last session missed target reps on at least one set ->
+ *            keep the same weight ("Missed target - repeat weight").
+ *   'deload' the last TWO sessions both missed target reps at the same
+ *            weight -> suggest a 5-10% cut, rounded to the equipment step.
+ *   'none'   not enough history to say anything; prefill last session as-is.
+ *
+ * "Target reps" is resolved PER SET via the caller-supplied
+ * `targetRepsForSet(set, arrayIndex)` so per-set rep ranges (program sets[])
+ * are honored, with the exercise-level targetReps as the fallback.
+ */
+
+export const PROGRESSION_BUMP = 'bump';
+export const PROGRESSION_REPEAT = 'repeat';
+export const PROGRESSION_DELOAD = 'deload';
+export const PROGRESSION_NONE = 'none';
+
+/** Session weight for comparison purposes: the first completed set's weight. */
+export function sessionWeight(sets) {
+    return (sets && sets.length > 0 && sets[0].weight) || 0;
+}
+
+/**
+ * True when EVERY completed set reached its own target reps. A set whose
+ * resolved target is 0/absent counts as a miss: without a target there is no
+ * evidence of a hit, and silently bumping the weight is the worse failure.
+ */
+export function setsHitTarget(sets, targetRepsForSet) {
+    if (!sets || sets.length === 0) return false;
+    return sets.every((set, i) => {
+        const target = Number(targetRepsForSet(set, i)) || 0;
+        if (target <= 0) return false;
+        return (set.reps || 0) >= target;
+    });
+}
+
+/**
+ * Weight to drop to after two failed sessions: the largest whole `increment`
+ * step that stays inside the 5-10% band. When even one step overshoots 10%
+ * (light weights, coarse plates) a single step is used - it is the smallest
+ * cut the equipment can actually make.
+ */
+export function deloadWeight(lastWeight, increment) {
+    if (!(lastWeight > 0) || !(increment > 0)) return 0;
+    let drop = Math.floor((lastWeight * 0.10 + 1e-9) / increment) * increment;
+    if (drop < lastWeight * 0.05) drop = increment;
+    const next = Math.round((lastWeight - drop) * 100) / 100;
+    return next > 0 ? next : 0;
+}
+
+/**
+ * Resolve the progression outcome for one exercise.
+ *
+ * @param {object} options
+ * @param {object[]} options.lastSets completed sets of the most recent session.
+ * @param {object[]|null} options.prevSets completed sets of the session before it.
+ * @param {(set:object, i:number) => number} options.targetRepsForSet per-set rep target.
+ * @param {number} options.increment equipment step for this exercise/unit.
+ * @returns {{status:string, lastWeight:number, suggestedWeight:number, delta:number}}
+ */
+export function evaluateProgression({ lastSets, prevSets = null, targetRepsForSet, increment = 0 }) {
+    const lastWeight = sessionWeight(lastSets);
+    const none = { status: PROGRESSION_NONE, lastWeight, suggestedWeight: lastWeight, delta: 0 };
+    if (!lastSets || lastSets.length === 0) return none;
+
+    const prevUsable = prevSets && prevSets.length > 0;
+
+    if (!setsHitTarget(lastSets, targetRepsForSet)) {
+        const sameWeight = prevUsable && lastWeight > 0 && sessionWeight(prevSets) === lastWeight;
+        if (sameWeight && !setsHitTarget(prevSets, targetRepsForSet)) {
+            const suggested = deloadWeight(lastWeight, increment);
+            if (suggested > 0 && suggested < lastWeight) {
+                return {
+                    status: PROGRESSION_DELOAD,
+                    lastWeight,
+                    suggestedWeight: suggested,
+                    delta: Math.round((suggested - lastWeight) * 100) / 100,
+                };
+            }
+        }
+        return { status: PROGRESSION_REPEAT, lastWeight, suggestedWeight: lastWeight, delta: 0 };
+    }
+
+    if (prevUsable
+        && increment > 0
+        && lastWeight > 0
+        && sessionWeight(prevSets) === lastWeight
+        && setsHitTarget(prevSets, targetRepsForSet)) {
+        return {
+            status: PROGRESSION_BUMP,
+            lastWeight,
+            suggestedWeight: Math.round((lastWeight + increment) * 100) / 100,
+            delta: increment,
+        };
+    }
+
+    return none;
+}

--- a/apps/gym-tracker/js/utils/warmup.js
+++ b/apps/gym-tracker/js/utils/warmup.js
@@ -1,0 +1,116 @@
+/**
+ * Warm-up ramp helpers (Item 6, runtime half) - pure.
+ *
+ * Heavy barbell work wants a ramp, not a cold first working set. The strip is
+ * driven by `gymTrackerWarmupSettings` in localStorage (written by Settings):
+ *
+ *   { enabled: true, thresholdKg: 40, thresholdLb: 90,
+ *     ramp: [{ pct: 0, reps: 8 }, { pct: 50, reps: 5 }, { pct: 75, reps: 3 }] }
+ *
+ * `pct: 0` means the empty bar. Absent or partial JSON falls back to exactly
+ * those defaults, field by field.
+ *
+ * Warm-up rows are NEVER Sets: they are not pushed into
+ * WorkoutExercise.sets, so they cannot reach totalVolume, targetSets
+ * completion, or the PR check by construction.
+ */
+
+export const WARMUP_DEFAULTS = Object.freeze({
+    enabled: true,
+    thresholdKg: 40,
+    thresholdLb: 90,
+    ramp: Object.freeze([
+        Object.freeze({ pct: 0, reps: 8 }),
+        Object.freeze({ pct: 50, reps: 5 }),
+        Object.freeze({ pct: 75, reps: 3 }),
+    ]),
+});
+
+const WARMUP_EQUIPMENT = new Set(['barbell', 'trap-bar']);
+
+function positiveNumber(value, fallback) {
+    const n = Number(value);
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function defaultRamp() {
+    return WARMUP_DEFAULTS.ramp.map(step => ({ pct: step.pct, reps: step.reps }));
+}
+
+/**
+ * Normalize whatever is in localStorage into a complete settings object.
+ * Accepts the raw string, a parsed object, or null/garbage.
+ */
+export function normalizeWarmupSettings(raw) {
+    let data = raw;
+    if (typeof data === 'string') {
+        try {
+            data = JSON.parse(data);
+        } catch {
+            data = null;
+        }
+    }
+    if (!data || typeof data !== 'object') {
+        return { ...WARMUP_DEFAULTS, ramp: defaultRamp() };
+    }
+
+    const ramp = Array.isArray(data.ramp)
+        ? data.ramp
+            .map(step => ({
+                pct: Number(step?.pct),
+                reps: Number(step?.reps),
+            }))
+            .filter(step => Number.isFinite(step.pct) && step.pct >= 0
+                && Number.isFinite(step.reps) && step.reps > 0)
+        : [];
+
+    return {
+        enabled: typeof data.enabled === 'boolean' ? data.enabled : WARMUP_DEFAULTS.enabled,
+        thresholdKg: positiveNumber(data.thresholdKg, WARMUP_DEFAULTS.thresholdKg),
+        thresholdLb: positiveNumber(data.thresholdLb, WARMUP_DEFAULTS.thresholdLb),
+        ramp: ramp.length > 0 ? ramp : defaultRamp(),
+    };
+}
+
+/** Threshold for the unit the session is displayed in. */
+export function warmupThreshold(settings, unit) {
+    return unit === 'lb' ? settings.thresholdLb : settings.thresholdKg;
+}
+
+/**
+ * Whether the warm-up strip applies. Barbell / trap-bar only, never for
+ * duration work, and only once the working weight reaches the threshold.
+ */
+export function shouldShowWarmup({ settings, unit, equipment, isDuration, workingWeight }) {
+    if (!settings || !settings.enabled) return false;
+    if (isDuration) return false;
+    if (!WARMUP_EQUIPMENT.has(equipment)) return false;
+    const weight = Number(workingWeight);
+    if (!Number.isFinite(weight) || weight <= 0) return false;
+    return weight >= warmupThreshold(settings, unit);
+}
+
+/**
+ * Build the ramp rows for a working weight. `roundWeight` snaps a target to a
+ * loadable weight (plate-calculator config); percentage rows that round to at
+ * or below the bar, or to the working weight itself, add nothing and are
+ * dropped.
+ *
+ * @returns {Array<{pct:number, reps:number, weight:number, isBar:boolean}>}
+ */
+export function buildWarmupRamp({ settings, workingWeight, barWeight = 0, roundWeight = (w) => w }) {
+    if (!settings) return [];
+    const working = Number(workingWeight);
+    const bar = Number(barWeight) || 0;
+    const rows = [];
+    for (const step of settings.ramp) {
+        if (step.pct === 0) {
+            if (bar > 0) rows.push({ pct: 0, reps: step.reps, weight: bar, isBar: true });
+            continue;
+        }
+        const weight = roundWeight((working * step.pct) / 100);
+        if (!Number.isFinite(weight) || weight <= bar || weight >= working) continue;
+        rows.push({ pct: step.pct, reps: step.reps, weight, isBar: false });
+    }
+    return rows;
+}

--- a/apps/gym-tracker/js/views/history-view.js
+++ b/apps/gym-tracker/js/views/history-view.js
@@ -7,6 +7,7 @@ import { trapModalFocus } from '../utils/modal-focus.js';
 import { DarkCalendar } from '../utils/dark-calendar.js';
 import { DarkSelect } from '../utils/dark-select.js';
 import { Program } from '../models/Program.js';
+import { sameId } from '../utils/id-utils.js';
 import { makePaginatorState, paginatorInfo, paginatorDualHTML } from '../utils/paginator.js';
 
 const HISTORY_PAGE_SIZE = 15;
@@ -22,6 +23,9 @@ class HistoryView {
         this.currentSort = 'date-desc';
         this.dateFrom = null;
         this.dateTo = null;
+        // Item 5: '' = All Programs. Deliberately not persisted, so a reload
+        // starts from the unfiltered list.
+        this.programFilter = '';
         this._pagination = makePaginatorState(HISTORY_PAGE_SIZE);
         this.setupEventListeners();
         this.wireListActions();
@@ -79,6 +83,18 @@ class HistoryView {
                 this.currentSort = e.target.value;
                 this._pagination.page = 1;
                 this.render();
+            });
+        }
+
+        // Program filter (Item 5). The options themselves are rebuilt on every
+        // render (see syncProgramFilter); this listener lives on the native
+        // select, which DarkSelect writes back to, so it survives the rebuild.
+        const programSelect = document.getElementById('history-program');
+        if (programSelect) {
+            programSelect.addEventListener('change', (e) => {
+                this.programFilter = e.target.value;
+                this._pagination.page = 1;
+                this.renderHistoryList();
             });
         }
 
@@ -147,12 +163,67 @@ class HistoryView {
     }
 
     render() {
+        this.syncProgramFilter();
         this.renderHistoryList();
+    }
+
+    /**
+     * Item 5: keep the Program dropdown in step with the saved programs.
+     * DarkSelect snapshots its options at construction, so the wrapper is
+     * torn down and rebuilt whenever a program is added, renamed or deleted.
+     * A filter pointing at a program that no longer exists falls back to
+     * All Programs rather than showing an empty list forever.
+     */
+    syncProgramFilter() {
+        const select = document.getElementById('history-program');
+        if (!select) return;
+
+        const programs = this.app.programs || [];
+        if (this.programFilter && !programs.some(p => sameId(p.id, this.programFilter))) {
+            this.programFilter = '';
+        }
+
+        const signature = programs.map(p => `${p.id}:${p.name}`).join('|');
+        if (this.programDropdown && signature === this._programFilterSignature) {
+            select.value = this.programFilter;
+            this.programDropdown.sync();
+            return;
+        }
+        this._programFilterSignature = signature;
+
+        select.innerHTML = ['<option value="">All Programs</option>']
+            .concat(programs.map(p =>
+                `<option value="${escapeHtml(String(p.id))}">${escapeHtml(p.name)}</option>`))
+            .join('');
+        select.value = this.programFilter;
+
+        if (this.programDropdown) {
+            this.programDropdown.close();
+            const wrapper = this.programDropdown.wrapper;
+            wrapper.parentNode.insertBefore(select, wrapper);
+            wrapper.remove();
+        }
+        this.programDropdown = new DarkSelect(select);
+        select.dataset.darkSelectInit = '1';
     }
 
     renderHistoryList() {
         const container = document.getElementById('history-list');
         let sessions = [...this.app.workoutSessions];
+
+        // Program filter (Item 5). Sessions started from a program record its
+        // id, so that's the identity we match on. Sessions predating programId
+        // (or imported without one) fall back to the workout name they were
+        // saved under, which is the program name at the time.
+        if (this.programFilter) {
+            const program = this.app.getProgramById(this.programFilter);
+            const programName = program ? program.name : null;
+            sessions = sessions.filter(session => (
+                session.programId != null
+                    ? sameId(session.programId, this.programFilter)
+                    : (programName !== null && session.workoutDayName === programName)
+            ));
+        }
 
         // Apply date filters
         if (this.dateFrom) {

--- a/apps/gym-tracker/js/views/insights-view.js
+++ b/apps/gym-tracker/js/views/insights-view.js
@@ -23,6 +23,10 @@ const CATEGORY_LABEL = {
     'full-body': 'Full body', cardio: 'Cardio', other: 'Other',
 };
 
+// Item 4: a programmed category with no volume inside this trailing window
+// counts as "not trained recently".
+const STALE_WINDOW_DAYS = 14;
+
 class InsightsView {
     constructor() {
         this.app = app;
@@ -34,17 +38,20 @@ class InsightsView {
         };
         on(EVENTS.SESSIONS_CHANGED, refresh);
         on(EVENTS.CUSTOM_EXERCISES_CHANGED, refresh);
+        on(EVENTS.PROGRAMS_CHANGED, refresh);
     }
 
     render() {
         const sessions = this.app.workoutSessions || [];
         const empty = document.getElementById('insights-empty');
         const volumeSection = document.getElementById('insights-volume-section');
+        const staleSection = document.getElementById('insights-stale-section');
         const heatmapSection = document.getElementById('insights-heatmap-section');
 
         if (sessions.length === 0) {
             if (empty) empty.hidden = false;
             if (volumeSection) volumeSection.hidden = true;
+            if (staleSection) staleSection.hidden = true;
             if (heatmapSection) heatmapSection.hidden = true;
             return;
         }
@@ -53,6 +60,7 @@ class InsightsView {
         if (heatmapSection) heatmapSection.hidden = false;
 
         this.renderVolumeBars(sessions);
+        this.renderStaleCategories(sessions);
         this.renderHeatmap(sessions);
     }
 
@@ -99,6 +107,45 @@ class InsightsView {
                     </div>
                     <div class="insights-bar-value">${Math.round(volume).toLocaleString()} ${escapeHtml(unit)}</div>
                 </div>
+            `;
+        }).join('');
+    }
+
+    /**
+     * Item 4: the companion to the volume bars, which drop empty buckets
+     * entirely. Lists the muscle categories the user PROGRAMMED but has not
+     * trained in the trailing window, so the gap is visible instead of just
+     * missing. Hidden when there are no programs or nothing is neglected.
+     */
+    renderStaleCategories(sessions) {
+        const section = document.getElementById('insights-stale-section');
+        const list = document.getElementById('insights-stale-list');
+        const caption = document.getElementById('insights-stale-caption');
+        if (!section || !list) return;
+
+        const stale = AnalyticsService.getStaleProgramCategories(
+            this.app.programs || [], sessions, this.app.exerciseDatabase || [],
+            { days: STALE_WINDOW_DAYS },
+        );
+
+        if (stale.length === 0) {
+            section.hidden = true;
+            list.innerHTML = '';
+            return;
+        }
+        section.hidden = false;
+        if (caption) caption.textContent = `No volume in the last ${STALE_WINDOW_DAYS} days`;
+
+        list.innerHTML = stale.map(({ category, daysSince }) => {
+            const label = CATEGORY_LABEL[category] || (category[0]?.toUpperCase() + category.slice(1));
+            const since = daysSince == null
+                ? 'Never trained'
+                : `${daysSince} days since last trained`;
+            return `
+                <li class="insights-stale-row">
+                    <span class="insights-stale-label">${escapeHtml(label)}</span>
+                    <span class="insights-stale-since">${escapeHtml(since)}</span>
+                </li>
             `;
         }).join('');
     }

--- a/apps/gym-tracker/js/views/measurements-view.js
+++ b/apps/gym-tracker/js/views/measurements-view.js
@@ -18,10 +18,20 @@ import {
     formatDate,
     escapeHtml,
     getTodayDateString,
+    computeGoalProgress,
 } from '../utils/helpers.js';
 import { trapModalFocus } from '../utils/modal-focus.js';
 import { on, EVENTS } from '../utils/event-bus.js';
 import { DarkCalendar } from '../utils/dark-calendar.js';
+import { DarkSelect } from '../utils/dark-select.js';
+import { storageService } from '../services/StorageService.js';
+
+/**
+ * Item 7: per-metric goal targets, keyed by metric id.
+ * Shape: { [metricKey]: { target: number, direction: 'increase' | 'decrease' } }
+ * Kept out of the measurement entries so clearing a goal never touches history.
+ */
+const GOALS_KEY = 'gymTrackerMeasurementGoals';
 
 const METRICS = [
     { key: 'weight',     label: 'Body weight', unitFromSettings: true },
@@ -87,6 +97,56 @@ class MeasurementsView {
                 if (btn.dataset.action === 'delete-measurement') this.confirmDelete(id);
             });
         }
+
+        // Delegated trend-tile actions: set/edit a goal.
+        const grid = document.getElementById('measurements-trends-grid');
+        if (grid) {
+            grid.addEventListener('click', (e) => {
+                const btn = e.target.closest('[data-action="set-goal"]');
+                if (btn) this.openGoalModal(btn.dataset.metric);
+            });
+        }
+
+        const goalModal = document.getElementById('measurement-goal-modal');
+        if (goalModal) {
+            goalModal.querySelectorAll('.modal-close').forEach(btn => {
+                btn.addEventListener('click', () => goalModal.classList.remove('active'));
+            });
+        }
+
+        const directionSelect = document.getElementById('goal-direction');
+        if (directionSelect && !directionSelect.dataset.darkSelectInit) {
+            this.directionDropdown = new DarkSelect(directionSelect);
+            directionSelect.dataset.darkSelectInit = '1';
+        }
+
+        const goalForm = document.getElementById('measurement-goal-form');
+        if (goalForm) {
+            goalForm.addEventListener('submit', (e) => {
+                e.preventDefault();
+                this.saveGoalFromForm();
+            });
+        }
+
+        const clearGoalBtn = document.getElementById('goal-clear-btn');
+        if (clearGoalBtn) clearGoalBtn.addEventListener('click', () => this.clearGoal());
+    }
+
+    /** All stored goals, keyed by metric id. Junk in storage reads as none. */
+    loadGoals() {
+        const raw = storageService.get(GOALS_KEY, {});
+        return raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
+    }
+
+    saveGoals(goals) {
+        storageService.set(GOALS_KEY, goals);
+    }
+
+    /** Display unit for a metric, matching the tile / history rendering. */
+    unitForMetric(metric) {
+        const weightUnit = this.app.settings?.weightUnit || 'kg';
+        const lengthUnit = weightUnit === 'lb' ? 'in' : 'cm';
+        return metric.unit || (metric.unitFromSettings ? weightUnit : lengthUnit);
     }
 
     render() {
@@ -123,6 +183,7 @@ class MeasurementsView {
         const settings = this.app.settings || {};
         const weightUnit = settings.weightUnit || 'kg';
         const lengthUnit = weightUnit === 'lb' ? 'in' : 'cm';
+        const goals = this.loadGoals();
 
         const tiles = METRICS.map(({ key, label, unitFromSettings, unit }) => {
             // chronological for sparkline + delta math
@@ -143,6 +204,14 @@ class MeasurementsView {
             const deltaSign = delta > 0 ? '+' : '';
             const deltaClass = delta === 0 ? '' : (delta > 0 ? 'is-up' : 'is-down');
 
+            // Goal progress runs from the earliest logged value (baseline)
+            // toward the target, so it reflects the whole tracked span.
+            const goal = goals[key];
+            const percent = goal ? computeGoalProgress(series[0].value, latest.value, goal) : null;
+            const goalLabel = goal && Number.isFinite(Number(goal.target))
+                ? `Goal: ${round1(goal.target)} ${tileUnit}`
+                : 'Set goal';
+
             return `
                 <div class="measurement-tile">
                     <div class="measurement-tile-label">${escapeHtml(label)}</div>
@@ -153,6 +222,19 @@ class MeasurementsView {
                         ${deltaSign}${delta} ${escapeHtml(tileUnit)} <span>vs 30d</span>
                     </div>
                     ${this.renderSparkline(series)}
+                    ${percent === null ? '' : `
+                        <div class="measurement-goal" data-metric="${escapeHtml(key)}">
+                            <div class="measurement-goal-track" role="img" aria-label="${percent}% to goal">
+                                <div class="measurement-goal-fill" style="width: ${percent}%"></div>
+                            </div>
+                            <div class="measurement-goal-pct">${percent}% to goal</div>
+                        </div>
+                    `}
+                    <button type="button" class="measurement-goal-btn" data-action="set-goal"
+                            data-metric="${escapeHtml(key)}"
+                            aria-label="Set goal for ${escapeHtml(label)}">
+                        ${escapeHtml(goalLabel)}
+                    </button>
                 </div>
             `;
         }).filter(Boolean).join('');
@@ -256,6 +338,67 @@ class MeasurementsView {
 
         modal.classList.add('active');
         trapModalFocus(modal);
+    }
+
+    openGoalModal(metricKey) {
+        const metric = METRICS.find(m => m.key === metricKey);
+        const modal = document.getElementById('measurement-goal-modal');
+        if (!metric || !modal) return;
+
+        this.goalMetricKey = metric.key;
+        const goal = this.loadGoals()[metric.key] || null;
+
+        const titleEl = document.getElementById('measurement-goal-modal-title');
+        if (titleEl) titleEl.textContent = `${metric.label} goal`;
+        const unitEl = document.getElementById('goal-target-unit');
+        if (unitEl) unitEl.textContent = `(${this.unitForMetric(metric)})`;
+
+        const targetInput = document.getElementById('goal-target');
+        if (targetInput) targetInput.value = goal ? goal.target : '';
+        const directionSelect = document.getElementById('goal-direction');
+        if (directionSelect) {
+            directionSelect.value = goal?.direction === 'increase' ? 'increase' : 'decrease';
+            if (this.directionDropdown) this.directionDropdown.sync();
+        }
+        const clearBtn = document.getElementById('goal-clear-btn');
+        if (clearBtn) clearBtn.hidden = !goal;
+
+        modal.classList.add('active');
+        trapModalFocus(modal);
+    }
+
+    saveGoalFromForm() {
+        if (!this.goalMetricKey) return;
+        const target = Number(document.getElementById('goal-target')?.value);
+        if (!Number.isFinite(target)) {
+            showToast('Enter a target value', 'error');
+            return;
+        }
+        const direction = document.getElementById('goal-direction')?.value === 'increase'
+            ? 'increase'
+            : 'decrease';
+
+        const goals = this.loadGoals();
+        goals[this.goalMetricKey] = { target, direction };
+        this.saveGoals(goals);
+
+        document.getElementById('measurement-goal-modal').classList.remove('active');
+        this.goalMetricKey = null;
+        showToast('Goal saved', 'success');
+        this.render();
+    }
+
+    /** Remove just this metric's goal. Measurement history is untouched. */
+    clearGoal() {
+        if (!this.goalMetricKey) return;
+        const goals = this.loadGoals();
+        delete goals[this.goalMetricKey];
+        this.saveGoals(goals);
+
+        document.getElementById('measurement-goal-modal').classList.remove('active');
+        this.goalMetricKey = null;
+        showToast('Goal cleared', 'info');
+        this.render();
     }
 
     saveFromForm() {

--- a/apps/gym-tracker/js/views/settings-view.js
+++ b/apps/gym-tracker/js/views/settings-view.js
@@ -2,10 +2,52 @@
  * Settings View Controller
  */
 import { app } from '../app.js';
-import { showToast, downloadJSON, showConfirmModal } from '../utils/helpers.js';
+import {
+    showToast,
+    downloadJSON,
+    downloadText,
+    buildSetsCsv,
+    showConfirmModal,
+} from '../utils/helpers.js';
 import { DarkSelect } from '../utils/dark-select.js';
+import { WARMUP_DEFAULTS } from '../utils/warmup.js';
 import { Settings } from '../models/Settings.js';
+import { storageService } from '../services/StorageService.js';
 import { closeModalSafely } from '../utils/modal-focus.js';
+
+/**
+ * Item 6: warm-up ramp configuration. Stored under its own localStorage key
+ * (not in the Settings model) because the workout view reads it directly.
+ * Shape: { enabled, thresholdKg, thresholdLb, ramp: [{ pct, reps }, ...] }
+ * where pct is a percentage of the working weight and pct 0 = empty bar.
+ */
+const WARMUP_KEY = 'gymTrackerWarmupSettings';
+/** Clamp `value` into [min, max], falling back to `fallback` for junk input. */
+function clampNumber(value, fallback, min, max, round = false) {
+    if (value === undefined || value === null || value === '') return fallback;
+    let n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    if (round) n = Math.round(n);
+    return Math.min(max, Math.max(min, n));
+}
+
+/** Clamp stored/entered warm-up config into writable bounds (the lenient
+ * read-side normalize lives in utils/warmup.js; this is the write-side gate). */
+function clampWarmupSettings(raw) {
+    const data = raw && typeof raw === 'object' ? raw : {};
+    const ramp = Array.isArray(data.ramp) ? data.ramp : [];
+    return {
+        enabled: data.enabled !== false,
+        // Thresholds stay positive: the workout-side reader treats a
+        // non-positive threshold as "missing" and falls back to its default.
+        thresholdKg: clampNumber(data.thresholdKg, WARMUP_DEFAULTS.thresholdKg, 1, 500),
+        thresholdLb: clampNumber(data.thresholdLb, WARMUP_DEFAULTS.thresholdLb, 1, 1100),
+        ramp: WARMUP_DEFAULTS.ramp.map((fallback, i) => ({
+            pct: clampNumber(ramp[i]?.pct, fallback.pct, 0, 100, true),
+            reps: clampNumber(ramp[i]?.reps, fallback.reps, 1, 30, true),
+        })),
+    };
+}
 
 function validateImportData(data) {
     if (!data) {
@@ -113,6 +155,26 @@ class SettingsView {
             });
         }
 
+        // Warm-up ramp (Item 6). These live in their own storage key and
+        // persist immediately on change, so they're outside the form's
+        // dirty-tracking / Save flow.
+        const warmupEnabled = document.getElementById('warmup-enabled');
+        if (warmupEnabled) {
+            warmupEnabled.addEventListener('change', () => this.saveWarmupSettings());
+        }
+        ['warmup-threshold-kg', 'warmup-threshold-lb'].forEach((id) => {
+            const input = document.getElementById(id);
+            if (input) input.addEventListener('change', () => this.saveWarmupSettings());
+        });
+        const rampWrap = document.getElementById('warmup-ramp');
+        if (rampWrap) {
+            rampWrap.addEventListener('change', (e) => {
+                if (e.target.matches('.warmup-ramp-pct, .warmup-ramp-reps')) {
+                    this.saveWarmupSettings();
+                }
+            });
+        }
+
         // Settings form submission
         const settingsForm = document.getElementById('settings-form');
         if (settingsForm) {
@@ -126,6 +188,12 @@ class SettingsView {
         const exportBtn = document.getElementById('export-data-btn');
         if (exportBtn) {
             exportBtn.addEventListener('click', () => this.exportData());
+        }
+
+        // Export every completed set as CSV (Item 8)
+        const exportCsvBtn = document.getElementById('export-csv-btn');
+        if (exportCsvBtn) {
+            exportCsvBtn.addEventListener('click', () => this.exportSetsCsv());
         }
 
         // Import data
@@ -267,9 +335,51 @@ class SettingsView {
         if (platesInput) platesInput.value = (settings.plates || []).join(', ');
         this.refreshPlatesPreview();
 
+        this.renderWarmupSettings();
+
         // Snapshot current values for dirty-state comparison
         this.savedSnapshot = this.snapshotForm();
         this.checkDirty();
+    }
+
+    /** Populate the warm-up controls from the stored (normalized) config. */
+    renderWarmupSettings() {
+        const warmup = clampWarmupSettings(storageService.get(WARMUP_KEY, null));
+
+        const enabledInput = document.getElementById('warmup-enabled');
+        if (enabledInput) enabledInput.checked = warmup.enabled;
+        const kgInput = document.getElementById('warmup-threshold-kg');
+        if (kgInput) kgInput.value = String(warmup.thresholdKg);
+        const lbInput = document.getElementById('warmup-threshold-lb');
+        if (lbInput) lbInput.value = String(warmup.thresholdLb);
+
+        warmup.ramp.forEach((step, i) => {
+            const pctInput = document.getElementById(`warmup-pct-${i}`);
+            if (pctInput) pctInput.value = String(step.pct);
+            const repsInput = document.getElementById(`warmup-reps-${i}`);
+            if (repsInput) repsInput.value = String(step.reps);
+        });
+    }
+
+    /**
+     * Read the warm-up controls, normalize, persist, and reflect the
+     * normalized values back into the inputs so the user always sees what
+     * actually got stored.
+     */
+    saveWarmupSettings() {
+        const ramp = WARMUP_DEFAULTS.ramp.map((_, i) => ({
+            pct: document.getElementById(`warmup-pct-${i}`)?.value,
+            reps: document.getElementById(`warmup-reps-${i}`)?.value,
+        }));
+        const warmup = clampWarmupSettings({
+            enabled: document.getElementById('warmup-enabled')?.checked !== false,
+            thresholdKg: document.getElementById('warmup-threshold-kg')?.value,
+            thresholdLb: document.getElementById('warmup-threshold-lb')?.value,
+            ramp,
+        });
+
+        storageService.set(WARMUP_KEY, warmup);
+        this.renderWarmupSettings();
     }
 
     /** Build a snapshot of all form values used for dirty-state checking. */
@@ -404,6 +514,24 @@ class SettingsView {
         const filename = `gym-tracker-data-${new Date().toISOString().split('T')[0]}.json`;
         downloadJSON(data, filename);
         showToast('Data exported successfully', 'success');
+    }
+
+    /**
+     * Item 8: one CSV row per completed set across every logged session.
+     * Plain Blob download so it works offline like the JSON export.
+     */
+    exportSetsCsv() {
+        const unit = this.app.settings?.weightUnit || 'kg';
+        const { csv, rowCount } = buildSetsCsv(this.app.workoutSessions || [], unit);
+
+        if (rowCount === 0) {
+            showToast('No completed sets to export yet. Log a workout first.', 'info', 4000);
+            return;
+        }
+
+        const filename = `gym-tracker-sets-${new Date().toISOString().split('T')[0]}.csv`;
+        downloadText(csv, filename, 'text/csv;charset=utf-8');
+        showToast(`Exported ${rowCount} ${rowCount === 1 ? 'set' : 'sets'} to CSV`, 'success');
     }
 
     importData(file) {

--- a/apps/gym-tracker/js/views/workout-view.js
+++ b/apps/gym-tracker/js/views/workout-view.js
@@ -8,7 +8,7 @@ import { WorkoutExercise } from '../models/WorkoutExercise.js';
 import { Set } from '../models/Set.js';
 import { timerService } from '../services/TimerService.js';
 import { storageService } from '../services/StorageService.js';
-import { showToast, showConfirmModal, formatMuscleGroup, vibrate, playSound, escapeHtml, debugLog, convertWeight } from '../utils/helpers.js';
+import { showToast, showConfirmModal, formatMuscleGroup, vibrate, playSound, escapeHtml, debugLog, convertWeight, formatDate } from '../utils/helpers.js';
 import { trapModalFocus } from '../utils/modal-focus.js';
 import { renderPausedBannerHTML, wirePausedBannerActions } from './paused-banner.js';
 import { orderPrograms } from '../utils/program-order.js';
@@ -21,8 +21,22 @@ import { allSetsReachMax, latestFeelForExercise, nextFeel, shouldShowFeelModal }
 import { recordPrSupersede, uniquePrChainCount, recomputePrSlots } from '../utils/pr-session.js';
 import { mergeSessionWithProgram } from '../utils/session-merge.js';
 import { weekStrip } from '../utils/program-schedule.js';
+import {
+    evaluateProgression,
+    PROGRESSION_BUMP,
+    PROGRESSION_DELOAD,
+    PROGRESSION_REPEAT,
+} from '../utils/progression.js';
+import {
+    normalizeWarmupSettings,
+    shouldShowWarmup,
+    buildWarmupRamp,
+} from '../utils/warmup.js';
 
 const PLATE_LOADED_EQUIPMENT = new globalThis.Set(['barbell', 'trap-bar', 'machine', 'plate', 'sled']);
+
+// Item 6: warm-up ramp configuration, written by Settings.
+const WARMUP_SETTINGS_KEY = 'gymTrackerWarmupSettings';
 
 class WorkoutView {
     constructor() {
@@ -55,6 +69,14 @@ class WorkoutView {
         // feel modal has already been shown, so it appears at most once per
         // exercise per session.
         this._feelModalShown = {};
+        // Item 6: warm-up strip state, keyed `"<exerciseIndex>:<rampIndex>"` for
+        // ticked-off ramp rows and by exercise index for the expanded strip.
+        // View-only on purpose: a warm-up row is never a Set, so it can never
+        // reach volume, completion or PR bookkeeping.
+        this.warmupDone = {};
+        this.warmupExpanded = {};
+        // Item 3: exercise index the swap picker is currently acting on.
+        this.swapTargetIndex = null;
         this.init();
     }
 
@@ -195,6 +217,38 @@ class WorkoutView {
                 case 'restore-last-time':
                     e.preventDefault();
                     this.restoreLastTime(exerciseIndex, slot, target);
+                    break;
+                case 'step-weight':
+                    e.preventDefault();
+                    this.stepWeight(exerciseIndex, slot, target.dataset.stepDir === 'up' ? 1 : -1);
+                    break;
+                case 'step-reps':
+                    e.preventDefault();
+                    this.stepReps(exerciseIndex, slot, target.dataset.stepDir === 'up' ? 1 : -1);
+                    break;
+                case 'toggle-progression-detail':
+                    e.preventDefault();
+                    this.toggleProgressionDetail(target);
+                    break;
+                case 'use-last-weight':
+                    e.preventDefault();
+                    this.useLastWeight(exerciseIndex, slot);
+                    break;
+                case 'toggle-warmup':
+                    e.preventDefault();
+                    this.toggleWarmup(exerciseIndex);
+                    break;
+                case 'toggle-warmup-set':
+                    e.preventDefault();
+                    this.toggleWarmupSet(exerciseIndex, Number(target.dataset.warmupIndex));
+                    break;
+                case 'swap-exercise':
+                    e.preventDefault();
+                    this.openSwapPicker(exerciseIndex);
+                    break;
+                case 'pick-swap-exercise':
+                    e.preventDefault();
+                    this.pickSwapExercise(target.dataset.exerciseId);
                     break;
             }
         });
@@ -678,6 +732,8 @@ class WorkoutView {
         this._prevCompleteState = {};
         this._activeRestType = null;
         this._feelModalShown = {};
+        this.warmupDone = {};
+        this.warmupExpanded = {};
         // Item R3-4: don't re-pop the feel modal on resume for exercises that
         // already satisfy the all-sets-at-max condition. The modal only fires on
         // the commit transition; mark satisfied exercises as already shown.
@@ -957,6 +1013,8 @@ class WorkoutView {
         this._prevCompleteState = {};
         this._activeRestType = null;
         this._feelModalShown = {};
+        this.warmupDone = {};
+        this.warmupExpanded = {};
 
         // Start workout timer
         timerService.startWorkoutTimer((elapsed) => {
@@ -1124,7 +1182,25 @@ class WorkoutView {
             }
         }
 
+        // Item 6: the ramp is sized off the weight the FIRST working set is
+        // pre-filled with, in the session display unit.
+        const firstPrior = (exercise.stickyValues && exercise.stickyValues[0])
+            || previousSets[0]
+            || previousSets[previousSets.length - 1]
+            || null;
+        const workingWeight = (firstPrior && firstPrior.weight !== '' && firstPrior.weight != null)
+            ? this.toSessionWeight(firstPrior.weight)
+            : 0;
+        const warmupHTML = this.renderWarmupStrip(index, {
+            equipment, isDuration, unit, workingWeight,
+        });
+
         let rowsHTML = '';
+        // Item 1 (owner call, 2026-08-04): the suggestion badge renders once,
+        // on the first planned row without user-typed values. Later rows still
+        // PREFILL the suggested weight; repeating the identical badge under
+        // every row read as noise, and one glance says it all.
+        let progressionShown = false;
         for (let i = 0; i < totalRows; i++) {
             const committed = setsBySlot.get(i);
             if (committed) {
@@ -1149,7 +1225,13 @@ class WorkoutView {
                 // Prefill each row with its own set's top-of-range target, not set 1's.
                 const slotTargetReps = (progSets && i < progSets.length)
                     ? progSets[i].repsMax : exercise.targetReps;
-                rowsHTML += this.renderPlannedRow(index, i, prior, isDuration, unit, slotTargetReps, isPlateLoaded, usesBarWeight, slotRepLabel);
+                // Item 1: the progression badge explains the PREFILL. A sticky
+                // value is the user's own number, so it gets no badge; and only
+                // the first badge-eligible row carries it (see progressionShown).
+                const rowProgression = (sticky || progressionShown)
+                    ? null : (previousSets.progression || null);
+                if (rowProgression) progressionShown = true;
+                rowsHTML += this.renderPlannedRow(index, i, prior, isDuration, unit, slotTargetReps, isPlateLoaded, usesBarWeight, slotRepLabel, rowProgression);
             }
         }
 
@@ -1217,6 +1299,13 @@ class WorkoutView {
                         </div>
                     </div>
                     <div class="exercise-header-controls">
+                        <button type="button" class="gt-iconbtn gt-swap-toggle"
+                            data-action="swap-exercise"
+                            data-exercise-index="${index}"
+                            aria-label="Swap this exercise for another"
+                            title="Swap exercise (this workout only)">
+                            <i class="fas fa-right-left" aria-hidden="true"></i>
+                        </button>
                         <button type="button" class="gt-iconbtn gt-notes-toggle${exercise.notes ? ' gt-notes-toggle--has-notes' : ''}"
                             data-action="toggle-exercise-notes"
                             data-exercise-index="${index}"
@@ -1242,6 +1331,8 @@ class WorkoutView {
                             placeholder="Notes for this exercise (form cues, how it felt, etc.)"
                             aria-label="Exercise notes">${escapeHtml(exercise.notes || '')}</textarea>
                     </div>
+
+                    ${warmupHTML}
 
                     <ol class="set-row-list" id="set-row-list-${index}">
                         ${rowsHTML}
@@ -1275,7 +1366,7 @@ class WorkoutView {
      * set and starts the rest timer. The row itself is NOT tappable — users
      * deliberately flick the toggle to complete.
      */
-    renderPlannedRow(exerciseIndex, slot, prior, isDuration, unit, targetReps, isPlateLoaded = false, usesBarWeight = false, repLabel = null) {
+    renderPlannedRow(exerciseIndex, slot, prior, isDuration, unit, targetReps, isPlateLoaded = false, usesBarWeight = false, repLabel = null, progression = null) {
         const setLabel = `${slot + 1}`;
         const toggle = this.renderSetToggle(false, 'commit-planned-set', exerciseIndex, slot, 'Mark set complete');
 
@@ -1324,24 +1415,179 @@ class WorkoutView {
             ? `data-prior-weight="${weight}" data-prior-reps="${reps}"`
             : '';
 
+        // Item 1: explain the prefill whenever it is not simply "what you lifted
+        // last time". Sticky rows pass progression = null (see renderExerciseEntry).
+        const progressionHTML = this.renderProgressionNote(exerciseIndex, slot, weight, unit, progression);
+        const step = this._overloadIncrement(
+            this.currentWorkoutSession?.exercises[exerciseIndex]?.exerciseId,
+            unit,
+        );
+
         return `
             <li class="set-row set-row-planned" data-slot="${slot}" ${restoreData}>
                 <span class="set-row-num">${setLabel}</span>
                 <div class="set-row-inputs">
-                    <input type="number" inputmode="decimal" class="set-weight"
-                        id="weight-${exerciseIndex}-${slot}" min="0" step="0.5"
-                        value="${weight === '' ? '' : weight}" placeholder="Weight" aria-label="Weight"
-                        data-plate-hint-target="${exerciseIndex}-${slot}">
+                    <div class="gt-stepper-group">
+                        ${this.renderStepper('step-weight', 'down', exerciseIndex, slot, `Decrease weight by ${step}${unit}`)}
+                        <input type="number" inputmode="decimal" class="set-weight"
+                            id="weight-${exerciseIndex}-${slot}" min="0" step="0.5"
+                            value="${weight === '' ? '' : weight}" placeholder="Weight" aria-label="Weight"
+                            data-plate-hint-target="${exerciseIndex}-${slot}">
+                        ${this.renderStepper('step-weight', 'up', exerciseIndex, slot, `Increase weight by ${step}${unit}`)}
+                    </div>
                     <span class="set-row-x">×</span>
-                    <input type="number" inputmode="numeric" class="set-reps"
-                        id="reps-${exerciseIndex}-${slot}" min="1"
-                        value="${reps === '' ? '' : reps}" placeholder="Reps" aria-label="Reps">
+                    <div class="gt-stepper-group">
+                        ${this.renderStepper('step-reps', 'down', exerciseIndex, slot, 'One rep fewer')}
+                        <input type="number" inputmode="numeric" class="set-reps"
+                            id="reps-${exerciseIndex}-${slot}" min="1"
+                            value="${reps === '' ? '' : reps}" placeholder="Reps" aria-label="Reps">
+                        ${this.renderStepper('step-reps', 'up', exerciseIndex, slot, 'One more rep')}
+                    </div>
                     ${repLabel ? `<span class="set-rep-target" aria-label="Target: ${repLabel}">${repLabel}</span>` : ''}
                 </div>
                 ${toggle}
                 ${plateHintHTML ? `<div class="plate-hint" id="plate-hint-${exerciseIndex}-${slot}">${plateHintHTML}</div>` : ''}
+                ${progressionHTML}
             </li>
         `;
+    }
+
+    /**
+     * Item 2: one-tap -/+ button flanking a planned-row input. `type="button"`
+     * plus the delegated handler means the input never takes focus, so tapping
+     * a stepper does not raise the mobile keyboard.
+     */
+    renderStepper(action, dir, exerciseIndex, slot, ariaLabel) {
+        return `
+            <button type="button" class="gt-stepper gt-stepper--${dir === 'up' ? 'plus' : 'minus'}"
+                data-action="${action}"
+                data-step-dir="${dir}"
+                data-exercise-index="${exerciseIndex}"
+                data-slot="${slot}"
+                aria-label="${ariaLabel}" title="${ariaLabel}">
+                <i class="fas fa-${dir === 'up' ? 'plus' : 'minus'}" aria-hidden="true"></i>
+            </button>
+        `;
+    }
+
+    /**
+     * Item 1: the badge/label under a planned row that explains the prefilled
+     * weight.
+     *   bump/deload -> tappable badge; opening it shows the two prior sessions
+     *                  and a "Use last weight" control.
+     *   repeat      -> a plain "Missed target - repeat weight" label.
+     * Nothing renders when the prefill IS the literal last-session weight.
+     */
+    renderProgressionNote(exerciseIndex, slot, weight, unit, progression) {
+        if (!progression) return '';
+        const { status } = progression;
+        // Bodyweight-style history (no load) has no weight to talk about.
+        if (!(progression.lastWeight > 0)) return '';
+        if (status === PROGRESSION_REPEAT) {
+            return `<span class="gt-progress-label gt-progress-label--miss">
+                <i class="fas fa-triangle-exclamation" aria-hidden="true"></i> Missed target - repeat weight
+            </span>`;
+        }
+        if (status !== PROGRESSION_BUMP && status !== PROGRESSION_DELOAD) return '';
+
+        const lastWeight = this.toSessionWeight(progression.lastWeight);
+        if (weight === '' || lastWeight === '' || Number(weight) === Number(lastWeight)) return '';
+
+        const delta = Math.round((Number(weight) - Number(lastWeight)) * 10) / 10;
+        const isBump = status === PROGRESSION_BUMP;
+        const text = isBump
+            ? `+${delta}${unit} suggested`
+            : `${delta}${unit} deload suggested`;
+        const detailId = `progression-detail-${exerciseIndex}-${slot}`;
+        const historyHTML = (progression.history || []).map(h => `
+            <li class="gt-progress-history-row">
+                <span class="gt-progress-history-date">${escapeHtml(formatDate(h.date, 'short'))}</span>
+                <span class="gt-progress-history-sets">${this.toSessionWeight(h.weight)}${unit} × ${h.reps.join(', ')}</span>
+            </li>
+        `).join('');
+
+        return `
+            <button type="button" class="gt-progress-badge gt-progress-badge--${isBump ? 'bump' : 'deload'}"
+                data-action="toggle-progression-detail"
+                data-exercise-index="${exerciseIndex}" data-slot="${slot}"
+                aria-expanded="false" aria-controls="${detailId}"
+                title="Why this weight? Tap for the last two sessions.">
+                <i class="fas fa-arrow-trend-${isBump ? 'up' : 'down'}" aria-hidden="true"></i>
+                <span class="gt-progress-badge-text">${text}</span>
+            </button>
+            <div class="gt-progress-detail" id="${detailId}" hidden>
+                <ul class="gt-progress-history">${historyHTML}</ul>
+                <button type="button" class="gt-progress-uselast"
+                    data-action="use-last-weight"
+                    data-exercise-index="${exerciseIndex}" data-slot="${slot}"
+                    data-last-weight="${lastWeight}">
+                    <i class="fas fa-rotate-left" aria-hidden="true"></i> Use last weight (${lastWeight}${unit})
+                </button>
+            </div>
+        `;
+    }
+
+    /**
+     * Item 2: nudge the weight input by the exercise's overload increment.
+     * Floors at 0 and re-uses the row's own 'input' event path so the plate
+     * hint and the restore chip stay in sync.
+     */
+    stepWeight(exerciseIndex, slot, dir) {
+        const input = document.getElementById(`weight-${exerciseIndex}-${slot}`);
+        if (!input) return;
+        const exerciseId = this.currentWorkoutSession?.exercises[exerciseIndex]?.exerciseId;
+        const step = this._overloadIncrement(exerciseId, this.sessionUnit());
+        const current = input.value === '' ? 0 : Number(input.value);
+        const next = Math.max(0, Math.round((current + dir * step) * 100) / 100);
+        this._setPlannedInputValue(input, next);
+    }
+
+    /** Item 2: nudge the reps input by one, floored at 0. */
+    stepReps(exerciseIndex, slot, dir) {
+        const input = document.getElementById(`reps-${exerciseIndex}-${slot}`);
+        if (!input) return;
+        const current = input.value === '' ? 0 : Number(input.value);
+        this._setPlannedInputValue(input, Math.max(0, Math.round(current) + dir));
+    }
+
+    /**
+     * Write a stepper/restore value into a planned input WITHOUT focusing it
+     * (no mobile keyboard), then fire the same bubbling 'input' event a
+     * keystroke would so the delegated listener refreshes the plate hint and
+     * the restore chip.
+     */
+    _setPlannedInputValue(input, value) {
+        input.value = String(value);
+        if (this.app.settings?.vibrationAlerts !== false) vibrate(10);
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    /** Item 1: reveal/hide the two prior sessions behind a progression badge. */
+    toggleProgressionDetail(badge) {
+        const detail = document.getElementById(badge.getAttribute('aria-controls'));
+        if (!detail) return;
+        const open = detail.hidden;
+        detail.hidden = !open;
+        badge.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+
+    /**
+     * Item 1: drop the suggestion for this row - reset the weight input to the
+     * literal last-session weight and remove the badge (and its panel) in
+     * place, no re-render. The row's restore baseline moves with it so the
+     * "same as last time" chip stays truthful.
+     */
+    useLastWeight(exerciseIndex, slot) {
+        const input = document.getElementById(`weight-${exerciseIndex}-${slot}`);
+        const row = input?.closest('.set-row-planned');
+        if (!input || !row) return;
+        const detail = document.getElementById(`progression-detail-${exerciseIndex}-${slot}`);
+        const lastWeight = detail?.querySelector('.gt-progress-uselast')?.dataset.lastWeight;
+        if (lastWeight === undefined) return;
+        if (row.dataset.priorWeight !== undefined) row.dataset.priorWeight = lastWeight;
+        row.querySelector('.gt-progress-badge')?.remove();
+        detail.remove();
+        this._setPlannedInputValue(input, lastWeight);
     }
 
     /**
@@ -1596,6 +1842,129 @@ class WorkoutView {
     }
 
     /**
+     * Item 6: warm-up configuration, read fresh so a change in Settings applies
+     * on the next render without a reload. Missing/partial JSON falls back to
+     * the documented defaults.
+     */
+    _warmupSettings() {
+        return normalizeWarmupSettings(storageService.get(WARMUP_SETTINGS_KEY));
+    }
+
+    /**
+     * Snap a session-unit target to a weight the user's plates can actually
+     * make. The plate config is stored in ACCOUNT units, so round there and
+     * convert back. Without a plate config, fall back to the nearest 0.5.
+     */
+    _loadableWeight(sessionWeight) {
+        const settings = this.app.settings;
+        const bar = Number(settings?.barWeight);
+        const plates = Array.isArray(settings?.plates) ? settings.plates : [];
+        if (!Number.isFinite(bar) || plates.length === 0) {
+            return Math.round(Number(sessionWeight) * 2) / 2;
+        }
+        const account = this.toAccountWeight(Number(sessionWeight));
+        const result = calculatePlates(account, bar, plates);
+        return this.toSessionWeight(result.achievable);
+    }
+
+    /**
+     * Item 6: the collapsed warm-up ramp shown above set 1 for heavy barbell
+     * work. Warm-up rows are display-only: ticking one never creates a Set, so
+     * they cannot touch exercise completion, volume or PR checks.
+     */
+    renderWarmupStrip(exerciseIndex, { equipment, isDuration, unit, workingWeight }) {
+        const settings = this._warmupSettings();
+        if (!shouldShowWarmup({ settings, unit, equipment, isDuration, workingWeight })) return '';
+
+        const barWeight = this.toSessionWeight(Number(this.app.settings?.barWeight) || 0);
+        const ramp = buildWarmupRamp({
+            settings,
+            workingWeight,
+            barWeight,
+            roundWeight: (w) => this._loadableWeight(w),
+        });
+        if (ramp.length === 0) return '';
+
+        const expanded = !!this.warmupExpanded[exerciseIndex];
+        const doneCount = ramp.reduce(
+            (n, _row, i) => n + (this.warmupDone[`${exerciseIndex}:${i}`] ? 1 : 0), 0,
+        );
+
+        const rowsHTML = ramp.map((row, i) => {
+            const done = !!this.warmupDone[`${exerciseIndex}:${i}`];
+            const label = row.isBar ? 'Bar' : `${row.pct}%`;
+            return `
+                <li class="gt-warmup-row${done ? ' gt-warmup-row--done' : ''}">
+                    <span class="gt-warmup-pct">${label}</span>
+                    <span class="gt-warmup-load">${row.weight}${unit} × ${row.reps}</span>
+                    <button type="button" class="gt-warmup-done"
+                        data-action="toggle-warmup-set"
+                        data-exercise-index="${exerciseIndex}" data-warmup-index="${i}"
+                        aria-pressed="${done ? 'true' : 'false'}"
+                        aria-label="${done ? 'Undo' : 'Mark'} warm-up set ${label} done">
+                        <i class="fas fa-check" aria-hidden="true"></i><span>Done</span>
+                    </button>
+                </li>
+            `;
+        }).join('');
+
+        return `
+            <div class="gt-warmup${expanded ? ' gt-warmup--open' : ''}" id="warmup-${exerciseIndex}">
+                <button type="button" class="gt-warmup-toggle"
+                    data-action="toggle-warmup" data-exercise-index="${exerciseIndex}"
+                    aria-expanded="${expanded ? 'true' : 'false'}"
+                    aria-controls="warmup-list-${exerciseIndex}">
+                    <i class="fas fa-fire-flame-curved" aria-hidden="true"></i>
+                    <span class="gt-warmup-title">Warm-up</span>
+                    <span class="gt-warmup-count" id="warmup-count-${exerciseIndex}">${doneCount}/${ramp.length}</span>
+                    <i class="fas fa-chevron-${expanded ? 'up' : 'down'} gt-warmup-chevron" aria-hidden="true"></i>
+                </button>
+                <ol class="gt-warmup-list" id="warmup-list-${exerciseIndex}"${expanded ? '' : ' hidden'}>
+                    ${rowsHTML}
+                </ol>
+            </div>
+        `;
+    }
+
+    /** Item 6: expand/collapse the warm-up ramp for one exercise. */
+    toggleWarmup(exerciseIndex) {
+        const open = !this.warmupExpanded[exerciseIndex];
+        this.warmupExpanded[exerciseIndex] = open;
+        const strip = document.getElementById(`warmup-${exerciseIndex}`);
+        const list = document.getElementById(`warmup-list-${exerciseIndex}`);
+        if (!strip || !list) return;
+        strip.classList.toggle('gt-warmup--open', open);
+        list.hidden = !open;
+        const toggle = strip.querySelector('.gt-warmup-toggle');
+        toggle?.setAttribute('aria-expanded', open ? 'true' : 'false');
+        const chevron = strip.querySelector('.gt-warmup-chevron');
+        chevron?.classList.toggle('fa-chevron-up', open);
+        chevron?.classList.toggle('fa-chevron-down', !open);
+    }
+
+    /**
+     * Item 6: tick a warm-up ramp row off. State lives on the view only - no
+     * Set is created, so nothing here reaches the session's totals.
+     */
+    toggleWarmupSet(exerciseIndex, rampIndex) {
+        const key = `${exerciseIndex}:${rampIndex}`;
+        const done = !this.warmupDone[key];
+        this.warmupDone[key] = done;
+        if (this.app.settings?.vibrationAlerts !== false) vibrate(15);
+
+        const strip = document.getElementById(`warmup-${exerciseIndex}`);
+        if (!strip) return;
+        const btn = strip.querySelector(`.gt-warmup-done[data-warmup-index="${rampIndex}"]`);
+        btn?.setAttribute('aria-pressed', done ? 'true' : 'false');
+        btn?.closest('.gt-warmup-row')?.classList.toggle('gt-warmup-row--done', done);
+
+        const rows = strip.querySelectorAll('.gt-warmup-row');
+        const doneCount = strip.querySelectorAll('.gt-warmup-row--done').length;
+        const count = document.getElementById(`warmup-count-${exerciseIndex}`);
+        if (count) count.textContent = `${doneCount}/${rows.length}`;
+    }
+
+    /**
      * Shared pill-toggle markup used for both the "not yet completed" state
      * (knob-left, muted pill) and the "completed" state (knob-right, green
      * gradient pill with a crisp check inside the knob). CSS drives the
@@ -1830,6 +2199,123 @@ class WorkoutView {
         if (fresh && host.parentNode) host.parentNode.replaceChild(fresh, host);
     }
 
+    /**
+     * Item 3: open the in-workout exercise picker for one slot of the CURRENT
+     * session. Pre-filtered to the original exercise's category, which is where
+     * a like-for-like substitute (busy rack, tweaked shoulder) will be.
+     */
+    openSwapPicker(exerciseIndex) {
+        const exercise = this.currentWorkoutSession?.exercises[exerciseIndex];
+        const modal = document.getElementById('swap-exercise-modal');
+        if (!exercise || !modal) return;
+
+        this.swapTargetIndex = exerciseIndex;
+        const current = this.app.getExerciseById(exercise.exerciseId);
+
+        const currentEl = document.getElementById('swap-exercise-current');
+        if (currentEl) currentEl.textContent = exercise.exerciseName;
+
+        const search = document.getElementById('swap-exercise-search');
+        const category = document.getElementById('swap-exercise-category-filter');
+        const equipment = document.getElementById('swap-exercise-equipment-filter');
+        if (search) search.value = '';
+        if (category) category.value = current?.category || '';
+        if (equipment) equipment.value = '';
+
+        if (!modal.dataset.wired) {
+            const rerender = () => this.renderSwapPicker();
+            search?.addEventListener('input', rerender);
+            category?.addEventListener('change', rerender);
+            equipment?.addEventListener('change', rerender);
+            modal.dataset.wired = '1';
+        }
+
+        this.renderSwapPicker();
+        modal.classList.add('active');
+        trapModalFocus(modal);
+    }
+
+    /** Item 3: render the swap picker list from the current search/filters. */
+    renderSwapPicker() {
+        const container = document.getElementById('swap-exercise-list');
+        if (!container) return;
+        const searchTerm = (document.getElementById('swap-exercise-search')?.value || '').toLowerCase();
+        const category = document.getElementById('swap-exercise-category-filter')?.value || '';
+        const equipment = document.getElementById('swap-exercise-equipment-filter')?.value || '';
+        const currentId = this.currentWorkoutSession?.exercises[this.swapTargetIndex]?.exerciseId;
+
+        const exercises = this.app.exerciseDatabase.filter(ex => {
+            if (sameId(ex.id, currentId)) return false;
+            if (searchTerm && !ex.name.toLowerCase().includes(searchTerm)
+                && !ex.muscleGroup.toLowerCase().includes(searchTerm)) return false;
+            if (category && ex.category !== category) return false;
+            if (equipment && ex.equipment !== equipment) return false;
+            return true;
+        });
+
+        if (exercises.length === 0) {
+            container.innerHTML = '<div class="empty-state"><p>No exercises found</p></div>';
+            return;
+        }
+
+        container.innerHTML = exercises.map(exercise => `
+            <div class="exercise-picker-card" role="button" tabindex="0"
+                 data-action="pick-swap-exercise" data-exercise-id="${escapeHtml(String(exercise.id))}">
+                <h4>${escapeHtml(exercise.name)}</h4>
+                <div class="exercise-meta">
+                    <span class="badge">${escapeHtml(exercise.category)}</span>
+                    <span class="badge">${escapeHtml(exercise.equipment)}</span>
+                </div>
+                <p>${escapeHtml(exercise.muscleGroup)}</p>
+            </div>
+        `).join('');
+    }
+
+    /**
+     * Item 3: replace the exercise in THIS session only. The saved Program is
+     * never touched - the swap lives on currentWorkoutSession.exercises[i], so
+     * history shows the substitute and its sets count toward the substitute's
+     * own PRs (the session PR map is recomputed against the new exercise id).
+     */
+    async pickSwapExercise(exerciseId) {
+        const index = this.swapTargetIndex;
+        const exercise = this.currentWorkoutSession?.exercises[index];
+        const replacement = this.app.exerciseDatabase.find(e => sameId(e.id, exerciseId));
+        if (!exercise || !replacement) return;
+
+        const loggedSets = exercise.sets.length;
+        if (loggedSets > 0) {
+            const confirmed = await showConfirmModal({
+                title: 'Swap exercise?',
+                message: `${loggedSets} logged set${loggedSets === 1 ? '' : 's'} will move under ${replacement.name}.`,
+                warning: 'Your saved program is not changed - this swap applies to this workout only.',
+                confirmText: 'Swap',
+                isDangerous: false,
+            });
+            if (!confirmed) return;
+        }
+
+        exercise.exerciseId = replacement.id;
+        exercise.exerciseName = replacement.name;
+        // Sticky values are the OLD exercise's numbers; they would prefill the
+        // substitute with weights that never belonged to it.
+        exercise.stickyValues = {};
+        // Same for the warm-up ramp: it was sized off the old lift.
+        this.warmupExpanded[index] = false;
+        Object.keys(this.warmupDone)
+            .filter(key => key.startsWith(`${index}:`))
+            .forEach(key => delete this.warmupDone[key]);
+
+        document.getElementById('swap-exercise-modal')?.classList.remove('active');
+        this.swapTargetIndex = null;
+
+        // PR badges were resolved against the old exercise's history.
+        this.rebuildSessionPrSlots();
+        storageService.saveActiveWorkout(this.currentWorkoutSession.toJSON());
+        this.renderActiveWorkout();
+        showToast(`Swapped to ${replacement.name}`, 'success');
+    }
+
     getPreviousExerciseData(exerciseId) {
         // Sort by full timestamp (not just calendar date) so that two workouts
         // on the same day order by time-of-day — a 6 PM session supersedes a
@@ -1853,51 +2339,72 @@ class WorkoutView {
 
         if (recentSessions.length === 0) return null;
 
-        const { exercise: lastExercise, completedSets: lastSets } = recentSessions[0];
+        const { session: lastSession, exercise: lastExercise, completedSets: lastSets } = recentSessions[0];
+        const prev = recentSessions[1] || null;
 
-        // Feature 6+8: detect progressive overload opportunity.
-        // If the lifter hit all target reps at a given weight in BOTH of the
-        // last two sessions, suggest (and auto-apply) an increment.
-        let suggestIncrement = false;
-        let increment = 0;
-        let previousWeight = 0;
+        // Item 1: the prefill is a coaching decision (bump / repeat / deload),
+        // resolved against each set's OWN rep target so per-set rep ranges are
+        // honored. The row renders a badge for whichever branch fired.
+        const unit = this.app.settings.weightUnit;
+        const increment = this._overloadIncrement(exerciseId, unit);
+        const targetRepsForSet = (set, arrIdx) =>
+            this._targetRepsForPriorSet(exerciseId, set, arrIdx, lastExercise.targetReps);
+        const progression = evaluateProgression({
+            lastSets,
+            prevSets: prev ? prev.completedSets : null,
+            targetRepsForSet,
+            increment,
+        });
 
-        if (recentSessions.length === 2) {
-            const { completedSets: prevSets } = recentSessions[1];
-            const targetReps = lastExercise.targetReps || 0;
-
-            // "All target reps" = every completed set hit at least targetReps.
-            const allHit = (sets) =>
-                sets.length > 0 &&
-                sets.every(s => (s.reps || 0) >= targetReps && targetReps > 0);
-
-            if (allHit(lastSets) && allHit(prevSets)) {
-                const lastWeight = lastSets[0]?.weight || 0;
-                const prevWeight = prevSets[0]?.weight || 0;
-                // Only suggest if both sessions used the same weight (no jump
-                // already happened between them).
-                if (lastWeight > 0 && lastWeight === prevWeight) {
-                    suggestIncrement = true;
-                    previousWeight = lastWeight;
-                    const unit = this.app.settings.weightUnit;
-                    increment = this._overloadIncrement(exerciseId, unit);
-                }
-            }
-        }
+        const usesSuggested = progression.status === PROGRESSION_BUMP
+            || progression.status === PROGRESSION_DELOAD;
 
         const sets = lastSets.map(set => ({
-            weight: suggestIncrement ? previousWeight + increment : set.weight,
+            weight: usesSuggested ? progression.suggestedWeight : set.weight,
             reps: set.reps,
             duration: set.duration,
             // Pass original weight so the chip can show "auto-bumped from Xkg"
             originalWeight: set.weight,
         }));
 
-        sets.suggestIncrement = suggestIncrement;
+        sets.suggestIncrement = progression.status === PROGRESSION_BUMP;
         sets.increment = increment;
-        sets.previousWeight = previousWeight;
+        sets.previousWeight = progression.lastWeight;
+        // Everything the planned row needs to explain itself: the branch that
+        // fired, the literal last-session weight to fall back to, and the two
+        // prior sessions for the tap-to-reveal panel.
+        sets.progression = {
+            ...progression,
+            history: [
+                this._progressionHistoryEntry(lastSession, lastSets),
+                prev ? this._progressionHistoryEntry(prev.session, prev.completedSets) : null,
+            ].filter(Boolean),
+        };
 
         return sets;
+    }
+
+    /**
+     * Rep target for a set logged in a PRIOR session: the current program's
+     * rep range for that slot, falling back to the exercise-level targetReps
+     * carried on the historical entry.
+     */
+    _targetRepsForPriorSet(exerciseId, set, arrIdx, fallbackTargetReps) {
+        const program = this.app.getProgramById(this.currentWorkoutSession?.programId);
+        const progEx = program?.exercises.find(e => sameId(e.exerciseId, exerciseId));
+        const progSets = (progEx?.sets && progEx.sets.length > 0) ? progEx.sets : null;
+        const slot = set.slot != null ? set.slot : arrIdx;
+        if (progSets && slot < progSets.length) return progSets[slot].repsMax;
+        return fallbackTargetReps || 0;
+    }
+
+    /** One row of the tap-to-reveal progression panel: "Jul 3 - 60kg x 8, 8, 7". */
+    _progressionHistoryEntry(session, sets) {
+        return {
+            date: session.date,
+            weight: sets[0]?.weight || 0,
+            reps: sets.map(s => s.reps || 0),
+        };
     }
 
     /**

--- a/apps/gym-tracker/sw.js
+++ b/apps/gym-tracker/sw.js
@@ -16,7 +16,7 @@
  * Old caches are pruned automatically on activate.
  */
 
-const CACHE_VERSION = '1.7.4';
+const CACHE_VERSION = '1.7.6';
 const PRECACHE = `gym-precache-${CACHE_VERSION}`;
 const RUNTIME = `gym-runtime-${CACHE_VERSION}`;
 
@@ -49,6 +49,8 @@ const PRECACHE_URLS = [
   './js/utils/modal-focus.js',
   './js/utils/plate-calculator.js',
   './js/utils/pr-session.js',
+  './js/utils/progression.js',
+  './js/utils/warmup.js',
   './js/utils/program-order.js',
   './js/utils/program-schedule.js',
   './js/utils/rest-cues.js',

--- a/apps/gym-tracker/tests/insights-stale-categories.test.mjs
+++ b/apps/gym-tracker/tests/insights-stale-categories.test.mjs
@@ -1,0 +1,140 @@
+process.env.TZ = 'UTC';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AnalyticsService } from '../js/services/AnalyticsService.js';
+
+const TODAY = new Date(2026, 3, 30); // 2026-04-30, local midnight
+
+const session = (date, exercises) => ({
+    id: date,
+    date,
+    timestamp: `${date}T12:00:00.000Z`,
+    workoutDayName: 'Day',
+    exercises: exercises.map(e => ({
+        exerciseId: e.exerciseId,
+        exerciseName: 'X',
+        sets: e.sets,
+    })),
+});
+
+const program = (exerciseIds) => ({
+    id: 1,
+    name: 'P',
+    exercises: exerciseIds.map(id => ({ exerciseId: id, exerciseName: 'X' })),
+});
+
+const db = [
+    { id: 1, category: 'chest' },
+    { id: 2, category: 'back' },
+    { id: 3, category: 'quads' },
+];
+
+test('getLastTrainedByCategory: keeps the most recent date per category', () => {
+    const sessions = [
+        session('2026-04-01', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }]),
+        session('2026-04-20', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }]),
+        session('2026-04-10', [{ exerciseId: 2, sets: [{ weight: 80, reps: 5 }] }]),
+    ];
+    const map = AnalyticsService.getLastTrainedByCategory(sessions, db);
+    assert.equal(map.get('chest'), '2026-04-20');
+    assert.equal(map.get('back'), '2026-04-10');
+    assert.equal(map.has('quads'), false);
+});
+
+test('getLastTrainedByCategory: zero-volume sets do not count as trained', () => {
+    const sessions = [session('2026-04-20', [
+        { exerciseId: 1, sets: [{ weight: 0, reps: 0 }] },
+    ])];
+    const map = AnalyticsService.getLastTrainedByCategory(sessions, db);
+    assert.equal(map.size, 0);
+});
+
+test('getStaleProgramCategories: lists a programmed category with no volume in the window', () => {
+    const sessions = [
+        session('2026-04-29', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }]),
+        session('2026-04-05', [{ exerciseId: 2, sets: [{ weight: 80, reps: 5 }] }]),
+    ];
+    const out = AnalyticsService.getStaleProgramCategories(
+        [program([1, 2])], sessions, db, { today: TODAY },
+    );
+    assert.deepEqual(out, [{ category: 'back', lastDate: '2026-04-05', daysSince: 25 }]);
+});
+
+test('getStaleProgramCategories: a never-trained programmed category reports null', () => {
+    const sessions = [session('2026-04-29', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }])];
+    const out = AnalyticsService.getStaleProgramCategories(
+        [program([1, 3])], sessions, db, { today: TODAY },
+    );
+    assert.deepEqual(out, [{ category: 'quads', lastDate: null, daysSince: null }]);
+});
+
+test('getStaleProgramCategories: categories absent from every program are never listed', () => {
+    // 'back' has not been trained in months, but nothing programs it.
+    const sessions = [
+        session('2026-01-02', [{ exerciseId: 2, sets: [{ weight: 80, reps: 5 }] }]),
+        session('2026-04-29', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }]),
+    ];
+    const out = AnalyticsService.getStaleProgramCategories(
+        [program([1])], sessions, db, { today: TODAY },
+    );
+    assert.deepEqual(out, []);
+});
+
+test('getStaleProgramCategories: training a category inside the window clears it', () => {
+    const stale = AnalyticsService.getStaleProgramCategories(
+        [program([1])],
+        [session('2026-04-01', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }])],
+        db, { today: TODAY },
+    );
+    assert.equal(stale.length, 1);
+
+    const cleared = AnalyticsService.getStaleProgramCategories(
+        [program([1])],
+        [
+            session('2026-04-01', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }]),
+            session('2026-04-28', [{ exerciseId: 1, sets: [{ weight: 60, reps: 1 }] }]),
+        ],
+        db, { today: TODAY },
+    );
+    assert.deepEqual(cleared, []);
+});
+
+test('getStaleProgramCategories: the window boundary day still counts as recent', () => {
+    const onBoundary = AnalyticsService.getStaleProgramCategories(
+        [program([1])],
+        [session('2026-04-16', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }])],
+        db, { today: TODAY }, // 14 days back = 2026-04-16
+    );
+    assert.deepEqual(onBoundary, []);
+
+    const dayBefore = AnalyticsService.getStaleProgramCategories(
+        [program([1])],
+        [session('2026-04-15', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }])],
+        db, { today: TODAY },
+    );
+    assert.deepEqual(dayBefore, [{ category: 'chest', lastDate: '2026-04-15', daysSince: 15 }]);
+});
+
+test('getStaleProgramCategories: no programs means nothing to report', () => {
+    const sessions = [session('2026-01-02', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }])];
+    assert.deepEqual(AnalyticsService.getStaleProgramCategories([], sessions, db, { today: TODAY }), []);
+});
+
+test('getStaleProgramCategories: never-trained sorts above longest-neglected', () => {
+    const sessions = [
+        session('2026-04-05', [{ exerciseId: 2, sets: [{ weight: 80, reps: 5 }] }]),
+        session('2026-04-10', [{ exerciseId: 1, sets: [{ weight: 100, reps: 5 }] }]),
+    ];
+    const out = AnalyticsService.getStaleProgramCategories(
+        [program([1, 2, 3])], sessions, db, { today: TODAY },
+    );
+    assert.deepEqual(out.map(r => r.category), ['quads', 'back', 'chest']);
+});
+
+test('getStaleProgramCategories: a programmed exercise missing from the catalog buckets into other', () => {
+    const out = AnalyticsService.getStaleProgramCategories(
+        [program([9999])], [], db, { today: TODAY },
+    );
+    assert.deepEqual(out, [{ category: 'other', lastDate: null, daysSince: null }]);
+});

--- a/apps/gym-tracker/tests/measurement-goal-progress.test.mjs
+++ b/apps/gym-tracker/tests/measurement-goal-progress.test.mjs
@@ -1,0 +1,60 @@
+// Item 7: measurement goal progress. The bar runs from the earliest logged
+// value (baseline) toward the target, so direction handling and clamping are
+// what keep a tile from claiming progress it has not made.
+process.env.TZ = 'UTC';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeGoalProgress } from '../js/utils/helpers.js';
+
+const decrease = (target) => ({ target, direction: 'decrease' });
+const increase = (target) => ({ target, direction: 'increase' });
+
+test('computeGoalProgress: a decrease goal fills as the value drops toward target', () => {
+    // 100 kg baseline, 75 kg target, now 83 kg → 17 of 25 kg travelled.
+    assert.equal(computeGoalProgress(100, 83, decrease(75)), 68);
+    assert.equal(computeGoalProgress(100, 100, decrease(75)), 0);
+    assert.equal(computeGoalProgress(100, 75, decrease(75)), 100);
+});
+
+test('computeGoalProgress: an increase goal fills as the value rises toward target', () => {
+    // 36 cm baseline arm, 40 cm target, now 38 cm → halfway.
+    assert.equal(computeGoalProgress(36, 38, increase(40)), 50);
+    assert.equal(computeGoalProgress(36, 36, increase(40)), 0);
+    assert.equal(computeGoalProgress(36, 40, increase(40)), 100);
+});
+
+test('computeGoalProgress: overshooting the target clamps at 100, not beyond', () => {
+    assert.equal(computeGoalProgress(100, 70, decrease(75)), 100);
+    assert.equal(computeGoalProgress(36, 44, increase(40)), 100);
+});
+
+test('computeGoalProgress: moving the wrong way clamps at 0 instead of going negative', () => {
+    assert.equal(computeGoalProgress(100, 110, decrease(75)), 0);
+    assert.equal(computeGoalProgress(36, 34, increase(40)), 0);
+});
+
+test('computeGoalProgress: a baseline already past the target reads as met or not met', () => {
+    // No span to travel: the only honest answers are 100 or 0.
+    assert.equal(computeGoalProgress(70, 70, decrease(75)), 100);
+    assert.equal(computeGoalProgress(70, 80, decrease(75)), 0);
+    assert.equal(computeGoalProgress(42, 42, increase(40)), 100);
+    assert.equal(computeGoalProgress(42, 38, increase(40)), 0);
+});
+
+test('computeGoalProgress: percent is a rounded integer for the "% to goal" label', () => {
+    // 1 of 3 kg travelled = 33.33%.
+    assert.equal(computeGoalProgress(80, 79, decrease(77)), 33);
+});
+
+test('computeGoalProgress: missing or junk inputs return null so no bar renders', () => {
+    assert.equal(computeGoalProgress(null, 80, decrease(75)), null);
+    assert.equal(computeGoalProgress(undefined, 80, decrease(75)), null);
+    assert.equal(computeGoalProgress(100, undefined, decrease(75)), null);
+    assert.equal(computeGoalProgress(100, 80, { direction: 'decrease' }), null);
+    assert.equal(computeGoalProgress(100, 80, { target: 'soon', direction: 'decrease' }), null);
+});
+
+test('computeGoalProgress: direction defaults to increase when unspecified', () => {
+    assert.equal(computeGoalProgress(36, 38, { target: 40 }), 50);
+});

--- a/apps/gym-tracker/tests/progression.test.mjs
+++ b/apps/gym-tracker/tests/progression.test.mjs
@@ -1,0 +1,160 @@
+// Item 1: the prefilled weight on a planned row is a coaching decision the
+// lifter must be able to see and override. These tests pin WHICH branch fires
+// (bump / repeat / deload / none), because a silent bump after a failed
+// session is the bug this feature exists to prevent.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+    evaluateProgression,
+    setsHitTarget,
+    deloadWeight,
+    PROGRESSION_BUMP,
+    PROGRESSION_REPEAT,
+    PROGRESSION_DELOAD,
+    PROGRESSION_NONE,
+} = await import('../js/utils/progression.js');
+
+// Every set targets the same reps unless a per-slot map is supplied.
+const flatTarget = (reps) => () => reps;
+// Per-slot targets: sets[] rep ranges differ row by row (Item 1c).
+const slotTarget = (targets) => (set, i) => targets[set.slot != null ? set.slot : i];
+
+const set = (weight, reps, slot) => ({ weight, reps, slot });
+
+// ---------------------------------------------------------------------------
+// setsHitTarget
+// ---------------------------------------------------------------------------
+
+test('setsHitTarget: every set at or above target counts as a hit', () => {
+    const sets = [set(100, 8, 0), set(100, 9, 1), set(100, 8, 2)];
+    assert.equal(setsHitTarget(sets, flatTarget(8)), true);
+});
+
+test('setsHitTarget: one short set is a miss', () => {
+    const sets = [set(100, 8, 0), set(100, 8, 1), set(100, 7, 2)];
+    assert.equal(setsHitTarget(sets, flatTarget(8)), false);
+});
+
+test('setsHitTarget: per-set rep ranges are evaluated against their OWN target', () => {
+    // Set 3 is programmed for 6 reps, so 6 is a hit even though sets 1-2 want 10.
+    const sets = [set(100, 10, 0), set(100, 10, 1), set(100, 6, 2)];
+    assert.equal(setsHitTarget(sets, slotTarget([10, 10, 6])), true,
+        'set 3 hit its own repsMax');
+    assert.equal(setsHitTarget(sets, flatTarget(10)), false,
+        'the exercise-level fallback would have called it a miss');
+});
+
+test('setsHitTarget: no target reps means no evidence of a hit', () => {
+    assert.equal(setsHitTarget([set(100, 12, 0)], flatTarget(0)), false);
+});
+
+test('setsHitTarget: an empty session is not a hit', () => {
+    assert.equal(setsHitTarget([], flatTarget(8)), false);
+});
+
+// ---------------------------------------------------------------------------
+// deloadWeight
+// ---------------------------------------------------------------------------
+
+test('deloadWeight: takes the largest equipment step inside the 5-10% band', () => {
+    assert.equal(deloadWeight(100, 2.5), 90, '10% is reachable exactly');
+    assert.equal(deloadWeight(225, 5), 205, '20lb off 225 is 8.9%, 25 would be 11%');
+});
+
+test('deloadWeight: falls back to a single step when 10% is under one increment', () => {
+    // 10% of 20kg is 2kg, smaller than the 2.5kg step the plates can make.
+    assert.equal(deloadWeight(20, 2.5), 17.5);
+});
+
+test('deloadWeight: never returns a non-positive weight', () => {
+    assert.equal(deloadWeight(2.5, 2.5), 0);
+    assert.equal(deloadWeight(0, 2.5), 0);
+});
+
+// ---------------------------------------------------------------------------
+// evaluateProgression
+// ---------------------------------------------------------------------------
+
+test('evaluateProgression: two clean sessions at the same weight suggest a bump', () => {
+    const last = [set(100, 8, 0), set(100, 8, 1)];
+    const prev = [set(100, 8, 0), set(100, 8, 1)];
+    const out = evaluateProgression({
+        lastSets: last, prevSets: prev, targetRepsForSet: flatTarget(8), increment: 2.5,
+    });
+    assert.equal(out.status, PROGRESSION_BUMP);
+    assert.equal(out.suggestedWeight, 102.5);
+    assert.equal(out.lastWeight, 100, 'the literal last weight is preserved for "use last weight"');
+});
+
+test('evaluateProgression: a weight jump between the two sessions blocks the bump', () => {
+    const out = evaluateProgression({
+        lastSets: [set(100, 8, 0)],
+        prevSets: [set(95, 8, 0)],
+        targetRepsForSet: flatTarget(8),
+        increment: 2.5,
+    });
+    assert.equal(out.status, PROGRESSION_NONE);
+    assert.equal(out.suggestedWeight, 100, 'prefill stays at the last weight');
+});
+
+test('evaluateProgression: only one session of history never bumps', () => {
+    const out = evaluateProgression({
+        lastSets: [set(100, 8, 0)], prevSets: null, targetRepsForSet: flatTarget(8), increment: 2.5,
+    });
+    assert.equal(out.status, PROGRESSION_NONE);
+});
+
+test('evaluateProgression: a missed set last session repeats the weight', () => {
+    const out = evaluateProgression({
+        lastSets: [set(100, 8, 0), set(100, 6, 1)],
+        prevSets: [set(100, 8, 0), set(100, 8, 1)],
+        targetRepsForSet: flatTarget(8),
+        increment: 2.5,
+    });
+    assert.equal(out.status, PROGRESSION_REPEAT);
+    assert.equal(out.suggestedWeight, 100, 'no bump after a miss');
+    assert.equal(out.delta, 0);
+});
+
+test('evaluateProgression: two missed sessions at the same weight suggest a deload', () => {
+    const out = evaluateProgression({
+        lastSets: [set(100, 6, 0)],
+        prevSets: [set(100, 7, 0)],
+        targetRepsForSet: flatTarget(8),
+        increment: 2.5,
+    });
+    assert.equal(out.status, PROGRESSION_DELOAD);
+    assert.equal(out.suggestedWeight, 90);
+    assert.ok(out.delta < 0, 'the badge renders a negative delta');
+});
+
+test('evaluateProgression: two misses at DIFFERENT weights only repeat', () => {
+    const out = evaluateProgression({
+        lastSets: [set(100, 6, 0)],
+        prevSets: [set(95, 6, 0)],
+        targetRepsForSet: flatTarget(8),
+        increment: 2.5,
+    });
+    assert.equal(out.status, PROGRESSION_REPEAT);
+});
+
+test('evaluateProgression: per-set rep ranges decide bump vs repeat', () => {
+    // Programmed 10/10/6. A 6-rep third set IS the target, so this is a bump,
+    // not a miss.
+    const sets = () => [set(60, 10, 0), set(60, 10, 1), set(60, 6, 2)];
+    const out = evaluateProgression({
+        lastSets: sets(), prevSets: sets(), targetRepsForSet: slotTarget([10, 10, 6]), increment: 2.5,
+    });
+    assert.equal(out.status, PROGRESSION_BUMP);
+    assert.equal(out.suggestedWeight, 62.5);
+});
+
+test('evaluateProgression: no history at all is a no-op', () => {
+    const out = evaluateProgression({
+        lastSets: [], prevSets: null, targetRepsForSet: flatTarget(8), increment: 2.5,
+    });
+    assert.equal(out.status, PROGRESSION_NONE);
+    assert.equal(out.suggestedWeight, 0);
+});

--- a/apps/gym-tracker/tests/sets-csv-export.test.mjs
+++ b/apps/gym-tracker/tests/sets-csv-export.test.mjs
@@ -1,0 +1,114 @@
+// Item 8: per-set CSV export. The flattening rules are what the user's
+// spreadsheet sees, so they are asserted on realistic session shapes.
+process.env.TZ = 'UTC';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSetsCsv, escapeCsvField, SETS_CSV_HEADER } from '../js/utils/helpers.js';
+
+const session = (overrides = {}) => ({
+    date: '2026-04-24',
+    workoutDayName: 'Push',
+    exercises: [],
+    ...overrides,
+});
+
+test('buildSetsCsv: header row matches the documented column order', () => {
+    const { csv, rowCount } = buildSetsCsv([], 'kg');
+    assert.equal(csv, 'date,program,exercise,setNumber,weight,reps,duration,volume,unit');
+    assert.equal(csv, SETS_CSV_HEADER.join(','));
+    assert.equal(rowCount, 0);
+});
+
+test('buildSetsCsv: zero workouts yields header only, so the caller can toast instead of downloading', () => {
+    assert.equal(buildSetsCsv(null, 'kg').rowCount, 0);
+    assert.equal(buildSetsCsv([session()], 'kg').rowCount, 0);
+});
+
+test('buildSetsCsv: one row per COMPLETED set, incomplete sets are skipped', () => {
+    const { csv, rowCount } = buildSetsCsv([session({
+        exercises: [{
+            exerciseName: 'Bench Press',
+            sets: [
+                { weight: 60, reps: 10, duration: 0, completed: true, slot: 0 },
+                { weight: 70, reps: 8, duration: 0, completed: true, slot: 1 },
+                { weight: 80, reps: 0, duration: 0, completed: false, slot: 2 },
+            ],
+        }],
+    })], 'kg');
+
+    const lines = csv.split('\r\n');
+    assert.equal(rowCount, 2);
+    assert.equal(lines.length, 3);
+    assert.equal(lines[1], '2026-04-24,Push,Bench Press,1,60,10,,600,kg');
+    assert.equal(lines[2], '2026-04-24,Push,Bench Press,2,70,8,,560,kg');
+});
+
+test('buildSetsCsv: timed sets report seconds and leave weight/reps empty', () => {
+    const { csv } = buildSetsCsv([session({
+        workoutDayName: 'Conditioning',
+        exercises: [{
+            exerciseName: 'Plank',
+            sets: [{ weight: 0, reps: 0, duration: 45, completed: true, slot: 0 }],
+        }],
+    })], 'kg');
+
+    assert.equal(csv.split('\r\n')[1], '2026-04-24,Conditioning,Plank,1,,,45,45,kg');
+});
+
+test('buildSetsCsv: setNumber follows the stable slot, falling back to position on legacy sets', () => {
+    const { csv } = buildSetsCsv([session({
+        exercises: [{
+            exerciseName: 'Squat',
+            sets: [
+                // Legacy set without a slot: numbered by position.
+                { weight: 100, reps: 5, completed: true },
+                // Slot 3 survived an un-checked set above it in the UI.
+                { weight: 110, reps: 3, completed: true, slot: 3 },
+            ],
+        }],
+    })], 'kg');
+
+    const lines = csv.split('\r\n');
+    assert.match(lines[1], /,Squat,1,100,5,/);
+    assert.match(lines[2], /,Squat,4,110,3,/);
+});
+
+test('buildSetsCsv: the session unit wins over the account unit', () => {
+    const { csv } = buildSetsCsv([session({
+        sessionUnit: 'lb',
+        exercises: [{
+            exerciseName: 'Deadlift',
+            sets: [{ weight: 225, reps: 5, completed: true, slot: 0 }],
+        }],
+    })], 'kg');
+
+    assert.ok(csv.split('\r\n')[1].endsWith(',lb'));
+});
+
+test('buildSetsCsv: fields with commas / quotes are escaped per RFC 4180', () => {
+    const { csv } = buildSetsCsv([session({
+        workoutDayName: 'Push, Pull',
+        exercises: [{
+            exerciseName: 'Farmer\'s "Heavy" Carry',
+            sets: [{ weight: 40, reps: 12, completed: true, slot: 0 }],
+        }],
+    })], 'kg');
+
+    assert.equal(
+        csv.split('\r\n')[1],
+        '2026-04-24,"Push, Pull","Farmer\'s ""Heavy"" Carry",1,40,12,,480,kg'
+    );
+});
+
+test('escapeCsvField: quotes only when the field needs it', () => {
+    assert.equal(escapeCsvField('Bench Press'), 'Bench Press');
+    assert.equal(escapeCsvField(12), '12');
+    assert.equal(escapeCsvField(''), '');
+    assert.equal(escapeCsvField(null), '');
+    assert.equal(escapeCsvField(undefined), '');
+    assert.equal(escapeCsvField('a,b'), '"a,b"');
+    assert.equal(escapeCsvField('say "hi"'), '"say ""hi"""');
+    assert.equal(escapeCsvField('line1\nline2'), '"line1\nline2"');
+    assert.equal(escapeCsvField('line1\r\nline2'), '"line1\r\nline2"');
+});

--- a/apps/gym-tracker/tests/warmup.test.mjs
+++ b/apps/gym-tracker/tests/warmup.test.mjs
@@ -1,0 +1,152 @@
+// Item 6: the warm-up ramp is a coaching aid, never a logged set. These tests
+// pin the config contract (exact defaults for absent/partial JSON), the
+// gating rules (barbell only, threshold, disabled), and the ramp math.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+    WARMUP_DEFAULTS,
+    normalizeWarmupSettings,
+    warmupThreshold,
+    shouldShowWarmup,
+    buildWarmupRamp,
+} = await import('../js/utils/warmup.js');
+
+// ---------------------------------------------------------------------------
+// normalizeWarmupSettings
+// ---------------------------------------------------------------------------
+
+test('normalizeWarmupSettings: absent key yields exactly the documented defaults', () => {
+    const s = normalizeWarmupSettings(null);
+    assert.equal(s.enabled, true);
+    assert.equal(s.thresholdKg, 40);
+    assert.equal(s.thresholdLb, 90);
+    assert.deepEqual(s.ramp, [{ pct: 0, reps: 8 }, { pct: 50, reps: 5 }, { pct: 75, reps: 3 }]);
+});
+
+test('normalizeWarmupSettings: parses the raw localStorage string', () => {
+    const s = normalizeWarmupSettings('{"thresholdKg":60}');
+    assert.equal(s.thresholdKg, 60);
+    assert.equal(s.thresholdLb, 90, 'untouched fields keep the default');
+});
+
+test('normalizeWarmupSettings: partial objects fall back field by field', () => {
+    const s = normalizeWarmupSettings({ ramp: [{ pct: 60, reps: 4 }] });
+    assert.equal(s.enabled, true);
+    assert.equal(s.thresholdKg, 40);
+    assert.deepEqual(s.ramp, [{ pct: 60, reps: 4 }]);
+});
+
+test('normalizeWarmupSettings: garbage JSON does not disable warm-ups', () => {
+    const s = normalizeWarmupSettings('{not json');
+    assert.deepEqual(s.ramp, WARMUP_DEFAULTS.ramp.map(r => ({ ...r })));
+    assert.equal(s.enabled, true);
+});
+
+test('normalizeWarmupSettings: enabled:false is honored', () => {
+    assert.equal(normalizeWarmupSettings({ enabled: false }).enabled, false);
+});
+
+test('normalizeWarmupSettings: invalid ramp rows are dropped, empty ramp falls back', () => {
+    const s = normalizeWarmupSettings({ ramp: [{ pct: 50, reps: 5 }, { pct: 'x', reps: 3 }, { pct: 75, reps: 0 }] });
+    assert.deepEqual(s.ramp, [{ pct: 50, reps: 5 }]);
+    const empty = normalizeWarmupSettings({ ramp: [{ reps: 0 }] });
+    assert.equal(empty.ramp.length, 3, 'nothing usable -> documented default ramp');
+});
+
+test('warmupThreshold: follows the display unit', () => {
+    const s = normalizeWarmupSettings(null);
+    assert.equal(warmupThreshold(s, 'kg'), 40);
+    assert.equal(warmupThreshold(s, 'lb'), 90);
+});
+
+// ---------------------------------------------------------------------------
+// shouldShowWarmup
+// ---------------------------------------------------------------------------
+
+const base = { settings: normalizeWarmupSettings(null), unit: 'kg', equipment: 'barbell', isDuration: false, workingWeight: 100 };
+
+test('shouldShowWarmup: heavy barbell work qualifies', () => {
+    assert.equal(shouldShowWarmup(base), true);
+    assert.equal(shouldShowWarmup({ ...base, equipment: 'trap-bar' }), true);
+});
+
+test('shouldShowWarmup: non-barbell equipment never ramps', () => {
+    assert.equal(shouldShowWarmup({ ...base, equipment: 'dumbbell' }), false);
+    assert.equal(shouldShowWarmup({ ...base, equipment: 'machine' }), false);
+});
+
+test('shouldShowWarmup: duration exercises never ramp', () => {
+    assert.equal(shouldShowWarmup({ ...base, isDuration: true }), false);
+});
+
+test('shouldShowWarmup: below the threshold there is nothing to warm up for', () => {
+    assert.equal(shouldShowWarmup({ ...base, workingWeight: 39.5 }), false);
+    assert.equal(shouldShowWarmup({ ...base, workingWeight: 40 }), true, 'at the threshold counts');
+});
+
+test('shouldShowWarmup: the lb threshold applies in an lb session', () => {
+    assert.equal(shouldShowWarmup({ ...base, unit: 'lb', workingWeight: 85 }), false);
+    assert.equal(shouldShowWarmup({ ...base, unit: 'lb', workingWeight: 95 }), true);
+});
+
+test('shouldShowWarmup: enabled:false turns the strip off entirely', () => {
+    const settings = normalizeWarmupSettings({ enabled: false });
+    assert.equal(shouldShowWarmup({ ...base, settings }), false);
+});
+
+test('shouldShowWarmup: an unknown working weight shows nothing', () => {
+    assert.equal(shouldShowWarmup({ ...base, workingWeight: 0 }), false);
+});
+
+// ---------------------------------------------------------------------------
+// buildWarmupRamp
+// ---------------------------------------------------------------------------
+
+// Stand-in for the plate calculator: 2.5kg-loadable weights on a 20kg bar.
+const roundTo2p5 = (w) => Math.max(20, Math.floor(w / 2.5) * 2.5);
+
+test('buildWarmupRamp: pct 0 is the empty bar, the rest are rounded percentages', () => {
+    const rows = buildWarmupRamp({
+        settings: normalizeWarmupSettings(null),
+        workingWeight: 100,
+        barWeight: 20,
+        roundWeight: roundTo2p5,
+    });
+    assert.deepEqual(rows, [
+        { pct: 0, reps: 8, weight: 20, isBar: true },
+        { pct: 50, reps: 5, weight: 50, isBar: false },
+        { pct: 75, reps: 3, weight: 75, isBar: false },
+    ]);
+});
+
+test('buildWarmupRamp: rounds to what the plates can actually load', () => {
+    const rows = buildWarmupRamp({
+        settings: normalizeWarmupSettings(null),
+        workingWeight: 61,
+        barWeight: 20,
+        roundWeight: roundTo2p5,
+    });
+    assert.deepEqual(rows.map(r => r.weight), [20, 30, 45], '50% of 61 = 30.5 -> 30');
+});
+
+test('buildWarmupRamp: ramp rows at or below the bar are dropped', () => {
+    const rows = buildWarmupRamp({
+        settings: normalizeWarmupSettings(null),
+        workingWeight: 40,
+        barWeight: 20,
+        roundWeight: roundTo2p5,
+    });
+    assert.deepEqual(rows.map(r => r.pct), [0, 75], '50% of 40 is the bar itself');
+});
+
+test('buildWarmupRamp: no bar weight configured drops the empty-bar row', () => {
+    const rows = buildWarmupRamp({
+        settings: normalizeWarmupSettings(null),
+        workingWeight: 100,
+        barWeight: 0,
+        roundWeight: (w) => w,
+    });
+    assert.deepEqual(rows.map(r => r.pct), [50, 75]);
+});

--- a/sync-system/app-sync-init.js
+++ b/sync-system/app-sync-init.js
@@ -56,7 +56,9 @@ const APP_SYNC_CONFIG = {
       'gymTrackerAchievements',   // Unlocked achievements
       'gymTrackerActiveProgram',  // Currently active program ID
       'gymTrackerCustomExercises', // User-created custom exercises
-      'gymTrackerMeasurements'    // Body measurements log
+      'gymTrackerMeasurements',   // Body measurements log
+      'gymTrackerMeasurementGoals', // Measurement target values + direction
+      'gymTrackerWarmupSettings'  // Warm-up ramp preferences (threshold, ramp rows)
     ]
   },
 


### PR DESCRIPTION
Gym Tracker round 8: eight features focused on what regular lifters do daily - logging faster, seeing progress clearer, planning smarter. Fourteen modified files plus six new ones; every file and what changed in it below.

## apps/gym-tracker

**js/views/workout-view.js** (+~590)
- Progressive-overload visibility: `getPreviousExerciseData` now delegates to the new `evaluateProgression` and attaches a progression record (status, last weight, suggested weight, delta, two-session history) to the prefill. A "+X suggested" badge with an expandable two-session history panel and a "Use last weight" control renders on the FIRST badge-eligible planned row only (owner call after review: later rows still prefill the suggested weight but repeating the identical badge read as noise). The missing regression half is now built: a missed-target session shows "Missed target - repeat weight", and two consecutive misses at the same weight suggest a 5-10% deload rounded to the equipment increment. Per-set rep ranges are honored: each prior set is judged against its own slot's repsMax with the exercise-level target as fallback.
- One-tap steppers: minus/plus buttons flank every planned row's weight input (steps by the equipment increment) and reps input (steps 1, floor 0), setting the value and dispatching the same bubbling input event typing uses, so plate hints and the "same as last time" restore chip stay live; the buttons never focus the input, so no phone keyboard.
- In-workout exercise swap: a header control opens a searchable picker (category/equipment filters, pre-filtered to the exercise's category) that rewrites only the session's exerciseId/exerciseName, clears that entry's sticky values, rebuilds PR slots, and re-saves the active session; the saved Program is never touched. Swapping with logged sets routes through the existing confirm modal.
- Warm-up ramp: barbell/trap-bar exercises whose prefilled working weight meets the threshold render a collapsed strip above set 1 (default bar x8, 50% x5, 75% x3, each rounded to loadable plates via the plate calculator). Warm-up rows are never Sets - tick state lives on the view - so volume, completion, and PR checks cannot see them by construction. Config is read fresh each render from `gymTrackerWarmupSettings`.

**js/utils/progression.js** (new) - pure module: `evaluateProgression`, `setsHitTarget`, `deloadWeight`, status constants.
**js/utils/warmup.js** (new) - pure module: defaults, lenient read-side `normalizeWarmupSettings`, threshold-by-unit, `shouldShowWarmup`, `buildWarmupRamp`.

**js/views/settings-view.js** (+~130)
- Warm-up ramp settings section (enable toggle, kg and lb thresholds, three editable ramp rows), persisting on change with write-side clamping (`clampWarmupSettings`; the shared defaults are imported from utils/warmup.js so reader and writer cannot drift).
- "Export CSV" beside the JSON export: flattens every completed set via `buildSetsCsv`, downloads `gym-tracker-sets-YYYY-MM-DD.csv`, and shows a toast instead of a silent no-op when there is nothing to export.

**js/utils/helpers.js** (+~100) - `downloadText`, `escapeCsvField` (RFC 4180), `SETS_CSV_HEADER`, `buildSetsCsv` (returns csv + rowCount), `computeGoalProgress` (clamped 0-100, direction-aware, null on junk).

**js/views/measurements-view.js** (+~140) - "Set goal" per trend tile with a modal (target, direction, clear); tiles with a goal render a progress bar plus "N% to goal" under the sparkline, measured from the earliest logged value. Stored under `gymTrackerMeasurementGoals` keyed by metric id.

**js/services/AnalyticsService.js** (+~75, additive) - `getLastTrainedByCategory` and `getStaleProgramCategories` (categories in saved programs with zero volume in a window; never-trained first, then longest-neglected), reusing the same category bucketing as the volume bars.

**js/views/insights-view.js** (+~45) - "Not trained recently" section rendering the stale-category list with "X days since last trained"/"Never trained"; hidden when every programmed category has recent volume or no programs exist; re-renders on program changes.

**js/views/history-view.js** (+~70) - Program filter dropdown (All Programs default plus each saved program, DarkSelect-styled) that filters sessions by programId with a workoutDayName fallback, combines with the existing sort and date-range controls, updates pagination, and rebuilds itself when programs are added/renamed/deleted. Deliberate: the existing Clear button still clears dates only.

**js/services/StorageService.js** - the two new keys (MEASUREMENT_GOALS, WARMUP_SETTINGS) join the keys map so Clear All Data wipes them.

**index.html** (+~180) - warm-up settings section, measurement-goal modal, CSV export button, swap-exercise modal, insights stale section, history program filter markup.

**css/gym-tracker.css** (+~540) and **css/refresh.css** (+~105) - styles for all of the above in two end-of-file blocks: progression badge/panel, steppers (44px targets at the phone breakpoint, with the planned-row input widened so three-digit decimals never clip), warm-up strip, swap picker, stale-list rows, program-filter select, goal bars and modal, every new control color-pinned against the sitewide main.css button overrides.

**sw.js** - CACHE_VERSION 1.7.4 -> 1.7.6; the two new utility modules added to the precache.

**README.md** - rows for all eight features in the matching sections (progression suggestions, steppers, swap, warm-up ramp, measurement goals, program filter, stale-category list, CSV export) plus the settings and export sections.

**tests/** (5 new files, ~60 tests) - progression.test.mjs, warmup.test.mjs, sets-csv-export.test.mjs, measurement-goal-progress.test.mjs, insights-stale-categories.test.mjs.

## sync-system

**app-sync-init.js** - `gymTrackerMeasurementGoals` and `gymTrackerWarmupSettings` added to the gym-tracker sync whitelist so goals and warm-up preferences follow a signed-in account.

## Judgment calls

- The goals storage key was renamed from the spec's `measurementGoals` to `gymTrackerMeasurementGoals` before shipping: all seven apps share one localStorage origin and every other gym-tracker key carries the prefix.
- Badge placement was reviewed as a product call: the spec's literal wording produced a badge under every planned row; the owner chose first-row-only, and the change went through a verified re-run (one badge, first row, prefills intact on all rows, desktop and 390px).
- Warm-up tick state is deliberately not persisted across pause/resume, keeping warm-ups entirely out of the session model.
- A planned row with no history prefills reps from the program's own per-slot target (only weight is blank); the test round initially flagged this and it was confirmed as intended behavior.
- The restore chip is a persistent diverged-from-prior indicator (clears only on exact reconvergence), identical for typing and stepping; the plan was corrected to assert that.
- Reader-side and writer-side warm-up normalization stay separate on purpose (lenient read vs clamped write) but share one defaults constant.

## How it was tested

- npm test: 2158/2158 (60 new unit tests across the five new suites).
- Living plan `.features/gym-tracker-claude.md` (prior round archived to `.features/archive/gym-tracker-{claude,human}-2026-08-03.md`): run 1 executed all 125 assertions (89 passed, 4 failed, 2 unverified, 30 observed-only); the 4 failures were wrong plan assumptions, corrected against the code and re-run in run 2 with all 5 corrected items passing; run 3 verified the badge-placement change with the plan's own seed (DOM probe plus desktop and 390px screenshots). Zero code defects surfaced across the round.
- Remaining human checks are written click-by-click in `.features/gym-tracker-human.md`: stepper hover and pressed colors, goal-button hover, and the real CSV download opening in a spreadsheet.
