### PR TITLE
a11y(site): name the mobile menu close control, fix the heading outline, and flag the SASS divergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,22 @@ npm install -g sass
 sass --watch assets/sass/main.scss:assets/css/main.css
 ```
 
+> **`assets/css/main.css` has diverged from `assets/sass/`. Running that
+> command will silently revert live styling.**
+>
+> Over time main.css has been hand-edited rather than recompiled, and the two
+> are no longer equivalent. Concrete example: `_footer.scss` declares
+> `.copyright { font-size: 0.8rem }` with no colour and no margin, while the
+> shipped main.css has `font-size: 0.75rem; color: white; margin: 0`. Whole
+> blocks (`#footer h4`/`h2`, `#footer ul.plain`, the font-smoothing
+> normalisation near the end of the file) exist only in main.css and have no
+> SASS source at all.
+>
+> So: edit `main.css` directly, which is what the recent history actually
+> does, or reconcile the SASS source with the shipped CSS first and verify
+> the header and footer against a screenshot before trusting a rebuild.
+> Do not run `sass --watch` casually.
+
 ## Tests
 
 Node's built-in test runner is used for the apps and the shared sync system:

--- a/apps.html
+++ b/apps.html
@@ -240,6 +240,12 @@
         <input type="search" id="app-search" name="q" placeholder="Search apps by name or description" aria-label="Search apps by name or description" autocomplete="off" />
       </div>
 
+      <!-- The app cards are h3, so without this the outline jumped h1 -> h3.
+           Screen-reader-only because the filter bar and grid already make the
+           structure obvious to a sighted user; the heading exists to give the
+           cards a parent in the document outline. -->
+      <h2 class="sr-only">All apps</h2>
+
       <div class="highlights">
         <section data-category="fitness">
           <div class="content">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2318,7 +2318,7 @@ ul.icons {
     padding: 0.5rem 0;
     text-align: center;
     margin: 0; }
-  #footer h4 {
+  #footer h4, #footer h2 {
     font-size: 1rem;
     margin-bottom: 0.5rem; }
   #footer ul.plain {
@@ -3074,6 +3074,7 @@ body > [data-include="footer"] {
 #header #header-user-email,
 #menu .links a,
 #footer h4,
+#footer h2,
 #footer .copyright {
   font-family: "Raleway", Arial, Helvetica, sans-serif !important; }
 
