### PR TITLE
fix(site): list apps A-Z everywhere, and give the hero two equal primaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ shevato/
 │   └── seo/                          # Reference JSON-LD fragments + metadata checklist
 │
 ├── apps/                             # Browser apps (each is self-contained)
-│   ├── mario-kart/                   # Mario Kart race tracker (8 Deluxe + World)
-│   ├── gym-tracker/                  # Gym workout tracker (PWA, manifest + service worker)
-│   ├── football-h2h/                 # Head-to-head football league manager
-│   ├── rising-shows/                 # TV shows ranked by rating-trend shape + Plex/Kometa integration
-│   ├── maptap-rivals/                # Daily MapTap.gg head-to-head tracker
 │   ├── arena/                        # Real-time multiplayer hub (Firestore Realtime DB)
+│   ├── football-h2h/                 # Head-to-head football league manager
+│   ├── gym-tracker/                  # Gym workout tracker (PWA, manifest + service worker)
+│   ├── maptap-rivals/                # Daily MapTap.gg head-to-head tracker
+│   ├── mario-kart/                   # Mario Kart race tracker (8 Deluxe + World)
+│   ├── rising-shows/                 # TV shows ranked by rating-trend shape + Plex/Kometa integration
 │   └── trip-planner/                 # Day-by-day trip itinerary builder with route map
 │
 ├── partials/                         # Header/footer fragments loaded by main.js
@@ -64,18 +64,23 @@ shevato/
 
 | App | Path | Category | Notes |
 |-----|------|----------|-------|
-| Mario Kart Tracker | `apps/mario-kart/` | Game stats | Race log, charts, achievements. Supports MK8 Deluxe + Mario Kart World |
-| Gym Tracker | `apps/gym-tracker/` | Health | Installable PWA, offline support, programs + measurements |
-| Football H2H League | `apps/football-h2h/` | Sports stats | Match log, penalty shootouts, player comparison table |
-| Rising Shows | `apps/rising-shows/` | TV / multimedia | Whole TV shows ranked by the shape of their rating trend across thousands of shows; Plex + Kometa integration under `apps/rising-shows/kometa/` |
-| MapTap Rivals | `apps/maptap-rivals/` | Game tracker | Daily MapTap.gg H2H against named friends; rivalry seasons + calendar heatmap |
 | Arena | `apps/arena/` | Real-time multiplayer | Private rooms for friends — Globe Drop, Trivia, more. Requires Firestore + Realtime Database |
+| Football H2H League | `apps/football-h2h/` | Sports stats | Match log, penalty shootouts, player comparison table |
+| Gym Tracker | `apps/gym-tracker/` | Health | Installable PWA, offline support, programs + measurements |
+| MapTap Rivals | `apps/maptap-rivals/` | Game tracker | Daily MapTap.gg H2H against named friends; rivalry seasons + calendar heatmap |
+| Mario Kart Tracker | `apps/mario-kart/` | Game stats | Race log, charts, achievements. Supports MK8 Deluxe + Mario Kart World |
+| Rising Shows | `apps/rising-shows/` | TV / multimedia | Whole TV shows ranked by the shape of their rating trend across thousands of shows; Plex + Kometa integration under `apps/rising-shows/kometa/` |
 | Trip Planner | `apps/trip-planner/` | Travel | Day-by-day itineraries: flights, stays, costs, night coverage, collision and gap warnings, route map, A-to-B travel options. Optional Firestore sync via site sign-in |
 
 ### Adding a new app (required surfaces checklist)
 
 Every place an existing app is referenced must reference the new one in the
 SAME round. Wire the app into ALL of these:
+
+**Apps are always listed A-Z**, on every surface below, with no featured app
+hoisted to the front. Insert alphabetically rather than appending. Five tests
+in `sync-system/tests/app-naming-consistency.test.mjs` enforce this; if one
+fails, fix the ordering rather than the test.
 
 1. `apps/<slug>/` - index.html (shared header/footer includes, full SEO head:
    canonical, OG + Twitter cards, SoftwareApplication JSON-LD, emoji favicon),

--- a/apps.html
+++ b/apps.html
@@ -247,19 +247,6 @@
       <h2 class="sr-only">All apps</h2>
 
       <div class="highlights">
