### PR TITLE
fix(trip-planner): D1 audit round - sort sentinel, phone overflow, and bulk-select vs filters

### DIFF
--- a/apps/trip-planner/css/styles.css
+++ b/apps/trip-planner/css/styles.css
@@ -1295,6 +1295,12 @@
   .leg-btn {
     border: 1px dashed var(--border); background: none; border-radius: 999px;
     padding: 4px 14px; font-size: 12.5px; font-weight: 600; color: var(--text);
+    /* the label is a whole sentence ("Kyoto, Japan -> Osaka, Japan · how to
+       get there"), and as a flex item it defaults to min-width:auto, so it
+       refused to shrink and pushed the PAGE 14px wider than a 360px phone.
+       Let it shrink and wrap instead: the overflow belongs to the label, not
+       to the document. */
+    min-width: 0; white-space: normal;
   }
   .leg-btn:hover { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
   /* ---------- read a booking confirmation ---------- */
@@ -2998,6 +3004,22 @@
   /* the caption already carries the break, so the hairline above it tightens */
   .tp-menu-panel .sep + .tp-menu-cap { padding-top: 3px; }
 
+  @media (max-width: 560px) {
+    /* 15 action rows plus two captions and two hairlines run the panel to
+       ~696px, and it opens ~172px down the page, so its tail fell past the
+       fold on a 844px phone with nothing to scroll: the panel is absolutely
+       positioned, so the PAGE cannot reach it either. It scrolls itself
+       instead. dvh second so it wins where supported - 100vh measures the
+       tallest viewport, i.e. the one with the URL bar already retracted. */
+    .tp-menu-panel {
+      max-height: calc(100vh - 190px);
+      max-height: calc(100dvh - 190px);
+      overflow-y: auto;
+      /* and the page does not take over once the panel bottoms out */
+      overscroll-behavior: contain;
+    }
+  }
+
   /* ---------- bulk selection ----------
      The toolbar toggle, the bar above the board, and the checkbox column a
      top-level row grows while the mode is on. Every interactive part here pins
@@ -3118,6 +3140,11 @@
        together rather than each grabbing one */
     .trip-planner-app .bulk-status { margin-left: 0; flex: 1 1 140px; min-height: 44px; }
     .trip-planner-app .bulk-del { flex: 1 1 130px; min-height: 44px; }
+    /* "Select all" is a label wrapping a 22px box, so it was a 22px tap target
+       sitting beside two 44px ones. The label is what the thumb actually hits
+       (the box and its text both toggle it), so the floor belongs here, not on
+       the checkbox - growing that would leave a 44px tick on a phone. */
+    .trip-planner-app .bulk-all { min-height: 44px; }
   }
 
 /* ===== Round 4: item fields, warnings and the totals breakdown family ===== */

--- a/apps/trip-planner/js/app.js
+++ b/apps/trip-planner/js/app.js
@@ -1066,7 +1066,8 @@
     const tv = $('#filterTraveler');
     if (tv) tv.value = '';
     ui.search = ''; ui.filterType = ''; ui.filterStatus = ''; ui.filterTraveler = '';
-    exitSelectMode();
+    // clearing only ever REVEALS rows, so there is nothing to prune and no
+    // reason to drop the mode - the same contract as the filter listeners
     render();
   }
 
@@ -1143,6 +1144,16 @@
   // and a filtered-to-nothing trip are handled by the same code.
   function syncSelectUi(visibleIds) {
     selVisible = visibleIds;
+    // Moving the filters moves which rows exist, so the selection is PRUNED to
+    // what the board just drew rather than torn down: a filter is transient,
+    // and dropping the mode as you type means re-entering it by hand once the
+    // search is right. An id the filters hid is forgotten outright - never
+    // silently re-pointed at a row the traveller cannot see - so a bulk action
+    // can only ever reach what is on screen.
+    if (selMode && selIds.size) {
+      const drawn = new Set(visibleIds);
+      for (const id of selIds) if (!drawn.has(id)) selIds.delete(id);
+    }
     const btn = $('#selectBtn');
     btn.textContent = selMode ? 'Cancel select' : 'Select items';
     btn.classList.toggle('on', selMode);
@@ -3649,8 +3660,15 @@
     }
     // trip name, then date. An undated item sorts to the END of its trip rather
     // than the top, where an empty string would otherwise put it.
+    // The date leg compares by CODE POINT, not localeCompare: ICU collation
+    // treats "~" as punctuation and sorts it BEFORE digits
+    // ("~".localeCompare("2026-08-18") === -1), which put every undated item at
+    // the TOP of its trip - the exact opposite of what the "~" sentinel is for.
+    // ISO dates are ASCII, so a plain codepoint compare orders them correctly
+    // and leaves "~" (0x7E) above every digit, as intended.
+    const byDate = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
     rows.sort((a, b) => a.tripName.localeCompare(b.tripName)
-      || (a.date || '~').localeCompare(b.date || '~')
+      || byDate(a.date || '~', b.date || '~')
       || a.title.localeCompare(b.title));
     return rows;
   }
@@ -8121,9 +8139,8 @@
       ui.search = $('#searchBox').value.trim();
       ui.filterType = $('#filterType').value;
       ui.filterStatus = $('#filterStatus').value;
-      // moving the filters moves which rows exist, so the selection made
-      // against the old ones is dropped rather than silently re-pointed
-      exitSelectMode();
+      // select mode survives a filter change; syncSelectUi prunes the selection
+      // to the rows the next render actually draws
       render();
     });
   });
