### PR TITLE
fix(site): give trip-planner a back-to-top and stop tall pages teleporting

### DIFF
--- a/apps/trip-planner/index.html
+++ b/apps/trip-planner/index.html
@@ -61,6 +61,7 @@
   <meta name="theme-color" content="#0e1116">
   <link rel="stylesheet" href="../../assets/css/main.css">
   <link rel="stylesheet" href="../../assets/css/sync-status.css">
+  <link rel="stylesheet" href="/assets/css/back-to-top.css">
   <link rel="stylesheet" href="css/styles.css?v=55">
 
   <!-- Google Analytics. Loaded async + defer so it never blocks first paint;
@@ -876,5 +877,6 @@
 
   <script src="js/trip-logic.js?v=33"></script>
   <script src="js/app.js?v=57"></script>
+  <script src="/assets/js/back-to-top.js" defer></script>
 </body>
 </html>

--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -51,6 +51,19 @@
   // frame) when a momentum scroll or URL-bar resize hovered right at the line.
   var SHOW_THRESHOLD = 400;
   var HIDE_THRESHOLD = 320;
+
+  // Longest distance we let the browser animate on its own. Chrome gives
+  // `behavior: 'smooth'` a roughly FIXED duration (~1.5s) no matter how far it
+  // has to travel, so on a very tall page the per-frame step grows without
+  // limit. The shows index is 535,000px tall: that works out at ~5,600px per
+  // frame against a 900px viewport, so every frame skips six whole screens and
+  // the result reads as an instant teleport rather than a scroll.
+  //
+  // Above this distance we jump instantly to MAX_SMOOTH_DISTANCE and let the
+  // browser animate only the final stretch. That keeps the per-frame step near
+  // what an ordinary long page produces (~130px/frame), so the arrival at the
+  // top looks the same everywhere instead of varying with page height.
+  var MAX_SMOOTH_DISTANCE = 12000;
   var EDGE_GAP = 16;       // px gap between the button and the modal rect edge
   var MODAL_Z_INDEX = 11001; // above apps' modal panels (z up to 11000)
   // While a finger/pointer is pressing the button (and briefly after release,
@@ -226,6 +239,25 @@
 
     // The scroll-to-top action, shared by the touch/pointer activation and the
     // mouse click path.
+    // Instantly close the distance down to MAX_SMOOTH_DISTANCE so the animation
+    // that follows covers a sane span. No-op when already close enough, or when
+    // the motion is going to be instant anyway.
+    function shortenLongJourney(el, smooth) {
+      if (!smooth) return;
+      if (el) {
+        if (el.scrollTop > MAX_SMOOTH_DISTANCE) el.scrollTop = MAX_SMOOTH_DISTANCE;
+        return;
+      }
+      var doc = document.documentElement;
+      var body = document.body;
+      var current = window.pageYOffset || doc.scrollTop || body.scrollTop || 0;
+      if (current <= MAX_SMOOTH_DISTANCE) return;
+      // Set every candidate: which one actually holds the offset varies by page,
+      // which is the same reason the scroll code below touches all three.
+      if (doc.scrollTop > MAX_SMOOTH_DISTANCE) doc.scrollTop = MAX_SMOOTH_DISTANCE;
+      if (body.scrollTop > MAX_SMOOTH_DISTANCE) body.scrollTop = MAX_SMOOTH_DISTANCE;
+    }
+
     function scrollToTop() {
       var behavior = prefersReducedMotion() ? 'auto' : 'smooth';
       // Recompute the context at activation time rather than trusting the
@@ -234,12 +266,14 @@
       // an invisible element while the page stays put.
       var target = findModalContainer();
       if (target) {
+        shortenLongJourney(target, behavior === 'smooth');
         if (typeof target.scrollTo === 'function') {
           target.scrollTo({ top: 0, behavior: behavior });
         } else {
           target.scrollTop = 0;
         }
       } else {
+        shortenLongJourney(null, behavior === 'smooth');
         window.scrollTo({ top: 0, behavior: behavior });
         // The window helper reports a scrolled state from the document element
         // OR the body (some app states make BODY the scroller, e.g. fh2h with


### PR DESCRIPTION
## TL;DR

Two back-to-top fixes found by auditing it across 40+ view and viewport combinations.

1. **trip-planner had no back-to-top at all** - the only app missing it, despite one of the longest scrolling views.
2. **The shows index teleported instead of scrolling.** Chrome gives `behavior: 'smooth'` a roughly fixed ~1.5s duration no matter how far it travels, so the per-frame step scales with page height. That page is 535,383px tall, which works out at **~5,626px per frame against a 900px viewport - six whole screens skipped per frame**. Technically animating, visually a teleport.

Measured on production, this was the only affected page:

| Page | Height | px/frame | Reads as |
| --- | --- | --- | --- |
| home | 2,798 | 20 | smooth |
| mario-kart | 3,779 | 30 | smooth |
| privacy | 8,389 | 79 | smooth |
| exercises index | 11,121 | 108 | smooth |
| **shows index** | **535,383** | **5,626** | **teleport** |

---

### `assets/js/back-to-top.js`

Adds `MAX_SMOOTH_DISTANCE` (12,000px) and `shortenLongJourney()`. When the distance to the top exceeds that, the offset is set instantly to 12,000px and the browser animates only the final stretch. That puts the per-frame step at roughly 130px, the same range an ordinary long page already produces, so arrival at the top looks identical everywhere rather than varying with page height.

Applied to both scroll paths. For the window path it sets `documentElement` and `body` rather than assuming which one holds the offset, matching what the surrounding code already does for the same reason. Guarded on `smooth`, so the reduced-motion path is untouched and still jumps instantly.

12,000px is chosen so the shortened journey lands in the same per-frame range as the tallest page that already reads correctly (exercises index at 11,121px / 108px per frame).

Nothing changes below 12,000px: the function returns early, so every modal, app view and marketing page keeps its existing motion. Verified rather than assumed - the rising-shows modal still animates 1,011 to 0 over 30 steps with a 134px max step, unchanged.

### `apps/trip-planner/index.html`

Adds the `back-to-top.css` and `back-to-top.js` tags, matching how the other six apps include them. All seven apps now have it.

---

Verified after the change, with a cold browser profile (a stale cache made the first run of this fix look like a no-op):

| Page | From | Max step | Result |
| --- | --- | --- | --- |
| shows index | 12,000 (shortened from 534,483) | 569px | readable |
| exercises index | 10,221 | 485px | readable |
| privacy | 7,489 | 370px | readable |
| home | 1,898 | 183px | readable |
| trip-planner (new) | 1,191 | 141px | readable |

Max step is now below the 900px viewport everywhere, so no frame skips a full screen. Reduced motion still jumps instantly; the modal container path is unchanged; short scrolls are unaffected.
