### PR TITLE
refactor(rising-shows): load app.js as a module so it stops owning the global namespace

### DIFF
--- a/apps/rising-shows/README.md
+++ b/apps/rising-shows/README.md
@@ -210,7 +210,11 @@ The default vote floor is deliberately low - IMDb's per-episode vote counts can 
 
 ## Viewing locally
 
-The page loads `data.json` via `fetch`, so serve the directory rather than opening `file://`:
+Serve the directory rather than opening `file://`. Two independent reasons now:
+the page loads `data.json` via `fetch`, and `js/app.js` is a `type="module"`
+script, which the browser refuses to execute from a `file://` origin. The
+module failure is the quieter of the two, since the page still renders its
+shell and simply never becomes interactive.
 
 ```sh
 cd apps/rising-shows

--- a/apps/rising-shows/index.html
+++ b/apps/rising-shows/index.html
@@ -553,11 +553,34 @@
        scope, so as a plain <script defer> the second one dies on a
        SyntaxError and never reaches its window.RisingShowsIntegrations
        assignment. It still attaches to window the same way, and app.js only
-       reads it from a click handler, so the later execution slot is fine. -->
+       reads it from a click handler, so the later execution slot is fine.
+
+       app.js is type="module" for the same reason, applied structurally
+       rather than one name at a time. As a classic script every one of its
+       ~500 top-level declarations became a global property, so any name it
+       shared with match.js or finder-lib.js silently overwrote theirs. That
+       produced three separate incidents: the CATEGORICAL_SHAPES SyntaxError
+       above, plus duplicate passesShapeAnd (which made finder-lib's own
+       filterAndSortRows call app.js's copy) and duplicate buildShowAgg. A
+       module gets its own scope, so app.js now contributes NOTHING to the
+       global namespace and the collision class is closed by construction
+       instead of by remembering to pick unique names.
+
+       Nothing needed to change inside app.js. It contains no import/export
+       syntax (so the node:vm test harness still loads it as a plain script),
+       it was already 'use strict', it assigns exactly one thing to window
+       (_rsTestExports, for those tests), and this page has no inline on*=
+       handlers that would need its functions to be global. It still reads
+       RisingShowsFinder and detectShapes as globals, which module scope
+       resolves through to window exactly as before.
+
+       Module scripts are deferred by default and execute in document order
+       alongside classic defer scripts, so match.js and finder-lib.js are
+       still guaranteed to run first. -->
   <script src="scripts/match.js" defer></script>
   <script src="scripts/finder-lib.js" defer></script>
   <script type="module" src="scripts/integrations-lib.js"></script>
-  <script src="js/app.js" defer></script>
+  <script type="module" src="js/app.js"></script>
   <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
As a classic script, `apps/rising-shows/js/app.js` put all **234** of its top-level declarations onto the global object, sharing one lexical scope with `scripts/match.js` and `scripts/finder-lib.js`. That single fact produced three separate incidents in this app:

1. `integrations-lib.js` and `finder-lib.js` both declared `const CATEGORICAL_SHAPES`, throwing `Uncaught SyntaxError: Identifier 'CATEGORICAL_SHAPES' has already been declared`. The entire file was skipped and `window.RisingShowsIntegrations` stayed undefined while app.js kept running, which would have shipped the compare modal's "Export to Kometa" button doing nothing.
2. `passesShapeAnd` was declared in both `app.js` and `finder-lib.js`, so finder-lib's own `filterAndSortRows()` executed app.js's copy at runtime.
3. `buildShowAgg` likewise, where app.js's zero-argument wrapper shadowed the library's two-argument function on the global.

The previous two rounds fixed 1 with a module tag and 2 and 3 by renaming. Renaming holds only for as long as every future contributor keeps picking unique names across 264 of them. This round removes the mechanism rather than the symptoms.

## `apps/rising-shows/index.html`

The functional change, one line: `<script src="js/app.js" defer>` becomes `<script type="module" src="js/app.js">`. A module gets its own scope, so app.js now contributes **zero** names to the global object and cannot collide again regardless of what is added to it. The shared global surface drops from 264 names to 30.

The surrounding comment block is expanded to record why the tag is what it is: which three incidents motivated it, that nothing inside app.js needed to change, and that module scripts are deferred by default and execute in document order alongside classic `defer` scripts, so `match.js` and `finder-lib.js` are still guaranteed to run first.

`js/app.js` itself has **no source changes**. A file does not need `import`/`export` syntax to be a module; being loaded as one is sufficient. That matters here for five reasons, each verified rather than assumed:

- It contains no ESM syntax, so `tests/app-features.test.js` still loads it into a `node:vm` context as a plain script.
- It was already `'use strict'`, so the implicit strict mode of modules changes nothing.
- It assigns exactly one thing to `window` (`_rsTestExports`), an explicit assignment that survives module scope, and that is what the vm harness reads.
- This page has no inline `on*=` handlers, so nothing in the markup depends on app.js functions being global.
- It has no `eval`, `new Function`, `window[...]` or `globalThis[...]` dynamic global lookups that module scope would break.

It still reads `RisingShowsFinder`, `detectShapes` and `RisingShowsIntegrations` as bare globals, which module scope resolves through to `window` exactly as before.

`match.js` and `finder-lib.js` remain classic scripts. They are dual-use: `scripts/build-data.js`, `scripts/export-integrations.js`, `tests/finder-lib.test.js` and `tests/match.test.js` all `require()` them, and `package.json` is `"type": "commonjs"`. Converting them would mean renaming to `.mjs` and rewriting every Node consumer, or maintaining a dual build. Their remaining 30 top-level names have no overlap with each other.

## `apps/rising-shows/README.md`

The "Viewing locally" section previously gave one reason to serve the directory rather than opening `file://`: the app fetches `data.json`. There are now two, and the new one fails differently. A `type="module"` script is refused outright from a `file://` origin, and that failure is quieter than a failed fetch: the page renders its shell and simply never becomes interactive. The section now states both reasons and calls out which one is the silent failure, so the next person who double-clicks `index.html` knows what they are looking at.
