### PR TITLE
fix(maptap-rivals): allow the pair-link existence probe in firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -180,8 +180,21 @@ service cloud.firestore {
     // afterwards (no update rule) so neither side can rewrite the other's
     // handle or name. Either member may delete, which is how "delete this
     // rival" tears the connection down.
+    //
+    // get vs list: the client probes a specific pair id BEFORE creating it
+    // (tryLinkRival's existence check). On a nonexistent doc `resource` is
+    // null, so a single `read` rule touching resource.data errors and the
+    // probe dies with permission-denied before the create can ever run -
+    // this silently broke the first live connection attempt. So `get`
+    // explicitly allows the resource == null case. The cost: a registered
+    // member can probe whether two specific uids are linked, which requires
+    // already knowing both uids and reveals only that a pair doc exists.
+    // `list` keeps the strict membership condition, which is what actually
+    // guards bulk reads.
     match /maptapRivalsLinks/{pairKey} {
-      allow read: if isRegistered()
+      allow get: if isRegistered()
+        && (resource == null || request.auth.uid in resource.data.uids);
+      allow list: if isRegistered()
         && request.auth.uid in resource.data.uids;
       allow create: if isRegistered()
         && request.resource.data.uids.size() == 2


### PR DESCRIPTION
Fixes the bug that silently blocked the first real two-account connection on the rival network (shipped in #330). Already deployed to production and verified live; this PR brings the repo file in sync with the deployed ruleset.

## firestore.rules

The only changed file. In `maptapRivalsLinks/{pairKey}`, the single `allow read` rule is split into `get` and `list`:

- `get` now explicitly allows the `resource == null` case. Before creating a pair link, the client probes the exact pair doc id to see whether it already exists (`tryLinkRival`'s existence check). On a nonexistent doc `resource` is null, so the old rule's `request.auth.uid in resource.data.uids` errored during evaluation and the probe came back permission-denied - the client's fail-soft catch swallowed it and the link was never created. Cost of the fix: a registered member can probe whether two specific uids are linked, which requires already knowing both uids and reveals only that a pair doc exists.
- `list` keeps the strict membership condition unchanged, so the bulk query surface is exactly as tight as before.

A comment block above the rule documents the split and why it exists.

## How it was found

Live two-account test on production: both accounts joined and published correctly, but no link doc ever appeared in `maptapRivalsLinks`. The second account's profile doc updated at the moment of the rival save, proving writes worked and isolating the failure to the link path.

## How it was tested

- Reproduced and verified with `@firebase/rules-unit-testing` against the Firestore emulator, simulating the exact client flow (probe nonexistent pair doc, create, read back from both members, `array-contains` self-query) plus the forbidden cases (stranger get/query/create, member update). Old rules: 12/13, failing exactly the existence probe. Fixed rules: 13/13, all forbidden cases still denied, and the `maptapRivalsNetwork` connected-peers read gate still correct.
- Deployed to `shevato-site` and confirmed end to end with two real accounts: connection created from one side, auto-add banner and Connected chip on the other, discovery lists working both ways.
- `npm test`: 2208 passing, 0 failing.