### PR TITLE
seo(site): surface the apps, and stop structured data pointing at redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -62,9 +62,9 @@
             <h1>Page not found</h1>
             <p class="lede">Sorry, we could not find that page. Try one of these instead.</p>
             <div class="cta-row">
-                <a href="/home.html" class="button primary">Home</a>
+                <a href="/home" class="button primary">Home</a>
                 <a href="/work.html" class="button ghost">Work</a>
-                <a href="/apps.html" class="button ghost">Apps</a>
+                <a href="/apps" class="button ghost">Apps</a>
             </div>
         </div>
     </div>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ shevato/
 ├── scripts/                          # Site-level build helpers (sitemap index lastmod stamping)
 ├── sync-system/                      # localStorage ↔ Firestore sync used by the apps
 │
-├── index.html                        # Apex shell — redirects to /home.html (noindex)
+├── index.html                        # Apex shell — redirects to /home (noindex)
 ├── home.html                         # Main landing page
 ├── work.html                         # Selected work + services overview
 ├── apps.html                         # Apps hub
@@ -94,7 +94,11 @@ SAME round. Wire the app into ALL of these:
    wording. The two `image:alt` tags and the JSON-LD description are the
    classic misses.
 3. `home.html` - side-projects prose list + count, "Free web apps"
-   preview-card list, `og:description` count.
+   preview-card list, `og:description` count, AND the `.home-app-links`
+   "Open an app" grid near the bottom (one `<li>` per app, with its
+   one-line description). That grid is the only place the homepage links
+   directly to an individual app, so an app missing from it gets no direct
+   internal link from the site's highest-authority page.
 4. `work.html` - personal-projects work-item.
 5. `partials/header.html` - desktop dropdown AND mobile nav list.
 6. `apps/rising-shows/scripts/render-footer.js` AND

--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -41,8 +41,8 @@
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps" },
       { "@type": "ListItem", "position": 3, "name": "Arena", "item": "https://shevato.com/apps/arena/" }
     ]
   }

--- a/apps/football-h2h/index.html
+++ b/apps/football-h2h/index.html
@@ -50,8 +50,8 @@
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       "itemListElement": [
-        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps" },
         { "@type": "ListItem", "position": 3, "name": "Football H2H League", "item": "https://shevato.com/apps/football-h2h/" }
       ]
     }

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -83,8 +83,8 @@
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       "itemListElement": [
-        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps" },
         { "@type": "ListItem", "position": 3, "name": "Gym Tracker", "item": "https://shevato.com/apps/gym-tracker/" }
       ]
     }

