### PR TITLE
fix(maptap-rivals): dashboard width parity across rival-network states + leaderboard title spacing

### DIFF
--- a/apps/maptap-rivals/css/styles.css
+++ b/apps/maptap-rivals/css/styles.css
@@ -210,6 +210,11 @@ body.maptap-rivals-app textarea:focus {
 /* ---------- Layout ---------- */
 
 .page {
+  /* main.css turns body into a column flex container on footer pages
+     (body:has(> [data-include="footer"]), sticky footer). With margin
+     auto alone the flex item shrinks to fit-content, so the dashboard
+     width would change with its text; width:100% pins it to the page. */
+  width: 100%;
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 1.25rem 3rem;
@@ -283,6 +288,11 @@ body.maptap-rivals-app textarea:focus {
   color: var(--text);
   letter-spacing: -0.01em;
 }
+
+/* The leaderboard title sits directly on the table wrap (no sub-line or
+   controls row between them like other views have), so give it its own
+   breathing room. */
+.view-leaderboard .section-title { margin-bottom: 0.85rem; }
 
 .empty-state {
   text-align: center;


### PR DESCRIPTION
Two CSS fixes for maptap-rivals: the reported dashboard width change when joining the Rival Network, and a spacing tweak under the leaderboard title.

## apps/maptap-rivals

### `css/styles.css` (+10)

**`.page` gains `width: 100%`** (with an explanatory comment) - fixes the reported bug where `.view.view-dashboard.is-active` renders wide when not on the Rival Network but collapses to a much narrower column after joining.

Root cause: `assets/css/main.css` makes `body` a column flex container on every page with the footer partial (`body:has(> [data-include="footer"]) { display: flex; flex-direction: column }`, the sticky-footer rule). Inside a column flexbox, a flex item with only `margin: 0 auto` does not stretch - it is sized shrink-to-fit, so `main.page`'s width silently tracked the widest text line of whatever the current view rendered. Not joined, the network card's long hint paragraph pushed it to ~1156px (at a 1280px viewport); joined, the card renders short status lines and the whole page collapsed to ~722px. Nothing network-specific ever touched layout - the width was content-driven the entire time, and every view in the app was subject to it.

With `width: 100%`, the auto margins go back to just centering and `max-width: 1200px` caps the page, so width is viewport-driven again. Safe with `.page`'s horizontal padding because the app sets `* { box-sizing: border-box }`.

Judgment call: fixed in the app stylesheet rather than in main.css. Changing the sitewide sticky-footer rule (or adding a global `body > main { width: 100% }`) would ripple into every other app and marketing page; the scoped one-liner fixes this app with zero blast radius. Other apps likely carry the same latent behavior and can adopt the same one-liner if it ever surfaces there.

**`.view-leaderboard .section-title` gains `margin-bottom: 0.85rem`** (with a comment) - the leaderboard heading ("Leaderboard: your win % against each rival") sat flush on the table wrap. Scoped to `.view-leaderboard` because `.section-title` is shared by 9 other headings that keep `margin: 0` and get their spacing from sub-lines or control rows the leaderboard does not have.

## How it was tested

- Reproduced and verified via a same-origin probe page that seeds `localStorage` (rivals + a joined `maptapRivalsNetwork` cache) before loading the app in an iframe, then measures `getBoundingClientRect`. Pre-fix: not-joined 1156px vs joined 722px. Post-fix: page exactly 1200px / view 1163px in both states at 1280px, and 380px / 351px with no horizontal overflow at 390px.
- Screenshot passes on desktop (1280) and mobile (390) for both network states, plus regression shots of the leaderboard and records views at the now-pinned full width and the sticky footer (still pinned).
- `npm test`: 2208/2208 passing.
- Living plan pair `.features/maptap-rivals-{claude,human}.md` rebuilt for this round (7/7 checks passing in the run report); prior round archived as `.features/archive/maptap-rivals-{claude,human}-2026-08-04-c.md`.
