### PR TITLE
feat(site): centralize GA4 behind a shared helper, cover the apps, and give every page one URL

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,8 +17,25 @@
     <link rel="dns-prefetch" href="https://www.google-analytics.com">
 
     <!-- Google Analytics -->
+    <!--
+      Netlify serves this document for any unmatched path while leaving that
+      path in the address bar, so GA4 was recording one distinct page_path per
+      broken link and per bot probe. That long tail is a large part of why 624
+      views were spread over 257 paths, and every one of those rows shows 0s
+      engagement, dragging the site average down.
+
+      Pinning page_path collapses all of them into a single /404 row. The path
+      that actually failed is still reported, as a parameter on a `page_not_found`
+      event below, so broken inbound links remain findable without polluting
+      Pages and Screens. This inline block must stay ahead of the deferred
+      analytics.js, which reads it at config time.
+    -->
+    <script>
+      window.SHEVATO_ANALYTICS_CONFIG = { pagePath: '/404', pageTitle: '404 Not Found' };
+    </script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
     <script defer src="/assets/js/analytics.js"></script>
+    <script defer src="/assets/js/analytics-404.js"></script>
 
     <link rel="stylesheet" href="/assets/css/main.css" />
     <link rel="stylesheet" href="/assets/css/brand-colors.css" />

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ shevato/
 │   ├── js/                           # Site-wide JavaScript modules
 │   │   ├── main.js                   # Auth UI + partials loader (jQuery)
 │   │   ├── jquery.min.js             # jQuery (vendored)
-│   │   ├── analytics.js              # Google Analytics bootstrap
+│   │   ├── analytics.js              # GA4 config + the shared tracking API (window.shevatoAnalytics)
+│   │   ├── analytics-404.js          # Reports the failed path on 404.html
 │   │   ├── language-switcher.js      # Tri-lingual switcher for the separately-branded landing
 │   │   ├── passive-events-fix.js     # Passive listeners polyfill
 │   │   ├── breakpoints.min.js, browser.min.js, util.js  # Responsive helpers
 │   │   └── pagination.js, global-icons.js
+│   ├── js/tests/                     # Unit tests for the analytics helper (npm run test:analytics)
 │   ├── sass/                         # SASS sources for main.css
 │   └── seo/                          # Reference JSON-LD fragments + metadata checklist
 │
@@ -159,9 +161,54 @@ npm run test:rising-shows           # render + integrations-lib
 npm run test:mario-kart
 npm run test:arena
 npm run test:sync                   # cross-cutting sync-system invariants
