### PR TITLE
fix(trip-planner): stop a shared link from rewriting the visitor's own trip data

### DIFF
--- a/apps/trip-planner/js/app.js
+++ b/apps/trip-planner/js/app.js
@@ -284,10 +284,10 @@
   // state the undo baseline: one Undo could hand the broken data back. Written
   // outsideHistory because the app straightening its own storage is
   // housekeeping, not an edit the traveller made and should have to undo.
-  function repairDb() {
+  function repairDb(skipSave) {
     const before = historyKey();
     repairTrips();
-    if (historyKey() !== before) save(null, null, true);
+    if (!skipSave && historyKey() !== before) save(null, null, true);
   }
   function repairTrips() {
     if (!Array.isArray(db.trips)) db.trips = [];
@@ -8343,12 +8343,18 @@
     $(id).max = DATE_MAX;
   }
   syncTimefmtLabel();
-  repairDb();
   // Same reader the view-hash writer consults, so the two can never disagree.
   // A hand-retyped "#SHARE=..." used to boot as a normal load, while that
   // writer (correctly case-insensitive) then refused to touch the fragment, so
   // the payload just sat in the URL doing nothing.
-  if (viewFromHash(location.hash, ui.view).isShare) {
+  const bootIsShare = viewFromHash(location.hash, ui.view).isShare;
+  // repairTrips() still runs so `db`/`realDb` is never handed downstream code
+  // (e.g. ensureTrip() on a failed share decode) in an unnormalized shape, but
+  // the write-back is skipped on a share boot: opening someone else's link
+  // must never touch this device's own real trip data, not even to fix up a
+  // stale schema field.
+  repairDb(bootIsShare);
+  if (bootIsShare) {
     enterSharedMode();
   } else {
     // Set before the first render so there is no flash of Timeline on a


### PR DESCRIPTION
One data-integrity fix, found while closing out **Parts D2 and D3** of the trip-planner living test plan (sections 33-55: forms and modals, Days view, Map, and every integration).

## Changed files

### `apps/trip-planner/js/app.js` (+10 / -4)

**Opening a shared link rewrote the visitor's own trip data.**

At boot the app called `repairDb()` unconditionally, which runs `repairTrips()` to normalize stale schema fields and then writes the result straight back to `trip-planner:v1` via `save(null, null, true)`. That happened *before* the boot path checked `viewFromHash(location.hash, ui.view).isShare`, so following someone else's `#share=...` link ran the housekeeping over the visitor's own saved trips and persisted it. The visitor never touched anything, and nothing about the read-only shared view that loaded afterwards indicated their own storage had just been written.

`repairDb()` now takes a `skipSave` flag, and the share check moved above the call so its result can be passed in as `bootIsShare`. `repairTrips()` still runs on a share boot, so downstream code never receives an unnormalized `db` or `realDb` (`ensureTrip()` on a failed share decode is the case that needs this), but the write-back is suppressed. The visitor's own data stays untouched until they explicitly choose "Import as my trip".

Verified with a seed, snapshot, compare fixture: `trip-planner:v1` is byte-identical across a share boot, and unchanged on a normal boot where the repair write is still expected to fire.

This also makes the app match what `apps/trip-planner/README.md` already claimed about the read-only shared view, that it "locks every action that would write to YOUR data". The README needed no edit; the bug was violating it.