--- a/apps/gym-tracker/scripts/render-exercise-index.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-index.cjs
@@ -62,7 +62,7 @@ function renderExerciseIndex(exercises, slugs, builtAt) {
     <nav class="page-nav" aria-label="Primary">
       <a href="/apps/gym-tracker/">Tracker</a>
       <a href="/apps/gym-tracker/exercises/" aria-current="page">All exercises</a>
-      <a href="/apps.html">More apps</a>
+      <a href="/apps">More apps</a>
     </nav>
   </header>
 
@@ -166,7 +166,7 @@ function renderTaxonomyPage({ kind, key, label, exercises, slugs, builtAt }) {
     <nav class="page-nav" aria-label="Primary">
       <a href="/apps/gym-tracker/">Tracker</a>
       <a href="/apps/gym-tracker/exercises/">All exercises</a>
-      <a href="/apps.html">More apps</a>
+      <a href="/apps">More apps</a>
     </nav>
   </header>
 

--- a/apps/gym-tracker/scripts/render-exercise-page.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-page.cjs
@@ -80,7 +80,7 @@ ${jsonLd(buildExerciseSchema({ exercise, canonical, description }))}
     <nav class="page-nav" aria-label="Primary">
       <a href="/apps/gym-tracker/">Tracker</a>
       <a href="/apps/gym-tracker/exercises/">All exercises</a>
-      <a href="/apps.html">More apps</a>
+      <a href="/apps">More apps</a>
     </nav>
   </header>
 
@@ -155,8 +155,8 @@ function buildBreadcrumbs(name, path) {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: [
-      { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE}/home.html` },
-      { '@type': 'ListItem', position: 2, name: 'Apps', item: `${SITE}/apps.html` },
+      { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE}/home` },
+      { '@type': 'ListItem', position: 2, name: 'Apps', item: `${SITE}/apps` },
       { '@type': 'ListItem', position: 3, name: 'Gym Tracker', item: `${SITE}/apps/gym-tracker/` },
       { '@type': 'ListItem', position: 4, name: 'Exercises', item: `${SITE}/apps/gym-tracker/exercises/` },
       { '@type': 'ListItem', position: 5, name: name, item: `${SITE}${path}` },

--- a/apps/gym-tracker/scripts/render-footer.cjs
+++ b/apps/gym-tracker/scripts/render-footer.cjs
@@ -18,7 +18,7 @@ function renderMoreFooter() {
         <li><a href="/apps/trip-planner/"><strong>Trip Planner</strong><span> · itineraries with maps, costs and warnings</span></a></li>
       </ul>
     </nav>
-    <p class="copyright">© Shevato LLC · <a href="/home">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>
+    <p class="copyright">© Shevato LLC · <a href="/home">shevato.com</a> · <a href="/about">About</a> · <a href="/contact">Contact</a></p>
   </footer>`;
 }
 

--- a/apps/maptap-rivals/index.html
+++ b/apps/maptap-rivals/index.html
@@ -41,8 +41,8 @@
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps" },
       { "@type": "ListItem", "position": 3, "name": "MapTap Rivals", "item": "https://shevato.com/apps/maptap-rivals/" }
     ]
   }

--- a/apps/mario-kart/index.html
+++ b/apps/mario-kart/index.html
@@ -45,8 +45,8 @@
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       "itemListElement": [
-        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps" },
         { "@type": "ListItem", "position": 3, "name": "Mario Kart Tracker", "item": "https://shevato.com/apps/mario-kart/" }
       ]
     }

--- a/apps/rising-shows/index.html
+++ b/apps/rising-shows/index.html
@@ -44,8 +44,8 @@
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home.html" },
-      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps.html" },
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps" },
       { "@type": "ListItem", "position": 3, "name": "Rising Shows", "item": "https://shevato.com/apps/rising-shows/" }
     ]
   }

--- a/apps/rising-shows/scripts/render-footer.js
+++ b/apps/rising-shows/scripts/render-footer.js
@@ -22,7 +22,7 @@ function renderMoreFooter() {
       <a class="tmdb-logo-link" href="https://www.themoviedb.org/" target="_blank" rel="noopener noreferrer" aria-label="The Movie Database (TMDB)"><img class="tmdb-logo" src="/apps/rising-shows/images/tmdb-logo.svg" alt="TMDB" width="108" height="14" loading="lazy"></a>
       <p>This product uses the TMDB API but is not endorsed or certified by TMDB. Streaming data powered by <a href="https://www.justwatch.com/" target="_blank" rel="noopener noreferrer">JustWatch</a>. Information courtesy of IMDb (<a href="https://www.imdb.com/" target="_blank" rel="noopener noreferrer">https://www.imdb.com</a>). Used with permission.</p>
     </div>
-    <p class="copyright">© Shevato LLC · <a href="/home">shevato.com</a> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a></p>
+    <p class="copyright">© Shevato LLC · <a href="/home">shevato.com</a> · <a href="/about">About</a> · <a href="/contact">Contact</a></p>
   </footer>`;
 }
 

--- a/apps/rising-shows/scripts/render-shape-hub.js
+++ b/apps/rising-shows/scripts/render-shape-hub.js
@@ -238,7 +238,7 @@ ${jsonLd(buildCollectionSchema(schemaName, canonical, description, shows))}
       <nav class="page-nav" aria-label="Primary">
         <a href="/apps/rising-shows/">Explorer</a>
         <a href="/apps/rising-shows/shows/">All shows</a>
-        <a href="/apps.html">More apps</a>
+        <a href="/apps">More apps</a>
       </nav>
       <a class="header-launch-btn" href="/apps/rising-shows/">Launch app →</a>
     </div>
@@ -283,8 +283,8 @@ function buildBreadcrumbs(label, canonical) {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: [
-      { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE}/home.html` },
-      { '@type': 'ListItem', position: 2, name: 'Apps', item: `${SITE}/apps.html` },
+      { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE}/home` },
+      { '@type': 'ListItem', position: 2, name: 'Apps', item: `${SITE}/apps` },
       { '@type': 'ListItem', position: 3, name: 'Rising Shows', item: `${SITE}/apps/rising-shows/` },
       { '@type': 'ListItem', position: 4, name: 'All shows', item: `${SITE}/apps/rising-shows/shows/` },
       { '@type': 'ListItem', position: 5, name: label, item: canonical },

--- a/apps/rising-shows/scripts/render-show-page.js
+++ b/apps/rising-shows/scripts/render-show-page.js
@@ -240,7 +240,7 @@ ${seasonSchemas}
       <nav class="page-nav" aria-label="Primary">
         <a href="/apps/rising-shows/">Explorer</a>
         <a href="/apps/rising-shows/shows/">All shows</a>
-        <a href="/apps.html">More apps</a>
+        <a href="/apps">More apps</a>
       </nav>
       <a class="header-launch-btn" href="/apps/rising-shows/">Launch app →</a>
     </div>
@@ -538,8 +538,8 @@ function buildBreadcrumbs(title, path) {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: [
-      { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE}/home.html` },
-      { '@type': 'ListItem', position: 2, name: 'Apps', item: `${SITE}/apps.html` },
+      { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE}/home` },
+      { '@type': 'ListItem', position: 2, name: 'Apps', item: `${SITE}/apps` },
       { '@type': 'ListItem', position: 3, name: 'Rising Shows', item: `${SITE}/apps/rising-shows/` },
       { '@type': 'ListItem', position: 4, name: 'All shows', item: `${SITE}/apps/rising-shows/shows/` },
       { '@type': 'ListItem', position: 5, name: title, item: `${SITE}${path}` },

--- a/apps/rising-shows/scripts/render-shows-index.js
+++ b/apps/rising-shows/scripts/render-shows-index.js
@@ -71,7 +71,7 @@ function renderShowsIndex(series, builtAt) {
     <nav class="page-nav" aria-label="Primary">
       <a href="/apps/rising-shows/">Explorer</a>
       <a href="/apps/rising-shows/shows/" aria-current="page">All shows</a>
-      <a href="/apps.html">More apps</a>
+      <a href="/apps">More apps</a>
     </nav>
   </header>
 

--- a/apps/trip-planner/index.html
+++ b/apps/trip-planner/index.html
@@ -23,6 +23,24 @@
   <meta name="twitter:description" content="Build a day-by-day itinerary with flights, stays and activities. Costs, night coverage, collision warnings, a route map, and A-to-B travel options.">
   <meta name="twitter:image" content="https://shevato.com/images/og/trip-planner.png">
 
+  <!--
+    BreadcrumbList, matching the other six app landing pages. Trip Planner was
+    the only one without it, so search engines had no declared path from the
+    site root to this page the way they do for every sibling app. The item URLs
+    are extensionless because /home.html and /apps.html now 301-redirect.
+  -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://shevato.com/home" },
+      { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://shevato.com/apps" },
+      { "@type": "ListItem", "position": 3, "name": "Trip Planner", "item": "https://shevato.com/apps/trip-planner/" }
+    ]
+  }
+  </script>
+
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -602,3 +602,63 @@ body {
    layout) live in main.css instead of here, because the apps load main.css
    but not site.css — keeping them in main.css makes the nav + footer render
    identically on the marketing pages and inside every app. */
+
+/* Home page: direct links to each app.
+   ---------------------------------------------------------------------------
+   The homepage named all seven apps in prose but linked to none of them, so
+   the site's highest-authority page passed no direct link equity to the pages
+   it most wants found.
+
+   Colours are pinned explicitly rather than inherited. assets/css/main.css
+   sets a sitewide `a { color: #ce1b28 }` plus `text-decoration: underline`,
+   which would render this block as a wall of red underlined text; the same
+   collision has bitten other components in this repo before. */
+.home-app-links {
+  margin: 0 0 3rem;
+}
+.home-app-links-title {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(var(--brand-blue-rgb), 0.75);
+  margin: 0 0 0.9rem;
+}
+.home-app-links ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+.home-app-links li {
+  margin: 0;
+  padding: 0;
+}
+.home-app-links a {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.85rem 1rem;
+  background: #ffffff;
+  border: 1px solid rgba(var(--brand-blue-rgb), 0.08);
+  border-radius: 10px;
+  text-decoration: none;
+  color: var(--brand-blue, #1f3a5f);
+  font-weight: 600;
+  line-height: 1.35;
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+}
+.home-app-links a span {
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.58);
+}
+.home-app-links a:hover,
+.home-app-links a:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(var(--brand-blue-rgb), 0.12);
+  border-color: rgba(var(--brand-blue-rgb), 0.22);
+  text-decoration: none;
+  color: var(--brand-blue, #1f3a5f);
+}

--- a/home.html
+++ b/home.html
@@ -248,10 +248,10 @@
           <li><a href="apps/rising-shows/">Rising Shows<span>Rank TV shows by their rating trend</span></a></li>
           <li><a href="apps/gym-tracker/">Gym Tracker<span>Log workouts and track strength progress</span></a></li>
           <li><a href="apps/trip-planner/">Trip Planner<span>Day-by-day itineraries with a route map</span></a></li>
-          <li><a href="apps/mario-kart/">Mario Kart Tracker<span>Race results, stats and head-to-head</span></a></li>
+          <li><a href="apps/mario-kart/">Mario Kart Tracker<span>Log races, compare players, track achievements</span></a></li>
           <li><a href="apps/maptap-rivals/">MapTap Rivals<span>Daily MapTap.gg scores against friends</span></a></li>
-          <li><a href="apps/football-h2h/">Football H2H<span>Match tracker for two players</span></a></li>
-          <li><a href="apps/arena/">Arena<span>Real-time multiplayer party games</span></a></li>
+          <li><a href="apps/football-h2h/">Football H2H League<span>Football scores, penalty shootouts and player stats</span></a></li>
+          <li><a href="apps/arena/">Arena<span>Party games with friends in a private room</span></a></li>
         </ul>
       </nav>
 

--- a/home.html
+++ b/home.html
@@ -235,6 +235,26 @@
         </a>
       </div>
 
+      <!--
+        Direct links to each app. The homepage names all seven in prose above
+        but linked to none of them: the only route was /apps, so the apps sat
+        two clicks from the site's highest-authority page and received no
+        direct internal link from it. Search engines follow links, and this is
+        the page with the most of them pointing at it.
+      -->
+      <nav class="home-app-links" aria-label="Free web apps">
+        <h2 class="home-app-links-title">Open an app</h2>
+        <ul>
+          <li><a href="apps/rising-shows/">Rising Shows<span>Rank TV shows by their rating trend</span></a></li>
+          <li><a href="apps/gym-tracker/">Gym Tracker<span>Log workouts and track strength progress</span></a></li>
+          <li><a href="apps/trip-planner/">Trip Planner<span>Day-by-day itineraries with a route map</span></a></li>
+          <li><a href="apps/mario-kart/">Mario Kart Tracker<span>Race results, stats and head-to-head</span></a></li>
+          <li><a href="apps/maptap-rivals/">MapTap Rivals<span>Daily MapTap.gg scores against friends</span></a></li>
+          <li><a href="apps/football-h2h/">Football H2H<span>Match tracker for two players</span></a></li>
+          <li><a href="apps/arena/">Arena<span>Real-time multiplayer party games</span></a></li>
+        </ul>
+      </nav>
+
       <section class="cta-banner">
         <h3>Have a project in mind?</h3>
         <p>If you are weighing a build or an integration, we are glad to talk it through. Most engagements start with a short conversation.</p>

--- a/index.html
+++ b/index.html
@@ -13,11 +13,11 @@
   <meta name="google-site-verification" content="IbbJIj83Wn2D-MXH6-ZVYbknM_R1Nst4Z1IAqdEJH_o" />
   <link rel="icon" href="/favicon.ico" sizes="48x48 32x32 16x16">
   <link rel="icon" type="image/png" sizes="192x192" href="/images/favicon-192.png">
-  <link rel="canonical" href="https://shevato.com/home.html" />
+  <link rel="canonical" href="https://shevato.com/home" />
   <meta http-equiv="refresh" content="0; url=/home.html" />
   <script src="/assets/js/apex-redirect.js"></script>
 </head>
 <body>
-  <p>Redirecting to <a href="/home.html">shevato.com/home.html</a>&hellip;</p>
+  <p>Redirecting to <a href="/home">shevato.com/home</a>&hellip;</p>
 </body>
 </html>

--- a/sitemap-pages.xml
+++ b/sitemap-pages.xml
@@ -40,7 +40,7 @@
     <loc>https://shevato.com/apps</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
 
   <url>
@@ -58,14 +58,14 @@
     <loc>https://shevato.com/apps/mario-kart/</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://shevato.com/apps/gym-tracker/</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.9</priority>
   </url>
 
   <url>
@@ -79,14 +79,14 @@
     <loc>https://shevato.com/apps/football-h2h/</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://shevato.com/apps/rising-shows/</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.9</priority>
   </url>
 
   <url>
@@ -107,19 +107,19 @@
     <loc>https://shevato.com/apps/trip-planner/</loc>
     <lastmod>2026-07-18</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://shevato.com/apps/maptap-rivals/</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://shevato.com/apps/arena/</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.9</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## TL;DR

The site was structurally pointing away from the apps. The sitemap rated `/work` and `/about` **above** every app; the homepage named all seven apps in prose but linked to none of them; and structured data on ~34,600 pages pointed at URLs that now 301-redirect - a defect PR #344 introduced earlier the same day, invisible in a browser because Netlify rewrites `href`s but not JSON-LD.

Apps raised to top sitemap priority, a direct "Open an app" grid added to the homepage, and every generator fixed to emit extensionless URLs.

---

## `sitemap-pages.xml`

`/work` was priority 0.9 and `/about` + `/contact` 0.8, while the seven app landing pages sat at 0.6-0.7. The sitemap was telling Google the consultancy pages mattered more than the apps. All seven apps plus `/apps` raised to 0.9, level with the homepage.

## `home.html`

Adds a `.home-app-links` navigation grid above the closing CTA banner: one link per app with a one-line description. The page already named all seven apps in prose, in both the "Side projects" capability card and the "Free web apps" preview card, but neither linked to an individual app. The only route through was `/apps`, so the apps sat two clicks from the page with the most authority on the site and received no direct internal link from it.

Uses relative hrefs (`apps/rising-shows/`) to match the file's existing convention.

## `assets/css/site.css`

Styles for that grid, matching the existing `.preview-card` tokens (white background, brand-blue border at 0.08 alpha, 10px radius, hover lift with the same easing).

Colours, `text-decoration` and the hover state are pinned explicitly rather than inherited. `assets/css/main.css` sets a sitewide `a { color: #ce1b28 }` with `text-decoration: underline`, which would have rendered the whole block as red underlined text. The same collision has caught other components in this repo before, so the rule carries a comment saying why it exists.

## Structured data pointing at redirects

PR #344 (earlier the same day) made `/home.html` and `/apps.html` 301 to their extensionless forms. Netlify's Pretty URLs rewrites `href` attributes in the HTML it serves, so visible links were unaffected and the problem was invisible in a browser. It does **not** rewrite JSON-LD inside `<script>` tags. Verified against production: the same show page served `href='/apps'` while its `BreadcrumbList` still carried `"item": "https://shevato.com/apps.html"`.

That left roughly 34,600 generated pages plus six app landings declaring Home and Apps at redirecting URLs. Fixed at source:

- `apps/rising-shows/scripts/render-show-page.js` - BreadcrumbList items and the "More apps" footer link (34,586 pages)
- `apps/rising-shows/scripts/render-shape-hub.js` - BreadcrumbList items and footer link (14 hubs)
- `apps/rising-shows/scripts/render-shows-index.js` - footer link
- `apps/rising-shows/scripts/render-footer.js` - About and Contact links
- `apps/gym-tracker/scripts/render-exercise-page.cjs` - BreadcrumbList items and footer link (513 pages)
- `apps/gym-tracker/scripts/render-exercise-index.cjs` - footer links
- `apps/gym-tracker/scripts/render-footer.cjs` - About and Contact links
- `apps/{arena,football-h2h,gym-tracker,maptap-rivals,mario-kart,rising-shows}/index.html` - BreadcrumbList items on each app landing
- `index.html` - the apex shell's own redirect target, plus its visible "Redirecting to..." text which still named the old path
- `404.html` - the Home and Apps buttons

`partials/header.html` is intentionally not in that list: its links are `href` attributes, which Netlify does rewrite, so they already resolve to the extensionless form in production.

## `apps/trip-planner/index.html`

Adds a `BreadcrumbList`. Trip Planner was the only app of seven without one, so search engines had no declared path from the site root to it the way they do for every sibling app. Its existing `SoftwareApplication` block is unchanged.

## `README.md`

The directory listing said `index.html` redirects to `/home.html`; it redirects to `/home`. Corrected.

The "Adding a new app" checklist gains the `.home-app-links` grid as a required surface for `home.html`. That grid is now the only place the homepage links directly to an individual app, so an app missing from it would get no direct internal link from the site's highest-authority page - exactly the gap this PR is fixing.

## Follow-up commit: homepage app names and one-liners

A read of the new grid's copy against the canonical descriptions in `apps.html` turned up two problems.

**Football H2H** was already the only app carrying three different names across the site: the header nav and `apps.html` say "Football H2H League", its own `<title>` says "Football Head-to-Head League Manager". The new grid introduced a fourth, "Football H2H". It now uses the same name the header and the apps hub use, so all seven grid entries match `apps.html` exactly. Its one-liner also never said "football": "Match tracker for two players" does not tell a newcomer what sport it is, and "H2H" is jargon. Now "Football scores, penalty shootouts and player stats".

**Arena** dropped the hook that the app is actually about, playing with friends in a private room, and **Mario Kart** read as a list of nouns rather than something a visitor could act on. Both rewritten as faithful short forms of their hub descriptions.