-        <section data-category="fitness">
-          <div class="content">
-            <img class="app-preview" src="images/app-previews/gym-tracker.webp" width="720" height="450" loading="lazy" decoding="async" alt="Gym Tracker weekly dashboard showing workouts, total volume, training time, and streak tiles above a recent workout card" />
-            <header>
-              <a href="apps/gym-tracker/" class="icon fa-heartbeat brand-color-primary" aria-label="Open Gym Tracker"></a>
-              <h3>Gym Tracker</h3>
-            </header>
-            <p>An installable PWA for logging workouts, building programs, and watching your numbers move. Works offline once installed.</p>
-            <ul class="actions special">
-              <li><a href="apps/gym-tracker/" class="button" aria-label="Start Tracking, Gym Tracker">Start Tracking</a></li>
-            </ul>
-          </div>
-        </section>
         <section data-category="game">
           <div class="content">
             <img class="app-preview" src="images/app-previews/arena.webp" width="720" height="450" loading="lazy" decoding="async" alt="Arena mid-game Globe Drop round with a Where is Naypyidaw geography question and a 3D Earth globe with a countdown timer" />
@@ -283,6 +270,19 @@
             <p>Head-to-head football match recorder. Scores, penalty shootouts, team selections, and a player comparison table for the long-running rivalry at home.</p>
             <ul class="actions special">
               <li><a href="apps/football-h2h/" class="button" aria-label="View League, Football H2H League">View League</a></li>
+            </ul>
+          </div>
+        </section>
+        <section data-category="fitness">
+          <div class="content">
+            <img class="app-preview" src="images/app-previews/gym-tracker.webp" width="720" height="450" loading="lazy" decoding="async" alt="Gym Tracker weekly dashboard showing workouts, total volume, training time, and streak tiles above a recent workout card" />
+            <header>
+              <a href="apps/gym-tracker/" class="icon fa-heartbeat brand-color-primary" aria-label="Open Gym Tracker"></a>
+              <h3>Gym Tracker</h3>
+            </header>
+            <p>An installable PWA for logging workouts, building programs, and watching your numbers move. Works offline once installed.</p>
+            <ul class="actions special">
+              <li><a href="apps/gym-tracker/" class="button" aria-label="Start Tracking, Gym Tracker">Start Tracking</a></li>
             </ul>
           </div>
         </section>

--- a/home.html
+++ b/home.html
@@ -160,12 +160,15 @@
         <h1 id="home-hero-title">Software engineering, <span class="accent">delivered cleanly</span>.</h1>
         <p class="lede">Shevato is a software engineering firm, shipping since 2019. We design and build backend systems, full stack web applications, and the platform tooling that holds them together. The pages here show what we do, what we have built, and where to reach us.</p>
         <div class="cta-row">
+          <!-- Two primaries, deliberately. This page serves two distinct
+               audiences: people hiring an engineering firm, and people who
+               came for the free apps. A single primary would tell both groups
+               that one of those is the real purpose of the site.
+               "Get in touch" stays secondary because it is a later step in the
+               same funnel "See the work" starts, not a third destination. -->
           <a href="work.html" class="button primary">See the work</a>
+          <a href="apps.html" class="button primary">Try the free apps</a>
           <a href="contact.html" class="button ghost">Get in touch</a>
-          <!-- Third CTA, for the other audience this page serves. Both original
-               buttons go to the consultancy funnel (work, contact), so someone
-               who came for the free apps had no route from the hero at all. -->
-          <a href="apps.html" class="button ghost">Try the free apps</a>
         </div>
       </section>
 
@@ -179,13 +182,13 @@
       <nav class="home-app-links" aria-label="Free web apps">
         <h2 class="home-app-links-title">Open an app</h2>
         <ul>
-          <li><a href="apps/rising-shows/">Rising Shows<span>Rank TV shows by their rating trend</span></a></li>
-          <li><a href="apps/gym-tracker/">Gym Tracker<span>Log workouts and track strength progress</span></a></li>
-          <li><a href="apps/trip-planner/">Trip Planner<span>Day-by-day itineraries with a route map</span></a></li>
-          <li><a href="apps/mario-kart/">Mario Kart Tracker<span>Log races, compare players, track achievements</span></a></li>
-          <li><a href="apps/maptap-rivals/">MapTap Rivals<span>Daily MapTap.gg scores against friends</span></a></li>
-          <li><a href="apps/football-h2h/">Football H2H League<span>Football scores, penalty shootouts and player stats</span></a></li>
           <li><a href="apps/arena/">Arena<span>Party games with friends in a private room</span></a></li>
