### PR TITLE
seo(gym-tracker): noindex the 513 individual exercise pages

### DIFF
--- a/apps/gym-tracker/README.md
+++ b/apps/gym-tracker/README.md
@@ -91,6 +91,37 @@ gym-tracker/
 └── tests/                      # node:test unit suites
 ```
 
+### Indexability of the generated pages
+
+`npm run build:gym-tracker:pages` writes three kinds of page, and they are
+treated differently on purpose:
+
+| Pages | Count | Robots | In `sitemap-exercises.xml` |
+|---|---:|---|---|
+| Individual exercises | 513 | `noindex, follow` | no |
+| Muscle + equipment taxonomy | 51 | `index, follow` | yes |
+| `/exercises/` directory index | 1 | `index, follow` | yes |
+
+The individual pages are templated, roughly 2,500 characters each, and compete
+against sites with real editorial depth on the same query. They are the same
+thin-pages-at-scale shape that put ~60k Rising Shows pages into Google's
+"Crawled - currently not indexed" bucket and dragged the whole domain, which is
+why that long tail carries the same directive (see
+`apps/rising-shows/scripts/render-show-page.js`).
+
+The `follow` half matters: these pages link to the app, the taxonomy pages and
+the index, all of which stay indexable, so their internal link equity keeps
+flowing to pages that can realistically rank. They are also kept OUT of the
+sitemap, because a sitemap is a request to index and listing a page you have
+told the crawler to skip is a contradiction that wastes crawl budget. That took
+the exercise sitemap from 565 URLs to 52.
+
+The taxonomy and index pages are deliberately exempt: they are list/hub pages
+that aggregate content, the same role the Rising Shows shape hubs play. The
+split is pinned by tests in `tests/build-exercise-pages.test.cjs`, because the
+robots directive and the sitemap live in different files and could otherwise
+drift apart silently.
+
 ### Data Models
 
 #### Program

--- a/apps/gym-tracker/scripts/render-exercise-page.cjs
+++ b/apps/gym-tracker/scripts/render-exercise-page.cjs
@@ -36,7 +36,19 @@ function renderExercisePage({ exercise, slug, related, builtAt }) {
   <title>${escapeHtml(pageTitle)}</title>
   <meta name="description" content="${escapeHtml(description)}">
   <meta name="author" content="Shevato LLC">
-  <meta name="robots" content="index, follow, max-image-preview:large">
+  <!-- noindex, FOLLOW. Each of these 513 pages is a templated ~2,500-character
+       description of one exercise, competing against sites with real editorial
+       depth on the same query. They are the same thin-pages-at-scale shape that
+       put ~60k Rising Shows pages into "Crawled - currently not indexed" and
+       dragged the whole domain, which is why that long tail carries the same
+       directive (see render-show-page.js).
+       The follow half is deliberate: these pages link to the app, the muscle
+       and equipment taxonomy pages and the exercise index, all of which stay
+       indexable, so their internal link equity keeps flowing to the pages that
+       can realistically rank. Only the individual exercise pages leave the
+       index; the taxonomy and index pages are list/hub pages with aggregate
+       value and are kept. -->
+  <meta name="robots" content="noindex, follow">
   <meta name="theme-color" content="#0a0c14">
   <meta name="color-scheme" content="dark">
   <link rel="canonical" href="${canonical}">

--- a/apps/gym-tracker/scripts/render-sitemap.cjs
+++ b/apps/gym-tracker/scripts/render-sitemap.cjs
@@ -2,8 +2,19 @@
 
 const { SITE } = require('./render-exercise-page.cjs');
 
-// Sitemap entries: the /exercises/ landing page, every per-exercise
-// page, every muscle-group taxonomy page, and every equipment page.
+// Sitemap entries: the /exercises/ landing page, every muscle-group taxonomy
+// page, and every equipment page.
+//
+// The 513 individual exercise pages are deliberately NOT listed. They carry
+// `noindex, follow` (see render-exercise-page.cjs), and a sitemap is a request
+// to index: listing a page while telling the crawler not to index it is a
+// contradiction that wastes crawl budget on URLs that can never appear in
+// results. Rising Shows solves the same problem the same way, by curating its
+// sitemap down from ~34,600 pages to the 2,000 it actually wants indexed.
+//
+// `exercises` and `slugs` are still accepted so the caller does not change and
+// so restoring per-exercise entries later is a one-line edit rather than a
+// signature change.
 function renderExercisesSitemap({ exercises, slugs, muscles, equipment, builtAt }) {
   const lastmod = (builtAt ? new Date(builtAt) : new Date()).toISOString().slice(0, 10);
   const urls = [];
@@ -15,9 +26,6 @@ function renderExercisesSitemap({ exercises, slugs, muscles, equipment, builtAt 
   }
   for (const e of equipment) {
     urls.push(url(`${SITE}/apps/gym-tracker/exercises/equipment/${e}/`, lastmod, 'monthly', '0.6'));
-  }
-  for (const ex of exercises) {
-    urls.push(url(`${SITE}/apps/gym-tracker/exercises/${slugs.get(ex.id)}/`, lastmod, 'monthly', '0.5'));
   }
 
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/apps/gym-tracker/tests/build-exercise-pages.test.cjs
+++ b/apps/gym-tracker/tests/build-exercise-pages.test.cjs
@@ -121,7 +121,7 @@ test('renderTaxonomyPage targets a high-volume query', () => {
   assert.ok(!html.includes(LEGACY_SCROLL_TOP_TOKEN), 'no bespoke inline back-to-top markup or script must be emitted on taxonomy page');
 });
 
-test('renderExercisesSitemap covers per-exercise, taxonomy, and index URLs', () => {
+test('renderExercisesSitemap lists the index and taxonomy pages', () => {
   const slugs = assignSlugs(SAMPLE);
   const xml = renderExercisesSitemap({
     exercises: SAMPLE,
@@ -134,8 +134,74 @@ test('renderExercisesSitemap covers per-exercise, taxonomy, and index URLs', () 
   assert.ok(xml.includes('https://shevato.com/apps/gym-tracker/exercises/</loc>'));
   assert.ok(xml.includes('https://shevato.com/apps/gym-tracker/exercises/muscle/pectorals/</loc>'));
   assert.ok(xml.includes('https://shevato.com/apps/gym-tracker/exercises/equipment/cable/</loc>'));
-  assert.ok(xml.includes('https://shevato.com/apps/gym-tracker/exercises/archer-push-ups/</loc>'));
-  // Count locs: index + 4 muscles + 3 equipment + 4 exercises = 12
+  // index + 4 muscles + 3 equipment, and nothing else.
   const locs = (xml.match(/<loc>/g) || []).length;
-  assert.equal(locs, 1 + 4 + 3 + SAMPLE.length);
+  assert.equal(locs, 1 + 4 + 3);
+});
+
+test('renderExercisesSitemap omits the individual exercise pages', () => {
+  // Those pages carry `noindex, follow`, so listing them would ask the crawler
+  // to index URLs it has just been told to skip. This asserts the absence
+  // rather than only the count, so re-adding them is a visible failure and not
+  // a silently larger sitemap.
+  const slugs = assignSlugs(SAMPLE);
+  const xml = renderExercisesSitemap({
+    exercises: SAMPLE,
+    slugs,
+    muscles: ['pectorals'],
+    equipment: ['cable'],
+    builtAt: '2026-05-18T00:00:00.000Z',
+  });
+  for (const ex of SAMPLE) {
+    const loc = `https://shevato.com/apps/gym-tracker/exercises/${slugs.get(ex.id)}/</loc>`;
+    assert.ok(!xml.includes(loc), `sitemap must not list the noindexed page ${loc}`);
+  }
+  assert.equal((xml.match(/<loc>/g) || []).length, 1 + 1 + 1);
+});
+
+// ---------------------------------------------------------------------------
+// Indexability.
+//
+// The 513 individual exercise pages are templated, roughly 2,500 characters
+// each, and compete against sites with real editorial depth on the same query.
+// They are the same thin-pages-at-scale shape that put ~60k Rising Shows pages
+// into "Crawled - currently not indexed" and dragged the whole domain, so they
+// carry `noindex, follow` and are kept out of the sitemap.
+//
+// The taxonomy and index pages are deliberately NOT part of that: they are
+// list/hub pages that aggregate content, the same role the Rising Shows shape
+// hubs play, and they stay indexable. These tests pin that split, because the
+// two halves live in different files and could drift apart silently.
+// ---------------------------------------------------------------------------
+
+test('individual exercise pages are noindex, follow', () => {
+  const html = renderExercisePage({
+    exercise: SAMPLE[0], slug: 'archer-push-ups', related: [], builtAt: '2026-05-18T00:00:00.000Z',
+  });
+  assert.ok(
+    html.includes('<meta name="robots" content="noindex, follow">'),
+    'exercise pages must ask not to be indexed',
+  );
+  // follow, not nofollow: these pages link to the app and to the taxonomy and
+  // index pages, which do stay indexable, so the equity must keep flowing.
+  assert.ok(!html.includes('nofollow'), 'links out of an exercise page must still be followed');
+});
+
+test('taxonomy and index pages stay indexable', () => {
+  const slugs = assignSlugs(SAMPLE);
+  const taxo = renderTaxonomyPage({
+    kind: 'muscle',
+    key: 'pectorals',
+    label: 'Pectorals',
+    exercises: [SAMPLE[0]],
+    slugs,
+    builtAt: '2026-05-18T00:00:00.000Z',
+  });
+  assert.ok(taxo.includes('content="index, follow'), 'taxonomy pages must remain indexable');
+  assert.ok(!taxo.includes('content="noindex'), 'taxonomy pages must not be noindexed');
+
+  // positional args, not an options object
+  const index = renderExerciseIndex(SAMPLE, slugs, '2026-05-18T00:00:00.000Z');
+  assert.ok(index.includes('content="index, follow'), 'the exercise index must remain indexable');
+  assert.ok(!index.includes('content="noindex'), 'the exercise index must not be noindexed');
 });


