### PR TITLE
fix(site): give the hero CTAs one consistent style and a pressed state

### DIFF
--- a/404.html
+++ b/404.html
@@ -63,7 +63,7 @@
             <p class="lede">Sorry, we could not find that page. Try one of these instead.</p>
             <div class="cta-row">
                 <a href="/home" class="button primary">Home</a>
-                <a href="/work.html" class="button ghost">Work</a>
+                <a href="/work" class="button ghost">Work</a>
                 <a href="/apps" class="button ghost">Apps</a>
             </div>
         </div>

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -74,6 +74,22 @@
   box-shadow: inset 0 0 0 1px rgba(var(--brand-blue-rgb), 0.35);
 }
 
+/* Pressed state. There was none: a click went straight from the hover colour
+   back to rest with no feedback that the press registered, which reads as an
+   unresponsive control on touch devices in particular, where there is no
+   hover phase at all to confirm the target. Both variants get the same
+   treatment so the row keeps behaving as one set. */
+.hero .cta-row .button.primary:active {
+  background-color: var(--brand-blue-hover);
+  box-shadow: 0 2px 6px rgba(var(--brand-blue-rgb), 0.22);
+  transform: translateY(1px);
+}
+.hero .cta-row .button.ghost:active {
+  background-color: rgba(var(--brand-blue-rgb), 0.16);
+  box-shadow: inset 0 0 0 1px rgba(var(--brand-blue-rgb), 0.4);
+  transform: translateY(1px);
+}
+
 @media screen and (max-width: 736px) {
   .hero h1 { font-size: 2.1rem; }
   .hero p.lede { font-size: 1rem; }

--- a/home.html
+++ b/home.html
@@ -160,15 +160,20 @@
         <h1 id="home-hero-title">Software engineering, <span class="accent">delivered cleanly</span>.</h1>
         <p class="lede">Shevato is a software engineering firm, shipping since 2019. We design and build backend systems, full stack web applications, and the platform tooling that holds them together. The pages here show what we do, what we have built, and where to reach us.</p>
         <div class="cta-row">
-          <!-- Two primaries, deliberately. This page serves two distinct
-               audiences: people hiring an engineering firm, and people who
-               came for the free apps. A single primary would tell both groups
-               that one of those is the real purpose of the site.
-               "Get in touch" stays secondary because it is a later step in the
-               same funnel "See the work" starts, not a third destination. -->
+          <!-- All three share one variant, deliberately. They are three
+               parallel destinations, not one recommended action plus two
+               fallbacks: which one matters depends entirely on why the visitor
+               arrived, and this page serves people hiring a firm and people
+               after the free apps in roughly equal measure. Emphasising any
+               one of them only encodes whichever audience the page happened to
+               be written for at the time, and reads as an arbitrary styling
+               difference rather than a hierarchy.
+               Contrast with 404.html, which keeps one primary on purpose:
+               there the visitor is lost and "Home" is a genuinely recommended
+               recovery, so the emphasis carries real meaning. -->
           <a href="work.html" class="button primary">See the work</a>
           <a href="apps.html" class="button primary">Try the free apps</a>
-          <a href="contact.html" class="button ghost">Get in touch</a>
+          <a href="contact.html" class="button primary">Get in touch</a>
         </div>
       </section>
 


### PR DESCRIPTION
## TL;DR

The three hero buttons on the homepage now share one style instead of two-blue-plus-one-outlined, because a 2+1 split reads as one button having accidentally been given the wrong class rather than as a ranking. Also adds the pressed (`:active`) state the hero buttons never had, which left taps on touch devices with no feedback at all.

Follow-up to #355, which shipped the 2+1 version.

---

### `home.html`

The third CTA, `Get in touch`, changes from `class="button ghost"` to `class="button primary"`, so all three hero buttons are now the same variant.

The three destinations are parallel, not ranked: which one matters depends entirely on whether the visitor came to hire a firm or to use the free apps, and the page serves both in roughly equal measure. Any emphasis therefore encodes whichever audience the page was last written for rather than a real hierarchy, which is how the original single-primary styling ended up pointing at the portfolio (set when the site was consultancy-only) with the apps CTA given the least weight of the three.

The explanatory comment above the block is rewritten to state that reasoning, and to record why `404.html` deliberately does not follow the same rule.

### `assets/css/site.css`

Adds `.hero .cta-row .button.primary:active` and `.hero .cta-row .button.ghost:active`. No `:active` rule existed for these buttons anywhere in the stylesheet, so a click went from the hover colour straight back to rest with nothing confirming the press had registered. That is worst on touch, where there is no hover phase to confirm the target in the first place. Both variants get the same treatment (darkened fill, tightened shadow, 1px downward nudge) so the row keeps behaving as one set, and so the rule still holds if a ghost button is reintroduced elsewhere.

### `404.html`

Fixes `href="/work.html"` to `href="/work"`. Netlify Pretty URLs redirects the extension form, so this link cost every 404 visitor who clicked it an extra round trip. The earlier pass that removed redirecting `.html` hrefs covered home/apps/about/contact but missed `work` on this page.

`404.html` otherwise keeps its one-primary-plus-two-ghost pattern on purpose and is not restyled: there the visitor is lost and `Home` is a genuinely recommended recovery action, so the emphasis carries meaning that the homepage's did not.