@@ -8133,7 +8150,7 @@
   $('#travelerFilterWrap').addEventListener('input', e => {
     if (e.target.id !== 'filterTraveler') return;
     ui.filterTraveler = e.target.value;
-    exitSelectMode();
+    // pruned, not exited - the same contract as the toolbar filters above
     render();
   });
 


### PR DESCRIPTION
Five behaviour fixes found while sweeping **Part D1 (sections 22-32)** of the trip-planner living test plan: app shell, board, and global state. Every one was reproduced with measurements before being touched, and re-verified afterwards at desktop and phone widths.

Part D1 finished at **131/131 boxes ticked**, 0 open, 0 unverified.

## Changed files

### `apps/trip-planner/js/app.js` (+23 / -5)

**1. Cross-trip search sorted undated items to the TOP of their trip instead of the bottom** (`tripSearchRows`, line ~3660).

The sort used `(a.date || '~').localeCompare(b.date || '~')`. The `'~'` sentinel only works under code-point ordering (U+007E sits above every digit), but `localeCompare` uses ICU collation, which treats `~` as punctuation and sorts it *first*: `'~'.localeCompare('2026-08-18') === -1`, while `'~' > '2026-08-18'` is `true`. The sentinel therefore did the exact reverse of the intent stated in the comment directly above it.

Fixed by comparing the date leg by code point via a small `byDate` helper. Trip name and title stay on `localeCompare`, where locale awareness is actually wanted. Measured with a 25-item fixture: the undated row moved from index 0 to index 12 of 20, the end of its own trip's block.

**2. Filters tore down bulk-select mode instead of pruning the selection** (`syncSelectUi` ~1144, the filter listeners ~8139 and ~8150, `clearFilters` ~1066).

The plan asserts the selection is pruned to what is still on screen and the mode stays on. Observed, the mode was destroyed outright. This was an app-internal contradiction rather than just a wrong bullet: the filter `input` listeners called `exitSelectMode()`, while `syncSelectUi` carried a long comment arguing the mode must be *kept*, and its entire `is-empty` / "Nothing to select: the filters are hiding every item" branch existed only to serve that design. With the exit in place, that branch was unreachable by the path it was written for (be in select mode, then type) and reachable only in reverse order.

Fixed on the side the app's own rationale argued for: `syncSelectUi` now prunes `selIds` to the ids the board just drew, and the three filter paths (`['searchBox','filterType','filterStatus']`, the delegated `#travelerFilterWrap`, and `clearFilters()`) no longer call `exitSelectMode()`. An id the filters hid is forgotten outright, never silently re-pointed, so a bulk action can only ever reach what is on screen. The exits that survive are the ones that change *which board exists* rather than what it shows: trip switch, view switch, and the last item leaving a trip.

### `apps/trip-planner/css/styles.css` (+27 / -0)

**3. The route-leg pill forced 14px of horizontal PAGE scroll at 360px** (`.leg-btn`, line ~1295). Found in section 25, but it affected every view.

`.leg-btn` is a flex item of `.leg-row`, so it defaulted to `min-width: auto` and refused to shrink below its sentence-length label ("Kyoto, Japan -> Osaka, Japan - how to get there?"), measuring 388px inside a 360px viewport and pushing `documentElement.scrollWidth` to 374. Fixed with `min-width: 0; white-space: normal`, so the overflow belongs to the label rather than the document. Unchanged at 1280 (one line, 388x28); wraps cleanly at 360 (two lines, 296x45, still above its 44px phone floor).

**4. "Select all" was a 22px tap target on phones** (`.bulk-all`, in the existing `max-width: 560px` block).

Layout was exactly as specified (two bands, the status select and delete button each ~half width and both exactly 44px tall), but the `.bulk-all` label measured 22px, half the 44px floor the phone stylesheet applies elsewhere (`.leg-btn`, `.assist-quick-links a`). Fixed with `min-height: 44px` on the label. The checkbox inside stays 22px: the label is the hit area, and an oversized tick box would read wrong.

**5. The trip menu ran past the fold at 390x844 and could not scroll** (`.tp-menu-panel`, new `max-width: 560px` block).

Fifteen action rows plus two captions and two hairlines ran the panel to 696px starting at `top=172`, so its bottom landed at 869 against an 844px viewport. It also computed `overflow-y: visible` / `max-height: none` with `scrollHeight === clientHeight`, so the plan's "scrollable inside itself" clause was simply unimplemented, and because the panel is absolutely positioned the page could not reach the overflow either. Fixed with `max-height: calc(100dvh - 190px)`, preceded by a `100vh` declaration as the fallback since `100vh` measures the tallest viewport, plus `overflow-y: auto` and `overscroll-behavior: contain` so the page does not take over once the panel bottoms out. The panel now ends at 826 inside the fold with `scrollHeight 694 > clientHeight 652` and all 15 rows reachable; at 1280 the rule does not apply at all (`max-height: none`, `overflow-y: visible`, `scrollHeight === clientHeight === 694`).

## Plan corrections (the plan was wrong, the app was right)

- Section 24's unconverted-money fixture was **unfalsifiable**: it assumed a mismatched rates-cache `base` forces an unconverted amount "regardless of network access", but `ensureRates()` refetches and replaces the cache on every render, so the item converted normally. Rewritten around VND, which frankfurter never publishes.
- Section 23's browser Back/Forward bullet was wrong as written. `setView` -> `applyView` -> `syncViewHash` only ever calls `history.replaceState`, never `pushState`, so a session never creates a second history entry to go Back into. Rewritten around `history.length` never growing.
- Section 27's `#clearFiltersBtn` box asserted that clicking it exits bulk-select mode, which was true before fix 2 above. Clearing a filter only ever reveals rows, so there is nothing to prune and the mode is now kept; that clause is amended in place and cross-linked to section 28.
