### PR TITLE
ci: run the browser regression suite on pull requests

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,0 +1,50 @@
+name: browser tests
+
+# Runs the end-to-end browser suite on pull requests, so interaction and layout
+# regressions are caught before merge rather than by someone remembering to run
+# it locally.
+#
+# Separate from `tests` on purpose: that workflow is pure Node and finishes in
+# seconds, while this one needs a browser and takes minutes. Keeping them apart
+# means a slow browser run never delays the fast feedback from unit tests.
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  browser:
+    runs-on: ubuntu-latest
+    # The suite drives 15 pages with real timing; well above the ~4 min it takes,
+    # but low enough that a hung browser fails instead of burning a full hour.
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      # Chrome ships on the GitHub runner image. Resolve it rather than assuming
+      # a name, so an image change surfaces as a clear error here instead of a
+      # confusing timeout waiting for a debugging port that never opens.
+      - name: Resolve browser
+        run: |
+          set -e
+          for c in google-chrome google-chrome-stable chromium chromium-browser; do
+            if command -v "$c" >/dev/null 2>&1; then
+              echo "CHROME_BIN=$c" >> "$GITHUB_ENV"
+              echo "Using $c: $("$c" --version)"
+              exit 0
+            fi
+          done
+          echo "No Chrome/Chromium found on the runner image." >&2
+          exit 1
+
+      # The rising-shows dataset is gitignored and lives on a GitHub release, so
+      # it is absent here. The suite skips its six data-dependent checks and
+      # reports them; every other app is fully exercised. Downloading 111 MB on
+      # every pull request is not worth those six assertions.
+      - name: Run browser regression suite
+        run: npm run test:browser


### PR DESCRIPTION
## TL;DR

Runs the browser regression suite from #358 on every pull request. Until now it only ran when someone remembered to, which removes most of the value of having it.

This PR exercises the new workflow on itself, so the check appearing green below is the feature working rather than a claim about it.

---

### `.github/workflows/browser-tests.yml` (new)

Triggers on `pull_request` and `workflow_dispatch`. Not on `push`, so merging does not immediately re-run what the PR already proved.

Kept as a separate workflow rather than a step inside `tests`: that one is pure Node, needs no browser, and finishes in seconds. Folding a multi-minute browser run into it would delay the fast unit-test feedback on every push for no gain, and would make the whole check depend on a browser being present.

**Resolve browser step.** Chrome ships on the GitHub runner image, but the step probes for `google-chrome`, `google-chrome-stable`, `chromium` and `chromium-browser` and exports the first hit as `CHROME_BIN`, failing loudly if none exists. Assuming a binary name would turn a future runner-image change into a 20-minute timeout waiting for a debugging port that never opens, which is a much worse thing to debug than a one-line "No Chrome/Chromium found".

**`timeout-minutes: 20`** against a suite that takes about 4, so a hung browser fails in minutes rather than burning a full-hour default.

**rising-shows data.** The dataset is gitignored and lives on a GitHub release, so it is absent on the runner and the suite's six data-dependent finder checks skip with an explanatory message (the skip handling added in #359). Every other app is exercised in full. Downloading 111 MB on every pull request is not worth those six assertions.

Verified before pushing: YAML parses to the intended triggers and steps, the resolve-browser probe returns a working binary locally, and the suite passes 190/190 when driven through `CHROME_BIN` rather than the default binary name, which is the path CI actually takes.