+npm run test:analytics              # shared GA4 helper (privacy + dedupe rules)
 ```
 
 The repo has cross-cutting invariant tests under `sync-system/tests/`, so run `npm test` after any non-trivial change before committing.
+
+## Analytics
+
+Every page loads GA4 through one file, `assets/js/analytics.js`, which configures
+the property and installs `window.shevatoAnalytics`. **Call that API — never
+`gtag()` directly.** It centralises the privacy rules, the dedupe, and the
+guarantee that a tracking failure cannot throw into app code.
+
+Apps reach it through a small local `track(method, ...args)` shim that resolves
+`window.shevatoAnalytics` at call time (the helper is deferred, so app code can
+run first) and swallows everything. Gym Tracker, being ES modules, imports the
+same shim from `apps/gym-tracker/js/utils/analytics.js`.
+
+Events, all carrying `app_name` and `app_section` automatically:
+
+| Event | Fired when | Key parameters |
+|---|---|---|
+| `page_view` | once per document load | `page_path` (no query, no hash, no `.html`) |
+| `app_open` | an app's own entry page loads | — |
+| `app_view` | in-app section/tab change | `view_name` |
+| `search` | a search runs | `search_scope`, `query_length`, `results_count`, `has_results` |
+| `search_result_select` | a result is picked | `content_type`, `content_id`, `result_position` |
+| `filter_change` | a filter/sort control changes | `filter_name`, `filter_value` |
+| `content_view` | a detail record opens | `content_type`, `content_id` |
+| `load_more` | pagination advances | `page_number`, `items_shown` |
+| `app_action` | a meaningful action completes | `action_name` + per-action counts |
+| `outbound_click` | a link to another origin | `link_domain` |
+| `site_nav_click` | an internal link or mailto/tel | `nav_location`, `link_destination` |
+| `app_error` | uncaught error or rejection | `error_scope`, `error_message` (capped at 5/page) |
+| `page_not_found` | 404.html renders | `not_found_path`, `referrer_domain` |
+
+Two rules when adding tracking:
+
+1. **Never send anything the user typed.** Report a query's length and result
+   count, not its text; report a catalogue id (a show slug), not a title someone
+   entered. `scrub()` drops parameters whose names look like free text or
+   identity and values that look like emails or generated ids, but it is a
+   backstop — do not rely on it.
+2. **One event per gesture.** `trackView`/`trackFilter` drop repeats; call
+   `primeFilter` at boot to register default filter state so the first control a
+   user touches reports once instead of the whole panel reporting its defaults.
+
+In-app navigation deliberately reports `app_view`, never a synthetic
+`page_view`, so client routing can never invent URLs in Pages and Screens.
 
 ## Deployment
 

--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -98,6 +98,14 @@
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="/assets/css/back-to-top.css">
+
+  <!-- Google Analytics. Loaded async + defer so it never blocks first paint;
+       all tracking goes through the shared helper in analytics.js, which
+       no-ops if gtag is blocked. See privacy.html "Analytics and cookies". -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body class="brain-arena-app">
   <!-- Sync status banner (managed by assets/js/sync-status.js) - only visible when offline. -->

--- a/apps/arena/js/app.js
+++ b/apps/arena/js/app.js
@@ -41,6 +41,22 @@ const {
     increment, deleteField
 } = firestore;
 
+/**
+ * Analytics shim. Resolved at call time (the shared helper is installed by a
+ * deferred classic script, this is a module) and never throws. Arena is
+ * multiplayer, so the rule is stricter than elsewhere: no room codes, no
+ * display names, no uids - a room code is a shared secret that lets anyone
+ * join, and it must not leave the app.
+ */
+function track(method, ...args) {
+    try {
+        const a = typeof window !== 'undefined' ? window.shevatoAnalytics : null;
+        if (a && typeof a[method] === 'function') a[method](...args);
+    } catch (e) {
+        /* analytics must never break the app */
+    }
+}
+
 const Config = window.BrainArena.Config;
 const Scoring = window.BrainArena.Scoring;
 const Feedback = window.BrainArena.Feedback;
@@ -1346,6 +1362,11 @@ async function createRoom(opts) {
         ? 'globe-drop'
         : (state.selectedGameType === 'globe-drop' ? 'globe-drop' : 'trivia');
 
+    // Which game and which mode people pick is the whole product question for
+    // Arena. Both values are fixed enumerations defined right here, not user
+    // input, and neither identifies the room or the players.
+    track('trackAction', 'room_created', { game_type: gameType, room_mode: mode });
+
     // Solo / daily rooms are always private to keep them out of any future
     // public-room discovery. They have no password - only this user is in
     // them, and the room code itself acts as the (single-use) secret.
@@ -1623,6 +1644,14 @@ async function joinRoom() {
     // can show a "Spectating - joining next round" banner and gate submitting.
     const isSpectator = data.status === 'playing';
     await joinPlayer(code, displayName, /* isHost */ false, isSpectator ? (data.currentQuestionIndex || 0) : -1);
+    // Reported only after every guard has passed and the player doc is
+    // written, so a wrong password, a full room or an abandoned name prompt is
+    // never counted as a join. The room code is a shared secret that grants
+    // entry, and the display name is user-entered - neither is sent.
+    track('trackAction', 'room_joined', {
+        game_type: data.gameType || 'unknown',
+        joined_as: isSpectator ? 'spectator' : 'player',
+    });
     enterRoom(code);
 }
 

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -109,6 +109,14 @@
     <!-- Visual refresh layer — must load last so it wins specificity ties. -->
     <link rel="stylesheet" href="css/refresh.css">
   <link rel="stylesheet" href="/assets/css/back-to-top.css">
+
+  <!-- Google Analytics. Loaded async + defer so it never blocks first paint;
+       all tracking goes through the shared helper in analytics.js, which
+       no-ops if gtag is blocked. See privacy.html "Analytics and cookies". -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body class="mario-kart-app football-h2h-tracker">
     <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->

--- a/apps/football-h2h/js/football-h2h.js
+++ b/apps/football-h2h/js/football-h2h.js
@@ -1,5 +1,19 @@
 // Football H2H Tracker JavaScript
 
+/**
+ * Analytics shim. Resolves window.shevatoAnalytics at call time (the shared
+ * helper is deferred, this is a classic script) and never throws, so a
+ * tracking failure can never stop a match being saved.
+ */
+function track(method, ...args) {
+    try {
+        const a = typeof window !== 'undefined' ? window.shevatoAnalytics : null;
+        if (a && typeof a[method] === 'function') a[method](...args);
+    } catch (e) {
+        /* analytics must never break the app */
+    }
+}
+
 // Data structure for games
 let games = [];
 let currentEditId = null;
@@ -615,7 +629,13 @@ function saveGame(event) {
         player2Team,
         penaltyWinner: penaltyWinner || null
     };
-    
+
+    // Logged after validation passes. Team names are excluded on purpose:
+    // the "Other" option makes them a free-text field.
+    track('trackAction', currentEditId ? 'match_edited' : 'match_logged', {
+        went_to_penalties: Boolean(penaltyWinner),
+    });
+
     if (currentEditId) {
         // Edit existing game
         const gameIndex = games.findIndex(m => m.id === currentEditId);
@@ -2041,6 +2061,10 @@ function syncStatsTabFromHash() {
 // hashchange — otherwise we'd briefly re-stamp the same hash, which
 // is harmless but pointless.
 function switchStatsTab(tabName, { fromHash = false } = {}) {
+    // Which stats tab people actually read. trackView dedupes, so the
+    // boot-time call and the hash sync do not double-report the same tab.
+    track('trackView', tabName);
+
     // Remove active class from all tabs and contents
     document.querySelectorAll('.stats-tab').forEach(tab => {
         tab.classList.remove('active');

--- a/apps/gym-tracker/README.md
+++ b/apps/gym-tracker/README.md
@@ -78,7 +78,9 @@ gym-tracker/
 │   │                           #   Set, Achievement, Measurement, Settings
 │   ├── services/               # Storage, Timer, Analytics, Achievement
 │   ├── utils/                  # plate-calculator, program-schedule, pr-session, rest-cues,
-│   │                           #   session-merge, paginator, event-bus, dark-select, helpers, ...
+│   │                           #   session-merge, paginator, event-bus, dark-select, helpers,
+│   │                           #   analytics (bridge to the site-wide GA4 helper — distinct
+│   │                           #   from services/Analytics, which computes workout stats), ...
 │   └── views/                  # home, programs, workout, history, exercises, calendar,
 │                               #   achievements, insights, measurements, settings, paused-banner
 ├── data/

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -108,6 +108,14 @@
     <!-- Visual refresh layer — must load last so it wins specificity ties. -->
     <link rel="stylesheet" href="css/refresh.css">
   <link rel="stylesheet" href="/assets/css/back-to-top.css">
+
+  <!-- Google Analytics. Loaded async + defer so it never blocks first paint;
+       all tracking goes through the shared helper in analytics.js, which
+       no-ops if gtag is blocked. See privacy.html "Analytics and cookies". -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body class="gym-tracker">
     <div data-include="header"></div>

--- a/apps/gym-tracker/js/app.js
+++ b/apps/gym-tracker/js/app.js
@@ -21,6 +21,7 @@ import { trapModalFocus, closeModalSafely } from './utils/modal-focus.js';
 import { mountSyncStatusPill } from './utils/sync-status.js';
 import { emit, EVENTS } from './utils/event-bus.js';
 import { sameId } from './utils/id-utils.js';
+import { track } from './utils/analytics.js';
 
 class GymTrackerApp {
     constructor() {
@@ -496,6 +497,13 @@ class GymTrackerApp {
         }
 
         this.currentView = viewName;
+
+        // Reported here rather than at the top of showView: the early return
+        // above means a repeat tap on the current tab is not a navigation, and
+        // the beforeLeave guard can cancel the move entirely. By this line the
+        // view has actually changed. Sent as app_view, never a synthetic
+        // page_view, so hash routing cannot invent URLs in GA4.
+        track('trackView', viewName);
 
         // Switching views is a context switch: land the user at the top of
         // the new view instead of wherever the previous view was scrolled

--- a/apps/gym-tracker/js/utils/analytics.js
+++ b/apps/gym-tracker/js/utils/analytics.js
@@ -1,0 +1,23 @@
+/**
+ * Gym Tracker's bridge to the shared site analytics helper.
+ *
+ * The helper itself lives at /assets/js/analytics.js and is installed on
+ * window by a deferred classic script, so it cannot be imported directly from
+ * an ES module. This wrapper resolves it at call time (not import time,
+ * because module evaluation can beat the deferred script) and swallows
+ * everything, so a tracking failure can never surface as a broken workout.
+ */
+
+/**
+ * Calls a method on the shared analytics helper if it is present.
+ * @param {string} method one of the shevatoAnalytics API methods
+ * @param {...*} args forwarded verbatim
+ */
+export function track(method, ...args) {
+  try {
+    const a = typeof window !== 'undefined' ? window.shevatoAnalytics : null;
+    if (a && typeof a[method] === 'function') a[method](...args);
+  } catch (e) {
+    /* analytics must never break the app */
+  }
+}

--- a/apps/gym-tracker/js/views/workout-view.js
+++ b/apps/gym-tracker/js/views/workout-view.js
@@ -32,6 +32,7 @@ import {
     shouldShowWarmup,
     buildWarmupRamp,
 } from '../utils/warmup.js';
+import { track } from '../utils/analytics.js';
 
 const PLATE_LOADED_EQUIPMENT = new globalThis.Set(['barbell', 'trap-bar', 'machine', 'plate', 'sled']);
 
@@ -3214,6 +3215,17 @@ class WorkoutView {
         // Save workout session
         this.app.workoutSessions.push(this.currentWorkoutSession);
         this.app.saveWorkoutSessions();
+
+        // The app's single most meaningful completion. Counts and duration
+        // only: no exercise names, no notes, no heart-rate or calorie figures,
+        // which are health data and have no place in analytics.
+        track('trackAction', 'workout_completed', {
+            exercise_count: this.currentWorkoutSession.exercises.length,
+            set_count: this.currentWorkoutSession.exercises.reduce(
+                (n, ex) => n + ((ex.sets || []).filter((s) => s.completed).length), 0
+            ),
+            duration_minutes: this.currentWorkoutSession.duration || 0,
+        });
 
         // Integration 4: persistent per-exercise PR achievements. Fires only for
         // exercises that beat their all-time best with 2+ prior sessions; the

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -92,6 +92,14 @@
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="/assets/css/back-to-top.css">
+
+  <!-- Google Analytics. Loaded async + defer so it never blocks first paint;
+       all tracking goes through the shared helper in analytics.js, which
+       no-ops if gtag is blocked. See privacy.html "Analytics and cookies". -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body class="maptap-rivals-app">
   <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->

--- a/apps/maptap-rivals/js/app.js
+++ b/apps/maptap-rivals/js/app.js
@@ -24,6 +24,20 @@
 (function () {
   'use strict';
 
+  /**
+   * Analytics shim. Resolves window.shevatoAnalytics at call time (the shared
+   * helper is deferred, this IIFE can run first) and never throws.
+   * Rival names are user-entered and never leave the app.
+   */
+  function track(method, ...args) {
+    try {
+      const a = typeof window !== 'undefined' ? window.shevatoAnalytics : null;
+      if (a && typeof a[method] === 'function') a[method](...args);
+    } catch (e) {
+      /* analytics must never break the app */
+    }
+  }
+
   // ---------- storage helpers ----------
   const KEY = {
     RIVALS: 'maptapRivalsRivals',
@@ -715,6 +729,9 @@
   function setView(view) {
     const changed = state.view !== view;
     state.view = view;
+    // Reported unconditionally; trackView drops repeats itself, so the
+    // `changed` flag below stays purely about rendering.
+    track('trackView', view);
     $$('.view-tab').forEach(tab => {
       const active = tab.dataset.view === view;
       tab.classList.toggle('is-active', active);
@@ -2417,6 +2434,16 @@
       savedGames.push({ game: newGame, rival });
     }
     persistGames();
+
+    // One event per save action carrying a count, not one per game: a paste
+    // can create a dozen games at once and that would be a dozen events for
+    // a single user gesture.
+    if (savedGames.length) {
+      track('trackAction', 'games_logged', {
+        entry_method: 'paste',
+        game_count: savedGames.length,
+      });
+    }
 
     // Briefly highlight the rows that just saved before we clear them.
     const savedIds = new Set(targets.map(x => x.rival.id));
@@ -6415,6 +6442,9 @@
         added++;
       }
       if (added || backfilled || updated) persistGames();
+      if (added) {
+        track('trackAction', 'games_logged', { entry_method: 'maptap_sync', game_count: added });
+      }
 
       const parts = [];
       if (added)      parts.push(`${added} new`);
@@ -6870,6 +6900,10 @@
         });
         pushed++;
       }
+    }
+
+    if (pushed) {
+      track('trackAction', 'games_logged', { entry_method: 'whatsapp_import', game_count: pushed });
     }
 
     persistRivals();

--- a/apps/mario-kart/index.html
+++ b/apps/mario-kart/index.html
@@ -117,6 +117,14 @@
     <script src="../../sync-system/sync-immediate.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha384-bs/nf9FbdNouRbMiFcrcZfLXYPKiPaGVGplVbv7dLGECccEXDW+S3zjqSKR5ZEaD" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <link rel="stylesheet" href="/assets/css/back-to-top.css">
+
+  <!-- Google Analytics. Loaded async + defer so it never blocks first paint;
+       all tracking goes through the shared helper in analytics.js, which
+       no-ops if gtag is blocked. See privacy.html "Analytics and cookies". -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body class="mario-kart-app mario-kart-tracker">
     <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->

--- a/apps/mario-kart/js/dataManager.js
+++ b/apps/mario-kart/js/dataManager.js
@@ -129,7 +129,19 @@ function addRace() {
     }
 
     races.push(raceObject);
-    
+
+    // The app's core action, reported only after every validation above has
+    // passed. Player count and whether a course was picked, never player
+    // names or finishing positions.
+    if (typeof window !== 'undefined' && window.shevatoAnalytics) {
+        try {
+            window.shevatoAnalytics.trackAction('race_logged', {
+                player_count: activePlayers.length,
+                has_course: Boolean(selectedCourse),
+            });
+        } catch (e) { /* analytics must never break the app */ }
+    }
+
     // Save action for undo/redo
     saveAction('ADD_RACE', { race: raceObject });
     

--- a/apps/mario-kart/js/main.js
+++ b/apps/mario-kart/js/main.js
@@ -1,3 +1,18 @@
+/**
+ * Analytics shim. Resolves window.shevatoAnalytics at call time (the shared
+ * helper is deferred and this file is a classic script) and never throws.
+ * Returns silently under node:vm, where the tests load this file with no
+ * window at all.
+ */
+function track(method, ...args) {
+    try {
+        const a = typeof window !== 'undefined' ? window.shevatoAnalytics : null;
+        if (a && typeof a[method] === 'function') a[method](...args);
+    } catch (e) {
+        /* analytics must never break the app */
+    }
+}
+
 let currentView = 'achievements';
 let sortColumn = null;
 let sortDirection = 'asc';
@@ -690,6 +705,10 @@ function toggleView(view) {
 
     // Now update currentView
     currentView = view;
+
+    // Which tabs people actually use. app_view, not a synthetic page_view, so
+    // the hash mirroring below cannot create phantom URLs in GA4.
+    track('trackView', view);
 
     // Mirror to URL hash so reload + back/forward preserves the view.
     // replaceState (not pushState) keeps the existing history entry —

--- a/apps/rising-shows/index.html
+++ b/apps/rising-shows/index.html
@@ -95,6 +95,14 @@
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="/assets/css/back-to-top.css">
+
+  <!-- Google Analytics. Loaded async + defer so it never blocks first paint;
+       all tracking goes through the shared helper in analytics.js, which
+       no-ops if gtag is blocked. See privacy.html "Analytics and cookies". -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body class="rising-shows-app">
   <!-- Sync status banner — only visible when offline (and briefly on recovery). Managed by assets/js/sync-status.js. -->

--- a/apps/rising-shows/js/app.js
+++ b/apps/rising-shows/js/app.js
@@ -1,5 +1,21 @@
 'use strict';
 
+/**
+ * Analytics shim. Resolves window.shevatoAnalytics at call time, not load
+ * time, because assets/js/analytics.js is deferred and this file may execute
+ * first. Returns silently when the helper is missing, which is the normal
+ * case in the node:vm test harness (no window at all) and when a visitor
+ * blocks gtag.js. Nothing in the app may ever depend on a return value.
+ */
+function track(method, ...args) {
+  try {
+    const a = typeof window !== 'undefined' ? window.shevatoAnalytics : null;
+    if (a && typeof a[method] === 'function') a[method](...args);
+  } catch (e) {
+    /* analytics must never break the app */
+  }
+}
+
 // --- Feature 7: std dev helper (exported via window for tests) ---
 function computeStdDev(episodes) {
   const n = episodes.length;
@@ -815,6 +831,9 @@ function applyStateFromURL() {
   // syncFinderControls once they exist.
   mode = 'finder';
   applyFinderStateFromParams(p);
+  // Seed the analytics dedupe with whatever state we booted into, so only
+  // changes the user actually makes are reported from here on.
+  primeFinderAnalytics();
 
   // Deep links that open a modal on load: a show permalink (?show=) opens the
   // show modal; a legacy season link (?season=) opens that season's detail
@@ -2188,6 +2207,11 @@ function openShowModal(seriesId, opts = {}) {
     .sort((a, b) => a.season - b.season);
   if (seasons.length === 0) return;
 
+  // Reported after the early return, so a failed lookup is not counted as a
+  // view. This is the in-app counterpart to a page_view on the generated
+  // /shows/<slug>/ page, and lets the two be compared for the same show.
+  track('trackContentView', { contentType: 'show', contentId: seriesId });
+
   pushModalHistory(opts, `show:${seriesId}`);
   const wasSeasonOpen = !els.modal.hidden;
   // Inherit origin from the season modal we're closing, so closing the
@@ -3045,6 +3069,10 @@ function renderFinder() {
   syncFinderShapeChips();
   updateFinderMoodActive();
   const rows = filterAndSortFinder();
+  // Stashed for onFinderFilterChange's analytics call, which runs right after
+  // this and would otherwise have to re-run the whole filter pass to learn
+  // how many results the user ended up with.
+  lastFinderRowCount = rows.length;
   els.finderCount.textContent = rows.length === 1
     ? '1 show matches your filters'
     : `${rows.length.toLocaleString()} shows match your filters`;
@@ -3370,6 +3398,9 @@ function goToFinderPage(n, scrollAfter = true) {
   finderState.page = n;
   writeFinderStateToURL();
   renderFinder();
+  // How deep people page is the clearest signal of whether the default sort
+  // surfaces what they came for.
+  track('trackLoadMore', { pageNumber: n, itemsShown: lastFinderRowCount });
   if (scrollAfter) {
     const top = els.finderResults.getBoundingClientRect().top + window.scrollY - 70;
     window.scrollTo({ top, behavior: 'smooth' });
@@ -3378,11 +3409,70 @@ function goToFinderPage(n, scrollAfter = true) {
 
 const renderFinderDebounced = debounce(renderFinder, 120);
 
+// Result count from the most recent renderFinder(), for analytics only.
+let lastFinderRowCount = 0;
+
 // Page resets to 1 whenever a filter or sort changes (matches Seasons).
 function onFinderFilterChange() {
   finderState.page = 1;
   writeFinderStateToURL();
   renderFinder();
+  reportFinderChange();
+}
+
+/**
+ * Reports what the user filtered by and how well it worked.
+ *
+ * The search box's contents are deliberately never sent: it is a free-text
+ * field, so it could contain anything. What goes out is the query's length,
+ * whether it matched anything, and the result count - enough to see whether
+ * search is used and whether it succeeds, with none of the words. What people
+ * actually look for is recovered from search_result_select, which reports the
+ * catalogue id of the show they picked.
+ *
+ * Filter values are safe to send verbatim because every one of them is chosen
+ * from a fixed set the app defines (shape names, genres, sort keys), never
+ * typed. trackFilter() drops repeats, so dragging a slider reports one event
+ * per settled value rather than one per pixel.
+ */
+function reportFinderChange() {
+  const f = finderState;
+  const query = (f.search || '').trim();
+
+  if (query) {
+    track('trackSearch', {
+      scope: 'shows',
+      queryLength: query.length,
+      resultsCount: lastFinderRowCount,
+    });
+  }
+
+  for (const [name, value] of finderFilterSnapshot()) {
+    track('trackFilter', name, value);
+  }
+}
+
+/** The finder's filter state as [name, value] pairs, for analytics only. */
+function finderFilterSnapshot() {
+  const f = finderState;
+  return [
+    ['sort', `${f.sort}:${f.sortDir}`],
+    ['shapes', [...f.shapes].sort().join(',') || '(none)'],
+    ['genres', [...f.genres].sort().join(',') || '(none)'],
+    ['languages', [...f.languages].sort().join(',') || '(none)'],
+    ['hidden_gems', f.hiddenGems ? 'on' : 'off'],
+  ];
+}
+
+/**
+ * Registers the finder's boot state (defaults, or whatever a deep link set)
+ * as already-reported, so the first control the user touches produces one
+ * filter_change event rather than five.
+ */
+function primeFinderAnalytics() {
+  for (const [name, value] of finderFilterSnapshot()) {
+    track('primeFilter', name, value);
+  }
 }
 
 function finderHasActiveFilters() {
@@ -4332,6 +4422,13 @@ function moveFinderSuggestionActive(delta) {
 function selectFinderSuggestion(i) {
   const s = finderSuggestState.items[i];
   if (!s) return;
+  // The one place we learn what people search for, without storing queries:
+  // seriesId is a catalogue identifier, not anything the user typed.
+  track('trackSearchResultSelect', {
+    contentType: 'show',
+    contentId: s.seriesId,
+    position: i,
+  });
   closeFinderSuggestions();
   // Mirror the Seasons "pick a series" behavior: jump straight to the
   // picked show's modal.

--- a/apps/rising-shows/kometa/index.html
+++ b/apps/rising-shows/kometa/index.html
@@ -41,6 +41,14 @@
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="../css/kometa.css">
   <link rel="stylesheet" href="/assets/css/back-to-top.css">
+
+  <!-- Google Analytics. Loaded async + defer so it never blocks first paint;
+       all tracking goes through the shared helper in analytics.js, which
+       no-ops if gtag is blocked. See privacy.html "Analytics and cookies". -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body class="rising-shows-app rising-shows-kometa">
   <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>

--- a/apps/trip-planner/index.html
+++ b/apps/trip-planner/index.html
@@ -44,6 +44,14 @@
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
   <link rel="stylesheet" href="css/styles.css?v=55">
+
+  <!-- Google Analytics. Loaded async + defer so it never blocks first paint;
+       all tracking goes through the shared helper in analytics.js, which
+       no-ops if gtag is blocked. See privacy.html "Analytics and cookies". -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GEQGY35JJN"></script>
+  <script defer src="/assets/js/analytics.js"></script>
 </head>
 <body class="tp-page">
   <div id="sync-banner" class="sync-banner" role="status" aria-live="polite" hidden></div>

--- a/apps/trip-planner/js/app.js
+++ b/apps/trip-planner/js/app.js
@@ -1,6 +1,22 @@
 'use strict';
 (() => {
 
+  /**
+   * Analytics shim. Resolves window.shevatoAnalytics at call time because
+   * /assets/js/analytics.js is deferred and this IIFE can run first, and
+   * swallows everything so a tracking failure can never break a trip.
+   * Nothing here may ever send trip contents: destinations, item names and
+   * anything typed into Details are the user's travel plans.
+   */
+  function track(method, ...args) {
+    try {
+      const a = typeof window !== 'undefined' ? window.shevatoAnalytics : null;
+      if (a && typeof a[method] === 'function') a[method](...args);
+    } catch (e) {
+      /* analytics must never break the app */
+    }
+  }
+
   // ---------- constants ----------
   // Shown at the bottom of the trip menu so a bug report can name the exact
   // build it came from. THE RULE: TP_BUILD must always equal the `?v=` on
@@ -4370,6 +4386,11 @@
     // links fine; the real-world limit is chat apps truncating them. Hard
     // stop only at absurd sizes, advisory warning in between.
     if (url.length > 30000) { toastError('This trip is too large to share by link. Use Export trip (JSON) instead.'); return; }
+    // Item count only, never the link: the share URL's fragment encodes the
+    // entire trip, including confirmation numbers typed into Details.
+    track('trackAction', 'trip_shared', {
+      item_count: Array.isArray(t.items) ? t.items.length : 0,
+    });
     try {
       await navigator.clipboard.writeText(url);
       toast(url.length > 8000
@@ -5935,6 +5956,10 @@
   let assistReturnFocus = null;
 
   function openAssist(focusDate) {
+    // The assistant is the app's only paid dependency, so knowing how often it
+    // is opened at all is worth one event. The prompt and the reply are never
+    // touched here - they contain the trip.
+    track('trackAction', 'assistant_opened');
     const panel = $('#assistPanel');
     const opener = document.activeElement;
     if (opener && opener !== document.body && !panel.contains(opener)) assistReturnFocus = opener;
@@ -7914,6 +7939,9 @@
   // brings you back to the view that has the checkboxes.
   function setView(v) {
     ui.view = v;
+    // trackView drops repeats, so the several code paths that re-assert the
+    // current view (share exit, select-mode exit, hashchange) report once.
+    track('trackView', v);
     if (selMode && v !== 'timeline') { exitSelectMode(); render(); return; }
     applyView();
   }

--- a/assets/js/analytics-404.js
+++ b/assets/js/analytics-404.js
@@ -1,0 +1,31 @@
+/**
+ * Reports which URL actually 404'd.
+ *
+ * 404.html pins page_path to "/404" so one broken link cannot create one row
+ * in Pages and Screens. That keeps the report clean but would lose the thing
+ * we actually want from a 404: which URLs people and crawlers are asking for.
+ * This sends that path once, as an event parameter.
+ *
+ * Deferred, and loaded after analytics.js, so window.shevatoAnalytics exists.
+ */
+(function () {
+  'use strict';
+  var analytics = window.shevatoAnalytics;
+  if (!analytics) return;
+
+  // Path only — never the query string or hash. A mistyped or malicious URL
+  // can carry anything in its query, and none of it belongs in analytics.
+  var requestedPath = String(window.location.pathname || '').slice(0, 100);
+
+  analytics.track('page_not_found', {
+    not_found_path: requestedPath,
+    // Where the broken link was followed from, when the browser tells us.
+    // Same-origin referrers point at our own broken links, which are the ones
+    // we can actually fix.
+    referrer_domain: (function () {
+      try {
+        return document.referrer ? new URL(document.referrer).hostname : '(none)';
+      } catch (e) { return '(none)'; }
+    })()
+  });
+})();

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,4 +1,423 @@
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', 'G-GEQGY35JJN');
+/**
+ * Shevato analytics — the single place GA4 is configured and the single API
+ * the rest of the site and the apps are allowed to use.
+ *
+ * Design rules, in priority order:
+ *
+ *   1. Analytics must NEVER break the page. Every public method swallows its
+ *      own errors. If gtag.js is blocked, absent, or throws, callers keep
+ *      running as if the call succeeded.
+ *   2. No personal data. We never send user-entered free text (search boxes,
+ *      trip names, notes, exercise names typed by hand), no email addresses,
+ *      no account ids, no Firestore paths. See sendSafely() for the guard.
+ *   3. One page_view per page load, ever. In-app navigation reports a
+ *      custom `app_view` event instead of a synthetic page_view, so client
+ *      routing can never invent new URLs in the Pages and Screens report.
+ *   4. Bounded event volume. Repeated identical view/filter events are
+ *      deduplicated, and errors are capped per page load.
+ *
+ * Loaded with `defer`, alongside `<script async src="…/gtag/js?id=…">`.
+ * A page may set window.SHEVATO_ANALYTICS_CONFIG inline before this file to
+ * override the reported page_path (used by 404.html).
+ */
+(function () {
+  'use strict';
+
+  var MEASUREMENT_ID = 'G-GEQGY35JJN';
+
+  // Bail out if we somehow get loaded twice (a duplicate <script> tag, a
+  // partial injected after boot). Re-running gtag('config') would fire a
+  // second page_view for the same load and double every subsequent event.
+  if (window.shevatoAnalytics) return;
+
+  var pageConfig = window.SHEVATO_ANALYTICS_CONFIG || {};
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { window.dataLayer.push(arguments); }
+  // gtag.js installs its own identical shim; defining ours first means calls
+  // made before the library finishes loading are queued rather than lost.
+  if (typeof window.gtag !== 'function') window.gtag = gtag;
+
+  /* ---------------------------------------------------------------- context */
+
+  /**
+   * Which app (if any) this page belongs to, derived from the URL rather than
+   * hand-passed by each caller, so the parameter can never drift from reality.
+   * `/apps/rising-shows/shows/foo/` → "rising-shows". Marketing pages → "site".
+   */
+  function detectApp() {
+    var m = /^\/apps\/([^/]+)/.exec(window.location.pathname);
+    return m ? m[1] : 'site';
+  }
+
+  var APP_NAME = detectApp();
+
+  /**
+   * Section within an app, so Rising Shows' generated show pages can be told
+   * apart from the app itself without parsing paths in the GA4 UI.
+   * `/apps/rising-shows/shows/foo/` → "shows"; `/apps/rising-shows/` → "app";
+   * anything outside /apps/ → "site", so a marketing page is not mislabelled
+   * as an app section.
+   */
+  function detectAppSection() {
+    if (!/^\/apps\//.test(window.location.pathname)) return 'site';
+    var m = /^\/apps\/[^/]+\/([^/]+)/.exec(window.location.pathname);
+    return m ? m[1] : 'app';
+  }
+
+  /* ------------------------------------------------------------ privacy net */
+
+  // Parameter names we refuse to forward under any circumstances. This is a
+  // backstop, not the primary defence — the primary defence is that callers
+  // are given no helper that accepts free text in the first place.
+  var BANNED_PARAM = /(^|_)(query|q|term|text|name|title|email|user|uid|account|note|address|token|key|password|search_term)$/i;
+
+  /**
+   * Structural parameter names that describe the event itself rather than
+   * anything about the user, and so are exempt from BANNED_PARAM.
+   *
+   * Without this, the `_name$` rule above silently ate view_name, action_name
+   * and filter_name - the one parameter that gives app_view, app_action and
+   * filter_change their meaning - leaving every such event indistinguishable
+   * in GA4. Their values are fixed literals written in our own source, never
+   * user input; the rule is still doing its job on trip_name, player_name and
+   * the rest.
+   */
+  var STRUCTURAL_PARAM = /^(view_name|action_name|filter_name)$/;
+
+  var EMAIL_RE = /[^\s@]+@[^\s@]+\.[^\s@]+/;
+
+  /**
+   * Heuristic for generated identifiers (Firebase uids, session tokens), which
+   * must never be sent even if a caller passes one by mistake.
+   *
+   * The signature it keys on is: long, unbroken by any separator, and mixing
+   * upper and lower case - which is what a generated token looks like and what
+   * our own values never look like. Catalogue slugs such as
+   * "rick-and-morty-tt2861424" are hyphenated and lowercase, so they pass
+   * through: those are exactly what content_id exists to carry, and an earlier
+   * length-only rule silently swallowed them.
+   */
+  function looksLikeOpaqueId(value) {
+    return /^[A-Za-z0-9]{20,}$/.test(value)
+      && /[a-z]/.test(value)
+      && /[A-Z]/.test(value);
+  }
+
+  /**
+   * Strips parameters that could carry personal data, and clamps the rest to
+   * GA4-safe primitives. Returns a fresh object; never mutates the input.
+   */
+  function scrub(params) {
+    var safe = {};
+    if (!params) return safe;
+    Object.keys(params).forEach(function (key) {
+      var value = params[key];
+      if (value === null || value === undefined) return;
+      if (!STRUCTURAL_PARAM.test(key) && BANNED_PARAM.test(key)) return;
+      if (typeof value === 'number') {
+        if (isFinite(value)) safe[key] = value;
+        return;
+      }
+      if (typeof value === 'boolean') { safe[key] = value; return; }
+      if (typeof value !== 'string') return;
+      if (EMAIL_RE.test(value)) return;
+      if (looksLikeOpaqueId(value)) return;
+      // GA4 truncates parameter values at 100 chars; do it ourselves so we
+      // never ship a long string we did not mean to send.
+      safe[key] = value.length > 100 ? value.slice(0, 100) : value;
+    });
+    return safe;
+  }
+
+  /**
+   * The only path to gtag(). Adds shared context, scrubs, and guarantees the
+   * caller cannot be hurt by anything that happens in here.
+   */
+  function sendSafely(eventName, params) {
+    try {
+      if (typeof eventName !== 'string' || !eventName) return;
+      var payload = scrub(params);
+      payload.app_name = APP_NAME;
+      payload.app_section = detectAppSection();
+      window.gtag('event', eventName, payload);
+    } catch (err) {
+      /* analytics must never surface to the user */
+    }
+  }
+
+  /* -------------------------------------------------------------- page view */
+
+  var configParams = {
+    // Report a canonical path: no query string, no hash, no `.html`.
+    //
+    // Campaign parameters (utm_*, gclid) are read by GA4 from the full URL
+    // before page_path applies, so attribution still works — but stray query
+    // junk and client-routing hashes can no longer split one page into several
+    // rows in Pages and Screens.
+    //
+    // Dropping `.html` mirrors the canonical <link> every page already
+    // declares, and belts-and-braces the 301s added in netlify.toml: even if a
+    // `.html` URL is reached some way we did not foresee, GA4 still files it
+    // under the one canonical row. Trailing slashes are left alone so the
+    // existing directory-style URLs keep their reporting continuity.
+    page_path: pageConfig.pagePath || String(window.location.pathname).replace(/\.html$/i, '')
+  };
+  if (pageConfig.pageTitle) configParams.page_title = pageConfig.pageTitle;
+
+  try {
+    window.gtag('js', new Date());
+    window.gtag('config', MEASUREMENT_ID, configParams);
+  } catch (err) { /* no-op */ }
+
+  /* ----------------------------------------------------------- dedupe state */
+
+  var lastView = null;
+  var lastFilter = {};
+  var errorsSent = 0;
+  var MAX_ERRORS_PER_PAGE = 5;
+
+  /* ----------------------------------------------------------------- public */
+
+  var api = {
+    /** Event names, centralised so callers cannot invent variants by typo. */
+    events: {
+      APP_OPEN: 'app_open',
+      APP_VIEW: 'app_view',
+      SEARCH: 'search',
+      SEARCH_RESULT_SELECT: 'search_result_select',
+      FILTER_CHANGE: 'filter_change',
+      CONTENT_VIEW: 'content_view',
+      LOAD_MORE: 'load_more',
+      APP_ACTION: 'app_action',
+      OUTBOUND_CLICK: 'outbound_click',
+      SITE_NAV_CLICK: 'site_nav_click',
+      APP_ERROR: 'app_error'
+    },
+
+    /** Escape hatch for one-off events. Still scrubbed and still safe. */
+    track: function (eventName, params) { sendSafely(eventName, params); },
+
+    /**
+     * Fired once per app page load, after the app decides it is usable.
+     * Distinct from page_view: page_view counts the document, app_open counts
+     * a real app session start.
+     */
+    trackAppOpen: function (params) {
+      sendSafely('app_open', params);
+    },
+
+    /**
+     * In-app navigation. Deliberately NOT a page_view — see rule 3 at the top.
+     * Repeated calls for the same view are dropped, so routers that re-render
+     * on every state change do not spam GA4.
+     */
+    trackView: function (viewName, params) {
+      if (typeof viewName !== 'string' || !viewName) return;
+      if (viewName === lastView) return;
+      lastView = viewName;
+      var payload = params ? Object.assign({}, params) : {};
+      payload.view_name = viewName;
+      sendSafely('app_view', payload);
+    },
+
+    /**
+     * A search happened. The query text is NEVER sent — only its shape and how
+     * well it worked, which is what tells us whether search is useful.
+     */
+    trackSearch: function (opts) {
+      opts = opts || {};
+      sendSafely('search', {
+        search_scope: opts.scope,
+        results_count: typeof opts.resultsCount === 'number' ? opts.resultsCount : undefined,
+        query_length: typeof opts.queryLength === 'number' ? opts.queryLength : undefined,
+        has_results: typeof opts.resultsCount === 'number' ? opts.resultsCount > 0 : undefined
+      });
+    },
+
+    /**
+     * A search result was chosen. contentId must come from a closed catalogue
+     * (a show slug, an exercise slug) — never from anything the user typed.
+     * This is how we learn what people look for without storing their queries.
+     */
+    trackSearchResultSelect: function (opts) {
+      opts = opts || {};
+      sendSafely('search_result_select', {
+        content_type: opts.contentType,
+        content_id: opts.contentId,
+        result_position: typeof opts.position === 'number' ? opts.position : undefined
+      });
+    },
+
+    /**
+     * A filter/sort control changed. Only pass enumerable control values
+     * (a shape name, a sort key) — not free text.
+     */
+    trackFilter: function (filterName, filterValue) {
+      if (typeof filterName !== 'string' || !filterName) return;
+      var value = filterValue === undefined || filterValue === null ? '' : String(filterValue);
+      if (lastFilter[filterName] === value) return;
+      lastFilter[filterName] = value;
+      sendSafely('filter_change', { filter_name: filterName, filter_value: value });
+    },
+
+    /**
+     * Records a filter's current value as already-reported, WITHOUT sending
+     * anything. Apps call this once at boot for each filter they own.
+     *
+     * Without it, the first time a user touches any single control, every
+     * other control reports its untouched default too (the dedupe map starts
+     * empty), so one interaction produced a burst of filter_change events
+     * describing nothing the user did.
+     */
+    primeFilter: function (filterName, filterValue) {
+      if (typeof filterName !== 'string' || !filterName) return;
+      lastFilter[filterName] = filterValue === undefined || filterValue === null
+        ? '' : String(filterValue);
+    },
+
+    /** A detail record was opened (show, exercise, rival, course). */
+    trackContentView: function (opts) {
+      opts = opts || {};
+      sendSafely('content_view', {
+        content_type: opts.contentType,
+        content_id: opts.contentId
+      });
+    },
+
+    /** Pagination / "load more" / infinite scroll advanced. */
+    trackLoadMore: function (opts) {
+      opts = opts || {};
+      sendSafely('load_more', {
+        page_number: typeof opts.pageNumber === 'number' ? opts.pageNumber : undefined,
+        items_shown: typeof opts.itemsShown === 'number' ? opts.itemsShown : undefined
+      });
+    },
+
+    /**
+     * A meaningful app action completed (workout finished, match saved, trip
+     * shared). actionName must be a fixed literal from the calling app.
+     */
+    trackAction: function (actionName, params) {
+      if (typeof actionName !== 'string' || !actionName) return;
+      var payload = params ? Object.assign({}, params) : {};
+      payload.action_name = actionName;
+      sendSafely('app_action', payload);
+    },
+
+    /** A link to another origin was followed. Domain only, never the full URL. */
+    trackOutbound: function (url, params) {
+      var domain = '';
+      try { domain = new URL(url, window.location.href).hostname; } catch (e) { return; }
+      if (!domain || domain === window.location.hostname) return;
+      var payload = params ? Object.assign({}, params) : {};
+      payload.link_domain = domain;
+      sendSafely('outbound_click', payload);
+    },
+
+    /**
+     * Something failed. The message is truncated and scrubbed; stack traces are
+     * never sent. Capped per page load so an error loop cannot flood GA4.
+     */
+    trackError: function (scope, message, params) {
+      if (errorsSent >= MAX_ERRORS_PER_PAGE) return;
+      errorsSent++;
+      var payload = params ? Object.assign({}, params) : {};
+      payload.error_scope = typeof scope === 'string' ? scope : 'unknown';
+      payload.error_message = typeof message === 'string' ? message.slice(0, 100) : '';
+      sendSafely('app_error', payload);
+    }
+  };
+
+  /* ------------------------------------------------------- auto instruments */
+
+  /**
+   * Delegated click handling: outbound links everywhere, plus marketing-page
+   * navigation. One listener for the whole document beats a listener per link,
+   * and it keeps working for content rendered after load.
+   */
+  document.addEventListener('click', function (evt) {
+    try {
+      var anchor = evt.target && evt.target.closest ? evt.target.closest('a[href]') : null;
+      if (!anchor) return;
+      var href = anchor.getAttribute('href') || '';
+      if (!href || href.charAt(0) === '#' || /^(javascript|mailto|tel):/i.test(href)) {
+        // mailto/tel are conversions on the contact page, worth counting.
+        if (/^(mailto|tel):/i.test(href)) {
+          sendSafely('site_nav_click', {
+            nav_location: navLocation(anchor),
+            link_kind: href.split(':')[0].toLowerCase()
+          });
+        }
+        return;
+      }
+
+      var url;
+      try { url = new URL(href, window.location.href); } catch (e) { return; }
+
+      if (url.hostname !== window.location.hostname) {
+        api.trackOutbound(url.href, { nav_location: navLocation(anchor) });
+        return;
+      }
+
+      // Internal link. On marketing pages this is the answer to "where do
+      // homepage visitors go next", which page_view alone cannot tell us
+      // because it never records which link produced the next page.
+      sendSafely('site_nav_click', {
+        nav_location: navLocation(anchor),
+        link_destination: normalisePath(url.pathname),
+        link_kind: 'internal'
+      });
+    } catch (err) { /* never interfere with the click */ }
+  }, true);
+
+  /** Where on the page a link lives, so we can rank nav vs cards vs footer. */
+  function navLocation(anchor) {
+    if (anchor.closest('header, #header, nav, #nav, .site-header')) return 'header';
+    if (anchor.closest('footer, #footer, .site-footer')) return 'footer';
+    if (anchor.closest('.preview-card, .app-card, .card')) return 'card';
+    if (anchor.closest('.cta-banner, .cta-button')) return 'cta';
+    if (anchor.closest('main, #main-content')) return 'body';
+    return 'other';
+  }
+
+  /** Collapse `.html` and trailing-slash variants so one page is one value. */
+  function normalisePath(pathname) {
+    var p = String(pathname || '').replace(/\.html$/i, '');
+    if (p.length > 1) p = p.replace(/\/$/, '');
+    return p || '/';
+  }
+
+  /**
+   * Uncaught JS errors, so an abandoned session can be correlated with a
+   * broken script. Message only — never the stack, never local variables.
+   */
+  window.addEventListener('error', function (evt) {
+    if (!evt || !evt.message) return;
+    api.trackError('window', evt.message, {
+      error_source: evt.filename ? normalisePath(evt.filename) : undefined
+    });
+  });
+
+  window.addEventListener('unhandledrejection', function (evt) {
+    var reason = evt && evt.reason;
+    var message = reason && reason.message ? reason.message : String(reason || '');
+    api.trackError('promise', message);
+  });
+
+  /**
+   * `app_open` fires automatically for an app's own entry page, so the eight
+   * apps do not each need a line of boilerplate to report that they launched.
+   *
+   * Scoped to app_section === 'app' on purpose: the ~34,800 generated pages
+   * under shows/ and exercises/ are static content, not app launches, and
+   * counting them as such would recreate the exact distortion this whole
+   * change is undoing (page-view volume from crawled static pages swamping
+   * real usage).
+   */
+  if (APP_NAME !== 'site' && detectAppSection() === 'app') {
+    api.trackAppOpen();
+  }
+
+  window.shevatoAnalytics = api;
+})();

--- a/assets/js/tests/analytics.test.js
+++ b/assets/js/tests/analytics.test.js
@@ -1,0 +1,290 @@
+'use strict';
+
+// Tests for the shared analytics helper (assets/js/analytics.js).
+//
+// The module is a classic IIFE that installs window.shevatoAnalytics and
+// configures GA4. It is loaded into a fresh vm context per test with a
+// stubbed window/document, matching the pattern the app test suites use.
+//
+// Everything asserted here is a guarantee the rest of the site relies on:
+// one page_view per load, no personal data on the wire, dedupe on repeated
+// view/filter events, and total immunity to gtag failures.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'analytics.js'), 'utf8');
+
+/**
+ * Loads analytics.js into a fresh context.
+ * @param {object} opts
+ * @param {string} opts.pathname   window.location.pathname to simulate
+ * @param {object} [opts.pageConfig] value for window.SHEVATO_ANALYTICS_CONFIG
+ * @param {boolean} [opts.breakGtag] make gtag throw, to prove callers survive
+ * @returns {{api: object, calls: Array, listeners: object}}
+ */
+function load(opts) {
+  const calls = [];
+  const listeners = {};
+
+  const el = () => ({
+    closest: () => null,
+    getAttribute: () => null,
+  });
+
+  const sandbox = {
+    console,
+    Date,
+    JSON,
+    Math,
+    Object,
+    Array,
+    String,
+    Number,
+    Boolean,
+    isFinite,
+    URL,
+    RegExp,
+    document: {
+      addEventListener(type, fn) { listeners[type] = fn; },
+      querySelector: el,
+      referrer: '',
+    },
+  };
+
+  sandbox.window = {
+    location: { pathname: opts.pathname, hash: '', href: 'https://shevato.com' + opts.pathname, hostname: 'shevato.com' },
+    addEventListener(type, fn) { listeners[type] = fn; },
+    SHEVATO_ANALYTICS_CONFIG: opts.pageConfig,
+    gtag(...args) {
+      if (opts.breakGtag) throw new Error('gtag exploded');
+      calls.push(args);
+    },
+  };
+  sandbox.window.window = sandbox.window;
+
+  vm.createContext(sandbox);
+  vm.runInContext(SRC, sandbox);
+
+  return { api: sandbox.window.shevatoAnalytics, calls, listeners, win: sandbox.window };
+}
+
+/** Convenience: only the gtag('event', …) calls. */
+const events = (calls) => calls.filter((c) => c[0] === 'event');
+/** Convenience: only the gtag('config', …) calls. */
+const configs = (calls) => calls.filter((c) => c[0] === 'config');
+
+test('fires exactly one config (page_view) per page load', () => {
+  const { calls } = load({ pathname: '/home.html' });
+  assert.equal(configs(calls).length, 1);
+});
+
+test('reported page_path drops the .html extension', () => {
+  const { calls } = load({ pathname: '/apps.html' });
+  assert.equal(configs(calls)[0][2].page_path, '/apps');
+});
+
+test('extensionless paths are reported unchanged', () => {
+  const { calls } = load({ pathname: '/apps' });
+  assert.equal(configs(calls)[0][2].page_path, '/apps');
+});
+
+test('directory URLs keep their trailing slash', () => {
+  const { calls } = load({ pathname: '/apps/rising-shows/shows/24-tt0285331/' });
+  assert.equal(configs(calls)[0][2].page_path, '/apps/rising-shows/shows/24-tt0285331/');
+});
+
+test('a page may override page_path (404 collapsing)', () => {
+  const { calls } = load({ pathname: '/some/bogus/url', pageConfig: { pagePath: '/404' } });
+  assert.equal(configs(calls)[0][2].page_path, '/404');
+});
+
+test('loading twice does not double-configure', () => {
+  const { calls, win } = load({ pathname: '/home.html' });
+  assert.equal(configs(calls).length, 1);
+  // Re-running the IIFE against the same window must be a no-op, because
+  // a second gtag('config') would fire a second page_view for one load.
+  const sandbox = { console, Date, JSON, Math, Object, Array, String, Number, Boolean, isFinite, URL, RegExp, window: win, document: { addEventListener() {}, referrer: '' } };
+  vm.createContext(sandbox);
+  vm.runInContext(SRC, sandbox);
+  assert.equal(configs(calls).length, 1);
+});
+
+test('app_open fires automatically on an app entry page', () => {
+  const { calls } = load({ pathname: '/apps/gym-tracker/' });
+  const opens = events(calls).filter((c) => c[1] === 'app_open');
+  assert.equal(opens.length, 1);
+  assert.equal(opens[0][2].app_name, 'gym-tracker');
+});
+
+test('app_open does NOT fire on generated content pages', () => {
+  const { calls } = load({ pathname: '/apps/rising-shows/shows/24-tt0285331/' });
+  assert.equal(events(calls).filter((c) => c[1] === 'app_open').length, 0);
+});
+
+test('app_open does NOT fire on marketing pages', () => {
+  const { calls } = load({ pathname: '/home.html' });
+  assert.equal(events(calls).filter((c) => c[1] === 'app_open').length, 0);
+});
+
+test('app_name and app_section are derived from the URL', () => {
+  const { api, calls } = load({ pathname: '/apps/rising-shows/shows/foo/' });
+  api.trackContentView({ contentType: 'show', contentId: 'tt1' });
+  const e = events(calls).pop();
+  assert.equal(e[2].app_name, 'rising-shows');
+  assert.equal(e[2].app_section, 'shows');
+});
+
+test('structural parameters survive the scrubber', () => {
+  // Regression: the BANNED_PARAM `_name$` rule was stripping view_name,
+  // action_name and filter_name, which is the entire payload of app_view,
+  // app_action and filter_change. Every one of those events reached GA4
+  // carrying nothing but app_name/app_section, making them useless.
+  const { api, calls } = load({ pathname: '/apps/gym-tracker/' });
+
+  api.trackView('workout');
+  assert.equal(events(calls).pop()[2].view_name, 'workout');
+
+  api.trackAction('workout_completed', { set_count: 12 });
+  const action = events(calls).pop()[2];
+  assert.equal(action.action_name, 'workout_completed');
+  assert.equal(action.set_count, 12);
+
+  api.trackFilter('sort', 'votes:desc');
+  const filter = events(calls).pop()[2];
+  assert.equal(filter.filter_name, 'sort');
+  assert.equal(filter.filter_value, 'votes:desc');
+});
+
+test('the exemption does not weaken the ban on user-entered names', () => {
+  const { api, calls } = load({ pathname: '/apps/trip-planner/' });
+  api.track('probe', { trip_name: 'Split', player_name: 'Ann', rival_name: 'Bo', name: 'X' });
+  const p = events(calls).pop()[2];
+  assert.equal(p.trip_name, undefined);
+  assert.equal(p.player_name, undefined);
+  assert.equal(p.rival_name, undefined);
+  assert.equal(p.name, undefined);
+});
+
+test('trackView dedupes repeated views but allows a return visit', () => {
+  const { api, calls } = load({ pathname: '/apps/gym-tracker/' });
+  api.trackView('workout');
+  api.trackView('workout');
+  api.trackView('history');
+  assert.equal(events(calls).filter((c) => c[1] === 'app_view').length, 2);
+});
+
+test('trackFilter dedupes an unchanged value but reports a real change', () => {
+  const { api, calls } = load({ pathname: '/apps/rising-shows/' });
+  api.trackFilter('sort', 'votes:desc');
+  api.trackFilter('sort', 'votes:desc');
+  api.trackFilter('sort', 'rating:asc');
+  assert.equal(events(calls).filter((c) => c[1] === 'filter_change').length, 2);
+});
+
+test('trackSearch reports shape and outcome, never the query', () => {
+  const { api, calls } = load({ pathname: '/apps/rising-shows/' });
+  api.trackSearch({ scope: 'shows', queryLength: 7, resultsCount: 12 });
+  const p = events(calls).pop()[2];
+  assert.equal(p.query_length, 7);
+  assert.equal(p.results_count, 12);
+  assert.equal(p.has_results, true);
+  // No parameter may carry text that could be the query itself.
+  assert.equal(p.search_term, undefined);
+  assert.equal(p.query, undefined);
+});
+
+test('scrubber drops parameters whose names suggest free text or identity', () => {
+  const { api, calls } = load({ pathname: '/apps/trip-planner/' });
+  api.track('probe', {
+    trip_name: 'Honeymoon in Split',
+    search_term: 'anxiety meds',
+    user_email: 'a@b.com',
+    note: 'call mum',
+    item_title: 'Flight LH123',
+    safe_count: 4,
+  });
+  const p = events(calls).pop()[2];
+  assert.equal(p.trip_name, undefined);
+  assert.equal(p.search_term, undefined);
+  assert.equal(p.user_email, undefined);
+  assert.equal(p.note, undefined);
+  assert.equal(p.item_title, undefined);
+  assert.equal(p.safe_count, 4);
+});
+
+test('scrubber drops values that look like emails or opaque ids', () => {
+  const { api, calls } = load({ pathname: '/apps/arena/' });
+  api.track('probe', {
+    contact: 'someone@example.com',
+    ref: 'aVeryLongOpaqueIdentifier123456',
+    mode: 'solo',
+  });
+  const p = events(calls).pop()[2];
+  assert.equal(p.contact, undefined);
+  assert.equal(p.ref, undefined);
+  assert.equal(p.mode, 'solo');
+});
+
+test('catalogue slugs survive the opaque-id filter', () => {
+  // Regression: an earlier length-only rule (24+ chars of [A-Za-z0-9_-])
+  // matched real show slugs and silently dropped every content_id that
+  // Rising Shows reporting is built on. "rick-and-morty-tt2861424" is
+  // exactly 24 characters.
+  const { api, calls } = load({ pathname: '/apps/rising-shows/' });
+  const slugs = ['rick-and-morty-tt2861424', '24-tt0285331', 'the-lord-of-the-rings-the-rings-of-power-tt7631058'];
+  for (const slug of slugs) {
+    api.trackContentView({ contentType: 'show', contentId: slug });
+    assert.equal(events(calls).pop()[2].content_id, slug, `slug dropped: ${slug}`);
+  }
+});
+
+test('long strings are truncated to GA4s 100-char limit', () => {
+  const { api, calls } = load({ pathname: '/apps/arena/' });
+  api.track('probe', { blurb: 'x'.repeat(250) });
+  assert.equal(events(calls).pop()[2].blurb.length, 100);
+});
+
+test('trackOutbound reports the domain only, and ignores same-origin links', () => {
+  const { api, calls } = load({ pathname: '/home' });
+  api.trackOutbound('https://www.imdb.com/title/tt1/?ref=abc');
+  const p = events(calls).pop()[2];
+  assert.equal(p.link_domain, 'www.imdb.com');
+  assert.equal(JSON.stringify(p).includes('tt1'), false);
+
+  const before = events(calls).length;
+  api.trackOutbound('https://shevato.com/apps');
+  assert.equal(events(calls).length, before, 'same-origin link must not be outbound');
+});
+
+test('trackError truncates the message and caps volume per page', () => {
+  const { api, calls } = load({ pathname: '/apps/trip-planner/' });
+  for (let i = 0; i < 20; i++) api.trackError('scope', 'boom '.repeat(60));
+  const errs = events(calls).filter((c) => c[1] === 'app_error');
+  assert.equal(errs.length, 5, 'error events must be capped');
+  assert.equal(errs[0][2].error_message.length, 100);
+});
+
+test('a throwing gtag never propagates to the caller', () => {
+  const { api } = load({ pathname: '/apps/gym-tracker/', breakGtag: true });
+  // Each of these would break an app if analytics could throw.
+  assert.doesNotThrow(() => api.trackView('workout'));
+  assert.doesNotThrow(() => api.trackAction('workout_completed', { set_count: 3 }));
+  assert.doesNotThrow(() => api.trackSearch({ scope: 'x', resultsCount: 0 }));
+  assert.doesNotThrow(() => api.trackError('scope', 'msg'));
+  assert.doesNotThrow(() => api.track('anything', { a: 1 }));
+});
+
+test('malformed input is ignored rather than sent', () => {
+  const { api, calls } = load({ pathname: '/apps/gym-tracker/' });
+  const before = events(calls).length;
+  api.trackView('');
+  api.trackView(null);
+  api.trackFilter('', 'x');
+  api.track('');
+  api.trackOutbound('not a url');
+  assert.equal(events(calls).length, before);
+});

--- a/moadon-alef.html
+++ b/moadon-alef.html
@@ -33,13 +33,13 @@
   <link rel="icon" type="image/png" href="images/moadon-alef-header.png">
   
   <!-- SEO Enhancement: Canonical URL to prevent duplicate content issues -->
-  <link rel="canonical" href="https://shevato.com/moadon-alef.html" />
+  <link rel="canonical" href="https://shevato.com/moadon-alef" />
   
   <!-- SEO Enhancement: Language targeting for Israeli users and the Russian and English audiences served on the same page. -->
-  <link rel="alternate" hreflang="he-IL" href="https://shevato.com/moadon-alef.html" />
-  <link rel="alternate" hreflang="ru-IL" href="https://shevato.com/moadon-alef.html" />
-  <link rel="alternate" hreflang="en-IL" href="https://shevato.com/moadon-alef.html" />
-  <link rel="alternate" hreflang="x-default" href="https://shevato.com/moadon-alef.html" />
+  <link rel="alternate" hreflang="he-IL" href="https://shevato.com/moadon-alef" />
+  <link rel="alternate" hreflang="ru-IL" href="https://shevato.com/moadon-alef" />
+  <link rel="alternate" hreflang="en-IL" href="https://shevato.com/moadon-alef" />
+  <link rel="alternate" hreflang="x-default" href="https://shevato.com/moadon-alef" />
   
   <!-- SEO Enhancement: Robots meta tag for search engine crawling -->
   <meta name="robots" content="index, follow, max-image-preview:large" />
@@ -48,7 +48,7 @@
   <meta property="og:title" content="מועדון אלף - רופא עד הבית 24/7 | שירות רפואי מקצועי" />
   <meta property="og:description" content="שירות רופא עד הבית המוביל בישראל. טיפול רפואי מקצועי 24/7, כולל שבתות וחגים. התקשרו: 1-700-701-103" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://shevato.com/moadon-alef.html" />
+  <meta property="og:url" content="https://shevato.com/moadon-alef" />
   <meta property="og:image" content="https://shevato.com/images/og-card-moadon-alef.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -82,12 +82,12 @@
   {
     "@context": "https://schema.org",
     "@type": "MedicalOrganization",
-    "@id": "https://shevato.com/moadon-alef.html#organization",
+    "@id": "https://shevato.com/moadon-alef#organization",
     "name": "מועדון אלף",
     "alternateName": ["Moadon Alef", "Моадон Алеф"],
     "description": "שירות רופא עד הבית 24/7 המוביל בישראל. מספקים טיפול רפואי מקצועי, בדיקות, חיסונים וטיפולי חירום בנוחות ביתכם.",
     "slogan": "שירות רופא עד הבית 24/7",
-    "url": "https://shevato.com/moadon-alef.html",
+    "url": "https://shevato.com/moadon-alef",
     "telephone": "+972-1-700-701-103",
     "logo": {
       "@type": "ImageObject",
@@ -201,13 +201,13 @@
   {
     "@context": "https://schema.org",
     "@type": "WebSite",
-    "@id": "https://shevato.com/moadon-alef.html#website",
-    "url": "https://shevato.com/moadon-alef.html",
+    "@id": "https://shevato.com/moadon-alef#website",
+    "url": "https://shevato.com/moadon-alef",
     "name": "מועדון אלף",
     "alternateName": ["Moadon Alef", "Моадон Алеф"],
     "description": "שירות רופא עד הבית 24/7 בישראל",
     "inLanguage": ["he", "en", "ru"],
-    "publisher": { "@id": "https://shevato.com/moadon-alef.html#organization" }
+    "publisher": { "@id": "https://shevato.com/moadon-alef#organization" }
   }
   </script>
   
@@ -216,8 +216,8 @@
   {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "@id": "https://shevato.com/moadon-alef.html#webpage",
-    "url": "https://shevato.com/moadon-alef.html",
+    "@id": "https://shevato.com/moadon-alef#webpage",
+    "url": "https://shevato.com/moadon-alef",
     "name": "מועדון אלף - רופא עד הבית 24/7 | שירות רפואי מקצועי בישראל",
     "isPartOf": { "@id": "https://shevato.com/#website" },
     "about": { "@id": "https://shevato.com/#organization" },
@@ -241,7 +241,7 @@
         "@type": "ListItem",
         "position": 2,
         "name": "מועדון אלף - רופא עד הבית",
-        "item": "https://shevato.com/moadon-alef.html"
+        "item": "https://shevato.com/moadon-alef"
       }
     ]
   }

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,30 +16,138 @@
   port = 8888
   publish = "."
 
-# The site homepage lives at /home.html; "/" must be a clean edge 301 so
-# Google indexes the real homepage. force = true makes this win over the
-# committed index.html stub (which previously served at "/" carrying a
-# noindex meta that de-indexed the domain root - GSC, 2026-06). The stub
-# remains only as a local-dev / no-JS fallback.
+# ---------------------------------------------------------------------------
+# URL canonicalisation.
+#
+# Netlify's Pretty URLs serves every committed `foo.html` at BOTH /foo.html
+# and /foo, with a 200 on each and no redirect between them. Nothing here
+# used to collapse the pair, so one page was reachable at two live URLs:
+# GA4 filed them as two rows (/apps 11 views vs /apps.html 13), and Google
+# saw a duplicate it had to resolve via the canonical tag.
+#
+# Direction of travel is extensionless, because that is what every page's
+# <link rel="canonical"> and sitemap-pages.xml already declare - so these
+# redirects make the server agree with what we had been claiming, and
+# nothing needs re-indexing.
+#
+# force = true on each: the .html file physically exists, and without force
+# static file serving wins and the redirect never runs.
+#
+# NOTE: google10670283c9d04acd.html is deliberately absent. Search Console
+# fetches that exact .html path to verify domain ownership; redirecting it
+# would fail verification. Every rule below names one page for that reason -
+# a blanket *.html rule would have caught it.
+# ---------------------------------------------------------------------------
+
+# "/" must be a clean edge 301 so Google indexes the real homepage. force
+# makes this win over the committed index.html stub (which previously served
+# at "/" carrying a noindex meta that de-indexed the domain root - GSC,
+# 2026-06). The stub remains only as a local-dev / no-JS fallback.
+#
+# Targets /home, not /home.html: this redirect is the site's single busiest
+# entry point, and pointing it at the non-canonical variant is what drove
+# 279 of 624 page views onto /home.html while /home recorded almost none.
 [[redirects]]
   from = "/"
-  to = "/home.html"
+  to = "/home"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/index.html"
+  to = "/home"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/home.html"
+  to = "/home"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/apps.html"
+  to = "/apps"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/work.html"
+  to = "/work"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/about.html"
+  to = "/about"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/contact.html"
+  to = "/contact"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/privacy.html"
+  to = "/privacy"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/moadon-alef.html"
+  to = "/moadon-alef"
+  status = 301
+  force = true
+
+# Directory-index duplicates. Every generated page under shows/ and
+# exercises/ was reachable both as `/…/slug/` and `/…/slug/index.html`,
+# doubling the potential URL space for ~34,800 generated pages. Named
+# placeholders (:slug) rather than a splat, so the rule cannot escape the
+# directory it is meant to tidy.
+[[redirects]]
+  from = "/apps/rising-shows/shows/:slug/index.html"
+  to = "/apps/rising-shows/shows/:slug/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/apps/gym-tracker/exercises/:slug/index.html"
+  to = "/apps/gym-tracker/exercises/:slug/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/apps/:app/index.html"
+  to = "/apps/:app/"
+  status = 301
+  force = true
+
+# The Kometa builder sits one level deeper than the rule above reaches.
+[[redirects]]
+  from = "/apps/rising-shows/kometa/index.html"
+  to = "/apps/rising-shows/kometa/"
   status = 301
   force = true
 
 # product.html was retired as part of the marketing/portfolio refresh.
-# Its services content now lives at the top of /work.html. Permanent
-# redirect so anyone with a bookmark or inbound link lands cleanly.
+# Its services content now lives at the top of /work. Permanent redirect so
+# anyone with a bookmark or inbound link lands cleanly.
+#
+# Targets /work rather than /work.html: since /work.html now 301s to /work,
+# the old target would have made this a two-hop redirect chain, which costs
+# a round trip and dilutes the link signal Google passes through.
 [[redirects]]
   from = "/product.html"
-  to = "/work.html"
+  to = "/work"
   status = 301
   force = true
 
 # Extensionless variant in case anyone bookmarked /product without .html.
 [[redirects]]
   from = "/product"
-  to = "/work.html"
+  to = "/work"
   status = 301
   force = true
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "test": "node --test apps/gym-tracker/tests/ apps/football-h2h/tests/ apps/rising-shows/tests/ apps/mario-kart/tests/ apps/arena/tests/ apps/maptap-rivals/tests/ apps/trip-planner/tests/ netlify/functions/tests/ sync-system/tests/",
+    "test": "node --test apps/gym-tracker/tests/ apps/football-h2h/tests/ apps/rising-shows/tests/ apps/mario-kart/tests/ apps/arena/tests/ apps/maptap-rivals/tests/ apps/trip-planner/tests/ netlify/functions/tests/ sync-system/tests/ assets/js/tests/",
     "test:gym": "node --test apps/gym-tracker/tests/",
     "test:football": "node --test apps/football-h2h/tests/",
     "test:rising-shows": "node --test apps/rising-shows/tests/",
@@ -13,6 +13,7 @@
     "test:trip-planner": "node --test apps/trip-planner/tests/",
     "test:tp-assist-quota": "node --test netlify/functions/tests/tp-assist-quota.test.mjs",
     "test:sync": "node --test sync-system/tests/",
+    "test:analytics": "node --test assets/js/tests/",
     "sync:mario-kart-courses": "node apps/mario-kart/scripts/sync-courses.mjs",
     "build:trip-planner:airports": "node apps/trip-planner/scripts/build-airports.mjs",
     "build:rising-shows": "node apps/rising-shows/scripts/build-data.js",

--- a/privacy.html
+++ b/privacy.html
@@ -90,7 +90,7 @@
 
       <article class="about-shell">
 
-        <p><strong>Last reviewed:</strong> 22 July 2026. <!-- TODO(owner): update this date whenever the behaviour described below changes. --></p>
+        <p><strong>Last reviewed:</strong> 7 August 2026. <!-- TODO(owner): update this date whenever the behaviour described below changes. --></p>
 
         <h2>The short version</h2>
 
@@ -279,9 +279,17 @@
 
         <h2>Analytics and cookies</h2>
 
-        <p>Our own code sets no cookies. The marketing pages you are reading now, and the individual show pages under Rising Shows, load Google Analytics 4 with its default configuration, which stores its own identifier cookie in your browser and reports page views to Google.</p>
+        <p>Our own code sets no cookies. Every page on this site, including the apps, loads Google Analytics 4, which stores its own identifier cookie in your browser and reports page views to Google.</p>
 
-        <p>The app pages themselves do not load Google Analytics. Opening Mario Kart, Football H2H, Gym Tracker, MapTap Rivals, Trip Planner, Arena or the main Rising Shows app does not send anything to Analytics.</p>
+        <p>This changed in August 2026. Until then the app pages carried no analytics at all, which meant we could see that people arrived but not whether anything we built was worth using. The apps now report a small, fixed set of events. What follows is the complete list of what they send.</p>
+
+        <p>Alongside page views, we record: that an app was opened; which section or tab within an app you moved to; that a search ran, with how many characters you typed and how many results came back; which item you picked from a search result list; which filters or sorting you chose; that you opened a detail view, and which catalogue entry it was; that you paged through a list; that you followed a link to another website, and to which domain; a handful of completed actions specific to each app (a workout finished, a match or race logged, a trip shared, the Trip Planner assistant opened, an Arena room created or joined); and JavaScript errors, by their message.</p>
+
+        <p>What we deliberately do not send matters more than the list above. <strong>We never send anything you type.</strong> Search boxes report how long your query was and whether it matched anything, never the query itself. We never send your trip contents, destinations, item details or confirmation numbers; your workout notes, exercise names, weights, heart rate or calorie figures; your rivals' or players' names; custom team names; Arena room codes or display names; your email address, account id, or any Firestore path. Filter and sort values are sent as text, but only because every one of them is picked from a fixed list the app defines rather than typed by you.</p>
+
+        <p>The generated show pages under Rising Shows and the exercise pages under Gym Tracker report ordinary page views and nothing else.</p>
+
+        <p>Analytics is loaded so that it cannot interfere with the apps: every tracking call is wrapped so that a failure is silently discarded, and if you block Google Analytics with an extension or a content blocker, every app continues to work exactly as it does otherwise. Nothing on this site is gated on analytics loading.</p>
 
         <p>There's no contact form on this site; the contact page is just a set of links, so nothing is collected there.</p>
 

--- a/sitemap-pages.xml
+++ b/sitemap-pages.xml
@@ -44,7 +44,7 @@
   </url>
 
   <url>
-    <loc>https://shevato.com/moadon-alef.html</loc>
+    <loc>https://shevato.com/moadon-alef</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>


### PR DESCRIPTION
GA4 was installed on the marketing pages and the ~34,800 generated SEO pages (34,283 Rising Shows show pages + 516 Gym Tracker exercise pages), and on **none of the 8 apps**. The reported 3s average engagement was therefore a faithful measurement of the wrong surface: crawler-heavy static pages that bounce at 0s, with no visibility into the apps. That absence was documented behaviour rather than an oversight — `privacy.html` promised the apps loaded no analytics — so the policy is rewritten here in the same change.

Two further defects fell out of the same review: every `.html` page had a live extensionless twin serving 200 with no redirect between them (canonicals and the sitemap already declared extensionless, while `/` redirected to `/home.html`), and `404.html` reported each failed path as its own `page_path`, minting a distinct 0s row per broken link and bot probe.

## Shared analytics layer

**`assets/js/analytics.js`** — rewritten from a 4-line bootstrap into the single place GA4 is configured and the single API callers may use (`window.shevatoAnalytics`). Adds: parameter scrubbing that drops names suggesting free text or identity and values resembling emails or generated ids; repeat suppression on `trackView`/`trackFilter`; a 5-per-page cap on error events; domain-only outbound reporting; delegated click tracking for internal nav, outbound links and mailto/tel; automatic `app_name`/`app_section` derived from the URL; and a re-entry guard so a duplicate script tag cannot fire a second `page_view`. Every public method swallows its own errors, so tracking can never throw into app code. `page_path` is reported without query, hash or `.html`, mirroring the canonical tag. In-app navigation reports `app_view`, never a synthetic `page_view`, so client routing cannot invent URLs in Pages and Screens. `app_open` fires automatically on app entry pages only, deliberately not on the generated content pages.

Two bugs in this file were found during verification and fixed before it landed. The opaque-id filter (`24+ chars of [A-Za-z0-9_-]`) matched real show slugs — `rick-and-morty-tt2861424` is exactly 24 characters — and would have silently dropped every `content_id`; it now keys on unbroken mixed-case strings instead. The `BANNED_PARAM` `_name$` rule was stripping `view_name`, `action_name` and `filter_name`, i.e. the entire payload of `app_view`, `app_action` and `filter_change`, leaving those events indistinguishable; a `STRUCTURAL_PARAM` exemption fixes it. Both are pinned by regression tests.

**`assets/js/analytics-404.js`** — new. Reports the path that actually 404'd as an event parameter, so pinning `page_path` to `/404` does not lose the ability to find broken inbound links. Path only, never the query string.

**`assets/js/tests/analytics.test.js`** — new. 23 tests covering one-config-per-load, `.html` stripping, trailing-slash preservation, the 404 override, double-load protection, `app_open` scoping, view/filter dedupe, the scrubber (including the slug and structural-parameter regressions), truncation, outbound handling, the error cap, and that a throwing `gtag` never propagates.

**`package.json`** — `assets/js/tests/` added to `npm test`; new `test:analytics` script.

## URL canonicalisation

**`netlify.toml`** — 13 new redirects. `/` now targets `/home` rather than `/home.html` (that single rule is why `/home.html` took 279 of 624 views while `/home` recorded almost none). Per-page 301s for `/index.html`, `/home.html`, `/apps.html`, `/work.html`, `/about.html`, `/contact.html`, `/privacy.html`, `/moadon-alef.html`, all `force = true` because the `.html` file physically exists and would otherwise win. Directory-index rules collapse `/…/slug/index.html` onto `/…/slug/` for the shows and exercises trees, the app landings, and the Kometa builder, using named placeholders rather than a splat so they cannot escape their directory. `google10670283c9d04acd.html` is deliberately named nowhere: Search Console fetches that exact path to verify ownership, which is why every rule names one page instead of using a blanket `*.html`.

Also repoints the pre-existing `/product.html` and `/product` rules from `/work.html` to `/work` — once `/work.html` began redirecting, those became two-hop chains.

**`moadon-alef.html`** — canonical, four `hreflang` alternates, `og:url` and eight JSON-LD `@id`/`url`/`item` values moved off `.html`, since that URL now redirects. **`sitemap-pages.xml`** — matching `<loc>` update.

## App instrumentation

Each app gets the GA snippet (async + defer, with preconnect) and a small local `track()` shim that resolves `window.shevatoAnalytics` at call time — the helper is deferred and app code can run first — and swallows everything. Gym Tracker imports the same shim as an ES module.

- **`apps/rising-shows/js/app.js`** — search (length and result count, never the query text), `search_result_select` carrying the catalogue slug, `content_view` on show modal open placed after the early return so a failed lookup is not counted, `filter_change` for sort/shapes/genres/languages/hidden-gems, and `load_more` on pagination. `primeFinderAnalytics()` registers boot state so the first control a user touches reports once instead of the whole panel reporting its defaults. `renderFinder` stashes its row count so the reporting path does not re-run the filter pass.
- **`apps/gym-tracker/js/app.js`** — `app_view` in `showView`, placed after the early return and the `beforeLeave` guard so a cancelled navigation is not reported. **`js/views/workout-view.js`** — `workout_completed` with counts and duration; no exercise names, notes, heart rate or calories. **`js/utils/analytics.js`** — new importable shim.
- **`apps/trip-planner/js/app.js`** — `app_view` in `setView`, `trip_shared` with item count only (the share URL's fragment encodes the whole trip), and `assistant_opened`.
- **`apps/arena/js/app.js`** — `room_created` with game type and mode; `room_joined` moved to after every guard and the player-doc write, so a wrong password, a full room or an abandoned name prompt is not counted. Room codes and display names are never sent.
- **`apps/mario-kart/js/main.js`** — `app_view` in `toggleView`. **`js/dataManager.js`** — `race_logged` after validation, with player count and whether a course was picked.
- **`apps/football-h2h/js/football-h2h.js`** — `app_view` in `switchStatsTab`; `match_logged`/`match_edited` after validation, excluding team names because the "Other" option makes them free text.
- **`apps/maptap-rivals/js/app.js`** — `app_view` in `setView`; `games_logged` once per batch with a count and an `entry_method` of paste, maptap_sync or whatsapp_import, rather than one event per game inside the loops.

## Privacy and docs

**`privacy.html`** — the "Analytics and cookies" section is rewritten: the old two paragraphs claimed the apps sent nothing. It now lists every event collected, then states at greater length what is never sent (typed text, trip contents, workout notes and health figures, rivals' and players' names, custom team names, Arena room codes and display names, emails, account ids, Firestore paths), and records that blocking analytics leaves every app fully functional. "Last reviewed" bumped to 7 August 2026, per the in-file TODO.

**`404.html`** — inline config pinning `page_path` to `/404`, ahead of the deferred helper that reads it, plus the new reporter script.

**`README.md`** — new Analytics section: the call-the-helper-never-gtag rule, the shim pattern, a table of all 13 events with their parameters, and the two rules for adding tracking. File tree and test list updated. **`apps/gym-tracker/README.md`** — new `utils/analytics.js` noted, disambiguated from the existing `services/Analytics` that computes workout stats.

## Requires configuration in the GA4 console

Not in this repo: bot filtering, an internal-traffic IP rule, and marking any of the new events as key events. Expect reported traffic to shift rather than rise — `/home.html` folds into `/home` and the 404 long tail folds into one row.
