### PR TITLE
fix(arena): functional audit - 16 fixes from a 227-assertion behavioral sweep

### DIFF
--- a/apps/arena/css/styles.css
+++ b/apps/arena/css/styles.css
@@ -1882,6 +1882,18 @@ select option { background: var(--surface); color: var(--text); }
     animation: none;
     transform: none;
   }
+  /* Same trap one level up: every .stage element runs stage-fade (also
+     animation-fill-mode: both), which leaves #stage-globe-drop with a
+     resolved (identity) transform matrix even once fully faded in. That
+     ALSO establishes a containing block, so once the fab-stack above stops
+     doing it, position:fixed on Submit/Clear resolves against this stage
+     section instead of the viewport — landing the pair far down the page,
+     below the fold, instead of pinned to the bottom. Drop the animation
+     here too so #stage-globe-drop never establishes a containing block. */
+  #stage-globe-drop {
+    animation: none;
+    transform: none;
+  }
   /* Submit + Clear are pinned to the viewport bottom as a CENTRED PAIR.
      Pair width = Clear(56) + gap(10) + Submit(200) = 266px. We anchor each
      button off left:50% with fixed pixel offsets so the group is centred
@@ -4730,7 +4742,8 @@ select option { background: var(--surface); color: var(--text); }
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 /* ---------- Profile ---------- */

--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -211,6 +211,17 @@
                 </select>
               </label>
               <!-- Trivia-only fields -->
+              <!-- B2: the question-source picker. renderPackOptions() fills it
+                   (Live API always, plus a saved custom pack) and createRoom
+                   reads it. Without this element a pack saved in Profile could
+                   never be played, even though the profile form, the README and
+                   the page description all advertise custom packs. -->
+              <label class="lobby-field" data-game-type="trivia" hidden>
+                <span>Questions from</span>
+                <select id="create-pack-select">
+                  <option value="live">Live questions (The Trivia API)</option>
+                </select>
+              </label>
               <label class="lobby-field" data-game-type="trivia" hidden>
                 <span>Questions per game</span>
                 <select id="create-questions-count">
@@ -408,15 +419,19 @@
                 <dt>Round type</dt>
                 <dd id="room-settings-round-type">—</dd>
               </div>
-              <div class="room-settings-item">
+              <!-- B7: these three rows describe Globe Drop only. They carry ids
+                   so renderRoomSettings can hide them on a trivia room; without
+                   them the panel kept showing a previous room's difficulty,
+                   location count and timer. -->
+              <div class="room-settings-item" id="room-settings-item-difficulty">
                 <dt>Difficulty</dt>
                 <dd id="room-settings-difficulty">—</dd>
               </div>
-              <div class="room-settings-item">
+              <div class="room-settings-item" id="room-settings-item-locations">
                 <dt>Locations</dt>
                 <dd id="room-settings-locations">—</dd>
               </div>
-              <div class="room-settings-item">
+              <div class="room-settings-item" id="room-settings-item-timer">
                 <dt>Time / location</dt>
                 <dd id="room-settings-timer">—</dd>
               </div>
@@ -578,7 +593,13 @@
                  pulsing) instead of auto-expanding, so the globe never
                  moves mid-reveal. Hidden on desktop where both boards are
                  always visible. -->
-            <button type="button" class="globe-drop-standings-toggle" id="globe-drop-standings-toggle" aria-expanded="false" hidden>
+            <!-- B9: no `hidden` attribute. Nothing in app.js ever removed it,
+                 and this app's `[hidden] { display: none !important }` rule
+                 (styles.css) outranks the <=768px `display: inline-flex`, so
+                 the collapsible-standings control was dead at every width.
+                 Visibility is the stylesheet's job: none on desktop,
+                 inline-flex on mobile. -->
+            <button type="button" class="globe-drop-standings-toggle" id="globe-drop-standings-toggle" aria-expanded="false">
               <span class="globe-drop-standings-toggle-label">Standings</span>
               <svg class="globe-drop-standings-toggle-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
             </button>
