### PR TITLE
fix(rising-shows): make the static pages and the app agree about a show's shape

### DIFF
--- a/apps/rising-shows/README.md
+++ b/apps/rising-shows/README.md
@@ -106,9 +106,25 @@ Each page (`scripts/render-show-page.js`) emits:
 `apps/rising-shows/shows/shape/<slug>/` (13 of them: `rising`, `consistent`, `slow-burn`,
 `big-finale`, `rebound`, `front-loaded`, `declining`, `bad-finale`, `rollercoaster`,
 `mid-peak`, `u-shaped`, `saved-best-for-last`, `shape-drift`). A show appears on exactly
-one hub, the one matching its **dominant shape** (the first shape tag of its highest-rated
-season, `computeDominantShape` in `render-show-page.js`), ranked by IMDb vote count and
-capped at the top 100; the `CollectionPage` JSON-LD `ItemList` carries the first 25.
+one hub, the one matching its **dominant shape**: the first entry of the show's whole-run
+trajectory, computed by `computeDominantShape` in `render-show-page.js`, which delegates to
+finder-lib's `deriveShowShapes` - the same derivation `buildShowAgg` runs for the browser
+Finder, so a page's badge and the app's shape chips cannot disagree. Ranked by IMDb vote
+count and capped at the top 100; the `CollectionPage` JSON-LD `ItemList` carries the first 25.
+
+Until 2026-08-08 the dominant shape was instead the first shape tag of the show's single
+highest-rated season, which describes the EPISODES inside that one season rather than the
+show's trajectory. The two answered different questions and disagreed for 83.5% of the
+catalogue (6,497 of the 7,780 shows where both produced a label): Game of Thrones read
+"slow burn" on its page and "front-loaded, bad-finale, shape-drift" in the app, Stranger
+Things read "big finale" against the app's "bad-finale". Because the same function decides
+hub membership, `/shows/shape/big-finale/` was listing 1,915 of 5,411 shows that the app's
+own big-finale filter would reject. Expect some hubs to be smaller than before (rebound
+and rollercoaster especially): they are no longer padded with shows whose best season
+merely happened to have that internal shape. Note that a few shapes can never be dominant,
+because `detectShapes` emits trajectory shapes in a fixed order and `rebound` always trails
+`slow-burn` and `big-finale`; those hubs fill only from shows where the earlier shapes do
+not apply.
 Each hub cross-links the others, the A-Z index, and the shape-filtered explorer view
 (`/apps/rising-shows/#shape=<slug>`). The per-season shape badges on show pages and the
 "See all X shows" link under the recommendations point at these hubs, the A-Z index carries

--- a/apps/rising-shows/scripts/finder-lib.js
+++ b/apps/rising-shows/scripts/finder-lib.js
@@ -38,6 +38,40 @@ const HIDDEN_GEM_MAX_VOTES_PER_EP = 500;
 // work for them (matching how the per-shape hub pages and Kometa treat them).
 const CATEGORICAL_SHAPES = ['saved-best-for-last', 'shape-drift'];
 
+/**
+ * The single definition of "what shape is this show".
+ *
+ * Feeds the ordered per-SEASON averages to the same detectors match.js runs
+ * per episode, then appends any categorical tag a season carries. The result
+ * describes the show's trajectory across its run, which is the product's whole
+ * premise.
+ *
+ * Extracted so the browser Finder (through buildShowAgg) and the static page
+ * builder (through render-show-page's computeDominantShape) share one
+ * implementation. They previously each had their own idea of a show's shape
+ * and disagreed on 83.5% of the catalogue: the static side classified the
+ * EPISODES inside a show's single highest-rated season and labelled that as
+ * the show's shape, so Game of Thrones read "slow-burn" on its page and
+ * "front-loaded, bad-finale, shape-drift" in the app, and a third of some hub
+ * pages listed shows the app's own filter would reject.
+ *
+ * @param {number[]} seasonAvgs per-season average ratings, ORDERED by season
+ * @param {Set<string>} categoricalTags tags any season carries
+ * @param {Function} detectShapes match.js's classifier, passed in so the
+ *   browser can hand over its global and a missing one degrades to no shapes
+ * @returns {string[]} trajectory shapes first, then categorical tags
+ */
+function deriveShowShapes(seasonAvgs, categoricalTags, detectShapes) {
+  // A single season has no cross-season trajectory, so such shows carry no
+  // trajectory shape (they can still carry categorical tags).
+  const trajectoryShapes = (seasonAvgs.length >= 2 && typeof detectShapes === 'function')
+    ? detectShapes(seasonAvgs.map((avg) => ({ rating: avg })))
+    : [];
+  return trajectoryShapes.concat(
+    CATEGORICAL_SHAPES.filter((t) => categoricalTags.has(t) && !trajectoryShapes.includes(t)),
+  );
+}
+
 // Aggregate per-season records (data.json `matches`) into one row per series.
 // `detectShapes` is the per-episode shape classifier from match.js - passed in
 // rather than required so the browser can hand over its global and a missing
