### PR TITLE
test(site): add a browser regression suite for the site and all seven apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "commonjs",
   "scripts": {
     "test": "node --test apps/gym-tracker/tests/ apps/football-h2h/tests/ apps/rising-shows/tests/ apps/mario-kart/tests/ apps/arena/tests/ apps/maptap-rivals/tests/ apps/trip-planner/tests/ netlify/functions/tests/ sync-system/tests/ assets/js/tests/",
+    "test:browser": "node --experimental-websocket tests/browser/run.mjs",
     "test:gym": "node --test apps/gym-tracker/tests/",
     "test:football": "node --test apps/football-h2h/tests/",
     "test:rising-shows": "node --test apps/rising-shows/tests/",

--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -1,0 +1,84 @@
+# Browser regression suite
+
+End-to-end checks that drive the real site and all seven apps in headless
+Chrome. Complements `npm test`, which covers pure logic in Node and never opens
+a browser.
+
+```bash
+npm run test:browser
+```
+
+The runner starts its own static server and headless Chrome, runs every suite,
+tears both down, and exits non-zero on any failure. Nothing needs to be running
+beforehand.
+
+## Requirements
+
+- Chromium or Chrome on `PATH`, or `CHROME_BIN` pointing at one.
+- Python 3, used for the static server.
+- Node 20+. The driver needs `--experimental-websocket` on Node 20; the npm
+  script passes it. Node 22+ has `WebSocket` globally and ignores the flag.
+
+## Why it is not part of `npm test`
+
+`npm test` runs in CI on every push and finishes in seconds. This suite needs a
+browser binary and takes minutes. Keeping them separate means CI stays fast and
+does not depend on a Chromium install, while this stays available locally and
+before a release.
+
+## Configuration
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `BROWSER_TEST_PORT` | `8099` | Static server port |
+| `BROWSER_TEST_CDP_PORT` | `9222` | Chrome DevTools Protocol port |
+| `CHROME_BIN` | `chromium` | Browser binary |
+
+Ports 8080 and 8083 are reserved on the maintainer's machine and must never
+become defaults here.
+
+## Layout
+
+```
+tests/browser/
+  run.mjs            # lifecycle: start server + Chrome, run suites, tear down
+  cdp.mjs            # DevTools Protocol driver
+  suites/site.mjs    # 8 marketing pages, nav, forms, responsive
+  suites/apps.mjs    # all 7 apps: real feature flows, plus a mobile sweep
+```
+
+A suite exports `run({ base, cdpPort })` and returns
+`[{ name, pass, detail }]`. To add one, drop it in `suites/` and add its
+filename to `SUITES` in `run.mjs`.
+
+## Writing assertions that are actually true
+
+Clicks go through `Input.dispatchMouseEvent` at real coordinates, so they
+respect hit-testing, z-order and overlays. `element.click()` bypasses all three
+and will happily "succeed" against a button covered by a modal.
+
+Four traps produced convincing false failures when this suite was first written.
+All four are handled in `suites/apps.mjs`, and each is documented at the point
+it is applied:
+
+- **Collapsed sidebars.** football-h2h and mario-kart keep Add Game / Add Race,
+  undo, redo and export inside a sidebar that is closed by default on desktop.
+  Open it first or every one of those controls looks broken.
+- **First-run overlays.** gym-tracker shows `#onboarding-modal` at z-index 2000
+  over the nav. Dismiss it via its own control rather than deleting the node, so
+  the test still reflects what a user can do.
+- **Pagination.** rising-shows renders 24 rows per page, so a search matching
+  more than one page leaves the visible row count unchanged even though the
+  filter worked. Assert on the app's own "N shows" total.
+- **Correctly disabled controls.** trip-planner disables Days and Map until the
+  trip has items, and undo/redo until something has happened. These are not
+  bugs; assert the enable/disable transition instead of assuming clickability.
+
+Two further notes on state. Apps re-save debounced state, so a bare
+`localStorage.clear()` can be undone by an autosave firing just after it; clear
+per key and reload, as `fresh()` does. And app state is closure-scoped and read
+at boot, so seed storage *then* reload rather than expecting a live update.
+
+Analytics hosts are blackholed via `--host-resolver-rules`, and `cleanErrors()`
+filters the resulting network noise so a blocked beacon never reads as an app
+error.

--- a/tests/browser/cdp.mjs
+++ b/tests/browser/cdp.mjs
@@ -1,0 +1,225 @@
+// Minimal CDP driver. Node 20 needs --experimental-websocket for global WebSocket.
+import http from 'node:http';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function httpJson(port, path, method = 'GET') {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, path, method }, (res) => {
+      let b = '';
+      res.on('data', (c) => (b += c));
+      res.on('end', () => {
+        try { resolve(JSON.parse(b)); } catch (e) { reject(new Error(`${method} ${path}: ${b.slice(0, 120)}`)); }
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+export async function waitForBrowser(port, timeoutMs = 30000) {
+  const start = Date.now();
+  for (;;) {
+    try { return await httpJson(port, '/json/version'); }
+    catch { if (Date.now() - start > timeoutMs) throw new Error('browser never came up'); await sleep(250); }
+  }
+}
+
+export class Session {
+  constructor(ws) {
+    this.ws = ws;
+    this.id = 0;
+    this.pending = new Map();
+    this.handlers = [];
+    ws.addEventListener('message', (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.id != null && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(msg.error.message)); else resolve(msg.result);
+      } else if (msg.method) {
+        for (const h of this.handlers) h(msg.method, msg.params);
+      }
+    });
+  }
+  on(fn) { this.handlers.push(fn); }
+  send(method, params = {}) {
+    const id = ++this.id;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+      setTimeout(() => {
+        if (this.pending.has(id)) { this.pending.delete(id); reject(new Error('timeout: ' + method)); }
+      }, 45000);
+    });
+  }
+}
+
+// Opens a fresh tab so each page under test gets a clean target.
+export async function newPage(port) {
+  const target = await httpJson(port, '/json/new?about:blank', 'PUT');
+  const ws = new WebSocket(target.webSocketDebuggerUrl);
+  await new Promise((res, rej) => {
+    ws.addEventListener('open', res, { once: true });
+    ws.addEventListener('error', rej, { once: true });
+  });
+  const s = new Session(ws);
+  s.targetId = target.id;
+  await s.send('Page.enable');
+  await s.send('Runtime.enable');
+  await s.send('Log.enable');
+  await s.send('Network.enable');
+  await s.send('DOM.enable');
+
+  s.errors = [];
+  s.netFails = [];
+  s.on((method, p) => {
+    if (method === 'Runtime.exceptionThrown') {
+      const d = p.exceptionDetails;
+      s.errors.push(String((d.exception && (d.exception.description || d.exception.value)) || d.text));
+    } else if (method === 'Log.entryAdded' && p.entry.level === 'error') {
+      s.errors.push(String(p.entry.text));
+    } else if (method === 'Network.loadingFailed') {
+      s.netFails.push(`${p.errorText} ${p.type}`);
+    } else if (method === 'Network.responseReceived' && p.response.status >= 400) {
+      s.netFails.push(`HTTP ${p.response.status} ${p.response.url}`);
+    }
+  });
+  return s;
+}
+
+export async function closePage(port, s) {
+  try { await httpJson(port, `/json/close/${s.targetId}`); } catch {}
+  try { s.ws.close(); } catch {}
+}
+
+export async function goto(s, url, { settle = 2500 } = {}) {
+  s.errors.length = 0;
+  s.netFails.length = 0;
+  const loaded = new Promise((res) => {
+    const h = (m) => { if (m === 'Page.loadEventFired') res(); };
+    s.on(h);
+  });
+  await s.send('Page.navigate', { url });
+  await Promise.race([loaded, sleep(20000)]);
+  await sleep(settle);
+}
+
+export async function evaluate(s, expression) {
+  const r = await s.send('Runtime.evaluate', {
+    expression: `(()=>{ try { return JSON.stringify((${expression})); } catch(e) { return JSON.stringify({__evalError: String(e && e.message || e)}); } })()`,
+    returnByValue: true, awaitPromise: false,
+  });
+  const v = r.result && r.result.value;
+  if (v == null) return null;
+  try { return JSON.parse(v); } catch { return v; }
+}
+
+export async function setViewport(s, width, height, mobile = false) {
+  await s.send('Emulation.setDeviceMetricsOverride', {
+    width, height, deviceScaleFactor: 1, mobile,
+    screenWidth: width, screenHeight: height,
+  });
+}
+
+// Real coordinate-based click. Respects hit-testing, unlike element.click().
+export async function clickAt(s, x, y) {
+  const base = { x: Math.round(x), y: Math.round(y), button: 'left', clickCount: 1, buttons: 1 };
+  await s.send('Input.dispatchMouseEvent', { type: 'mouseMoved', ...base, buttons: 0 });
+  await s.send('Input.dispatchMouseEvent', { type: 'mousePressed', ...base });
+  await s.send('Input.dispatchMouseEvent', { type: 'mouseReleased', ...base });
+}
+
+// Clicks the centre of the first element matching sel, after scrolling it into view.
+export async function clickSel(s, sel, { nth = 0, settle = 400 } = {}) {
+  const box = await evaluate(s, `(()=>{
+    const els=[...document.querySelectorAll(${JSON.stringify(sel)})];
+    const el=els[${nth}]; if(!el) return null;
+    el.scrollIntoView({block:'center',inline:'center'});
+    const r=el.getBoundingClientRect();
+    if(r.width===0&&r.height===0) return {zero:true};
+    return {x:r.left+r.width/2, y:r.top+r.height/2};
+  })()`);
+  if (!box || box.zero) return false;
+  await clickAt(s, box.x, box.y);
+  await sleep(settle);
+  return true;
+}
+
+export async function typeInto(s, sel, text, { nth = 0 } = {}) {
+  const ok = await clickSel(s, sel, { nth, settle: 120 });
+  if (!ok) return false;
+  await evaluate(s, `(()=>{const e=[...document.querySelectorAll(${JSON.stringify(sel)})][${nth}]; if(e){e.focus(); e.value='';} return 1})()`);
+  for (const ch of text) {
+    await s.send('Input.dispatchKeyEvent', { type: 'keyDown', text: ch, unmodifiedText: ch });
+    await s.send('Input.dispatchKeyEvent', { type: 'keyUp', text: ch, unmodifiedText: ch });
+  }
+  // Frameworks here are vanilla, but fire both so listeners on either path see it.
+  await evaluate(s, `(()=>{const e=[...document.querySelectorAll(${JSON.stringify(sel)})][${nth}];
+    if(e){e.dispatchEvent(new Event('input',{bubbles:true}));e.dispatchEvent(new Event('change',{bubbles:true}));} return 1})()`);
+  await sleep(200);
+  return true;
+}
+
+export async function setValue(s, sel, value, { nth = 0 } = {}) {
+  return evaluate(s, `(()=>{const e=[...document.querySelectorAll(${JSON.stringify(sel)})][${nth}];
+    if(!e) return false; e.focus(); e.value=${JSON.stringify(value)};
+    e.dispatchEvent(new Event('input',{bubbles:true})); e.dispatchEvent(new Event('change',{bubbles:true})); return true})()`);
+}
+
+export async function pressKey(s, key, code, keyCode) {
+  const p = { key, code: code || key, windowsVirtualKeyCode: keyCode, nativeVirtualKeyCode: keyCode };
+  await s.send('Input.dispatchKeyEvent', { type: 'keyDown', ...p });
+  await s.send('Input.dispatchKeyEvent', { type: 'keyUp', ...p });
+  await sleep(150);
+}
+
+// Seed storage then reload, because app state is closure-scoped and only read at boot.
+export async function seedAndReload(s, url, kv) {
+  await goto(s, url, { settle: 900 });
+  await evaluate(s, `(()=>{ ${Object.entries(kv).map(([k, v]) =>
+    `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(typeof v === 'string' ? v : JSON.stringify(v))});`).join('')} return 1 })()`);
+  await goto(s, url, { settle: 2500 });
+}
+
+export async function screenshot(s, path) {
+  const r = await s.send('Page.captureScreenshot', { format: 'png' });
+  const { writeFile } = await import('node:fs/promises');
+  await writeFile(path, Buffer.from(r.data, 'base64'));
+}
+
+export { sleep };
+
+// Finds a visible clickable by exact-ish text and clicks its centre with FRESH
+// coordinates. Text matching survives re-renders that invalidate index-based
+// lookups, which is the usual way these suites go wrong.
+export async function clickText(s, text, { sel = 'button,a,[role=tab],label', exact = false, settle = 700 } = {}) {
+  const box = await evaluate(s, `(()=>{
+    const want=${JSON.stringify(text)}.toLowerCase();
+    const els=[...document.querySelectorAll(${JSON.stringify(sel)})].filter(e=>{
+      const r=e.getBoundingClientRect();
+      return r.width>2&&r.height>2&&getComputedStyle(e).visibility!=='hidden'&&!e.disabled;
+    });
+    const norm=e=>(e.getAttribute('aria-label')||e.textContent||'').replace(/\\s+/g,' ').trim().toLowerCase();
+    const el = ${exact ? 'els.find(e=>norm(e)===want)' : 'els.find(e=>norm(e).includes(want))'};
+    if(!el) return null;
+    el.scrollIntoView({block:'center',inline:'center'});
+    const r=el.getBoundingClientRect();
+    return {x:r.left+r.width/2, y:r.top+r.height/2};
+  })()`);
+  if (!box) return false;
+  await clickAt(s, box.x, box.y);
+  await sleep(settle);
+  return true;
+}
+
+export async function textPresent(s, needle) {
+  return evaluate(s, `document.body.innerText.toLowerCase().includes(${JSON.stringify(String(needle).toLowerCase())})`);
+}
+
+export async function count(s, sel) {
+  return evaluate(s, `document.querySelectorAll(${JSON.stringify(sel)}).length`);
+}
+
+export const NOISE = /googletagmanager|google-analytics|ERR_CONNECTION_REFUSED|gstatic|firebase|googleapis|favicon|fonts\.|firebaseio|Failed to load resource/i;
+export const cleanErrors = (s) => s.errors.filter((e) => !NOISE.test(e));

