### PR TITLE
seo(rising-shows): noindex the non-curated long tail (GSC recovery)

### DIFF
--- a/apps/rising-shows/README.md
+++ b/apps/rising-shows/README.md
@@ -73,10 +73,15 @@ These are gitignored build artifacts, derived from `data.json` (which the build 
 
 `sitemap-shows.xml` is deliberately curated: it lists only the top 2,000 series by
 IMDb vote count (`SITEMAP_LIMIT` in `build-show-pages.js`), not all ~34k, plus the
-A-Z index and the 13 shape hubs (2,014 URLs in total). Every page
-is still built and reachable through the A-Z index; the sitemap just focuses Google's
-crawl budget on shows with real search demand instead of parking the long tail in
-"Discovered - currently not indexed" (GSC, 2026-07). After the page builders run,
+A-Z index and the 13 shape hubs (2,014 URLs in total). Every page is still built
+and reachable through the A-Z index for app users, but since 2026-08 the
+non-curated pages carry `noindex, follow`: the 2026-05 full-catalogue launch put
+~34k templated pages in front of Google, which crawled them and then declined to
+index nearly all of them (GSC "Crawled - currently not indexed" ~60k by 2026-08,
+with the site's search traffic collapsing in June under the sitewide quality
+drag). Curating the sitemap alone did not shrink that backlog because the pages
+still self-identified as indexable; the explicit noindex drains it while the
+`follow` keeps internal link equity flowing to the curated pages. After the page builders run,
 `scripts/stamp-sitemap-index.mjs` (repo root) re-stamps the root `sitemap.xml`
 index's `<lastmod>` entries from the freshly generated sub-sitemaps.
 

--- a/apps/rising-shows/scripts/build-show-pages.js
+++ b/apps/rising-shows/scripts/build-show-pages.js
@@ -52,6 +52,16 @@ function main() {
   fs.rmSync(SHOWS_DIR, { recursive: true, force: true });
   fs.mkdirSync(SHOWS_DIR, { recursive: true });
 
+  // The curated set is decided BEFORE rendering: pages outside it are
+  // rendered with a noindex,follow robots meta. The May 2026 full-catalogue
+  // launch put ~34k templated pages in front of Google, which crawled the
+  // lot and then declined to index nearly all of it (GSC "Crawled -
+  // currently not indexed" ~60k by August), dragging sitewide quality
+  // signals down with it. The long tail stays generated and linked for app
+  // users and for link equity, but only the curated pages ask to be indexed.
+  const sitemapSeries = selectSitemapSeries(series, SITEMAP_LIMIT);
+  const curatedIds = new Set(sitemapSeries.map((s) => s.seriesId));
+
   let pageCount = 0;
   const start = Date.now();
   for (const s of series) {
@@ -75,7 +85,7 @@ function main() {
         }
       }
     }
-    const html = renderShowPage({ ...s, cast, builtAt: data.builtAt, dominantShape, dominantShapeSlug, relatedShows });
+    const html = renderShowPage({ ...s, cast, builtAt: data.builtAt, dominantShape, dominantShapeSlug, relatedShows, inSitemap: curatedIds.has(s.seriesId) });
     fs.writeFileSync(path.join(dir, 'index.html'), html);
     pageCount++;
     if (pageCount % 1000 === 0) {
@@ -98,9 +108,8 @@ function main() {
     console.log(`[build-show-pages] shape hub /${slug}/ · ${hubShows.length} shows`);
   }
 
-  const sitemapSeries = selectSitemapSeries(series, SITEMAP_LIMIT);
   fs.writeFileSync(SITEMAP_FILE, renderShowsSitemap(sitemapSeries.map(toIndexEntry), data.builtAt, SHAPE_SLUGS));
-  console.log(`[build-show-pages] sitemap curated to top ${sitemapSeries.length} of ${series.length} series by votes; the rest stay crawlable via the A-Z index`);
+  console.log(`[build-show-pages] sitemap curated to top ${sitemapSeries.length} of ${series.length} series by votes; the rest stay reachable for app users but carry noindex,follow`);
 
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);
   console.log(`[build-show-pages] wrote ${pageCount} show pages (${castCount} with cast) + index + sitemap in ${elapsed}s`);

--- a/apps/rising-shows/scripts/render-show-page.js
+++ b/apps/rising-shows/scripts/render-show-page.js
@@ -68,7 +68,7 @@ function computeDominantShape(show) {
 
 // --- sensitive (adult) posters ---
 // Titles carrying the IMDb "Adult" genre get their poster blurred behind a
-// CSS-only (checkbox) reveal — these static pages ship no app JS, so the
+// CSS-only (checkbox) reveal - these static pages ship no app JS, so the
 // reveal must not depend on it. Social/search previews can't be blurred, so
 // the OG/Twitter/JSON-LD image is swapped for the neutral site card instead.
 function isAdultGenres(genres) {
@@ -102,19 +102,25 @@ function wrapSensitivePoster(imgHtml, id, compact) {
 // Build a single static HTML page for one TV series, given every season's
 // data (already grouped from data.json's flat `matches` array). Returns a
 // complete HTML string.
-function renderShowPage({ seriesId, title, year, type, genres, seriesRating, seriesVotes, poster, overview, language, providers, tmdbId, cast, seasons, builtAt, dominantShape, dominantShapeSlug, relatedShows }) {
+function renderShowPage({ seriesId, title, year, type, genres, seriesRating, seriesVotes, poster, overview, language, providers, tmdbId, cast, seasons, builtAt, dominantShape, dominantShapeSlug, relatedShows, inSitemap = true }) {
   const path = `/apps/rising-shows/shows/${showPath(title, seriesId)}/`;
   const canonical = `${SITE}${path}`;
   const numberOfSeasons = seasons.length;
   const yearLabel = year ? ` (${year})` : '';
-  const pageTitle = `${title}${yearLabel} — Episode Ratings & Season Trajectories | Rising Shows`;
+  const pageTitle = `${title}${yearLabel} - Episode Ratings & Season Trajectories | Rising Shows`;
+  // Only curated (sitemap-listed) pages ask to be indexed. The long tail
+  // keeps noindex,FOLLOW so its links still pass equity to curated pages
+  // while Google drains ~60k thin pages out of "Crawled - not indexed".
+  const robots = inSitemap
+    ? 'index, follow, max-image-preview:large'
+    : 'noindex, follow';
   const cleanOverview = (overview || '').trim();
   const description = buildDescription(title, year, numberOfSeasons, seriesRating, seriesVotes, cleanOverview);
 
   const posterUrl = poster ? `${TMDB_POSTER}${poster}` : null;
   const isAdult = isAdultGenres(genres);
   // Adult posters are never exposed in link/search previews (which can't be
-  // blurred) — fall back to the neutral site card instead.
+  // blurred) - fall back to the neutral site card instead.
   const exposePoster = !!posterUrl && !isAdult;
   const ogImage = exposePoster ? posterUrl : `${SITE}/images/og-card.png`;
 
@@ -144,7 +150,7 @@ function renderShowPage({ seriesId, title, year, type, genres, seriesRating, ser
   <title>${escapeHtml(pageTitle)}</title>
   <meta name="description" content="${escapeHtml(description)}">
   <meta name="author" content="Shevato LLC">
-  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="robots" content="${robots}">
   <meta name="theme-color" content="#0b0d12">
   <meta name="color-scheme" content="dark">
   <link rel="canonical" href="${canonical}">
@@ -153,7 +159,7 @@ function renderShowPage({ seriesId, title, year, type, genres, seriesRating, ser
   <link rel="dns-prefetch" href="https://www.google-analytics.com">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="${escapeHtml(`${title}${yearLabel} — Episode Ratings & Season Trajectories`)}">
+  <meta property="og:title" content="${escapeHtml(`${title}${yearLabel} - Episode Ratings & Season Trajectories`)}">
   <meta property="og:description" content="${escapeHtml(description)}">
   <meta property="og:type" content="video.tv_show">
   <meta property="og:url" content="${canonical}">
@@ -164,7 +170,7 @@ function renderShowPage({ seriesId, title, year, type, genres, seriesRating, ser
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="${escapeHtml(`${title}${yearLabel} — Episode Ratings`)}">
+  <meta name="twitter:title" content="${escapeHtml(`${title}${yearLabel} - Episode Ratings`)}">
   <meta name="twitter:description" content="${escapeHtml(description)}">
   <meta name="twitter:image" content="${ogImage}">
   <meta name="twitter:site" content="@shevato">${twitterCardMeta}
@@ -186,7 +192,7 @@ ${seasonSchemas}
   <link rel="stylesheet" href="/apps/rising-shows/css/show-page.css">
   <link rel="stylesheet" href="/assets/css/back-to-top.css">
 
-  <!-- Google Analytics — shared site tag -->
+  <!-- Google Analytics - shared site tag -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
   <script defer src="/assets/js/analytics.js"></script>
 </head>
@@ -271,7 +277,7 @@ function renderHeroPoster(posterUrl, title, isAdult) {
 }
 
 // Top-billed cast strip. `cast` is the array stashed on the series by
-// enrich-tmdb.js — each entry is { id, name, character, profile_path }.
+// enrich-tmdb.js - each entry is { id, name, character, profile_path }.
 // Mirrors the in-app show modal's cast cards (same class names) so the
 // shared .cast-* styling applies. Returns '' when there's no cast so the
 // section is omitted entirely.
@@ -334,7 +340,7 @@ function renderSeasonSection(season, seriesId) {
         </header>
         ${curveSvg}
         <table class="episode-table">
-          <caption>Season ${season.season} episodes — IMDb ratings</caption>
+          <caption>Season ${season.season} episodes - IMDb ratings</caption>
           <thead><tr><th scope="col">#</th><th scope="col">Title</th><th scope="col">Rating</th><th scope="col">Votes</th></tr></thead>
           <tbody>
             ${season.episodes.map((ep) => `<tr><td>${ep.episode}</td><td>${escapeHtml(ep.name || '—')}</td><td><strong>${ep.rating.toFixed(1)}</strong></td><td>${ep.votes.toLocaleString()}</td></tr>`).join('\n            ')}
@@ -469,7 +475,7 @@ function buildDescription(title, year, n, rating, votes, overview) {
   const yearLabel = year ? ` (${year})` : '';
   const ratingLabel = rating ? ` IMDb ${rating.toFixed(1)}/10${votes ? ` (${votes.toLocaleString()} votes)` : ''}.` : '';
   const seasonLabel = n === 1 ? '1 season' : `${n} seasons`;
-  const lead = `${title}${yearLabel} — episode-by-episode IMDb ratings and season-shape analysis across ${seasonLabel}.${ratingLabel}`;
+  const lead = `${title}${yearLabel} - episode-by-episode IMDb ratings and season-shape analysis across ${seasonLabel}.${ratingLabel}`;
   if (!overview) return clip(lead, 300);
   return clip(`${lead} ${overview}`, 300);
 }

--- a/apps/rising-shows/tests/render-show-page.test.js
+++ b/apps/rising-shows/tests/render-show-page.test.js
@@ -45,7 +45,7 @@ test('renderShowPage produces a valid HTML5 document', () => {
 
 test('renderShowPage puts the show name in the title and h1', () => {
   const html = renderShowPage(BREAKING_BAD);
-  assert.ok(html.includes('<title>Breaking Bad (2008) — Episode Ratings'));
+  assert.ok(html.includes('<title>Breaking Bad (2008) - Episode Ratings'));
   assert.ok(html.match(/<h1>Breaking Bad/));
 });
 
@@ -414,4 +414,34 @@ test('groupBySeries backfills series-level fields from any season', () => {
   const grouped = groupBySeries(matches);
   assert.equal(grouped[0].poster, '/late.jpg');
   assert.equal(grouped[0].tmdbId, 99);
+});
+
+// ---------- curated vs long-tail robots meta (SEO cleanup, 2026-08-05) ----------
+// Only sitemap-listed pages ask to be indexed. The long tail keeps
+// noindex,FOLLOW so internal links still pass equity while Google drains the
+// ~60k "Crawled - currently not indexed" backlog created by the May 2026
+// full-catalogue launch.
+
+test('a curated page (inSitemap true) asks to be indexed', () => {
+  const html = renderShowPage({ ...BREAKING_BAD, inSitemap: true });
+  assert.ok(html.includes('<meta name="robots" content="index, follow, max-image-preview:large">'));
+  assert.ok(!html.includes('noindex'));
+});
+
+test('a long-tail page (inSitemap false) is noindex but still follow', () => {
+  const html = renderShowPage({ ...BREAKING_BAD, inSitemap: false });
+  assert.ok(html.includes('<meta name="robots" content="noindex, follow">'));
+  assert.ok(!html.includes('max-image-preview'));
+});
+
+test('inSitemap defaults to indexable so nothing regresses if a caller omits it', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  assert.ok(html.includes('<meta name="robots" content="index, follow, max-image-preview:large">'));
+});
+
+test('the page title uses a plain hyphen, never an em dash', () => {
+  const html = renderShowPage(BREAKING_BAD);
+  const title = html.match(/<title>([^<]*)<\/title>/)[1];
+  assert.ok(title.includes(' - '));
+  assert.ok(!title.includes('—'));
 });


### PR DESCRIPTION
## What this does

One behavioral change to the static page build, no UI impact: show pages OUTSIDE the curated top-2,000 sitemap set now render `<meta name="robots" content="noindex, follow">` instead of asking to be indexed. Curated pages are unchanged (`index, follow, max-image-preview:large`). Page titles also swap the em dash for a hyphen per the standing writing rule.

## Files

- **apps/rising-shows/scripts/build-show-pages.js**: the curated set (top 2,000 by IMDb votes, the existing `selectSitemapSeries`) is now computed BEFORE the render loop and each page gets an `inSitemap` flag; the sitemap write reuses the same set; the build log message no longer claims the long tail 'stays crawlable'.
- **apps/rising-shows/scripts/render-show-page.js**: `renderShowPage` accepts `inSitemap` (defaults to indexable so no caller can regress to mass-noindex by omission) and emits the robots meta accordingly; the title and seven other prose em dashes normalized (the lone '—' episode-name placeholder glyph kept - it is empty-state data the tests pin).
- **apps/rising-shows/tests/render-show-page.test.js**: title assertion updated; four new tests pin curated-indexed, long-tail-noindex-follow, the safe default, and the hyphenated title.
- **apps/rising-shows/README.md**: the sitemap section now documents the full cause-and-effect chain instead of the 'rest stays crawlable' rationale this change retires.

## Why (root cause, verified in git + prod)

2026-05-18 (088fc45) shipped ~34.5k programmatic show pages with a full sitemap. Google crawled the lot (late-May traffic spike), then its quality systems declined the templated long tail: GSC now shows 59,772 'Crawled - currently not indexed', climbing, with search traffic collapsing in June. The 2026-07-04 rebrand doubled the known-URL space to ~69k (the old namespace is the benign 5.2k redirect bucket; 301s verified single-hop to live targets). The 2026-07-29 curation trimmed the sitemap to 2,014 show URLs but deliberately left all ~34k pages generated, A-Z-linked, self-canonical and index-follow, so the backlog had no way to drain. This change gives Google the explicit signal while keeping every page working for app users and passing link equity (follow) to the curated set.

## Expected impact

Over the next 4-8 weeks of recrawl: 'Excluded by noindex' climbs, 'Crawled - currently not indexed' falls from ~60k, indexed count holds at the curated few thousand, and sitewide quality signals concentrate on 2,596 submitted URLs instead of diluting across 34k. Traffic recovery follows over months; the next GSC checkpoint is ~2026-09-05.

## How it was tested

npm test 2212/2212 (218 rising-shows tests incl. the 4 new robots/title pins). The pages regenerate on every deploy and daily data refresh, so rollout is automatic on merge.