### PR TITLE
fix(tests): skip rising-shows checks when its dataset is absent

### DIFF
--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -26,6 +26,21 @@ browser binary and takes minutes. Keeping them separate means CI stays fast and
 does not depend on a Chromium install, while this stays available locally and
 before a release.
 
+## Skipped checks
+
+A check reports `skip` when a precondition the repo cannot supply is missing.
+Skips are not failures and do not affect the exit code, but they are always
+listed so a partial run is never mistaken for a full one.
+
+The rising-shows dataset is the current case: `data.json` and
+`data-index.json` are gitignored and pulled from a GitHub release, so a clean
+clone has no shows and every finder assertion would fail for a reason that is
+not a bug. Those six checks skip with the fix in the message. To run them:
+
+```bash
+npm run fetch:rising-shows-data
+```
+
 ## Configuration
 
 | Variable | Default | Notes |

--- a/tests/browser/run.mjs
+++ b/tests/browser/run.mjs
@@ -82,9 +82,11 @@ try {
     results.push(...r);
     for (const x of r) {
       if (!x.pass) console.log(`  FAIL ${x.name}${x.detail ? '  [' + x.detail + ']' : ''}`);
+      else if (x.skipped) console.log(`  skip ${x.name}${x.detail ? '  [' + x.detail + ']' : ''}`);
     }
     const f = r.filter((x) => !x.pass).length;
-    console.log(`  ${r.length - f}/${r.length} passed`);
+    const sk = r.filter((x) => x.pass && x.skipped).length;
+    console.log(`  ${r.length - f - sk}/${r.length - sk} passed${sk ? `, ${sk} skipped` : ''}`);
   }
 } catch (e) {
   console.error('\nrunner error:', e.message);
@@ -94,8 +96,15 @@ try {
 }
 
 const failed = results.filter((r) => !r.pass);
+const skipped = results.filter((r) => r.pass && r.skipped);
+const ran = results.length - skipped.length;
 console.log(`\n${'='.repeat(52)}`);
-console.log(`BROWSER REGRESSION: ${results.length - failed.length}/${results.length} passed`);
+console.log(`BROWSER REGRESSION: ${ran - failed.length}/${ran} passed`
+  + (skipped.length ? `, ${skipped.length} skipped` : ''));
+if (skipped.length) {
+  console.log('\nSkipped (precondition missing, not a failure):');
+  for (const s of skipped) console.log(`  - ${s.name}${s.detail ? '  [' + s.detail + ']' : ''}`);
+}
 if (failed.length) {
   console.log('\nFailures:');
   for (const f of failed) console.log(`  - ${f.name}${f.detail ? '  [' + f.detail + ']' : ''}`);

--- a/tests/browser/suites/apps.mjs
+++ b/tests/browser/suites/apps.mjs
@@ -28,6 +28,9 @@ import {
 export async function run({ base, cdpPort }) {
   const R = [];
   const t = (name, pass, detail = '') => R.push({ name, pass: !!pass, detail });
+  // Skipped checks are not failures. Used when a precondition the repo cannot
+  // provide is missing, so a clean clone does not report phantom bugs.
+  const skip = (name, reason) => R.push({ name, pass: true, skipped: true, detail: reason });
 
   // Fresh page with storage genuinely emptied. The double navigation matters:
   // storage can only be cleared from a page on the target origin.
@@ -224,6 +227,22 @@ export async function run({ base, cdpPort }) {
 
     const baseRows = await rows();
     const baseTotal = await total();
+
+    // The show dataset is gitignored and pulled from a GitHub release, so a
+    // clean clone has no data and every finder assertion below would fail for a
+    // reason that is not a bug. Skip them with an actionable message instead.
+    if (baseRows === 0) {
+      const reason = 'no show data - run `npm run fetch:rising-shows-data`';
+      for (const check of ['results render', 'search narrows results', 'shape tab filters',
+        'min-seasons filter applies', 'sort changes result order', 'clicking a show opens its detail']) {
+        skip(`${A}: ${check}`, reason);
+      }
+      t(`${A}: app shell loads without data`, await textPresent(s, 'rising shows'));
+      t(`${A}: no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
+      await closePage(cdpPort, s);
+      throw { handled: true };
+    }
+
     t(`${A}: results render`, baseRows > 0, `${baseRows} rows of ${baseTotal}`);
 
     // Assert on the total, not the page of 24.
@@ -263,7 +282,11 @@ export async function run({ base, cdpPort }) {
 
     t(`${A}: no JS errors`, cleanErrors(s).length === 0, cleanErrors(s).slice(0, 2).join(' | '));
     await closePage(cdpPort, s);
-  } catch (e) { t('rising-shows: suite ran', false, String(e.message).slice(0, 140)); }
+  } catch (e) {
+    // `handled` means the block already recorded its own results and bailed
+    // out early (missing dataset), so there is nothing to report as a failure.
+    if (!(e && e.handled)) t('rising-shows: suite ran', false, String(e && e.message).slice(0, 140));
+  }
 
   /* ---------------------------- TRIP PLANNER ---------------------------- */
   try {


### PR DESCRIPTION
## TL;DR

Follow-up to #358. The browser suite reported **six false failures on any clean clone**, because the rising-shows dataset is gitignored and pulled from a GitHub release, so a fresh checkout ran the finder assertions against an empty app.

Those checks now report `skip` with the fix in the message, rather than `FAIL`.

Found by running the suite from a `git clone` instead of only from a working copy that happened to have the 111 MB of data sitting in it.

Verified both paths:

| Environment | Result |
| --- | --- |
| Working copy, data present | `190/190 passed`, exit 0 |
| Clean clone, no data | `185/185 passed, 6 skipped`, exit 0 |

---

### `tests/browser/suites/apps.mjs`

Adds a `skip(name, reason)` helper alongside `t()`, recording a result that counts as neither pass nor failure.

The rising-shows block now checks whether any rows rendered before asserting anything about filtering. With no rows, it skips the six data-dependent checks (`results render`, `search narrows results`, `shape tab filters`, `min-seasons filter applies`, `sort changes result order`, `clicking a show opens its detail`) with the message `no show data - run npm run fetch:rising-shows-data`, then still asserts the two things that remain meaningful without a dataset: that the app shell loads and that it throws no JS errors. An empty finder is a legitimate state to boot into, so that part stays a real check.

The early exit throws a sentinel rather than restructuring the block; the `catch` recognises it and stays silent, since results were already recorded.

### `tests/browser/run.mjs`

Skips are excluded from both the numerator and denominator, so a run with skips reads `185/185 passed, 6 skipped` rather than a misleading `185/191`. They are listed under their own heading, per suite and again in the summary, so a partial run cannot be misread as a full one. The exit code continues to depend only on real failures.

### `tests/browser/README.md`

New "Skipped checks" section explaining what a skip means, why the rising-shows dataset is the current case, and the one command that turns those six skips back into real assertions.
