### PR TITLE
fix(mario-kart): keep a player with races out of the count key's reach

### DIFF
--- a/apps/mario-kart/README.md
+++ b/apps/mario-kart/README.md
@@ -77,6 +77,22 @@ The tracker works best on modern browsers:
 - **Players**: Supports 1-4 players; layouts verified at all player counts
 - **Browser**: Chrome or Firefox on desktop for best experience
 
+### Player count vs the race log
+The player-count selector sets how wide the race-entry form is: how many
+people are playing now. It is stored under its own key
+(`marioKartPlayerCount`), separate from the race log (`marioKartRaces`), and
+cross-device sync carries the two independently, so they can disagree
+without anyone touching the app.
+
+Because of that, the history table, the per-player cards and every statistic
+read from a roster that unions the two: the entry width plus whoever
+actually has results in the race log. Narrowing the entry form therefore
+stops you entering a fourth score, but never hides a fourth player's
+recorded races, and their positions stay editable from the race-edit dialog.
+When no count has ever been stored, it is taken from the race log rather
+than from the built-in default of 3, so a device that receives the races
+without the count key does not silently drop a player.
+
 ## 🛠️ Technical Details
 
 ### Technologies Used

--- a/apps/mario-kart/js/dataManager.js
+++ b/apps/mario-kart/js/dataManager.js
@@ -35,6 +35,28 @@ function detectActivePlayersFromRaces(raceData) {
     return Math.max(1, Math.min(4, activeCount));
 }
 
+// Highest player slot that actually appears in the race log, or 0 when the
+// log is empty. Deliberately NOT detectActivePlayersFromRaces: that one
+// answers "how many players should an import switch to" and defaults to 3
+// for an empty log, which would drag a 1- or 2-player setup back up to 3.
+// This one answers "who has recorded results" and says 0 when nobody does.
+function highestPlayerWithRaces(raceData) {
+    if (!Array.isArray(raceData)) return 0;
+    let highest = 0;
+    for (const race of raceData) {
+        if (!race) continue;
+        for (let i = 4; i > highest; i--) {
+            const pos = race[`player${i}`];
+            if (pos !== null && pos !== undefined) {
+                highest = i;
+                break;
+            }
+        }
+        if (highest === 4) break;
+    }
+    return highest;
+}
+
 function addRace() {
     const date = document.getElementById('date').value;
     // Dynamic player data collection
@@ -460,17 +482,33 @@ function loadSavedData() {
         const savedPlayerCount = localStorage.getItem(storageKey);
         if (savedPlayerCount) {
             playerCount = parseInt(savedPlayerCount);
-            const allPlayers = ['player1', 'player2', 'player3', 'player4'];
-            players = allPlayers.slice(0, playerCount);
+        } else if (typeof highestPlayerWithRaces === 'function') {
+            // No stored count. A stored one is a choice we must respect even
+            // when it looks small (someone really can drop from four players
+            // to three), but an absent one records no choice at all, and the
+            // module default of 3 would silently narrow the entry form for
+            // someone whose race log plainly has four. This is the shape a
+            // device lands in when sync delivers the race log without the
+            // count key, since the two travel as independent keys.
+            playerCount = Math.max(playerCount, highestPlayerWithRaces(races));
+        }
 
-            // Update the select dropdown
-            const playerCountSelect = document.getElementById('player-count');
-            if (playerCountSelect) {
-                playerCountSelect.value = playerCount.toString();
-            }
+        // Update the select dropdown
+        const playerCountSelect = document.getElementById('player-count');
+        if (playerCountSelect) {
+            playerCountSelect.value = playerCount.toString();
         }
     } catch (e) {
         console.error('Error loading player count:', e);
+    }
+
+    // Always recompute the roster, count key or not. A device that received
+    // the race log but not the count key (or received a stale one) would
+    // otherwise read with the module default of 3 and drop a fourth player
+    // who has a full history. Runs outside the try above so a failed count
+    // read still leaves the roster matching the races we did load.
+    if (typeof refreshPlayerRoster === 'function') {
+        refreshPlayerRoster();
     }
 }
 