+          <li><a href="apps/football-h2h/">Football H2H League<span>Football scores, penalty shootouts and player stats</span></a></li>
+          <li><a href="apps/gym-tracker/">Gym Tracker<span>Log workouts and track strength progress</span></a></li>
+          <li><a href="apps/maptap-rivals/">MapTap Rivals<span>Daily MapTap.gg scores against friends</span></a></li>
+          <li><a href="apps/mario-kart/">Mario Kart Tracker<span>Log races, compare players, track achievements</span></a></li>
+          <li><a href="apps/rising-shows/">Rising Shows<span>Rank TV shows by their rating trend</span></a></li>
+          <li><a href="apps/trip-planner/">Trip Planner<span>Day-by-day itineraries with a route map</span></a></li>
         </ul>
       </nav>
 

--- a/sitemap-pages.xml
+++ b/sitemap-pages.xml
@@ -55,7 +55,13 @@
   </url>
 
   <url>
-    <loc>https://shevato.com/apps/mario-kart/</loc>
+    <loc>https://shevato.com/apps/arena/</loc>
+    <lastmod>2026-06-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://shevato.com/apps/football-h2h/</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
@@ -76,7 +82,14 @@
   </url>
 
   <url>
-    <loc>https://shevato.com/apps/football-h2h/</loc>
+    <loc>https://shevato.com/apps/maptap-rivals/</loc>
+    <lastmod>2026-06-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://shevato.com/apps/mario-kart/</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
@@ -106,19 +119,6 @@
   <url>
     <loc>https://shevato.com/apps/trip-planner/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://shevato.com/apps/maptap-rivals/</loc>
-    <lastmod>2026-06-13</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://shevato.com/apps/arena/</loc>
-    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/sync-system/tests/app-naming-consistency.test.mjs
+++ b/sync-system/tests/app-naming-consistency.test.mjs
@@ -152,3 +152,73 @@ test('netlify.toml keeps a 301 from tracker.html to the new mario-kart entry', (
     assert.match(toml, /to\s*=\s*"\/apps\/mario-kart\/"/);
     assert.match(toml, /status\s*=\s*301/);
 });
+
+// ---------------------------------------------------------------------------
+// Cross-cutting invariant: every user-facing list of apps is in A-Z order.
+//
+// The owner's rule is that apps are ALWAYS listed alphabetically. Before this
+// test the site disagreed with itself: the header nav and the apps.html
+// JSON-LD were alphabetical, apps.html's visible cards were alphabetical
+// except Gym Tracker hoisted to first, the homepage grid was in no order at
+// all, and both README lists and the sitemap followed a fourth arbitrary
+// order. Ordering is exactly the kind of thing that drifts silently every
+// time an app is added, so it is asserted rather than remembered.
+// ---------------------------------------------------------------------------
+
+/** Case-insensitive compare, so "MapTap" sorts before "Mario" on 'p' < 'r'. */
+function isSortedCI(names) {
+    const sorted = [...names].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    return names.join('|') === sorted.join('|');
+}
+
+function readRepoFile(...parts) {
+    return readFileSync(join(REPO_ROOT, ...parts), 'utf8');
+}
+
+test('the homepage app grid is in A-Z order', () => {
+    const html = readRepoFile('home.html');
+    const names = [...html.matchAll(/href="apps\/[a-z0-9-]+\/">([^<]*)<span>/g)].map((m) => m[1].trim());
+    assert.equal(names.length, 7, 'expected all seven apps in the homepage grid');
+    assert.ok(isSortedCI(names), `homepage grid out of A-Z order: ${names.join(', ')}`);
+});
+
+test('the apps hub cards are in A-Z order', () => {
+    const html = readRepoFile('apps.html');
+    const section = html.slice(html.indexOf('<div class="highlights">'));
+    const names = [...section.matchAll(/<h3>([^<]*)<\/h3>/g)].map((m) => m[1].trim());
+    assert.equal(names.length, 7, 'expected all seven app cards');
+    assert.ok(isSortedCI(names), `apps.html cards out of A-Z order: ${names.join(', ')}`);
+});
+
+test('the header nav app menu is in A-Z order', () => {
+    const html = readRepoFile('partials', 'header.html');
+    // The nav renders twice (desktop dropdown + mobile list); check each run
+    // separately rather than the concatenation, which would never be sorted.
+    const links = [...html.matchAll(/href="\/apps\/[a-z0-9-]+\/"[^>]*>([^<]*)</g)].map((m) => m[1].trim());
+    assert.equal(links.length, 14, 'expected seven apps in each of the two nav blocks');
+    const desktop = links.slice(0, 7);
+    const mobile = links.slice(7);
+    assert.ok(isSortedCI(desktop), `header desktop nav out of A-Z order: ${desktop.join(', ')}`);
+    assert.ok(isSortedCI(mobile), `header mobile nav out of A-Z order: ${mobile.join(', ')}`);
+});
+
+test('the apps hub CollectionPage JSON-LD lists apps in A-Z order', () => {
+    const html = readRepoFile('apps.html');
+    const blocks = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+    const names = [];
+    for (const [, raw] of blocks) {
+        const parsed = JSON.parse(raw); // also asserts the JSON-LD stays valid
+        for (const part of parsed.hasPart || []) {
+            if (part.name) names.push(part.name);
+        }
+    }
+    assert.equal(names.length, 7, 'expected all seven apps in hasPart');
+    assert.ok(isSortedCI(names), `apps.html JSON-LD out of A-Z order: ${names.join(', ')}`);
+});
+
+test('the sitemap lists the app landing pages in A-Z order', () => {
+    const xml = readRepoFile('sitemap-pages.xml');
+    const slugs = [...xml.matchAll(/<loc>https:\/\/shevato\.com\/apps\/([a-z0-9-]+)\/<\/loc>/g)].map((m) => m[1]);
+    assert.equal(slugs.length, 7, 'expected seven app landing pages in the sitemap');
+    assert.ok(isSortedCI(slugs), `sitemap app order not A-Z: ${slugs.join(', ')}`);
+});