### PR DESCRIPTION
## TL;DR

Gym Tracker's 513 individual exercise pages are templated ~2,500-character descriptions competing against sites with real editorial depth. They were the largest remaining block of the thin-pages-at-scale pattern that already put ~60k Rising Shows pages into "Crawled - currently not indexed" and dragged the domain.

They now carry `noindex, follow` and are dropped from the sitemap. The 51 taxonomy pages and the directory index stay indexable, mirroring how Rising Shows keeps its hubs while noindexing its long tail.

Exercise sitemap **565 → 52** URLs. Total indexable surface **2,597 → 2,084**.

---

## `apps/gym-tracker/scripts/render-exercise-page.cjs`

The robots directive on individual exercise pages changes from `index, follow, max-image-preview:large` to `noindex, follow`, with a comment recording the reasoning and pointing at the Rising Shows precedent in `render-show-page.js`.

The `follow` half is deliberate rather than incidental: these pages link to the app, to the muscle and equipment taxonomy pages, and to the exercise index, all of which stay indexable. Dropping to `nofollow` would strand that internal link equity.

## `apps/gym-tracker/scripts/render-sitemap.cjs`

Stops emitting the 513 per-exercise `<loc>` entries. The index and the 51 taxonomy entries are unchanged.

Both halves had to move together. A sitemap is a request to index, so listing a URL that has just been told `noindex` is a contradiction that spends crawl budget on pages which can never appear in results. The function still accepts `exercises` and `slugs` so the caller is untouched and restoring per-exercise entries later is a one-line change rather than a signature change.

## `apps/gym-tracker/tests/build-exercise-pages.test.cjs`

The existing sitemap test asserted the per-exercise URLs were present, which is now intentionally false. Split into two:

- `renderExercisesSitemap lists the index and taxonomy pages` - the positive case, now expecting index + muscles + equipment only.
- `renderExercisesSitemap omits the individual exercise pages` - asserts each per-exercise URL is **absent** rather than only checking the total count, so re-adding them fails loudly instead of quietly producing a larger sitemap.

Two new tests pin the indexability split itself, because the robots directive and the sitemap live in different files and could otherwise drift apart without anything failing:

- `individual exercise pages are noindex, follow` - also asserts the page contains no `nofollow`, since the follow half is load-bearing.
- `taxonomy and index pages stay indexable` - guards the exemption, so a future blanket change cannot silently sweep the hub pages in.

## `apps/gym-tracker/README.md`

Adds an "Indexability of the generated pages" section: a table of the three page kinds with their robots directive and sitemap membership, why the individual pages are excluded, why `follow` matters, why the sitemap and the directive have to agree, and that the split is test-pinned.