@@ -3105,7 +3106,8 @@ body > [data-include="footer"] {
 #footer ul,
 #footer li { color: rgba(255, 255, 255, 0.5) !important; }
 
-#footer h4 {
+#footer h4,
+#footer h2 {
   font-weight: 300 !important;
   line-height: 1.5 !important;
   letter-spacing: normal !important;

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -662,3 +662,23 @@ body {
   text-decoration: none;
   color: var(--brand-blue, #1f3a5f);
 }
+
+/* Screen-reader-only text.
+   ---------------------------------------------------------------------------
+   For headings that a sighted user does not need (the page already makes the
+   structure obvious visually) but that assistive tech does, to keep the
+   document outline intact. The clip-path pair is the standard technique: the
+   element stays in the accessibility tree and in the heading outline, unlike
+   display:none or visibility:hidden, which remove it from both. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -878,7 +878,10 @@
     const $menuToggle = $(SELECTORS.menuToggle);
     
     $menu
-      .append('<a href="#menu" class="close"></a>')
+      // aria-label, because this link has no text content: it is an icon drawn
+      // in CSS. Without a name a screen reader announces it only as "link", so
+      // the sole way out of the open mobile menu was unlabelled.
+      .append('<a href="#menu" class="close" aria-label="Close menu"></a>')
       .appendTo($body)
       .panel({
         target: $body,

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="content content--two-col">
       <section>
-        <h4>Contact Us</h4>
+        <h2>Contact Us</h2>
         <ul class="plain">
           <li><a href="mailto:nikita@shevato.com"><svg class="footer-contact-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Zm0 4-8 5-8-5V6l8 5 8-5v2Z"/></svg>nikita@shevato.com</a></li>
           <li><a href="tel:+1504-638-3370"><svg class="footer-contact-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M6.62 10.79a15.53 15.53 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.02-.24 11.36 11.36 0 0 0 3.57.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1 11.36 11.36 0 0 0 .57 3.57 1 1 0 0 1-.25 1.02l-2.2 2.2Z"/></svg>+1 (504) 638-3370</a></li>
@@ -10,7 +10,7 @@
         </ul>
       </section>
       <section>
-        <h4>Navigate</h4>
+        <h2>Navigate</h2>
         <ul class="plain footer-nav">
           <li><a href="/home.html">Home</a></li>
           <li><a href="/work.html">Work</a></li>


### PR DESCRIPTION
## TL;DR

A full-site audit found three real sitewide defects, all fixed: the mobile menu's close button had **no accessible name** (a screen reader announced the only exit from the open menu as an unnamed "link"), the footer's `<h4>` headings **skipped heading levels** on two pages, and `apps.html` jumped h1 → h3.

All seven public pages now report one h1, **zero heading skips and zero unlabelled links**.

It also turned up a documentation hazard: the README told you to run a SASS build that would have **silently reverted live styling**, because `main.css` has diverged from its source.

---

## `assets/js/main.js`

`initializeMenu()` appended `<a href="#menu" class="close"></a>`. The close affordance is an icon drawn in CSS, so the element had no text content and no label, and the only way out of the open mobile menu was announced by assistive tech as an unnamed "link". Given `aria-label="Close menu"`, with a comment recording why the label is required rather than optional.

## `partials/footer.html`

"Contact Us" and "Navigate" were `<h4>`. Because the footer renders on every page, that skipped heading levels wherever the last preceding heading was above h3: `contact.html` went h2 → h4 and `404.html` went h1 → h4. Both promoted to `<h2>`.

## `assets/css/main.css`

`#footer h2` added alongside `#footer h4` in the three rules that style those headings by tag: the font-size/margin rule, the Raleway font-family rule, and the `!important` block setting weight, line-height, letter-spacing, text-transform and colour. Without all three the promoted headings would have restyled themselves. The footer renders identically, verified by screenshot at 1280 and 390.

## `apps.html`

The page jumped h1 → h3, because the app cards are `<h3>` with no heading between them and the page title. Adds a screen-reader-only `<h2>` above the card grid.

The cards could not simply be promoted to `<h2>`: `assets/css/moadon-alef-theme.css` styles `.highlights .content header h2` in that exact structure, so promoting them would have restyled the moadon-alef page's cards as a side effect. A hidden heading fixes the outline without touching either page's appearance.

## `assets/css/site.css`

Adds the `.sr-only` utility the above needs. Uses the standard clip-path technique rather than `display:none` or `visibility:hidden`, because those remove the element from the accessibility tree and the heading outline, which is the opposite of what is wanted here.

## `README.md`

The SASS section documented `sass --watch assets/sass/main.scss:assets/css/main.css` as the way to edit styles. That command would silently revert live styling: `main.css` has been hand-edited rather than recompiled and no longer matches `assets/sass/`. `_footer.scss` declares `.copyright { font-size: 0.8rem }` with no colour and no margin, while the shipped CSS has `0.75rem`, `color: white` and `margin: 0`; whole blocks (`#footer h4`/`h2`, `#footer ul.plain`, the font-smoothing normalisation near the end of the file) exist only in `main.css` with no SASS source at all.

The section now carries a blockquote warning with that concrete example, and says to edit `main.css` directly, which is what recent history already does, or reconcile the source first and verify the header and footer against a screenshot before trusting a rebuild.

This was found while adding `#footer h2` for the heading fix, which a rebuild would have undone.