### PR DESCRIPTION
## TL;DR

Apps were listed in **four different orders at once** across the site. All six surfaces are now A-Z, enforced by five tests that were verified to actually fail on a scrambled list.

The hero also emphasised only one action, and it was the wrong one: the solid blue button pointed at the portfolio while the apps CTA carried the least emphasis of the three. `See the work` and `Try the free apps` are now both primary.

---

## Ordering: `home.html`, `apps.html`, `sitemap-pages.xml`, `README.md`

| Surface | Before |
|---|---|
| `partials/header.html` nav (both blocks) | already A-Z |
| `apps.html` CollectionPage JSON-LD | already A-Z |
| `apps.html` visible cards | A-Z except Gym Tracker hoisted to first |
| `home.html` app grid | no discernible order |
| `README.md` directory tree + apps table | a third arbitrary order |
| `sitemap-pages.xml` | a fourth arbitrary order |

All now read: Arena, Football H2H League, Gym Tracker, MapTap Rivals, Mario Kart Tracker, Rising Shows, Trip Planner. Comparison is case-insensitive, so MapTap precedes Mario on `p` < `r`.

**`sitemap-pages.xml` needed group-aware reordering, not a flat sort.** App sub-pages (`/exercises/`, `/shows/`, `/kometa/`) follow their parent app in the file, so sorting individual `<url>` blocks would have scattered them away from it. The fix sorts app *groups*, keeping each parent's sub-pages attached. The URL count is unchanged at 17.

**`apps.html` cards are DOM-reordered**, which the category filter and the search box both operate on. Both were re-verified after the change: the Games filter returns its 4 cards (still in A-Z order), searching "gym" returns 1, and the page logs no JS errors.

**`README.md`** also gains a standing note above the "Adding a new app" checklist stating that apps are always listed A-Z, placed above the numbered list rather than as one step within it, since it applies to every surface the list enumerates.

## Hero call-to-action: `home.html`

`See the work` and `Try the free apps` are both `button primary`; `Get in touch` becomes `button ghost`.

The previous hierarchy was intentional (one primary action per section) but predated the decision to serve app visitors: it was set when the homepage was consultancy-only, so the loudest button on the site's highest-traffic page pointed at the portfolio, and the apps CTA added earlier the same day had been given the least emphasis of the three.

Two primaries is the accurate expression of a page with two distinct audiences; a single primary tells both groups that one of them is the site's real purpose. `Get in touch` stays secondary because it is a later step in the funnel `See the work` begins, not a third destination.

The three were also reordered so the two primaries sit together and the secondary is last. This wraps better at 390px, where the ghost button previously sat between the two solid ones.

## `sync-system/tests/app-naming-consistency.test.mjs`

Five tests, one per surface: the homepage grid, the apps hub cards, both header nav blocks (checked as two separate runs, since the concatenation of two sorted lists is never itself sorted), the CollectionPage JSON-LD (which also re-parses it, so the JSON-LD stays valid), and the sitemap's app landing pages.

Each failure message names the offending order rather than only asserting a boolean. Ordering drifts silently every time an app is added, which is how the four orders accumulated, so the tests were checked by scrambling the homepage grid and confirming the assertion fired before restoring it.
