### PR TITLE
fix(rising-shows): stop app.js shadowing two of finder-lib's exported functions

### DIFF
--- a/apps/rising-shows/js/app.js
+++ b/apps/rising-shows/js/app.js
@@ -717,7 +717,7 @@ async function load() {
   bindAdvancedDrawer();
   bindShapeTagTouchTooltips();
   bindShortcutLegend();
-  showAgg = buildShowAgg();
+  showAgg = buildShowAggFromDataset();
   showShapesBySeries = new Map(showAgg.map((s) => [s.seriesId, s.shapes]));
   renderFinderShapes();
   renderFinderMoods();
@@ -943,11 +943,15 @@ function languageLabel(code) {
 
 // --- filter + sort ---
 
-function passesShapeAnd(m, shapeSet) {
-  if (shapeSet.size === 0) return true;
-  for (const s of shapeSet) if (!m.shapes.includes(s)) return false;
-  return true;
-}
+// passesShapeAnd deliberately does NOT live here. finder-lib.js owns it and
+// exports it on RisingShowsFinder; this file used to declare a byte-identical
+// copy at top level. Both are classic scripts sharing one global lexical
+// scope and app.js is deferred second, so that copy silently overwrote the
+// library's own and finder-lib's internal filterAndSortRows() ended up calling
+// THIS file's version. Harmless only for as long as the two stayed identical.
+// It is the same collision class that made integrations-lib.js throw
+// "Identifier 'CATEGORICAL_SHAPES' has already been declared" and silently
+// skip the whole file. Call RisingShowsFinder.passesShapeAnd instead.
 
 // --- render ---
 
@@ -2768,7 +2772,15 @@ function formatCompactVotes(n) {
 // Kometa are built from exactly the rows this view shows. `detectShapes` comes
 // from match.js, loaded before this script; guard so a missing global never
 // breaks the finder.
-function buildShowAgg() {
+// Named buildShowAggFromDataset, not buildShowAgg: a bare `buildShowAgg` here
+// would overwrite finder-lib.js's exported function of that name on the shared
+// global (both are classic scripts and this one is deferred second), leaving a
+// zero-argument wrapper standing where a two-argument function is expected.
+// Nothing in finder-lib calls it by the bare name today, so that shadow was
+// harmless, but it is the same collision that made integrations-lib.js throw
+// "Identifier 'CATEGORICAL_SHAPES' has already been declared" and skip its
+// whole file. Distinct names keep the global free of look-alikes.
+function buildShowAggFromDataset() {
   return RisingShowsFinder.buildShowAgg(
     dataset.matches,
     typeof detectShapes === 'function' ? detectShapes : null,
@@ -2915,7 +2927,7 @@ function makeFinderShapeChip(shape, name, icon) {
 function syncFinderShapeChips() {
   if (!els.finderShapes) return;
   const base = finderRowsBeforeShape();
-  const current = base.filter((s) => passesShapeAnd(s, finderState.shapes));
+  const current = base.filter((s) => RisingShowsFinder.passesShapeAnd(s, finderState.shapes));
   const counts = finderShapeCounts(current);
   for (const btn of els.finderShapes.querySelectorAll('.shape-chip')) {
     const shape = btn.dataset.shape;
@@ -3179,7 +3191,7 @@ function finderRowsBeforeShape() {
 function filterAndSortFinder() {
   const f = finderState;
   const rows = finderRowsBeforeShape()
-    .filter((s) => passesShapeAnd(s, f.shapes));
+    .filter((s) => RisingShowsFinder.passesShapeAnd(s, f.shapes));
   rows.sort(RisingShowsFinder.finderComparator(f.sort, f.sortDir));
   return rows;
 }


### PR DESCRIPTION
`apps/rising-shows/js/app.js` declared `passesShapeAnd` and `buildShowAgg` at top level, and so does `scripts/finder-lib.js`. Both are classic scripts sharing one global lexical scope, and app.js is deferred second (`match.js` → `finder-lib.js` → `app.js`), so app.js's copies silently overwrote the library's.

`passesShapeAnd` was the live one. finder-lib's own `filterAndSortRows()` calls it by bare name, so at runtime the library was executing app.js's copy rather than its own. Nothing was broken, because the two implementations were byte-identical apart from parameter names (`(s, shapeSet)` vs `(m, shapeSet)`) - but that is a property nobody was maintaining deliberately, and it would have held only until someone edited one of them.

`buildShowAgg` was never actually reached, since finder-lib only defines and exports it and never calls it internally. It was, however, the more dangerous shape: app.js's version is a zero-argument wrapper that reads `dataset.matches` from module state, standing on the global where a two-argument `(matches, detectShapes)` function is expected. Any future finder-lib code calling it by bare name would have had its arguments silently dropped.

This is the same collision class that, in the previous round, made `integrations-lib.js` throw `Uncaught SyntaxError: Identifier 'CATEGORICAL_SHAPES' has already been declared`, skip its entire file, and leave `window.RisingShowsIntegrations` undefined while app.js kept running - which would have shipped the Kometa export button dead. That one was fixed by loading integrations-lib as `<script type="module">`; this change removes the two remaining look-alikes from the shared global scope.

## `apps/rising-shows/js/app.js`

The only file in the diff.

- **Removed the duplicate `passesShapeAnd`**, replaced by a comment recording why it must not come back: which file owns it, why the shadow was invisible, and the CATEGORICAL_SHAPES precedent.
- **Both call sites now use `RisingShowsFinder.passesShapeAnd(...)`** - in `syncFinderShapeChips` (the chip-count preview) and in `filterAndSortFinder` (the main grid filter). This matches the convention the file already used one line above in `filterAndSortFinder`, which called `RisingShowsFinder.passesFinderFilters(...)`; the bare `passesShapeAnd` sitting directly beneath it was the visible tell.
- **Renamed the local wrapper `buildShowAgg()` to `buildShowAggFromDataset()`**, with its single caller in `load()` updated. The wrapper itself is unchanged: it still calls `RisingShowsFinder.buildShowAgg(dataset.matches, detectShapes)` with the existing guard for a missing `detectShapes` global. Only the name it occupies on the global scope changed, so the library's export is no longer shadowed.

Behavior is unchanged by design, and was measured rather than assumed. In a headless browser against the local `data.json` snapshot: unfiltered **34,201 shows**, the Rebound chip **184**, Rebound plus Shape drift **46** - each identical to the figures measured before the change - with zero uncaught errors captured by a `window.addEventListener('error')` probe on boot. That last point matters because the rename touches load-time code (`showAgg = buildShowAggFromDataset()` inside `load()`), where a mistake means the app does not start at all rather than degrading quietly. Shape-chip disabling also still behaves (14 chips enabled at baseline, 10 enabled / 4 disabled after selecting Rebound), which exercises the same function through a second code path.

A scan of every top-level `function` / `const` / `let` / `var` name across all three classic scripts on the finder page (`match.js`, `finder-lib.js`, `app.js`) now reports no shared names. Before this change it reported exactly these two.

The structural fix for this bug class is converting these files to modules, so distinct names are not load-bearing. That is a larger round; until then the collision scan is worth repeating whenever a new top-level name is added to `app.js`.