@@ -607,7 +628,10 @@
               <div class="rounds-history-scoreboard" id="rounds-history-scoreboard"></div>
             </section>
 
-            <p class="globe-drop-hint" id="globe-drop-hint" hidden></p>
+            <!-- B11: the empty #globe-drop-hint paragraph was removed. It was
+                 un-hidden on every new question but no code ever set its text,
+                 so it rendered as a blank line; hints live in
+                 #globe-drop-prompt-hints. -->
             <!-- Status element kept (display:none) so JS callsites don't
                  crash. Action bar removed by request — phase feedback
                  lives in the reveal panel + visual pin. -->

--- a/apps/arena/js/app.js
+++ b/apps/arena/js/app.js
@@ -465,6 +465,13 @@ async function tryLoadPendingPostMatch() {
         state.roomData = data;
         state.roomPlayers = players;
         state.postMatchCode = code;
+        // B1: renderEndStage only swaps STAGES; the panel swap lives in
+        // enterRoom, which a view-only recap never calls. Without this the
+        // recap renders inside a hidden #room-panel and the visitor sees the
+        // lobby, so a shared recap link looked broken.
+        show($('#room-panel'));
+        hide($('#lobby-panel'));
+        setText($('#room-code-display'), code);
         syncUrlToState();
         renderEndStage(false);
     } catch (err) {
@@ -676,12 +683,13 @@ function applyAuthState(user) {
     else $('#auth-gate').hidden = false;
 
     // Invite-link landing: if a signed-out user arrived via an
-    // /?room=ABCDE link, silently sign them in as a guest and join.
-    // applyAuthState fires again once the anon user exists, which
-    // re-runs the signedIn branch below and tryRejoinPendingRoom
-    // takes them straight to the room. We only kick this off once per
-    // boot to avoid an auth-loop if the sign-in itself fails.
-    if (!signedIn && state.pendingRoomCode && !state.inviteSignInPrompted) {
+    // /?room=ABCDE or /?postMatch=ABCDE link, silently sign them in as a
+    // guest and join / load the recap. applyAuthState fires again once the
+    // anon user exists, which re-runs the signedIn branch below and
+    // tryRejoinPendingRoom / tryLoadPendingPostMatch takes them straight
+    // there. We only kick this off once per boot to avoid an auth-loop if
+    // the sign-in itself fails.
+    if (!signedIn && (state.pendingRoomCode || state.pendingPostMatchCode) && !state.inviteSignInPrompted) {
         state.inviteSignInPrompted = true;
         ensureGuestAuth();
     }
@@ -936,7 +944,7 @@ function wireCustomPack() {
 
     saveBtn.addEventListener('click', async () => {
         msg.classList.remove('is-ok', 'is-err');
-        if (!state.user) { setText(msg, 'Sign in first.'); msg.classList.add('is-err'); return; }
+        if (!state.user || isGuest()) { setText(msg, 'Sign in first.'); msg.classList.add('is-err'); return; }
         let parsed;
         try {
             parsed = JSON.parse($('#custom-pack-input').value || '');
@@ -1047,6 +1055,12 @@ function wireGameTypeToggle() {
                     // .lobby-solo-actions uses a CSS transition instead of hidden.
                     if (el.classList.contains('lobby-solo-actions')) {
                         el.classList.toggle('is-hidden', shouldHide);
+                    } else if (el.id === 'create-globe-drop-time-field') {
+                        // This field's visibility is independently owned by
+                        // the timer-override checkbox, so only ever hide it
+                        // here, never force it open just because Globe Drop
+                        // became the active tab again.
+                        el.hidden = shouldHide || !$('#create-globe-drop-timer-override').checked;
                     } else {
                         el.hidden = shouldHide;
                     }
@@ -1450,11 +1464,13 @@ async function createRoom(opts) {
                 questionTimeMs: seconds * 1000
             }));
         } else {
-            // The pack-select dropdown was retired — live API is the only
-            // built-in source. A saved custom pack still goes through
-            // buildQuestionsForRound('custom', …) elsewhere; the lobby
-            // doesn't expose pack choice anymore.
-            const sel = 'live';
+            // B2: read the question source the host picked. Falls back to the
+            // live API when the picker is absent or holds a stale 'custom'
+            // whose pack has since been cleared, so a missing pack can never
+            // create an unplayable room.
+            const packSel = $('#create-pack-select');
+            const wanted = packSel ? packSel.value : 'live';
+            const sel = (wanted === 'custom' && state.customPack) ? 'custom' : 'live';
             const count = parseInt($('#create-questions-count').value, 10) || 10;
             const seconds = parseInt($('#create-trivia-time').value, 10) || 15;
             btn.innerHTML = 'Fetching questions…';
@@ -1911,7 +1927,13 @@ async function leaveRoom({ silent = false, reason = null } = {}) {
     if (joinPw) joinPw.value = '';
     setJoinPwFieldVisible(false);
     clearJoinError();
-    if (!silent && reason) alert(reason);
+    // B8: `silent` means "no blocking alert", not "say nothing". A room that
+    // vanishes under a player (host closed it, cleanup) used to bounce them to
+    // the lobby with no explanation at all; the reason now rides a toast.
+    if (reason) {
+        if (silent) showToast(reason, { icon: '👋', key: 'room-left-reason' });
+        else alert(reason);
+    }
     teardownMap();
     syncUrlToState();
 }
@@ -2226,7 +2248,14 @@ function wireChat() {
 
 async function sendChatEmoji(emoji) {
     if (!state.user || !state.roomCode || !emoji) return;
-    if (Chat.shouldRateLimit(chatState.lastSentAt, Date.now())) return;
+    // B17: same error surfacing as sendChatMessage. A silently dropped tap
+    // (rate limit or write failure) read as "the button is broken".
+    const err = $('#room-chat-error');
+    if (err) { err.hidden = true; err.textContent = ''; }
+    if (Chat.shouldRateLimit(chatState.lastSentAt, Date.now())) {
+        if (err) { err.textContent = 'Slow down. Wait a moment before sending again.'; err.hidden = false; }
+        return;
+    }
     const displayName = (state.profile && state.profile.displayName) || deriveInitialDisplayName();
     try {
         await addDoc(collection(db, 'triviaRooms', state.roomCode, 'chat'), {
@@ -2238,6 +2267,7 @@ async function sendChatEmoji(emoji) {
         chatState.lastSentAt = Date.now();
     } catch (e) {
         console.warn('sendChatEmoji failed:', e);
+        if (err) { err.textContent = 'Could not send. Try again.'; err.hidden = false; }
     }
 }
 
@@ -2495,9 +2525,14 @@ function renderRoomSettings(isHost) {
 
     // Globe Drop-specific settings rows — hide for trivia rooms.
     const isGlobeDrop = room.gameType === 'globe-drop';
-    const roundTypeItem = $('#room-settings-item-round-type');
-    if (roundTypeItem) roundTypeItem.hidden = !isGlobeDrop;
-    const diffEl = document.querySelector('.room-settings-item:has(#room-settings-difficulty)');
+    // B7: every Globe Drop row hides on a trivia room, not just round type.
+    // The other three used to stay on screen showing the last globe-drop
+    // room's values, which read as facts about the trivia room.
+    for (const id of ['#room-settings-item-round-type', '#room-settings-item-difficulty',
+        '#room-settings-item-locations', '#room-settings-item-timer']) {
+        const item = $(id);
+        if (item) item.hidden = !isGlobeDrop;
+    }
 
     if (isGlobeDrop) {
         const roundType = room.roundType || 'capitals';
@@ -2552,7 +2587,9 @@ function openRoomSettingsEditor() {
     $('#room-settings-edit-round-type').value = room.roundType || 'capitals';
     $('#room-settings-edit-difficulty').value = room.difficulty || 'medium';
     $('#room-settings-edit-count').value = String(room.totalQuestions || 5);
-    const seconds = Math.round((room.questionTimeMs || 120000) / 1000);
+    // B14: fall back to the same 60s every difficulty tier actually creates
+    // with, not a 120s figure nothing else uses.
+    const seconds = Math.round((room.questionTimeMs || Config.GLOBE_DROP_DEFAULT_TIMER_SEC * 1000) / 1000);
     $('#room-settings-edit-time').value = String(seconds);
     const msg = $('#room-settings-msg');
     if (msg) { msg.hidden = true; msg.textContent = ''; msg.classList.remove('is-busy', 'is-err'); }
@@ -2575,7 +2612,7 @@ async function saveRoomSettings() {
     const newRoundType = $('#room-settings-edit-round-type').value || 'capitals';
     const newDifficulty = $('#room-settings-edit-difficulty').value || 'medium';
     const newCount = Math.max(Config.GLOBE_DROP_LOCATIONS_MIN, Math.min(10, parseInt($('#room-settings-edit-count').value, 10) || 5));
-    const newSeconds = parseInt($('#room-settings-edit-time').value, 10) || 120;
+    const newSeconds = parseInt($('#room-settings-edit-time').value, 10) || Config.GLOBE_DROP_DEFAULT_TIMER_SEC;
     const diff = GlobeDropScoring.difficultySettings(newDifficulty);
 
     const oldRoundType = state.roomData.roundType || 'capitals';
@@ -2652,7 +2689,15 @@ async function switchRoomGameType() {
     const switchBtn = $('#room-switch-game-type-btn');
     if (switchBtn) switchBtn.disabled = true;
     try {
-        await updateDoc(doc(db, 'triviaRooms', state.roomCode), { gameType: next });
+        // B14 root cause: a switched room used to keep the OLD game's timer
+        // (or none), which is how the odd 120s fallback ever became visible.
+        // Stamp the target game's own default so the room is coherent.
+        await updateDoc(doc(db, 'triviaRooms', state.roomCode), {
+            gameType: next,
+            questionTimeMs: next === 'globe-drop'
+                ? Config.GLOBE_DROP_DEFAULT_TIMER_SEC * 1000
+                : Config.QUESTION_TIME_MS,
+        });
         // Also update state.selectedGameType so the local create-form toggle
         // stays in sync on subsequent room-settings renders.
         state.selectedGameType = next;
@@ -3510,7 +3555,6 @@ function renderGlobeDropStage() {
             triviaEl.textContent = '';
             triviaEl.hidden = true;
             $('#globe-drop-countdown').hidden = true;
-            $('#globe-drop-hint').hidden = false;
             setText($('#globe-drop-status'), '');
             $('#globe-drop-status').classList.remove('is-correct', 'is-wrong');
         }
@@ -4583,6 +4627,16 @@ async function startGame() {
 async function submitAnswer(choiceIndex, question) {
     if (!state.user || !state.roomCode) return;
     if (state.submittedQuestionId === question.id) return; // double-click guard
+
+    // B6: same spectator gate submitGuess already had. A player who joins
+    // mid-question spectates it; without this they could answer (and score on)
+    // the very question the spectator banner says they are sitting out.
+    const mePlayer = state.roomPlayers.find((p) => p.uid === state.user.uid);
+    const joinedAtQIdx = mePlayer && typeof mePlayer.joinedAtQuestionIndex === 'number'
+        ? mePlayer.joinedAtQuestionIndex : -1;
+    const curQIdx = typeof state.roomData.currentQuestionIndex === 'number'
+        ? state.roomData.currentQuestionIndex : -1;
+    if (joinedAtQIdx >= 0 && curQIdx <= joinedAtQIdx) return;
 
     const startMs = state.roomData.questionStartedAt && state.roomData.questionStartedAt.toMillis
         ? state.roomData.questionStartedAt.toMillis() : Date.now();
@@ -5930,11 +5984,23 @@ async function proposeRematch() {
  * fields immediately so opponents stop seeing the prompt. */
 const PROPOSAL_TIMEOUT_MS = 10000;
 let proposalPendingTimerId = null;
+// B10: Escape cancels the pending proposal, matching the Escape contract every
+// other modal in the app honors (it is exactly the Cancel button's action).
+// Backdrop clicks stay deliberately inert: the modal auto-resolves in 10s and
+// an accidental tap should not burn a restart allowance.
+function onProposalPendingKeydown(e) {
+    if (e.key !== 'Escape') return;
+    const modal = document.getElementById('proposal-pending-modal');
+    if (!modal || modal.hasAttribute('hidden')) return;
+    e.preventDefault();
+    cancelOwnProposal('cancel');
+}
 function openProposalPendingModal() {
     const modal = document.getElementById('proposal-pending-modal');
     if (!modal) return;
     state.proposalPendingDeadline = Date.now() + PROPOSAL_TIMEOUT_MS;
     modal.removeAttribute('hidden');
+    document.addEventListener('keydown', onProposalPendingKeydown);
     // Reset the depletion bar to full width and kick off the 10-second
     // shrink. transition: transform 0.25s linear in CSS smooths the
     // 250ms render cadence into a continuous animation.
@@ -5968,6 +6034,7 @@ function closeProposalPendingModal() {
         proposalPendingTimerId = null;
     }
     state.proposalPendingDeadline = null;
+    document.removeEventListener('keydown', onProposalPendingKeydown);
 }
 function renderProposalPendingModal() {
     const list = document.getElementById('proposal-response-list');
@@ -6473,7 +6540,7 @@ async function renderH2HComparison() {
     const eb = entries.find((e) => e.uid === b.value);
     const empty = $('#h2h-empty');
     const result = $('#h2h-result');
-    if (!ea || !eb) {
+    if (!ea || !eb || ea.uid === eb.uid) {
         if (empty) empty.hidden = false;
         if (result) result.hidden = true;
         return;


### PR DESCRIPTION
Exhaustive functional audit of Arena: 227 assertions executed against the live app across every view, form, modal, list, flow, and both game types, including real two- and three-client multiplayer sessions. Sixteen behavioral fixes across three files; every file and what changed in it below.

## apps/arena

**js/app.js** (+~111/-~20)
- Shared recap links (`?postMatch=CODE`): the view-only recap loader never performed the lobby-to-room panel swap that `enterRoom` does, so visitors saw the lobby with the recap rendered underneath a hidden panel; and `applyAuthState`'s invite auto-guest-sign-in only checked `pendingRoomCode`, never `pendingPostMatchCode`, so signed-out visitors on a recap link were never signed in at all. Both paths fixed.
- Trivia spectator gate: `submitAnswer` now carries the same joined-mid-question gate `submitGuess` always had; a latecomer's answer click during their spectated question is a no-op instead of scoring. Verified with a real three-client session (latecomer blocked, control click confirms the handler itself works).
- Custom packs (with index.html): `createRoom` reads the restored `#create-pack-select` instead of hardcoding the live API, falling back to live questions when a stale `custom` selection has no saved pack, so a missing pack can never mint an unplayable room.
- Room settings truthfulness: all four Globe Drop rows (round type, difficulty, locations, timer) hide on trivia rooms; previously only round type hid and the other three kept showing the prior Globe Drop room's values.
- Room-closed messaging: `leaveRoom`'s `silent` flag now means "no blocking alert", not "say nothing" - the reason rides a toast, so a player whose room vanishes sees "Room closed." instead of an unexplained bounce to the lobby (verified on both clients of a live room).
- Proposal-pending modal: Escape now cancels the pending rematch/restart proposal, matching the Escape contract every other modal honors; backdrop clicks stay deliberately inert so an accidental tap cannot burn one of the limited proposal allowances.
- Chat emoji sends surface rate-limit and write-failure errors in the same `#room-chat-error` element text sends use, instead of silently dropping the tap.
- Game-type switching stamps the target game's own default `questionTimeMs` (60s Globe Drop / 15s trivia) instead of carrying the old game's timer, and the settings editor's fallbacks now agree with the 60 seconds every difficulty tier actually creates with (previously a 120s figure nothing else uses).
- H2H view: selecting the same player in both dropdowns shows the "pick two different players" empty state instead of a nonsense self-comparison.
- Guest custom-pack saves get an honest "Sign in first." instead of a false "Saved" (the old guard checked for no user, which an anonymous guest passes).
- Create-card game-type toggle no longer reveals the Globe Drop time field when the timer-override checkbox is unchecked (it special-cases the field the same way the solo actions block already was).
- Removed the un-hide of the empty `#globe-drop-hint` paragraph (element deleted in index.html).

**index.html** (+~34/-~4)
- Restored the "Questions from" source picker (`#create-pack-select`, trivia-only field) that `renderPackOptions()` populates and `createRoom` reads; without it, packs saved on the Profile view - a feature the README, the profile UI, and the page's own meta description all advertise - could never be played.
- Removed the stale `hidden` attribute from the collapsible-standings toggle: nothing ever removed it, and this app's `[hidden] { display: none !important }` rule outranked the mobile CSS that was supposed to show it, leaving the control dead at every width. Visibility is now purely the stylesheet's (none on desktop, inline-flex on phones).
- Gave the difficulty/locations/timer settings rows ids so the render can hide them on trivia rooms.
- Deleted the permanently-empty `#globe-drop-hint` paragraph that was un-hidden on every new question with no code ever setting its text.

**css/styles.css** (+~13/-~2)
- Globe Drop stage: the stage's fade-in animation left a resolved transform via fill-mode, which silently established a CSS containing block for the stage's `position: fixed` mobile Submit/Clear buttons - they rendered ~500px below the visible viewport at 390px. Mirrored the identical fix already present for the FAB stack.
- Leaderboard: the table wrap was `overflow: hidden` with no scroll affordance, clipping the last six columns on phones with no way to reach them; now scrolls horizontally like the app's other wide tables.

## Judgment calls

- The pack picker was restored rather than the feature deleted: the retirement left the profile upload form, the pack option renderer, and the custom question builder all live and advertised, so completing the wiring was the smaller, truer change.
- The bottom-of-recap Rematch/Back buttons were NOT resurrected: the code comments document their removal as deliberate with guarded listeners, and the header rematch button is the intended path; the dead render branches are catalogued in the audit report for a future cleanup round.
- Escape-only on the proposal modal (backdrop inert) - reasoning above.
- The rounds-history board's masking branch turned out to be dead code guarding a board that only renders completed rounds (nothing to peek; the mini-board carries the real anti-peek and passed) - plan corrected, no code change.
- Four items were escalated to the owner rather than decided here, recorded in the archived audit report: plaintext room passwords readable by signed-in clients, session H2H being registered-only by rules design, a mobile timer/action-button visual collision, and the absence of a sound/haptics toggle.

## How it was tested

- npm test: 2158/2158 before and after every fix.
- Living plan `.features/arena-claude.md` (prior round archived to `.features/archive/arena-{claude,human}-2026-08-04.md`): a rebuilt 227-assertion, 43-section plan derived from a source-level behavioral inventory (also archived, `.features/archive/arena-functional-audit-2026-08-04.md`), executed in full across six runs: chunks 1-2 DOM-level (49/58, rest auth-gated to later chunks), chunk 3 solo Globe Drop end-to-end (45/53), chunk 4 daily/leaderboards/H2H/profile/packs (29/36), chunk 5 trivia single-client and spectator gate (22/22), chunk 6 real two/three-client multiplayer protocol (33/36), chunk 7 pure-logic and wiring (21/23). Every failure either became one of the fixes above, a plan correction verified against source, or an escalated decision; zero unfixed app-level failures remain.
- Multiplayer flows (sync, host handoff, spectator, chat both directions, rematch accept/decline/timeout, pause/resume allowances, room-closed propagation) ran as genuine concurrent anonymous-guest clients against live Firebase; all probe rooms were verified deleted afterward.
- The headless Firebase harness built for this audit (IndexedDB shim + dependency-free CDP driver) is preserved verbatim inside the plan's run reports for future re-runs.