--- a/tests/browser/run.mjs
+++ b/tests/browser/run.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Browser regression runner.
+//
+// Starts a static server and a headless Chrome, runs every suite against them,
+// then tears both down and exits non-zero if anything failed.
+//
+// Run with: npm run test:browser
+//
+// This is deliberately NOT part of `npm test`. It needs Chromium on the machine
+// and takes minutes rather than seconds, so CI keeps running the fast unit
+// suites while this stays an explicit local/pre-release check.
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..');
+
+// 8080 and 8083 are reserved on the maintainer's machine; never default to them.
+const PORT = Number(process.env.BROWSER_TEST_PORT || 8099);
+const CDP_PORT = Number(process.env.BROWSER_TEST_CDP_PORT || 9222);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+const SUITES = ['site.mjs', 'apps.mjs'];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function waitFor(check, timeoutMs, label) {
+  return (async () => {
+    const start = Date.now();
+    for (;;) {
+      if (await check()) return true;
+      if (Date.now() - start > timeoutMs) throw new Error(`timed out waiting for ${label}`);
+      await sleep(250);
+    }
+  })();
+}
+
+const httpOk = (url) => new Promise((resolve) => {
+  const req = http.get(url, (res) => { res.resume(); resolve(res.statusCode > 0); });
+  req.on('error', () => resolve(false));
+  req.setTimeout(1500, () => { req.destroy(); resolve(false); });
+});
+
+let server, chrome, profileDir;
+
+async function startAll() {
+  server = spawn('python3', ['-m', 'http.server', String(PORT), '--bind', '127.0.0.1'],
+    { cwd: REPO, stdio: 'ignore' });
+  await waitFor(() => httpOk(`${BASE}/home.html`), 20000, 'static server');
+
+  profileDir = await mkdtemp(path.join(tmpdir(), 'shevato-browser-test-'));
+  const bin = process.env.CHROME_BIN || 'chromium';
+  chrome = spawn(bin, [
+    '--headless=new', '--disable-gpu', '--no-sandbox', '--no-first-run',
+    `--remote-debugging-port=${CDP_PORT}`,
+    `--user-data-dir=${profileDir}`,
+    // Blackhole analytics so a blocked beacon never looks like an app error.
+    '--host-resolver-rules=MAP www.googletagmanager.com 127.0.0.1:1, MAP *.google-analytics.com 127.0.0.1:1',
+    'about:blank',
+  ], { stdio: 'ignore' });
+  chrome.on('error', (e) => { console.error(`\nCould not launch "${bin}": ${e.message}\nSet CHROME_BIN to a Chrome/Chromium binary.`); });
+  await waitFor(() => httpOk(`http://127.0.0.1:${CDP_PORT}/json/version`), 30000, 'headless Chrome');
+}
+
+async function stopAll() {
+  for (const p of [chrome, server]) { try { p && p.kill(); } catch {} }
+  await sleep(400);
+  if (profileDir) { try { await rm(profileDir, { recursive: true, force: true }); } catch {} }
+}
+
+const results = [];
+try {
+  await startAll();
+  for (const name of SUITES) {
+    const mod = await import(path.join(HERE, 'suites', name));
+    process.stdout.write(`\n--- ${name.replace('.mjs', '')} ---\n`);
+    const r = await mod.run({ base: BASE, cdpPort: CDP_PORT });
+    results.push(...r);
+    for (const x of r) {
+      if (!x.pass) console.log(`  FAIL ${x.name}${x.detail ? '  [' + x.detail + ']' : ''}`);
+    }
+    const f = r.filter((x) => !x.pass).length;
+    console.log(`  ${r.length - f}/${r.length} passed`);
+  }
+} catch (e) {
+  console.error('\nrunner error:', e.message);
+  results.push({ name: 'runner completed', pass: false, detail: e.message });
+} finally {
+  await stopAll();
+}
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${'='.repeat(52)}`);
+console.log(`BROWSER REGRESSION: ${results.length - failed.length}/${results.length} passed`);
+if (failed.length) {
+  console.log('\nFailures:');
+  for (const f of failed) console.log(`  - ${f.name}${f.detail ? '  [' + f.detail + ']' : ''}`);
+}
+process.exit(failed.length ? 1 : 0);

--- a/tests/browser/suites/apps.mjs
+++ b/tests/browser/suites/apps.mjs
@@ -1,0 +1,352 @@
+// App regression: exercises each app's real features through driven interaction
+// rather than page-load smoke tests.
+//
+// Several apps need a setup step before their controls are reachable at all.
+// Getting these wrong produces convincing false failures, so they are documented
+// where they are applied:
+//   football-h2h / mario-kart - Add Game, Add Race, undo/redo and export all
+//     live inside a sidebar that is COLLAPSED by default on desktop.
+//   gym-tracker - a first-run #onboarding-modal (z-index 2000) covers the nav
+//     until dismissed. Dismiss it the way a user does, do not delete the node.
+//   trip-planner - the Days and Map views are correctly `disabled` until the
+//     trip has items, and undo/redo are correctly disabled until something has
+//     happened. Clearing storage needs an explicit per-key removal: the app
+//     re-saves debounced state, so a bare localStorage.clear() can be undone by
+//     an autosave that fires after it.
+//
+// Counting rules that matter:
+//   rising-shows paginates at 24 rows, so a search that still matches more than
+//     one page leaves the visible row count unchanged. Assert on the app's own
+//     "N shows" total instead.
+//   gym-tracker's exercise list renders through a picker container, so assert on
+//     its own "Showing N of M" label rather than counting DOM nodes.
+import {
+  newPage, closePage, goto, evaluate, clickText, clickSel, setViewport,
+  setValue, sleep, textPresent, cleanErrors,
+} from '../cdp.mjs';
+
+export async function run({ base, cdpPort }) {
+  const R = [];
+  const t = (name, pass, detail = '') => R.push({ name, pass: !!pass, detail });
+
+  // Fresh page with storage genuinely emptied. The double navigation matters:
+  // storage can only be cleared from a page on the target origin.
+  async function fresh(path, settle = 4000) {
+    const s = await newPage(cdpPort);
+    await setViewport(s, 1280, 900);
+    await goto(s, base + path, { settle: 1200 });
+    await evaluate(s, `(()=>{ try{ for(const k of Object.keys(localStorage)) localStorage.removeItem(k);
+      localStorage.clear(); sessionStorage.clear(); }catch(e){} return 1 })()`);
+    await goto(s, base + path, { settle });
+    return s;
+  }
+
+  const trackDownloads = (s) => evaluate(s, `(()=>{ window.__dl=null;
+    const oc=HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click=function(){
+      if(this.download || /^blob:|^data:/.test(this.href)) window.__dl='anchor';
+      return oc.apply(this,arguments); };
+    const ou=URL.createObjectURL;
+    URL.createObjectURL=function(b){ window.__dl='blob'; return ou.apply(this,arguments); };
+    return 1 })()`);
+
+  /* ------------------------------- ARENA -------------------------------- */
+  try {
+    const A = 'arena';
+    const s = await fresh('/apps/arena/');
+    t(`${A}: loads`, await textPresent(s, 'arena'));
+    t(`${A}: room-create controls present`, (await evaluate(s, "!!document.getElementById('create-globe-drop-round-type')")));
+    t(`${A}: join-code input present`, (await evaluate(s, "!!document.getElementById('join-code')")));
+    t(`${A}: difficulty select changes`, await evaluate(s, `(()=>{const e=document.getElementById('create-globe-drop-difficulty');
+      if(!e||!e.options||e.options.length<2) return false; e.selectedIndex=1;
+      e.dispatchEvent(new Event('change',{bubbles:true})); return e.selectedIndex===1})()`));
+    t(`${A}: private-room toggle flips`, await evaluate(s, `(()=>{const e=document.getElementById('create-private-toggle');
+      if(!e) return false; const b=e.checked; e.click(); return e.checked!==b})()`));
+
+    await setValue(s, '#join-code', 'ZZZZZZ');
+    await clickText(s, 'Join room', { settle: 1400 });
+    t(`${A}: bad join code does not crash`, await evaluate(s, "location.pathname.includes('arena')"));
+
+    await clickText(s, 'Play solo', { settle: 2600 });
+    t(`${A}: solo play responds`, await evaluate(s,
+      "/round|score|guess|map|location|loading/i.test(document.body.innerText)"));
+    t(`${A}: no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
+    await closePage(cdpPort, s);
+  } catch (e) { t('arena: suite ran', false, String(e.message).slice(0, 140)); }
+
+  /* ------------------- FOOTBALL H2H and MARIO KART ---------------------- */
+  // Same sidebar-driven architecture, so the same flow verifies both.
+  for (const [A, path, addLabel, exportLabel] of [
+    ['football-h2h', '/apps/football-h2h/', 'Add Game', 'Export data'],
+    ['mario-kart', '/apps/mario-kart/', 'Add Race', 'Export Data'],
+  ]) {
+    try {
+      const s = await fresh(path);
+      t(`${A}: loads`, (await evaluate(s, 'document.body.innerText.length')) > 100);
+
+      await clickText(s, 'Toggle sidebar', { settle: 1100 });
+      t(`${A}: sidebar opens`, await evaluate(s,
+        "(()=>{const sb=document.querySelector('.sidebar');return !!sb&&/open/.test(sb.className)})()"));
+
+      await clickText(s, addLabel, { settle: 1400 });
+      const form = await evaluate(s, `(()=>{
+        const vis=e=>e.getBoundingClientRect().height>0;
+        const f=document.querySelector('#sidebar-game-form,.sidebar-game-form,#sidebar-race-form,.sidebar-race-form');
+        if(!f) return {none:true};
+        const inputs=[...f.querySelectorAll('input,select')].filter(vis);
+        return {open:/open/.test(f.className), n:inputs.length,
+                numbers:inputs.filter(e=>e.type==='number').length};})()`);
+      t(`${A}: "${addLabel}" opens an entry form`, !form.none && form.open && form.n >= 2,
+        `open=${form.open} inputs=${form.n}`);
+
+      if (!form.none && form.open) {
+        const filled = await evaluate(s, `(()=>{
+          const f=document.querySelector('#sidebar-game-form,.sidebar-game-form,#sidebar-race-form,.sidebar-race-form');
+          const ns=[...f.querySelectorAll('input[type=number]')].filter(e=>e.getBoundingClientRect().height>0);
+          ns.forEach((e,i)=>{e.focus(); e.value=String(i+1);
+            e.dispatchEvent(new Event('input',{bubbles:true}));
+            e.dispatchEvent(new Event('change',{bubbles:true}));});
+          return ns.length})()`);
+        await clickText(s, 'Save', { settle: 1600 });
+        t(`${A}: an entry can be filled and saved`, filled >= 1, `${filled} numeric fields`);
+      }
+
+      t(`${A}: undo responds`, await clickText(s, 'Undo', { settle: 700 }));
+      t(`${A}: redo responds`, await clickText(s, 'Redo', { settle: 700 }));
+
+      await trackDownloads(s);
+      await clickText(s, exportLabel, { settle: 1600 });
+      t(`${A}: export produces a file`, (await evaluate(s, "window.__dl||''")) !== '');
+
+      let ranges = 0;
+      for (const label of ['Today', 'Last 7 Days', 'Last 30 Days', 'All Time']) {
+        if (await clickText(s, label, { exact: true, settle: 400 })) ranges++;
+      }
+      t(`${A}: date-range filters clickable`, ranges >= 3, `${ranges}/4`);
+
+      t(`${A}: no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
+      await closePage(cdpPort, s);
+    } catch (e) { t(`${A}: suite ran`, false, String(e.message).slice(0, 140)); }
+  }
+
+  /* ---------------------------- GYM TRACKER ----------------------------- */
+  try {
+    const A = 'gym-tracker';
+    const s = await fresh('/apps/gym-tracker/');
+
+    const dismissed = (await clickText(s, 'Skip tour', { settle: 900 }))
+      || (await clickText(s, 'Close welcome', { settle: 900 }));
+    t(`${A}: onboarding modal dismisses`, dismissed && await evaluate(s,
+      `(()=>{const m=document.getElementById('onboarding-modal');
+        return !m || !/active/.test(m.className) || m.getBoundingClientRect().height===0})()`));
+
+    const views = ['Programs', 'History', 'Exercises', 'Calendar', 'Insights', 'Measurements', 'Achievements', 'Settings'];
+    let switched = 0;
+    for (const v of views) {
+      const before = await evaluate(s, 'document.body.innerText.slice(0,3000)');
+      await clickText(s, v, { sel: '.nav-links .nav-link', exact: true, settle: 800 });
+      const after = await evaluate(s, 'document.body.innerText.slice(0,3000)');
+      const active = await evaluate(s, `(()=>{const b=[...document.querySelectorAll('.nav-links .nav-link')]
+        .find(x=>x.textContent.trim()===${JSON.stringify(v)}); return b?/active/.test(b.className):false})()`);
+      if (before !== after && active) switched++;
+    }
+    t(`${A}: all nav views switch`, switched === views.length, `${switched}/${views.length}`);
+
+    // Exercise search and category filter, asserted via the app's own count label.
+    await clickText(s, 'Exercises', { sel: '.nav-links .nav-link', exact: true, settle: 1800 });
+    const readCount = () => evaluate(s, `(()=>{const vis=e=>e.getBoundingClientRect().height>0;
+      return [...document.querySelectorAll('*')].filter(e=>vis(e)&&e.children.length===0
+        && /available|Showing/i.test(e.textContent||'')).map(e=>e.textContent.trim())[0]||null})()`);
+    const baseCount = await readCount();
+    await evaluate(s, `(()=>{const e=document.getElementById('exercise-db-search');
+      if(!e) return false; e.focus(); e.value='bench';
+      e.dispatchEvent(new Event('input',{bubbles:true})); return true})()`);
+    await sleep(1500);
+    const searchedCount = await readCount();
+    t(`${A}: exercise search filters`, !!baseCount && !!searchedCount && baseCount !== searchedCount,
+      `${baseCount} -> ${searchedCount}`);
+
+    await evaluate(s, `(()=>{const e=document.getElementById('exercise-db-search');
+      if(e){e.value=''; e.dispatchEvent(new Event('input',{bubbles:true}));}
+      const c=document.getElementById('exercise-db-category');
+      if(c&&c.options.length>1){c.selectedIndex=1; c.dispatchEvent(new Event('change',{bubbles:true}));}
+      return 1})()`);
+    await sleep(1400);
+    const catCount = await readCount();
+    t(`${A}: exercise category filter applies`, !!catCount && catCount !== baseCount, `${baseCount} -> ${catCount}`);
+
+    t(`${A}: no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
+    await closePage(cdpPort, s);
+  } catch (e) { t('gym-tracker: suite ran', false, String(e.message).slice(0, 140)); }
+
+  /* --------------------------- MAPTAP RIVALS ---------------------------- */
+  try {
+    const A = 'maptap-rivals';
+    const s = await fresh('/apps/maptap-rivals/');
+    t(`${A}: loads`, await textPresent(s, 'maptap'));
+    t(`${A}: username field accepts input`,
+      (await setValue(s, '#my-name', 'Tester')) || (await setValue(s, '#profile-username-input', 'Tester')));
+
+    await clickText(s, 'Add rival', { settle: 1000 });
+    const modalOpen = await evaluate(s, `(()=>{const m=document.getElementById('rival-modal');
+      return !!m && m.getBoundingClientRect().height>0})()`);
+    t(`${A}: Add rival opens the modal`, modalOpen);
+    if (modalOpen) {
+      await evaluate(s, `(()=>{const i=[...document.querySelectorAll('#rival-modal input[type=text],#rival-modal input:not([type])')]
+        .filter(e=>e.getBoundingClientRect().height>0)[0];
+        if(i){i.focus(); i.value='Rival One'; i.dispatchEvent(new Event('input',{bubbles:true}));}
+        return !!i})()`);
+      await clickText(s, 'Save', { settle: 1300 });
+      t(`${A}: rival persists to storage`, await evaluate(s,
+        `(()=>{for(const k of Object.keys(localStorage)){
+          if(/maptap|rival/i.test(k) && /Rival One/.test(String(localStorage.getItem(k)||''))) return true}
+          return false})()`));
+    }
+
+    t(`${A}: score paste box accepts input`, await setValue(s, '#paste-mine-input', '1. Paris 2. Tokyo 3. Lima'));
+
+    await trackDownloads(s);
+    await clickText(s, 'Export', { exact: true, settle: 1400 });
+    t(`${A}: export produces a file`, (await evaluate(s, "window.__dl||''")) !== '');
+
+    t(`${A}: no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
+    await closePage(cdpPort, s);
+  } catch (e) { t('maptap-rivals: suite ran', false, String(e.message).slice(0, 140)); }
+
+  /* ---------------------------- RISING SHOWS ---------------------------- */
+  try {
+    const A = 'rising-shows';
+    const s = await fresh('/apps/rising-shows/', 9000); // large dataset, slower boot
+    const rows = () => evaluate(s, `[...document.querySelectorAll('.show-row,.show-card,tbody tr,[data-series-id]')]
+      .filter(e=>e.getBoundingClientRect().height>0).length`);
+    const total = () => evaluate(s, `(()=>{const m=document.body.innerText.match(/([\\d,]+)\\s+shows?/i);
+      return m?m[1]:null})()`);
+
+    const baseRows = await rows();
+    const baseTotal = await total();
+    t(`${A}: results render`, baseRows > 0, `${baseRows} rows of ${baseTotal}`);
+
+    // Assert on the total, not the page of 24.
+    await setValue(s, '#finderSearch', 'breaking bad');
+    await sleep(2600);
+    const searchTotal = await total();
+    t(`${A}: search narrows results`, !!searchTotal && searchTotal !== baseTotal,
+      `${baseTotal} -> ${searchTotal}`);
+    await setValue(s, '#finderSearch', '');
+    await sleep(1800);
+
+    await clickText(s, 'Rising', { settle: 2200 });
+    t(`${A}: shape tab filters`, (await rows()) > 0);
+
+    await setValue(s, '#finderMinSeasons', '5');
+    await sleep(2000);
+    t(`${A}: min-seasons filter applies`, (await total()) !== baseTotal, `total now ${await total()}`);
+    await setValue(s, '#finderMinSeasons', '');
+    await sleep(1500);
+
+    const firstBefore = await evaluate(s, `(()=>{const r=document.querySelector('.show-row,.show-card,tbody tr,[data-series-id]');
+      return r?r.innerText.slice(0,50):null})()`);
+    await evaluate(s, `(()=>{const e=document.getElementById('finderSort');
+      if(e&&e.options.length>1){e.selectedIndex=(e.selectedIndex+1)%e.options.length;
+        e.dispatchEvent(new Event('change',{bubbles:true}));} return 1})()`);
+    await sleep(2200);
+    const firstAfter = await evaluate(s, `(()=>{const r=document.querySelector('.show-row,.show-card,tbody tr,[data-series-id]');
+      return r?r.innerText.slice(0,50):null})()`);
+    t(`${A}: sort changes result order`, firstBefore !== firstAfter);
+
+    const clicked = await clickSel(s, '.show-row,.show-card,tbody tr,[data-series-id]', { settle: 3000 });
+    const modal = await evaluate(s, `(()=>{const vis=e=>e.getBoundingClientRect().height>0;
+      const m=[...document.querySelectorAll('#showModal,#detailModal,.modal')].filter(vis)[0];
+      return m?{id:m.id,len:m.innerText.length}:null})()`);
+    t(`${A}: clicking a show opens its detail`, clicked && !!modal && modal.len > 40,
+      modal ? `${modal.id} len=${modal.len}` : 'no modal');
+
+    t(`${A}: no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
+    await closePage(cdpPort, s);
+  } catch (e) { t('rising-shows: suite ran', false, String(e.message).slice(0, 140)); }
+
+  /* ---------------------------- TRIP PLANNER ---------------------------- */
+  try {
+    const A = 'trip-planner';
+    const s = await fresh('/apps/trip-planner/');
+
+    const disabled = () => evaluate(s, `(()=>({days:document.getElementById('viewDays').disabled,
+      map:document.getElementById('viewMap').disabled}))()`);
+    const items = () => evaluate(s, `(()=>{try{const j=JSON.parse(localStorage.getItem('trip-planner:v1')||'{}');
+      const tr=j.trips||j; const first=Array.isArray(tr)?tr[0]:Object.values(tr||{})[0];
+      return ((first&&(first.items||first.entries))||[]).length}catch(e){return -1}})()`);
+
+    const empty = await disabled();
+    t(`${A}: Days/Map disabled while empty`, empty.days && empty.map, JSON.stringify(empty));
+
+    await clickText(s, 'Load an example trip', { settle: 3500 });
+    const loadedItems = await items();
+    const loadedState = await disabled();
+    t(`${A}: sample trip loads items`, loadedItems > 0, `${loadedItems} items`);
+    t(`${A}: Days/Map enable once populated`, !loadedState.days && !loadedState.map, JSON.stringify(loadedState));
+
+    let views = 0;
+    for (const id of ['viewDays', 'viewMap', 'viewTimeline']) {
+      await clickSel(s, `#${id}`, { settle: 2200 });
+      if (await evaluate(s, `/on|active/.test(document.getElementById(${JSON.stringify(id)}).className)`)) views++;
+    }
+    t(`${A}: all three views switch`, views === 3, `${views}/3`);
+
+    const beforeSearch = await evaluate(s, 'document.body.innerText.length');
+    await setValue(s, '#searchBox', 'zzzzzznomatch');
+    await sleep(1600);
+    t(`${A}: search filters the itinerary`,
+      (await evaluate(s, 'document.body.innerText.length')) !== beforeSearch);
+    await setValue(s, '#searchBox', '');
+    await sleep(1200);
+
+    await clickText(s, 'Add item', { settle: 1600 });
+    const addOpen = await evaluate(s, `(()=>{const m=document.getElementById('itemForm');
+      return !!m && m.getBoundingClientRect().height>0})()`);
+    t(`${A}: Add item opens the form`, addOpen);
+    if (addOpen) {
+      await evaluate(s, `(()=>{const b=[...document.querySelectorAll('#itemForm button')]
+        .find(x=>/cancel|close/i.test(x.textContent)); if(b) b.click(); return 1})()`);
+      await sleep(800);
+    }
+
+    // Undo is correctly disabled until something has happened, so assert the
+    // round trip rather than just that the button is clickable.
+    const beforeUndo = await items();
+    await clickText(s, 'Undo', { settle: 2000 });
+    const afterUndo = await items();
+    t(`${A}: undo reverses a change`, afterUndo < beforeUndo, `${beforeUndo} -> ${afterUndo}`);
+    await clickText(s, 'Redo', { settle: 2000 });
+    t(`${A}: redo restores it`, (await items()) > afterUndo);
+
+    t(`${A}: currency selector changes`, await evaluate(s, `(()=>{const e=document.getElementById('currencySel');
+      if(!e||e.options.length<2) return false; e.selectedIndex=1;
+      e.dispatchEvent(new Event('change',{bubbles:true})); return true})()`));
+
+    t(`${A}: no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
+    await closePage(cdpPort, s);
+  } catch (e) { t('trip-planner: suite ran', false, String(e.message).slice(0, 140)); }
+
+  /* --------------------------- MOBILE SWEEP ----------------------------- */
+  for (const [name, path] of [
+    ['arena', '/apps/arena/'], ['football-h2h', '/apps/football-h2h/'],
+    ['gym-tracker', '/apps/gym-tracker/'], ['maptap-rivals', '/apps/maptap-rivals/'],
+    ['mario-kart', '/apps/mario-kart/'], ['rising-shows', '/apps/rising-shows/'],
+    ['trip-planner', '/apps/trip-planner/'],
+  ]) {
+    try {
+      const s = await newPage(cdpPort);
+      await setViewport(s, 390, 844, true);
+      await goto(s, base + path, { settle: name === 'rising-shows' ? 8000 : 4500 });
+      const m = await evaluate(s, `(()=>({
+        overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        painted: document.body.innerText.trim().length }))()`);
+      t(`${name}: mobile no horizontal overflow`, m.overflow <= 1, `${m.overflow}px`);
+      t(`${name}: mobile renders content`, m.painted > 100, `${m.painted} chars`);
+      t(`${name}: mobile no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
+      await closePage(cdpPort, s);
+    } catch (e) { t(`${name}: mobile suite ran`, false, String(e.message).slice(0, 140)); }
+  }
+
+  return R;
+}

--- a/tests/browser/suites/site.mjs
+++ b/tests/browser/suites/site.mjs
@@ -1,0 +1,125 @@
+// Marketing-site regression: the 8 root pages plus navigation and responsive
+// behaviour. Assertions here are deliberately about structure and wiring, not
+// wording, so ordinary copy edits do not turn the suite red.
+import {
+  newPage, closePage, goto, evaluate, clickSel, setViewport, sleep, cleanErrors,
+} from '../cdp.mjs';
+
+const PAGES = ['home', 'work', 'apps', 'about', 'contact', 'privacy', '404', 'moadon-alef'];
+
+// moadon-alef is a standalone, separately-branded landing: it injects its own
+// footer partial (footer-moadon-alef) and deliberately carries no site header
+// or nav. 404 deliberately has no canonical, because it carries noindex and is
+// not a real page. Both are design decisions, not omissions.
+const NO_SITE_CHROME = new Set(['moadon-alef']);
+const NO_CANONICAL = new Set(['404']);
+
+export async function run({ base, cdpPort }) {
+  const R = [];
+  const t = (name, pass, detail = '') => R.push({ name, pass: !!pass, detail });
+
+  const s = await newPage(cdpPort);
+  await setViewport(s, 1280, 900);
+
+  for (const p of PAGES) {
+    await goto(s, `${base}/${p}.html`, { settle: 2600 });
+    const d = await evaluate(s, `(()=>({
+      title: document.title,
+      h1count: document.querySelectorAll('h1').length,
+      header: !!document.querySelector('#header'),
+      footer: !!document.querySelector('#footer'),
+      navLinks: document.querySelectorAll('#header nav a').length,
+      canonical: !!document.querySelector('link[rel=canonical]'),
+      desc: !!document.querySelector('meta[name=description]'),
+      lang: document.documentElement.lang || null,
+      imgsNoAlt: [...document.images].filter(i=>!i.hasAttribute('alt')).length,
+      unnamedLinks: [...document.querySelectorAll('a')].filter(a=>
+        !a.textContent.trim() && !a.getAttribute('aria-label')
+        && !a.querySelector('img[alt]:not([alt=""])')).length
+    }))()`);
+
+    t(`${p}: no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
+    t(`${p}: has a title`, !!d.title && d.title.length > 5, d.title);
+    t(`${p}: exactly one h1`, d.h1count === 1, `found ${d.h1count}`);
+    t(`${p}: footer partial injected`, d.footer);
+    t(`${p}: meta description present`, d.desc);
+    t(`${p}: html lang set`, !!d.lang, String(d.lang));
+    t(`${p}: every image has alt`, d.imgsNoAlt === 0, `${d.imgsNoAlt} missing`);
+    t(`${p}: no unnamed links`, d.unnamedLinks === 0, `${d.unnamedLinks} unnamed`);
+    if (!NO_CANONICAL.has(p)) t(`${p}: canonical present`, d.canonical);
+    if (!NO_SITE_CHROME.has(p)) {
+      t(`${p}: header partial injected`, d.header);
+      if (p !== '404') t(`${p}: nav links present`, d.navLinks >= 5, `${d.navLinks} links`);
+    }
+  }
+
+  // --- hero CTAs + app grid ------------------------------------------------
+  await goto(s, `${base}/home.html`, { settle: 2600 });
+  const home = await evaluate(s, `(()=>{
+    const btns=[...document.querySelectorAll('.hero .cta-row .button')];
+    const links=[...document.querySelectorAll('.home-app-links li a')];
+    const names=links.map(a=>a.firstChild.textContent.trim());
+    return { ctaCount:btns.length,
+      variants:[...new Set(btns.map(b=>b.className))],
+      backgrounds:[...new Set(btns.map(b=>getComputedStyle(b).backgroundColor))],
+      names, hrefs:links.map(a=>a.getAttribute('href')),
+      sorted: JSON.stringify(names)===JSON.stringify([...names].sort((a,b)=>
+        a.toLowerCase()<b.toLowerCase()?-1:1)) };})()`);
+  t('home: three hero CTAs', home.ctaCount === 3, String(home.ctaCount));
+  t('home: CTAs share one variant', home.variants.length === 1, home.variants.join(' / '));
+  t('home: CTAs share one background', home.backgrounds.length === 1, home.backgrounds.join(' / '));
+  t('home: seven apps listed', home.names.length === 7, String(home.names.length));
+  t('home: apps listed A-Z', home.sorted, home.names.join(', '));
+
+  for (let i = 0; i < home.hrefs.length; i++) {
+    await goto(s, `${base}/${home.hrefs[i]}`, { settle: 1500 });
+    const ok = await evaluate(s, "document.title.length>0 && !!document.querySelector('h1,h2')");
+    t(`home: app link ${home.names[i]} resolves`, !!ok, home.hrefs[i]);
+  }
+
+  // --- nav by real click ---------------------------------------------------
+  for (const label of ['work', 'apps', 'about', 'contact']) {
+    await goto(s, `${base}/home.html`, { settle: 1800 });
+    const clicked = await clickSel(s, `#header nav a[href*="${label}"]`);
+    const pathNow = await evaluate(s, 'location.pathname');
+    t(`nav: "${label}" navigates`, clicked && pathNow.includes(label), `-> ${pathNow}`);
+  }
+
+  // --- contact form --------------------------------------------------------
+  await goto(s, `${base}/contact.html`, { settle: 2200 });
+  const cf = await evaluate(s, `(()=>{
+    const f=document.querySelector('form'); if(!f) return {none:true};
+    const fields=[...f.querySelectorAll('input,textarea,select')].filter(x=>x.type!=='hidden');
+    return { count:fields.length,
+      labelled: fields.every(x=> !!f.querySelector('label[for="'+x.id+'"]')
+        || !!x.getAttribute('aria-label') || !!x.closest('label') || !!x.placeholder) };})()`);
+  t('contact: form present', !cf.none);
+  if (!cf.none) t('contact: all fields labelled', cf.labelled, `${cf.count} fields`);
+
+  // --- mobile menu ---------------------------------------------------------
+  await setViewport(s, 390, 844, true);
+  await goto(s, `${base}/home.html`, { settle: 2600 });
+  const opened = await clickSel(s, 'a[href="#menu"]');
+  await sleep(700);
+  const menu = await evaluate(s, `(()=>{
+    const m=document.querySelector('#menu'), c=document.querySelector('#menu .close');
+    return { visible: !!m && getComputedStyle(m).visibility!=='hidden',
+      links: m?m.querySelectorAll('a').length:0,
+      closeNamed: !!c && !!(c.getAttribute('aria-label')||c.textContent.trim()) };})()`);
+  t('mobile: menu opens', opened && menu.visible);
+  t('mobile: menu has links', menu.links >= 5, String(menu.links));
+  t('mobile: close control is named', menu.closeNamed);
+
+  // --- responsive ----------------------------------------------------------
+  for (const [w, h, label] of [[390, 844, 'mobile'], [768, 1024, 'tablet'], [1280, 900, 'desktop']]) {
+    await setViewport(s, w, h, w < 500);
+    for (const p of ['home', 'apps', 'work']) {
+      await goto(s, `${base}/${p}.html`, { settle: 1600 });
+      const over = await evaluate(s, 'document.documentElement.scrollWidth - document.documentElement.clientWidth');
+      t(`${label} ${p}: no horizontal overflow`, over <= 1, `${over}px`);
+    }
+  }
+
+  await closePage(cdpPort, s);
+  return R;
+}


### PR DESCRIPTION
## TL;DR

Adds a browser regression suite: **190 assertions** across the 8 marketing pages and all 7 apps, driving real features in headless Chrome. `npm run test:browser` starts its own server and browser, runs everything, tears down, and exits non-zero on failure.

Deliberately **not** part of `npm test`, which stays fast and needs no Chromium in CI.

Verified to actually fail: flipping one homepage CTA back to the `ghost` variant produced `FAIL home: CTAs share one variant [button primary / button ghost]` and exit 1. A suite that cannot fail is worse than no suite.

---

### `tests/browser/run.mjs` (new)

Lifecycle runner. Starts `python3 -m http.server` on 8099 and headless Chrome with a CDP port on 9222 and a throwaway profile, waits for both to answer, imports each suite, aggregates results, then kills both and removes the profile in a `finally` block so a crashed suite cannot leak a browser or hold a port. Exits 1 if any assertion failed.

Analytics hosts are blackholed via `--host-resolver-rules` so a blocked beacon never registers as an app error. Ports and the browser binary are overridable via `BROWSER_TEST_PORT`, `BROWSER_TEST_CDP_PORT` and `CHROME_BIN`; 8080 and 8083 are never used as defaults.

### `tests/browser/cdp.mjs` (new)

DevTools Protocol driver over a raw WebSocket, with no third-party dependency. Provides navigation with load-event waiting, `evaluate` with JSON round-tripping and in-page error capture, viewport and mobile emulation, storage seeding with reload, typing, and screenshots.

Clicks matter most: `clickAt`/`clickSel`/`clickText` dispatch real `Input.dispatchMouseEvent` sequences at element coordinates, so they respect hit-testing, z-order and overlays. `clickText` re-queries by text on every call, because these controls re-render and index-based lookups go stale mid-suite. Every session collects console errors and failed requests; `cleanErrors()` filters known-blocked hosts.

### `tests/browser/suites/site.mjs` (new)

114 assertions over `home`, `work`, `apps`, `about`, `contact`, `privacy`, `404` and `moadon-alef`: JS errors, single `h1`, partial injection, canonical, meta description, `lang`, image `alt`, unnamed links. Then hero CTA variant and background consistency, the seven-app grid in A-Z order with every link resolving, header nav by real click, contact-form field labelling, mobile menu open with a named close control, and horizontal-overflow checks at 390, 768 and 1280.

Two pages carry documented exemptions rather than assertions bent to fit them: `404` has no canonical because it carries `noindex` and is not a real page, and `moadon-alef` is a standalone branded landing that injects its own footer partial and intentionally has no site header or nav.

### `tests/browser/suites/apps.mjs` (new)

76 assertions driving real flows: arena's room controls, toggles, bad join code and solo play; football-h2h and mario-kart's add-entry, save, undo, redo, export and date filters; gym-tracker's onboarding dismissal, all 9 nav views, exercise search and category filter; maptap-rivals' add-rival with persistence, score paste and export; rising-shows' search, shape tabs, numeric filters, sort and detail modal; trip-planner's sample load, three views, search, add-item form, undo/redo round trip and currency selector. Closes with a mobile sweep of all seven apps.

Four setup requirements are encoded here because getting them wrong produces convincing false failures, and each is documented where it is applied: collapsed sidebars hide most controls in football-h2h and mario-kart; gym-tracker's `#onboarding-modal` covers the nav at z-index 2000; rising-shows paginates at 24 rows so filter assertions read the app's own "N shows" total; and trip-planner correctly disables Days/Map until the trip has items and undo/redo until something has happened.

Storage clearing is per key followed by a reload, because these apps re-save debounced state and a bare `localStorage.clear()` can be undone by an autosave firing immediately after it.

### `tests/browser/README.md` (new)

How to run it, requirements, why it is separate from `npm test`, the configuration table, the suite contract (`run({base, cdpPort})` returning `[{name, pass, detail}]`), and the four false-failure traps written up so the next person does not rediscover them.

### `package.json`

Adds `test:browser`. The `test` script is unchanged, so CI behaviour is identical.
