### PR TITLE
feat(site): give the homepage a route to the apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,12 @@ SAME round. Wire the app into ALL of these:
    classic misses.
 3. `home.html` - side-projects prose list + count, "Free web apps"
    preview-card list, `og:description` count, AND the `.home-app-links`
-   "Open an app" grid near the bottom (one `<li>` per app, with its
-   one-line description). That grid is the only place the homepage links
-   directly to an individual app, so an app missing from it gets no direct
-   internal link from the site's highest-authority page.
+   "Open an app" grid, which sits directly under the hero (one `<li>` per
+   app, with its one-line description). That grid is the only place the
+   homepage links directly to an individual app, so an app missing from it
+   gets no direct internal link from the site's highest-authority page.
+   Keep each one-liner consistent with that app's description in
+   `apps.html`; the names must match the apps hub exactly.
 4. `work.html` - personal-projects work-item.
 5. `partials/header.html` - desktop dropdown AND mobile nav list.
 6. `apps/rising-shows/scripts/render-footer.js` AND

--- a/home.html
+++ b/home.html
@@ -162,8 +162,32 @@
         <div class="cta-row">
           <a href="work.html" class="button primary">See the work</a>
           <a href="contact.html" class="button ghost">Get in touch</a>
+          <!-- Third CTA, for the other audience this page serves. Both original
+               buttons go to the consultancy funnel (work, contact), so someone
+               who came for the free apps had no route from the hero at all. -->
+          <a href="apps.html" class="button ghost">Try the free apps</a>
         </div>
       </section>
+
+      <!--
+        Direct links to each app. The homepage names all seven in prose above
+        but linked to none of them: the only route was /apps, so the apps sat
+        two clicks from the site's highest-authority page and received no
+        direct internal link from it. Search engines follow links, and this is
+        the page with the most of them pointing at it.
+      -->
+      <nav class="home-app-links" aria-label="Free web apps">
+        <h2 class="home-app-links-title">Open an app</h2>
+        <ul>
+          <li><a href="apps/rising-shows/">Rising Shows<span>Rank TV shows by their rating trend</span></a></li>
+          <li><a href="apps/gym-tracker/">Gym Tracker<span>Log workouts and track strength progress</span></a></li>
+          <li><a href="apps/trip-planner/">Trip Planner<span>Day-by-day itineraries with a route map</span></a></li>
+          <li><a href="apps/mario-kart/">Mario Kart Tracker<span>Log races, compare players, track achievements</span></a></li>
+          <li><a href="apps/maptap-rivals/">MapTap Rivals<span>Daily MapTap.gg scores against friends</span></a></li>
+          <li><a href="apps/football-h2h/">Football H2H League<span>Football scores, penalty shootouts and player stats</span></a></li>
+          <li><a href="apps/arena/">Arena<span>Party games with friends in a private room</span></a></li>
+        </ul>
+      </nav>
 
       <div class="section-heading">
         <h2>What we do</h2>
@@ -234,26 +258,6 @@
           <span class="more">Read about us</span>
         </a>
       </div>
-
-      <!--
-        Direct links to each app. The homepage names all seven in prose above
-        but linked to none of them: the only route was /apps, so the apps sat
-        two clicks from the site's highest-authority page and received no
-        direct internal link from it. Search engines follow links, and this is
-        the page with the most of them pointing at it.
-      -->
-      <nav class="home-app-links" aria-label="Free web apps">
-        <h2 class="home-app-links-title">Open an app</h2>
-        <ul>
-          <li><a href="apps/rising-shows/">Rising Shows<span>Rank TV shows by their rating trend</span></a></li>
-          <li><a href="apps/gym-tracker/">Gym Tracker<span>Log workouts and track strength progress</span></a></li>
-          <li><a href="apps/trip-planner/">Trip Planner<span>Day-by-day itineraries with a route map</span></a></li>
-          <li><a href="apps/mario-kart/">Mario Kart Tracker<span>Log races, compare players, track achievements</span></a></li>
-          <li><a href="apps/maptap-rivals/">MapTap Rivals<span>Daily MapTap.gg scores against friends</span></a></li>
-          <li><a href="apps/football-h2h/">Football H2H League<span>Football scores, penalty shootouts and player stats</span></a></li>
-          <li><a href="apps/arena/">Arena<span>Party games with friends in a private room</span></a></li>
-        </ul>
-      </nav>
 
       <section class="cta-banner">
         <h3>Have a project in mind?</h3>


### PR DESCRIPTION
## TL;DR

The homepage sold consultancy above the fold while the apps sat roughly four screens down, after six capability cards and three preview cards, on the page that takes 45% of all views. Both hero buttons led into the consultancy funnel, so a visitor who came for the free apps had no route from the hero at all.

Adds a third hero CTA to the apps page and moves the existing app-links grid directly under the hero. **The positioning is deliberately unchanged** - headline, lede, both original CTAs and every existing section are untouched.

---

## `home.html`

**A third hero CTA.** `Try the free apps` -> `apps.html`, alongside the existing `See the work` and `Get in touch`. Styled `button ghost` to match the secondary action rather than competing with the primary one, so the consultancy call to action keeps visual priority.

**The `.home-app-links` grid moved up.** It previously sat between the "Where to next" preview cards and the closing CTA banner. It now sits immediately after the hero and before the "What we do" section heading. Nothing inside the block changed: same seven links, same one-liners, same markup and styling.

Nothing was removed and no copy was rewritten. The H1, the lede, both original CTAs, the six capability cards, the three preview cards and the closing "Have a project in mind?" banner are all present and keep their order relative to each other. The only structural difference is where the app grid sits.

The rendered heading outline is unaffected: the moved block's "Open an app" `h2` now precedes the "What we do" `h2`, so the page still reports one `h1` and zero skips post-JS.

The alternative considered was an apps-first hero, rewriting the H1 and lede around the free tools. That would signal more strongly to both visitors and search engines where the apps live, but the homepage would stop leading with the services, which is a decision about the business rather than the site.

## `README.md`

The "Adding a new app" checklist described the `.home-app-links` grid as being "near the bottom" of `home.html`, which is no longer where it is. Updated to say it sits directly under the hero, and to add that each one-liner must stay consistent with that app's description in `apps.html` and that the names must match the apps hub exactly - the constraint that a previous round had to correct after the grid introduced a fourth spelling of "Football H2H League".
