### PR TITLE
perf(rising-shows): split the 4.8 MB shows index into paginated letter pages

### DIFF
--- a/apps/rising-shows/scripts/build-show-pages.js
+++ b/apps/rising-shows/scripts/build-show-pages.js
@@ -11,7 +11,9 @@ const path = require('path');
 
 const { showPath } = require('./slugify.js');
 const { renderShowPage, computeDominantShape } = require('./render-show-page.js');
-const { renderShowsIndex } = require('./render-shows-index.js');
+const {
+  renderShowsIndex, renderShowsLetterPage, groupByLetter, letterPages,
+} = require('./render-shows-index.js');
 const {
   renderShapeHub,
   renderGapHub,
@@ -106,10 +108,37 @@ function main() {
     }
   }
 
+  // The browse index: a small /shows/ hub plus paginated per-letter pages.
+  // Every show appears on exactly one letter page, which matters because the
+  // sitemap lists only the curated top ~2,000 and these pages are the sole
+  // crawl path to the other ~32,500.
+  const indexEntries = series.map(toIndexEntry);
   fs.writeFileSync(
     path.join(SHOWS_DIR, 'index.html'),
-    renderShowsIndex(series.map(toIndexEntry), data.builtAt),
+    renderShowsIndex(indexEntries, data.builtAt),
   );
+
+  const letterGroups = groupByLetter(indexEntries);
+  const browsePages = letterPages(letterGroups);
+  let listedShows = 0;
+  for (const page of browsePages) {
+    // page.path is site-absolute (/apps/rising-shows/shows/letter/s/2/); the
+    // segments below SHOWS_DIR are what gets created on disk.
+    const rel = page.path.replace('/apps/rising-shows/shows/', '').replace(/\/$/, '');
+    const dir = path.join(SHOWS_DIR, ...rel.split('/'));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'index.html'),
+      renderShowsLetterPage({ ...page, groups: letterGroups, builtAt: data.builtAt }),
+    );
+    listedShows += page.items.length;
+  }
+  // Guard the property that matters: a split that silently drops shows would
+  // orphan them from every crawl path, and nothing else here would notice.
+  if (listedShows !== indexEntries.length) {
+    throw new Error(`browse pages list ${listedShows} shows but there are ${indexEntries.length}; every show must stay reachable`);
+  }
+  console.log(`[build-show-pages] browse index · ${letterGroups.size} letters · ${browsePages.length} pages · ${listedShows} shows listed`);
 
   // Per-shape topic hubs. Safe to nest inside SHOWS_DIR: show directories
   // always end in -tt<digits>, so "shape" can never collide with one.
@@ -128,7 +157,10 @@ function main() {
   fs.writeFileSync(path.join(gapDir, 'index.html'), renderGapHub(gapHubShows, data.builtAt));
   console.log(`[build-show-pages] gap hub /${GAP_HUB_SLUG}/ · ${gapHubShows.length} shows · gap ${gapHubShows[0] ? gapHubShows[0].gap : 0} down to ${gapHubShows.length ? gapHubShows.at(-1).gap : 0}`);
 
-  fs.writeFileSync(SITEMAP_FILE, renderShowsSitemap(sitemapSeries.map(toIndexEntry), data.builtAt, HUB_SLUGS));
+  fs.writeFileSync(SITEMAP_FILE, renderShowsSitemap(
+    sitemapSeries.map(toIndexEntry), data.builtAt, HUB_SLUGS,
+    browsePages.map((p) => p.path),
+  ));
   console.log(`[build-show-pages] sitemap curated to top ${sitemapSeries.length} of ${series.length} series by votes; the rest stay reachable for app users but carry noindex,follow`);
 
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);

--- a/apps/rising-shows/scripts/render-shows-index.js
+++ b/apps/rising-shows/scripts/render-shows-index.js
@@ -5,10 +5,41 @@ const { escapeHtml, SITE } = require('./render-show-page.js');
 const { renderHubNav } = require('./render-shape-hub.js');
 const { renderMoreFooter } = require('./render-footer.js');
 