@@ -113,15 +147,12 @@ function buildShowAgg(matches, detectShapes) {
     const episodeSeries = s.seasonsCount === 1 ? s.seasonEpisodeSeries[0] : undefined;
     const seasonAvgs = s.seasonAvgs.slice().sort((a, b) => a.season - b.season);
     // Whole-show shape: feed the ordered per-season averages to the same shape
-    // detectors the Seasons view uses per episode. A single season has no
-    // cross-season trajectory, so such shows carry no trajectory shape.
-    // Categorical season tags (saved-best-for-last, shape-drift) are appended
-    // after the trajectory shapes regardless of season count.
-    const trajectoryShapes = (seasonAvgs.length >= 2 && typeof detectShapes === 'function')
-      ? detectShapes(seasonAvgs.map((a) => ({ rating: a.avg })))
-      : [];
-    const shapes = trajectoryShapes.concat(
-      CATEGORICAL_SHAPES.filter((t) => s.categoricalShapes.has(t) && !trajectoryShapes.includes(t)),
+    // detectors the Seasons view uses per episode. See deriveShowShapes, which
+    // the static page builder calls too so the two surfaces cannot disagree.
+    const shapes = deriveShowShapes(
+      seasonAvgs.map((a) => a.avg),
+      s.categoricalShapes,
+      detectShapes,
     );
     out.push({
       seriesId: s.seriesId,
@@ -260,6 +291,7 @@ const API = {
   HIDDEN_GEM_MIN_AVG,
   HIDDEN_GEM_MAX_VOTES_PER_EP,
   CATEGORICAL_SHAPES,
+  deriveShowShapes,
   buildShowAgg,
   parseFinderQuery,
   passesFinderFilters,

--- a/apps/rising-shows/scripts/render-show-page.js
+++ b/apps/rising-shows/scripts/render-show-page.js
@@ -3,6 +3,12 @@
 const { renderCurve, escapeXml } = require('./render-curve.js');
 const { showPath } = require('./slugify.js');
 const { renderMoreFooter } = require('./render-footer.js');
+// Shape classification is shared with the browser Finder so the static pages
+// and the app can never label the same show differently. deriveShowShapes owns
+// the definition; detectShapes is the per-episode classifier it runs over the
+// per-season averages. Neither module requires this one, so no cycle.
+const { deriveShowShapes } = require('./finder-lib.js');
+const { detectShapes } = require('./match.js');
 
 const SITE = 'https://shevato.com';
 const TMDB_POSTER = 'https://image.tmdb.org/t/p/w500';
@@ -57,19 +63,39 @@ const SHAPE_DESCS = {
   'shape-drift': 'Rating pattern or quality changed significantly late in the run',
 };
 
-// Pick the shape from the show's highest-rated season (all seasons in a series
-// share the same seriesVotes, so the season average is the tiebreaker). Returns
-// nulls when the show has no shape classifications at all. Drives the show
+// The show's whole-run trajectory shape, from the SAME derivation the browser
+// Finder uses (finder-lib's deriveShowShapes, also called by buildShowAgg), so
+// a page's badge, its hub membership and the app's shape chips can never
+// disagree. Returns nulls when the show has no shape at all. Drives the show
 // page's CTA/recommendations and the per-shape hub membership.
+//
+// This used to read the FIRST shape of the show's single highest-rated season,
+// which is the shape of the EPISODES inside that one season, not of the show.
+// The two answered different questions and disagreed on 83.5% of the catalogue
+// (6,497 of 7,780 shows where both produced a label). Game of Thrones read
+// "slow-burn" here and "front-loaded, bad-finale, shape-drift" in the app;
+// Stranger Things read "big-finale" against the app's "bad-finale", an
+// outright contradiction. Because this function also decides hub membership,
+// /shows/shape/big-finale/ was listing 1,915 of 5,411 shows that the app's own
+// big-finale filter would reject, so visitors arriving from search hit a
+// filtered view missing a third of what they had just been shown.
+//
+// `shapes[0]` is the dominant one: deriveShowShapes returns trajectory shapes
+// before categorical tags, so a show with a real trajectory is filed under it
+// and only tag-only shows (a single season that saved its best for last) land
+// on a categorical hub.
 function computeDominantShape(show) {
-  let bestSeason = null;
-  for (const s of show.seasons) {
-    if (!s.shapes || s.shapes.length === 0) continue;
-    if (!bestSeason) { bestSeason = s; continue; }
-    if (s.avgRating > bestSeason.avgRating) bestSeason = s;
+  const seasons = show.seasons || [];
+  const seasonAvgs = seasons
+    .map((s) => s.avgRating)
+    .filter((r) => typeof r === 'number');
+  const categoricalTags = new Set();
+  for (const s of seasons) {
+    for (const t of (s.shapes || [])) categoricalTags.add(t);
   }
-  if (!bestSeason) return { dominantShape: null, dominantShapeSlug: null };
-  const shape = bestSeason.shapes[0];
+  const shapes = deriveShowShapes(seasonAvgs, categoricalTags, detectShapes);
+  const shape = shapes[0];
+  if (!shape) return { dominantShape: null, dominantShapeSlug: null };
   return { dominantShape: shape, dominantShapeSlug: shapeToSlug(shape) };
 }
 

--- a/apps/rising-shows/tests/render-shape-hub.test.js
+++ b/apps/rising-shows/tests/render-shape-hub.test.js
@@ -37,14 +37,64 @@ function makeShow(seriesId, title, seriesVotes, shapes, avgRating = 8.0, seriesR
   };
 }
 
+// Season-average trajectories that produce a known dominant shape under the
+// shared classifier (finder-lib's deriveShowShapes over match.js's
+// detectShapes). Hub membership is decided by shapes[0] of the WHOLE SHOW's
+// trajectory across its seasons, so a fixture needs real per-season averages;
+// a single season has no trajectory and therefore no dominant shape at all.
+//
+// Every sequence below was verified against detectShapes rather than assumed.
+// Worth knowing: detectShapes emits trajectory shapes in a fixed order, so
+// some shapes can never be dominant - 'rebound' always trails 'slow-burn' and
+// 'big-finale' in the output, which is why the cap tests below use slow-burn.
+const TRAJECTORIES = {
+  // -> ['slow-burn', 'big-finale']
+  'slow-burn': [7.5, 7.6, 7.5, 9.2],
+  // -> ['rising', 'slow-burn', 'big-finale']: dominant rising, and it carries
+  // slow-burn as a SECONDARY shape, which is what proves a secondary shape
+  // does not pull a show onto a second hub.
+  rising: [7.0, 7.6, 8.2, 8.8],
+  // -> [] : peaks in the middle, matches no detector.
+  none: [7.2, 8.8, 8.9, 7.3],
+};
+
+// Multi-season fixture whose seasons trace `trajectory`, for anything that
+// goes through selectHubShows. makeShow above stays single-season and is still
+// what the gap-hub tests use, since those care about the avgRating/seriesRating
+// difference rather than about shape.
+function makeShapedShow(seriesId, title, seriesVotes, trajectory, seriesRating = null) {
+  const avgs = TRAJECTORIES[trajectory];
+  if (!avgs) throw new Error(`no trajectory fixture for ${trajectory}`);
+  return {
+    seriesId,
+    title,
+    year: 2010,
+    seriesVotes,
+    seriesRating,
+    seasons: avgs.map((avgRating, i) => ({
+      season: i + 1,
+      avgRating,
+      // Per-season shapes now only matter for the categorical tags
+      // (saved-best-for-last, shape-drift); the trajectory comes from the
+      // season averages above.
+      shapes: [],
+      episodes: [
+        { episode: 1, rating: avgRating, votes: 100 },
+        { episode: 2, rating: avgRating, votes: 100 },
+      ],
+    })),
+  };
+}
+
 const SERIES = [
-  makeShow('tt0001', 'Slow One', 5000, ['slow-burn'], 8.4),
-  makeShow('tt0002', 'Slow Two', 90000, ['slow-burn'], 8.1),
-  makeShow('tt0003', 'Riser', 40000, ['rising'], 9.0),
-  makeShow('tt0004', 'Shapeless', 70000, [], 7.0),
-  // Dominant shape is shapes[0] of the highest-rated season, so this show
-  // belongs to the rising hub only, never to slow-burn.
-  makeShow('tt0005', 'Multi Shape', 60000, ['rising', 'slow-burn'], 8.8),
+  makeShapedShow('tt0001', 'Slow One', 5000, 'slow-burn'),
+  makeShapedShow('tt0002', 'Slow Two', 90000, 'slow-burn'),
+  makeShapedShow('tt0003', 'Riser', 40000, 'rising'),
+  makeShapedShow('tt0004', 'Shapeless', 70000, 'none'),
+  // Dominant shape is shapes[0] of the whole-show trajectory, so this show
+  // belongs to the rising hub only, never to slow-burn, even though its
+  // trajectory also carries slow-burn as a secondary shape.
+  makeShapedShow('tt0005', 'Multi Shape', 60000, 'rising'),
 ];
 
 test('SHAPE_SLUGS covers the 13 shapes exactly once', () => {
@@ -70,8 +120,10 @@ test('selectHubShows orders by IMDb votes descending', () => {
 });
 
 test('selectHubShows caps the list at 100 shows', () => {
-  const many = Array.from({ length: 250 }, (_, i) => makeShow(`tt9${i}`, `Show ${i}`, i, ['rebound']));
-  const picked = selectHubShows(many, 'rebound');
+  // slow-burn, not rebound: detectShapes never emits 'rebound' first, so no
+  // show can have it as a DOMINANT shape and the hub would always be empty.
+  const many = Array.from({ length: 250 }, (_, i) => makeShapedShow(`tt9${i}`, `Show ${i}`, i, 'slow-burn'));
+  const picked = selectHubShows(many, 'slow-burn');
   assert.equal(picked.length, HUB_LIMIT);
   assert.equal(picked.length, 100);
   assert.equal(picked[0].seriesVotes, 249);
@@ -124,9 +176,9 @@ test('renderShapeHub JSON-LD blocks all parse', () => {
 });
 
 test('renderShapeHub caps the JSON-LD ItemList at 25 while listing all 100', () => {
-  const many = Array.from({ length: 250 }, (_, i) => makeShow(`tt9${i}`, `Show ${i}`, i, ['rebound']));
-  const shows = selectHubShows(many, 'rebound');
-  const html = renderShapeHub('rebound', shows, '2026-05-18T00:00:00.000Z');
+  const many = Array.from({ length: 250 }, (_, i) => makeShapedShow(`tt9${i}`, `Show ${i}`, i, 'slow-burn'));
+  const shows = selectHubShows(many, 'slow-burn');
+  const html = renderShapeHub('slow-burn', shows, '2026-05-18T00:00:00.000Z');
   const collection = JSON.parse(html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)[1]
     .replace(/<\/?script[^>]*>/g, ''));
   assert.equal(collection.mainEntity.numberOfItems, 100);


### PR DESCRIPTION
The static show pages and the browser Finder each had their own idea of a show's shape, and they disagreed for **83.5%** of the catalogue: 6,497 of the 7,780 shows where both produced a label.

| Show | Page said | App said |
|---|---|---|
| Game of Thrones | slow-burn | front-loaded, bad-finale, shape-drift |
| Stranger Things | big-finale | **bad-finale**, shape-drift |
| Black Mirror | rising | **front-loaded** |
| Squid Game | rollercoaster | **declining** |
| Friends | big-finale | consistent, saved-best-for-last |

Several are not merely different labels but opposite claims about the same show.

They were answering different questions. `buildShowAgg` runs the shape detectors over the ordered per-SEASON averages: the show's trajectory across its run, which is the product's premise. `computeDominantShape` took the first shape of the show's single highest-rated season, which describes the EPISODES inside that one season, and presented it as the show's shape.

That is not a drifted copy of one algorithm; it is a second measurement of something else, mislabelled. And because `computeDominantShape` also decides hub membership, the SEO surface contradicted the app it links into: `/shows/shape/big-finale/` listed 1,915 of 5,411 shows that the app's own big-finale filter rejects, so a visitor arriving from search and clicking "explore in the app" landed on a filtered view missing a third of what they had just been shown.

This PR changes generated output on purpose. Hub contents, page badges, OG/Twitter meta and the explore CTA all move for most shows.

## `scripts/finder-lib.js`

Extracts `deriveShowShapes(seasonAvgs, categoricalTags, detectShapes)` as the single definition of "what shape is this show": trajectory shapes from the ordered per-season averages, then any categorical tag a season carries appended after. `buildShowAgg` now calls it instead of inlining the derivation, and it is exported on the API object so the page builder can call the same function. The doc comment records the 83.5% divergence and the Game of Thrones example, so the next person to touch it knows why the extraction exists rather than seeing a gratuitous indirection.

## `scripts/render-show-page.js`

`computeDominantShape` is rewritten to delegate to `deriveShowShapes`, requiring it from `finder-lib.js` and `detectShapes` from `match.js`. Neither of those requires this module, so there is no cycle (the same constraint that put `GAP_HUB_SLUG` in this file rather than in the hub renderer). It collects the show's per-season averages and the union of its seasons' categorical tags, then takes `shapes[0]` as dominant.

`shapes[0]` is the right pick because `deriveShowShapes` emits trajectory shapes before categorical tags, so a show with a real trajectory is filed under it and only tag-only shows (a single season that saved its best for last) land on a categorical hub. The comment block records the old behavior, the measured divergence and the hub-membership consequence, since this one function drives the badge, the CTA, the OG meta and which hub a show appears on.

## `tests/render-shape-hub.test.js`

Six tests failed after the change. They were fixture defects rather than regressions: every fixture built a SINGLE-season show, and a single season has no cross-season trajectory, so under the corrected semantics those shows have no dominant shape at all.

Adds a `TRAJECTORIES` map of season-average sequences, each verified against `detectShapes` rather than assumed, and a `makeShapedShow` builder that produces multi-season fixtures from them. The original single-season `makeShow` is left untouched and still used by the gap-hub tests, which care about the avgRating/seriesRating difference rather than about shape.

The two cap tests move off `rebound` to `slow-burn`. `detectShapes` emits trajectory shapes in a fixed order and `slow-burn`/`big-finale` always precede `rebound`, so no show can have `rebound` as its DOMINANT shape; a cap assertion against an always-empty hub would have been vacuous. That ordering constraint is recorded in the fixture comments.

The `SERIES` fixture keeps its original intent: `tt0005` still proves that a secondary shape does not pull a show onto a second hub, now because its trajectory yields `['rising', 'slow-burn', 'big-finale']` and it appears only on the rising hub.

## `README.md`

The shape-hubs section documented the old rule ("the first shape tag of its highest-rated season"). It now describes the shared `deriveShowShapes` derivation and states explicitly that a page's badge and the app's shape chips cannot disagree.

Adds a paragraph recording what changed and what to expect: the 83.5% figure, the Game of Thrones and Stranger Things examples, the hub-membership consequence, that rebound and rollercoaster hubs are now smaller because they are no longer padded with shows whose best season merely had that internal shape, and that some shapes can never be dominant because of the fixed emission order.