--- a/apps/mario-kart/js/playerManager.js
+++ b/apps/mario-kart/js/playerManager.js
@@ -2,6 +2,36 @@ let playerCount = 3;
 let players = ['player1', 'player2', 'player3'];
 const maxPlayers = 4;
 
+// The slots every table, chart and statistic reads with.
+//
+// `playerCount` is the entry-form width: how many people are playing now.
+// The race log is a separate record of who has ever played, and cross-device
+// sync carries the two under independent last-write-wins keys
+// (marioKartPlayerCount, marioKartRaces), so they can disagree without anyone
+// touching the app. Reading with the count alone is how a player with a full
+// history disappears from the history table and from every statistic while
+// their results sit intact in storage.
+//
+// Union of the two, so narrowing the entry form never hides a recorded
+// result, and a slot you have added but not yet played still gets its column.
+function rosterForCount(count) {
+    const allPlayers = ['player1', 'player2', 'player3', 'player4'];
+    const wanted = Number.isFinite(count) ? count : 0;
+    let played = 0;
+    if (typeof highestPlayerWithRaces === 'function' && typeof races !== 'undefined') {
+        played = highestPlayerWithRaces(races);
+    }
+    const slots = Math.max(1, Math.min(maxPlayers, Math.max(wanted, played)));
+    return allPlayers.slice(0, slots);
+}
+
+// Recompute the roster from the current count and race log. Called after the
+// race log loads or changes, since either can widen it.
+function refreshPlayerRoster() {
+    players = rosterForCount(playerCount);
+    return players;
+}
+
 // Use centralized player name manager
 let playerNames = window.PlayerNameManager ? window.PlayerNameManager.getAll() : {
     player1: 'Player 1',
@@ -78,8 +108,7 @@ function updatePlayerCount(newCount) {
     playerCount = newCount;
 
     // Update players array
-    const allPlayers = ['player1', 'player2', 'player3', 'player4'];
-    players = allPlayers.slice(0, playerCount);
+    players = rosterForCount(playerCount);
 
     // Update UI visibility
     updatePlayerFieldsVisibility();

--- a/apps/mario-kart/tests/core.test.js
+++ b/apps/mario-kart/tests/core.test.js
@@ -89,6 +89,93 @@ test('detectActivePlayersFromRaces: clamps between 1 and 4', () => {
   assert.equal(fn([{ player1: null, player2: null, player3: null, player4: null }]), 1);
 });
 
+// --- highestPlayerWithRaces ------------------------------------------------
+// Unlike detectActivePlayersFromRaces this one must NOT default to 3: it
+// answers "who has recorded results", and a wrong floor would drag a 1- or
+// 2-player setup back up to 3 every load.
+
+test('highestPlayerWithRaces: an empty or missing log is 0, not 3', () => {
+  const ctx = makeContext();
+  loadInto(ctx, 'dataManager.js');
+  const fn = ctx.highestPlayerWithRaces;
+  assert.equal(fn([]), 0);
+  assert.equal(fn(null), 0);
+  assert.equal(fn(undefined), 0);
+  assert.equal(fn('not an array'), 0);
+});
+
+test('highestPlayerWithRaces: returns the highest slot holding a position', () => {
+  const ctx = makeContext();
+  loadInto(ctx, 'dataManager.js');
+  const fn = ctx.highestPlayerWithRaces;
+  assert.equal(fn([{ player1: 1, player2: 2, player3: null, player4: null }]), 2);
+  assert.equal(fn([{ player1: 1, player2: null, player3: 3, player4: null }]), 3);
+  assert.equal(fn([{ player1: 1, player2: 2, player3: 3, player4: 4 }]), 4);
+});
+
+test('highestPlayerWithRaces: scans the whole log, not just the first race', () => {
+  const ctx = makeContext();
+  loadInto(ctx, 'dataManager.js');
+  const fn = ctx.highestPlayerWithRaces;
+  assert.equal(fn([
+    { player1: 1, player2: 2, player3: null, player4: null },
+    { player1: 1, player2: 2, player3: 3, player4: 4 },
+  ]), 4);
+});
+
+test('highestPlayerWithRaces: a position of 1 counts, null and undefined do not', () => {
+  const ctx = makeContext();
+  loadInto(ctx, 'dataManager.js');
+  const fn = ctx.highestPlayerWithRaces;
+  assert.equal(fn([{ player1: null, player2: null, player3: null, player4: 1 }]), 4);
+  assert.equal(fn([{ player1: 1 }]), 1);
+  assert.equal(fn([null, { player1: 1, player2: 2 }]), 2);
+});
+
+// --- rosterForCount --------------------------------------------------------
+// The roster every table and statistic reads with: the entry-form width and
+// the race log unioned, so a narrower form never hides a recorded result.
+
+// dataManager.js declares `let races` at top level, which shadows anything
+// the sandbox was seeded with, so the log has to be assigned after loading.
+// Rosters come back as arrays built by the vm's own Array, so compare joined
+// strings rather than tripping deepEqual's cross-realm prototype check.
+function rosterCtx(raceLog) {
+  const ctx = makeContext();
+  loadInto(ctx, 'dataManager.js');
+  loadInto(ctx, 'playerManager.js');
+  vm.runInContext(`races = ${JSON.stringify(raceLog)}`, ctx);
+  return (count) => vm.runInContext(
+    `rosterForCount(${JSON.stringify(count)}).join(',')`, ctx);
+}
+
+test('rosterForCount: with no race log the roster is exactly the entry width', () => {
+  const roster = rosterCtx([]);
+  assert.equal(roster(2), 'player1,player2');
+  assert.equal(roster(1), 'player1');
+  assert.equal(roster(4), 'player1,player2,player3,player4');
+});
+
+test('rosterForCount: a player with races is kept even when the count is short', () => {
+  // This is the divergence: the count key says 3, the race log says 4.
+  const roster = rosterCtx([{ player1: 1, player2: 2, player3: 3, player4: 4 }]);
+  assert.equal(roster(3), 'player1,player2,player3,player4');
+  assert.equal(roster(1), 'player1,player2,player3,player4');
+});
+
+test('rosterForCount: a slot added but not yet played still gets its column', () => {
+  const roster = rosterCtx([{ player1: 1, player2: 2, player3: null, player4: null }]);
+  assert.equal(roster(4), 'player1,player2,player3,player4');
+});
+
+test('rosterForCount: never empty and never past four', () => {
+  const roster = rosterCtx([]);
+  assert.equal(roster(0), 'player1');
+  assert.equal(roster(-2), 'player1');
+  assert.equal(roster(99), 'player1,player2,player3,player4');
+  assert.equal(roster(null), 'player1');
+});
+
 // --- getFilteredRaces ------------------------------------------------------
 
 test('getFilteredRaces: "all" returns every race', () => {


### PR DESCRIPTION
A fourth player could disappear from the history table, the per-player cards, every statistic and the race-edit dialog, while their races sat intact in storage.

Found by sweeping the other apps for the class of bug behind PR #338 (maptap-rivals' "Unknown rival"): two synced localStorage keys that reference each other, drifting apart. Mario Kart was the one real hit, and it fails the opposite way round. maptap-rivals invented a player; this hid one, which is harder to notice because no phantom row tips you off, the totals just get smaller.

## Root cause

Everything read from the global `players`, which was `allPlayers.slice(0, playerCount)`. `marioKartPlayerCount` and `marioKartRaces` sync as independent last-write-wins keys, so a count narrower than the race log dropped a player nobody had removed. With no count key stored at all, the module default of 3 applied, which is the shape a device lands in when sync delivers the race log without the count.

Reproduced headless before any code changed, at a seed of 12 four-player races with the count key absent: three player cards, three history columns, and race rows showing a finishing position of 4 with no fourth player to own it.

`detectActivePlayersFromRaces` already existed for exactly this question and is unit-tested, but it is wired only into the JSON-import path, never into load.

## Changed files

**`apps/mario-kart/js/dataManager.js`**
- New `highestPlayerWithRaces(raceData)`: the highest player slot holding a position anywhere in the log, or 0 for an empty or malformed log. Deliberately separate from `detectActivePlayersFromRaces`, which defaults to 3 for an empty log; reusing it would have dragged a 1- or 2-player setup up to 3 on every load. Short-circuits once it reaches slot 4.
- `loadSavedData` no longer computes the roster only inside the `if (savedPlayerCount)` branch. An absent count is now taken from the race log instead of the module default; a stored count is left untouched. The dropdown sync moved out of that branch so it reflects the resolved count either way.
- A `refreshPlayerRoster()` call at the end of `loadSavedData`, outside the try block, so a failed count read still leaves the roster matching the races that did load.

**`apps/mario-kart/js/playerManager.js`**
- New `rosterForCount(count)`: the union of the entry-form width and the slots with recorded results, clamped to 1..4, tolerant of non-finite input, and safe when `races` is not yet defined.
- New `refreshPlayerRoster()` so the race log can widen the roster after it loads or changes.
- `updatePlayerCount` builds the roster through `rosterForCount` instead of slicing by count.

**`apps/mario-kart/tests/core.test.js`** (+8 tests)
- `highestPlayerWithRaces`: empty/null/undefined/non-array is 0 not 3; returns the highest occupied slot; scans the whole log rather than the first race; a position of 1 counts while null and undefined do not; a null race entry is skipped.
- `rosterForCount`: with no race log the roster is exactly the entry width; a player with races survives a short count (the divergence itself); a slot added but not yet played still gets its column; clamped for 0, negative, oversized and non-finite input.

**`apps/mario-kart/README.md`**
- New "Player count vs the race log" subsection explaining that the two are separate keys that sync independently, that the count sets entry width only, and that an absent count is read from the race log.

## Judgment calls

- **The count and the log answer different questions, so neither is made to win.** An absent count records no choice and is derived from the log. A stored count is respected even when it looks small, because dropping from four players to three is a real thing people do, and there is nothing locally that distinguishes a deliberate 3 from a stale one.
- **Widening the roster rather than editing ~95 call sites.** Redefining what `players` holds propagates to every table, chart, statistic and the edit dialog without touching them. Entry-side paths key off `playerCount` (`updatePlayerFieldsVisibility`, `generateSidebarRaceInputs`, `addRace` via `allPlayers`) and are unaffected. The four `players.length` uses are all roster iteration and stay correct with a longer roster.
- **Accepted asymmetry, documented in the plan.** With a stored count of 3 the fourth player appears in history but has no entry-side card, because those achievement bars live inside `.input-field#player4-field` in the markup. Raising the count to 4 restores it. Separating the bars from the entry field is a markup restructure and was left out of a divergence fix.
- **A behavior change worth naming:** deliberately narrowing the entry form no longer hides past races from history and statistics. A recorded result is a record of what happened, and hiding it was the complaint.

## Testing

- `npm test`: **2224/2224 passing**, including the 8 new cases.
- Acceptance plan `.features/mario-kart-claude.md` Part D, run of 2026-08-06: **4/4 sections passed (D1 to D4), 0 failed, 0 unverified.** That plan is a genuinely living document by its own header ("Extend both parts on the next run"), so this round was appended as Part D / Round 4 rather than replacing earlier rounds.
- Before/after screenshots at 1280px and 390px plus the stale-count case. Before shots came from the master checkout served on a second port at the identical seed, so the pair is a true A/B rather than a recollection of the old state.
- The race-edit dialog was driven end to end against both builds: open `editRace(0)`, count inputs, save, then compare `races[0]` and the persisted `marioKartRaces`, watching `window.onerror`. The fixed build renders four inputs and round-trips cleanly; the unfixed build renders three.
- Roster and numeric assertions came from a `--dump-dom` readback probe rather than from reading pixels.

## Bugfix found along the way

The unfixed build renders only three inputs in the edit dialog for a four-player race, so the fourth player's position could not be edited at all. It was **not** destroyed on save: the save merges rather than rebuilds, verified directly against the unfixed build. Old behavior was hidden-but-intact, and the dialog now covers every player in the race.

Two test-harness traps are recorded in the plan for whoever extends these: `dataManager.js` declares `let races` at top level, which shadows anything `makeContext({races})` seeds, so the log must be assigned with `vm.runInContext` after loading; and rosters come back built by the vm's own `Array`, so `assert.deepEqual` trips its cross-realm prototype check.