-// Single A-Z browse index of every show. This is the crawler's primary
-// entry point into the per-show pages — Google follows the links here to
-// discover and rank each /shows/{slug}-{tt}/ page.
-function renderShowsIndex(series, builtAt) {
+// The crawler's primary entry point into the per-show pages. The sitemap
+// deliberately lists only the top ~2,000 shows by votes, so these browse pages
+// are the ONLY crawl path to the other ~32,500 - splitting them must never drop
+// a show.
+//
+// It used to be one page holding every show: 4.79 MB of HTML, 34,601 links and
+// 535,383px tall. That is far past what a browser lays out comfortably, past
+// the "few thousand links" a single page should carry, and so tall that a
+// back-to-top click skipped six screens per animation frame.
+//
+// Now /shows/ is a small hub listing each letter, and the shows themselves live
+// on paginated per-letter pages. PER_PAGE is set so a page stays near the
+// 12,000px that back-to-top.js can animate without shortening the journey - at
+// roughly 26px per row, 500 rows lands about there.
+const PER_PAGE = 500;
+
+// Sits under /shows/ alongside /shows/shape/. Safe from collisions for the same
+// reason: show directories always end in -tt<digits>, so a show can never be
+// named "letter".
+const LETTER_BASE = '/apps/rising-shows/shows/letter';
+
+function letterSlug(letter) {
+  return letter === '#' ? 'other' : letter.toLowerCase();
+}
+
+// Page 1 lives at the letter root; later pages get a /2/, /3/ suffix. Keeping
+// page 1 un-suffixed means the hub's links stay the canonical ones.
+function letterPath(letter, pageNum = 1) {
+  const base = `${LETTER_BASE}/${letterSlug(letter)}/`;
+  return pageNum <= 1 ? base : `${base}${pageNum}/`;
+}
+
+// Groups every series under its display letter, each group sorted by title.
+// Returns a Map so insertion order (A-Z then #) is preserved for callers.
+function groupByLetter(series) {
   const sorted = [...series].sort((a, b) => sortTitle(a.title).localeCompare(sortTitle(b.title)));
   const groups = new Map();
   for (const s of sorted) {
@@ -16,25 +47,48 @@ function renderShowsIndex(series, builtAt) {
     if (!groups.has(letter)) groups.set(letter, []);
     groups.get(letter).push(s);
   }
-  const letters = [...groups.keys()];
+  return groups;
+}
 
-  const canonical = `${SITE}/apps/rising-shows/shows/`;
-  const description = `Browse all ${sorted.length.toLocaleString()} TV shows in Rising Shows. Episode-by-episode IMDb ratings and season-shape analysis for every series.`;
+function pageCount(total) {
+  return Math.max(1, Math.ceil(total / PER_PAGE));
+}
 
+// Every browse page that should exist, as { letter, pageNum, path, items }.
+// The build script writes these and the sitemap lists them.
+function letterPages(groups) {
+  const out = [];
+  for (const [letter, items] of groups) {
+    const pages = pageCount(items.length);
+    for (let n = 1; n <= pages; n++) {
+      out.push({
+        letter,
+        pageNum: n,
+        totalPages: pages,
+        path: letterPath(letter, n),
+        items: items.slice((n - 1) * PER_PAGE, n * PER_PAGE),
+        letterTotal: items.length,
+      });
+    }
+  }
+  return out;
+}
+
+function shell({ title, description, canonical, breadcrumbs, head = '', body }) {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>All Shows | Rising Shows — Browse Every TV Series by Episode Ratings</title>
+  <title>${escapeHtml(title)}</title>
   <meta name="description" content="${escapeHtml(description)}">
   <meta name="author" content="Shevato LLC">
   <meta name="robots" content="index, follow, max-image-preview:large">
   <meta name="theme-color" content="#0b0d12">
   <meta name="color-scheme" content="dark">
   <link rel="canonical" href="${canonical}">
-
-  <meta property="og:title" content="All Shows | Rising Shows">
+${head}
+  <meta property="og:title" content="${escapeHtml(title)}">
   <meta property="og:description" content="${escapeHtml(description)}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="${canonical}">
@@ -46,10 +100,7 @@ function renderShowsIndex(series, builtAt) {
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       "itemListElement": [
-        { "@type": "ListItem", "position": 1, "name": "Home", "item": "${SITE}/home.html" },
-        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "${SITE}/apps.html" },
-        { "@type": "ListItem", "position": 3, "name": "Rising Shows", "item": "${SITE}/apps/rising-shows/" },
-        { "@type": "ListItem", "position": 4, "name": "All shows", "item": "${canonical}" }
+${breadcrumbs.map((b, i) => `        { "@type": "ListItem", "position": ${i + 1}, "name": ${JSON.stringify(b.name)}, "item": "${b.item}" }`).join(',\n')}
       ]
     }
   </script>
@@ -70,50 +121,13 @@ function renderShowsIndex(series, builtAt) {
     </a>
     <nav class="page-nav" aria-label="Primary">
       <a href="/apps/rising-shows/">Explorer</a>
-      <a href="/apps/rising-shows/shows/" aria-current="page">All shows</a>
+      <a href="/apps/rising-shows/shows/"${canonical.endsWith('/shows/') ? ' aria-current="page"' : ''}>All shows</a>
       <a href="/apps">More apps</a>
     </nav>
   </header>
 
   <main id="main" class="shows-index">
-    <nav class="crumbs" aria-label="Breadcrumb">
-      <a href="/home">Shevato</a> ›
-      <a href="/apps/rising-shows/">Rising Shows</a> ›
-      <span>All shows</span>
-    </nav>
-
-    <header class="index-hero">
-      <h1>All shows</h1>
-      <p class="lede">Every series in Rising Shows (${sorted.length.toLocaleString()} shows). Each links to an episode-by-episode rating page with season-shape analysis.</p>
-    </header>
-
-    <nav class="shape-nav" aria-label="Browse by shape">
-      <span class="shape-nav-label">Browse by shape</span>
-      ${renderHubNav()}
-    </nav>
-
-    <nav class="alpha-jump" aria-label="Jump to letter">
-      ${letters.map((l) => `<a href="#letter-${escapeHtml(l)}">${escapeHtml(l)}</a>`).join('')}
-    </nav>
-
-    ${letters
-      .map((l) => {
-        const items = groups.get(l);
-        return `<section class="alpha-group" id="letter-${escapeHtml(l)}">
-      <h2>${escapeHtml(l)}</h2>
-      <ul class="shows-list">
-        ${items
-          .map((s) => {
-            const slug = showPath(s.title, s.seriesId);
-            return `<li><a href="/apps/rising-shows/shows/${slug}/">${escapeHtml(s.title)}${s.year ? ` <span class="muted">(${s.year})</span>` : ''}</a></li>`;
-          })
-          .join('\n        ')}
-      </ul>
-    </section>`;
-      })
-      .join('\n    ')}
-
-    <p class="index-footer">Refreshed ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : 'weekly'}. Source: <a href="https://datasets.imdbws.com/" rel="noopener" target="_blank">IMDb datasets</a>.</p>
+${body}
   </main>
 
   ${renderMoreFooter()}
@@ -121,6 +135,135 @@ function renderShowsIndex(series, builtAt) {
 </body>
 </html>
 `;
+}
+
+// The A-Z strip. Rendered on the hub and on every letter page so a crawler (or
+// a reader) can move between letters without going back to the hub first.
+function alphaNav(groups, currentLetter) {
+  return `<nav class="alpha-jump" aria-label="Browse by letter">
+      ${[...groups.keys()]
+    .map((l) => {
+      const current = l === currentLetter;
+      return `<a href="${letterPath(l)}"${current ? ' aria-current="page"' : ''}>${escapeHtml(l)}</a>`;
+    })
+    .join('')}
+    </nav>`;
+}
+
+function renderShowsIndex(series, builtAt) {
+  const groups = groupByLetter(series);
+  const total = series.length;
+  const canonical = `${SITE}/apps/rising-shows/shows/`;
+  const description = `Browse all ${total.toLocaleString()} TV shows in Rising Shows by first letter. Episode-by-episode IMDb ratings and season-shape analysis for every series.`;
+
+  const body = `    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/home">Shevato</a> ›
+      <a href="/apps/rising-shows/">Rising Shows</a> ›
+      <span>All shows</span>
+    </nav>
+
+    <header class="index-hero">
+      <h1>All shows</h1>
+      <p class="lede">Every series in Rising Shows (${total.toLocaleString()} shows), grouped by first letter. Each links to an episode-by-episode rating page with season-shape analysis.</p>
+    </header>
+
+    <nav class="shape-nav" aria-label="Browse by shape">
+      <span class="shape-nav-label">Browse by shape</span>
+      ${renderHubNav()}
+    </nav>
+
+    ${alphaNav(groups, null)}
+
+    <ul class="shows-list letter-directory">
+      ${[...groups.entries()]
+    .map(([letter, items]) => {
+      const pages = pageCount(items.length);
+      return `<li><a href="${letterPath(letter)}">${escapeHtml(letter)} <span class="muted">(${items.length.toLocaleString()} show${items.length === 1 ? '' : 's'}${pages > 1 ? `, ${pages} pages` : ''})</span></a></li>`;
+    })
+    .join('\n      ')}
+    </ul>
+
+    <p class="index-footer">Refreshed ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : 'weekly'}. Source: <a href="https://datasets.imdbws.com/" rel="noopener" target="_blank">IMDb datasets</a>.</p>`;
+
+  return shell({
+    title: 'All Shows | Rising Shows — Browse Every TV Series by Episode Ratings',
+    description,
+    canonical,
+    breadcrumbs: [
+      { name: 'Home', item: `${SITE}/home.html` },
+      { name: 'Apps', item: `${SITE}/apps.html` },
+      { name: 'Rising Shows', item: `${SITE}/apps/rising-shows/` },
+      { name: 'All shows', item: canonical },
+    ],
+    body,
+  });
+}
+
+function renderShowsLetterPage({ letter, items, pageNum, totalPages, letterTotal, groups, builtAt }) {
+  const canonical = `${SITE}${letterPath(letter, pageNum)}`;
+  const label = letter === '#' ? 'numbers and symbols' : `the letter ${letter}`;
+  const pageSuffix = totalPages > 1 ? ` (page ${pageNum} of ${totalPages})` : '';
+  const description = `TV shows starting with ${label}${pageSuffix}: ${letterTotal.toLocaleString()} series with episode-by-episode IMDb ratings and season-shape analysis.`;
+
+  // Self-canonical on every page, with prev/next as the relationship hint.
+  // Pointing later pages at page 1 would tell Google the shows listed here do
+  // not need crawling, which is the opposite of what this page exists for.
+  const head = [
+    pageNum > 1 ? `  <link rel="prev" href="${SITE}${letterPath(letter, pageNum - 1)}">` : '',
+    pageNum < totalPages ? `  <link rel="next" href="${SITE}${letterPath(letter, pageNum + 1)}">` : '',
+  ].filter(Boolean).join('\n');
+
+  const pager = totalPages > 1
+    ? `<nav class="pager" aria-label="Pagination">
+      ${pageNum > 1 ? `<a rel="prev" href="${letterPath(letter, pageNum - 1)}">← Previous</a>` : ''}
+      <span class="pager-status">Page ${pageNum} of ${totalPages}</span>
+      ${pageNum < totalPages ? `<a rel="next" href="${letterPath(letter, pageNum + 1)}">Next →</a>` : ''}
+    </nav>`
+    : '';
+
+  const body = `    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/home">Shevato</a> ›
+      <a href="/apps/rising-shows/">Rising Shows</a> ›
+      <a href="/apps/rising-shows/shows/">All shows</a> ›
+      <span>${escapeHtml(letter)}${pageSuffix}</span>
+    </nav>
+
+    <header class="index-hero">
+      <h1>Shows starting with ${escapeHtml(letter)}${pageSuffix}</h1>
+      <p class="lede">${letterTotal.toLocaleString()} series. Each links to an episode-by-episode rating page with season-shape analysis.</p>
+    </header>
+
+    ${alphaNav(groups, letter)}
+
+    ${pager}
+
+    <ul class="shows-list">
+      ${items
+    .map((s) => {
+      const slug = showPath(s.title, s.seriesId);
+      return `<li><a href="/apps/rising-shows/shows/${slug}/">${escapeHtml(s.title)}${s.year ? ` <span class="muted">(${s.year})</span>` : ''}</a></li>`;
+    })
+    .join('\n      ')}
+    </ul>
+
+    ${pager}
+
+    <p class="index-footer">Refreshed ${builtAt ? new Date(builtAt).toISOString().slice(0, 10) : 'weekly'}. Source: <a href="https://datasets.imdbws.com/" rel="noopener" target="_blank">IMDb datasets</a>.</p>`;
+
+  return shell({
+    title: `Shows starting with ${letter}${pageSuffix} | Rising Shows`,
+    description,
+    canonical,
+    head,
+    breadcrumbs: [
+      { name: 'Home', item: `${SITE}/home.html` },
+      { name: 'Apps', item: `${SITE}/apps.html` },
+      { name: 'Rising Shows', item: `${SITE}/apps/rising-shows/` },
+      { name: 'All shows', item: `${SITE}/apps/rising-shows/shows/` },
+      { name: `${letter}${pageSuffix}`, item: canonical },
+    ],
+    body,
+  });
 }
 
 function sortTitle(s) {
@@ -132,4 +275,14 @@ function firstLetter(s) {
   return /[A-Z]/.test(c) ? c : '#';
 }
 
-module.exports = { renderShowsIndex, sortTitle, firstLetter };
+module.exports = {
+  renderShowsIndex,
+  renderShowsLetterPage,
+  groupByLetter,
+  letterPages,
+  letterPath,
+  letterSlug,
+  sortTitle,
+  firstLetter,
+  PER_PAGE,
+};

--- a/apps/rising-shows/scripts/render-sitemap.js
+++ b/apps/rising-shows/scripts/render-sitemap.js
@@ -9,7 +9,12 @@ const { SITE } = require('./render-show-page.js');
 // spends its crawl budget on shows people actually search for instead
 // of parking 30k+ long-tail pages in "Discovered - currently not
 // indexed" (GSC, 2026-07). The rest stay reachable via the A-Z index.
-function renderShowsSitemap(series, builtAt, hubSlugs = []) {
+//
+// `browsePaths` are the per-letter browse pages. They are listed because they
+// ARE the crawl path to the ~32,500 shows the sitemap omits: /shows/ alone only
+// links to the letter roots, so without these the later pages of each letter
+// would sit two hops from anything a crawler is told about.
+function renderShowsSitemap(series, builtAt, hubSlugs = [], browsePaths = []) {
   const lastmod = builtAt ? new Date(builtAt).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10);
   const urls = [
     `  <url>
@@ -18,6 +23,12 @@ function renderShowsSitemap(series, builtAt, hubSlugs = []) {
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>`,
+    ...browsePaths.map((p) => `  <url>
+    <loc>${SITE}${p}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>`),
     // The topic hubs (13 shapes plus the gap hub) sit above the individual
     // shows: they're the landing pages the show pages link back into.
     ...hubSlugs.map((slug) => `  <url>

--- a/apps/rising-shows/tests/render-sitemap.test.js
+++ b/apps/rising-shows/tests/render-sitemap.test.js
@@ -4,7 +4,10 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const { renderShowsSitemap, selectSitemapSeries } = require('../scripts/render-sitemap.js');
-const { renderShowsIndex, sortTitle, firstLetter } = require('../scripts/render-shows-index.js');
+const {
+  renderShowsIndex, renderShowsLetterPage, groupByLetter, letterPages, letterPath,
+  sortTitle, firstLetter, PER_PAGE,
+} = require('../scripts/render-shows-index.js');
 const { SHAPE_SLUGS, HUB_SLUGS, GAP_HUB_SLUG, hubPath } = require('../scripts/render-shape-hub.js');
 
 const SERIES = [
@@ -102,14 +105,71 @@ test('firstLetter buckets non-letters into "#"', () => {
   assert.equal(firstLetter(''), '#');
 });
 
-test('renderShowsIndex emits the count and links to every series', () => {
+test('renderShowsIndex is a letter hub, not a list of every show', () => {
   const html = renderShowsIndex(SERIES, '2026-05-18T00:00:00.000Z');
   assert.ok(html.includes('3 shows'));
-  assert.ok(html.includes('/apps/rising-shows/shows/breaking-bad-tt0903747/'));
-  assert.ok(html.includes('/apps/rising-shows/shows/game-of-thrones-tt0944947/'));
-  // "The Office" is alphabetized under O, not T
-  assert.ok(html.includes('id="letter-O"'));
-  assert.ok(html.includes('/apps/rising-shows/shows/the-office-tt0386676/'));
+  // The hub links to letter pages...
+  assert.ok(html.includes('href="/apps/rising-shows/shows/letter/b/"'));
+  assert.ok(html.includes('href="/apps/rising-shows/shows/letter/g/"'));
+  // ..."The Office" is alphabetized under O, not T...
+  assert.ok(html.includes('href="/apps/rising-shows/shows/letter/o/"'));
+  // ...and it must NOT carry the show links itself. All 34,586 on one page is
+  // what made this 4.79 MB and 535,383px tall.
+  assert.ok(!html.includes('/apps/rising-shows/shows/breaking-bad-tt0903747/'));
+  assert.ok(!html.includes('/apps/rising-shows/shows/the-office-tt0386676/'));
+});
+
+test('letter pages carry the shows, and every show lands on exactly one', () => {
+  const groups = groupByLetter(SERIES);
+  const pages = letterPages(groups);
+  const seen = [];
+  for (const page of pages) {
+    const html = renderShowsLetterPage({ ...page, groups, builtAt: '2026-05-18T00:00:00.000Z' });
+    for (const s of page.items) seen.push(s.seriesId);
+    assert.ok(html.includes(`<h1>Shows starting with ${page.letter}`));
+    // Self-canonical: pointing later pages at page 1 would tell Google the shows
+    // listed there need no crawling, which is the opposite of the point.
+    assert.ok(html.includes(`<link rel="canonical" href="https://shevato.com${page.path}">`));
+  }
+  assert.deepEqual(seen.sort(), SERIES.map((s) => s.seriesId).sort());
+});
+
+test('a letter longer than PER_PAGE splits into linked pages', () => {
+  const many = Array.from({ length: PER_PAGE + 5 }, (_, i) => ({
+    seriesId: `tt${String(i).padStart(7, '0')}`,
+    title: `Zulu Show ${String(i).padStart(4, '0')}`,
+    year: 2020,
+  }));
+  const groups = groupByLetter(many);
+  const pages = letterPages(groups);
+  assert.equal(pages.length, 2);
+  assert.equal(pages[0].items.length, PER_PAGE);
+  assert.equal(pages[1].items.length, 5);
+  assert.equal(pages[0].path, '/apps/rising-shows/shows/letter/z/');
+  assert.equal(pages[1].path, '/apps/rising-shows/shows/letter/z/2/');
+
+  const first = renderShowsLetterPage({ ...pages[0], groups, builtAt: null });
+  const second = renderShowsLetterPage({ ...pages[1], groups, builtAt: null });
+  assert.ok(first.includes(`<link rel="next" href="https://shevato.com${pages[1].path}">`));
+  assert.ok(!first.includes('rel="prev"'));
+  assert.ok(second.includes(`<link rel="prev" href="https://shevato.com${pages[0].path}">`));
+  assert.ok(!second.includes('rel="next"'));
+});
+
+test('non-letter titles get a URL-safe "other" slug rather than a bare #', () => {
+  assert.equal(letterPath('#'), '/apps/rising-shows/shows/letter/other/');
+  assert.equal(letterPath('#', 3), '/apps/rising-shows/shows/letter/other/3/');
+});
+
+test('the sitemap lists the browse pages, not just the curated shows', () => {
+  const browsePaths = ['/apps/rising-shows/shows/letter/b/', '/apps/rising-shows/shows/letter/b/2/'];
+  const xml = renderShowsSitemap(SERIES, '2026-05-18T00:00:00.000Z', [], browsePaths);
+  for (const p of browsePaths) {
+    assert.ok(xml.includes(`<loc>https://shevato.com${p}</loc>`));
+  }
+  // Omitting them would leave every page past a letter's first sitting two hops
+  // from anything the sitemap mentions.
+  assert.ok(xml.includes('<loc>https://shevato.com/apps/rising-shows/shows/</loc>'));
 });
 
 test('renderShowsIndex carries a browse strip to all 13 shape hubs plus the gap hub', () => {


### PR DESCRIPTION
## TL;DR

`/apps/rising-shows/shows/` held every show on a single page: **4.79 MB of HTML, 34,601 links, 535,383px tall**. It is now a 12 KB hub listing each letter, with the shows on 83 paginated per-letter pages.

| | Before | After |
| --- | --- | --- |
| `/shows/` size | 4.79 MB | **12 KB** |
| `/shows/` height | 535,383px | **1,406px** |
| Links on one page | 34,601 | 69 (hub) / 500 (letter page) |
| Largest page | 4.79 MB | **77 KB** |

All 34,586 shows verified still reachable: 34,586 directories on disk, 34,586 linked from letter pages, zero orphans.

Only build scripts and tests change. The pages themselves are gitignored and regenerated by `build:site` on every deploy.

---

### Why this needed care

The sitemap deliberately lists only the curated top 2,000 shows by votes, to keep Google's crawl budget off 30k+ long-tail pages. That makes these browse pages **the only crawl path to the other 32,500 shows**. A split that silently dropped some would orphan them from search entirely, and nothing else in the build would notice.

So the invariant is enforced in two places, both verified to actually fire by injecting a split that drops one show per page:

- `build-show-pages.js` throws `browse pages list 34530 shows but there are 34586` and fails the deploy.
- A unit test asserts every seeded show lands on exactly one page.

### `apps/rising-shows/scripts/render-shows-index.js`

`renderShowsIndex` now renders a hub: the A-Z strip, the shape nav, and one link per letter with its show count and page count. It no longer emits show links at all.

New `renderShowsLetterPage` renders one page of one letter. New helpers `groupByLetter`, `letterPages`, `letterPath` and `letterSlug` compute the split; the shared page shell was extracted so the hub and letter pages cannot drift apart in head tags, header, footer or analytics.

`PER_PAGE` is 500. At roughly 26px per row that lands each page near 13,000px, which keeps it inside the distance `back-to-top.js` animates without shortening the journey (the fix in #361). 1,000 per page would have produced 26,000px pages and re-created a milder version of the original problem.

Pages live at `/shows/letter/<x>/` with `/2/`, `/3/` for the rest. Page 1 is unsuffixed so the hub's links are the canonical ones. `#` becomes `other` for a URL-safe slug. The path sits under `/shows/` alongside `/shows/shape/`, safe from collisions for the reason already documented there: show directories always end in `-tt<digits>`.

Every page is self-canonical with `rel=prev`/`rel=next` as the relationship hint. Pointing later pages at page 1 would tell Google the shows listed there need no crawling, which is the opposite of what these pages exist for.

### `apps/rising-shows/scripts/build-show-pages.js`

Writes the hub, then each letter page, then throws if the pages do not account for every show. Passes the browse-page paths to the sitemap renderer. Logs `27 letters · 83 pages · 34586 shows listed`.

### `apps/rising-shows/scripts/render-sitemap.js`

Takes a fourth `browsePaths` argument and emits the 83 letter pages at priority 0.6. Without them, every page past a letter's first would sit two hops from anything the sitemap mentions. Sitemap goes from 2,015 to 2,098 URLs.

### `apps/rising-shows/tests/render-sitemap.test.js`

The old `renderShowsIndex emits the count and links to every series` test guarded the behaviour this PR deliberately removes, so it is rewritten to assert the hub links to letter pages and specifically does **not** carry show links. Four tests added: every show lands on exactly one page; a letter over `PER_PAGE` splits with correct prev/next wiring; `#` maps to `other`; the sitemap lists browse pages.
