### PR TITLE
fix: full-stack review - quota race, sync data loss, flaky-network resilience

### DIFF
--- a/apps/arena/index.html
+++ b/apps/arena/index.html
@@ -180,9 +180,9 @@
               <label class="lobby-field" data-game-type="globe-drop">
                 <span>Difficulty</span>
                 <select id="create-globe-drop-difficulty">
-                  <option value="easy">Easy &mdash; name + country + continent + region</option>
-                  <option value="medium" selected>Medium &mdash; name + country + continent</option>
-                  <option value="hard">Hard &mdash; name + country only</option>
+                  <option value="easy">Easy: name + country + continent + region</option>
+                  <option value="medium" selected>Medium: name + country + continent</option>
+                  <option value="hard">Hard: name + country only</option>
                 </select>
               </label>
               <label class="lobby-field" data-game-type="globe-drop">

--- a/apps/arena/js/globe-drop-locations.js
+++ b/apps/arena/js/globe-drop-locations.js
@@ -241,7 +241,16 @@
         _countryMetaPromise = (async () => {
             try {
                 const res = await fetch(COUNTRIES_DATA_URL, { cache: 'force-cache' });
-                if (!res.ok) return {};
+                // A failed load must not stay cached: this promise is stored
+                // before it settles, so returning {} while leaving it in place
+                // pinned "no country metadata" (difficulty scoring, area and
+                // population hints) for the whole session after one flaky
+                // request. Clearing the cache slot means the next round simply
+                // retries.
+                if (!res.ok) {
+                    _countryMetaPromise = null;
+                    return {};
+                }
                 const raw = await res.json();
                 const idx = {};
                 for (const c of (Array.isArray(raw) ? raw : [])) {
@@ -266,6 +275,7 @@
                 }
                 return idx;
             } catch (_) {
+                _countryMetaPromise = null;
                 return {};
             }
         })();

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -1043,7 +1043,7 @@
                 <section class="section" id="measurements-empty" hidden>
                     <div class="empty-state">
                         <i class="fas fa-ruler-vertical"></i>
-                        <p>No measurements yet — log your first entry to start tracking trends.</p>
+                        <p>No measurements yet. Log your first entry to start tracking trends.</p>
                     </div>
                 </section>
 

--- a/apps/gym-tracker/js/app.js
+++ b/apps/gym-tracker/js/app.js
@@ -248,7 +248,7 @@ class GymTrackerApp {
             console.error(`Failed to load ${label}:`, error);
             // Lazily import-free toast — helpers.showToast is already in scope.
             try {
-                showToast(`Could not load ${label} — that section reset to empty.`, 'error', 5000);
+                showToast(`Could not load ${label}, so that section reset to empty.`, 'error', 5000);
             } catch (_) { /* toast layer not ready yet on first paint */ }
             return fallback;
         }
@@ -437,7 +437,7 @@ class GymTrackerApp {
                 // the top of the page, not wherever they had scrolled to.
                 window.scrollTo(0, 0);
                 if (this.programs.length === 0) {
-                    showToast('Create a program first — then pick it to start a workout.', 'info', 4000);
+                    showToast('Create a program first, then pick it to start a workout.', 'info', 4000);
                     this.viewControllers.programs?.createProgramFromElsewhere();
                 } else {
                     this.showView('workout');

--- a/apps/gym-tracker/js/utils/sync-status.js
+++ b/apps/gym-tracker/js/utils/sync-status.js
@@ -85,7 +85,7 @@ function updateBanner(prev, next) {
         bannerEl.hidden = false;
         bannerEl.dataset.state = 'offline';
         bannerEl.dataset.fading = 'false';
-        bannerEl.textContent = 'You’re offline — changes saved on this device';
+        bannerEl.textContent = 'You’re offline. Changes are saved on this device';
         return;
     }
 
@@ -95,7 +95,7 @@ function updateBanner(prev, next) {
         bannerEl.hidden = false;
         bannerEl.dataset.state = 'synced';
         bannerEl.dataset.fading = 'false';
-        bannerEl.textContent = 'Back online — synced';
+        bannerEl.textContent = 'Back online. Synced';
         recoveryTimer = setTimeout(() => {
             if (!bannerEl) return;
             bannerEl.dataset.fading = 'true';

--- a/apps/gym-tracker/js/views/calendar-view.js
+++ b/apps/gym-tracker/js/views/calendar-view.js
@@ -319,7 +319,7 @@ class CalendarView {
                     </div>
                     ${scheduledHTML}
                     <p class="calendar-detail-empty">
-                        <i class="fas fa-bed"></i> Rest day — nothing recorded for this date.
+                        <i class="fas fa-bed"></i> Rest day. Nothing recorded for this date.
                     </p>
                 </div>
             `;

--- a/apps/gym-tracker/js/views/settings-view.js
+++ b/apps/gym-tracker/js/views/settings-view.js
@@ -276,7 +276,7 @@ class SettingsView {
         const confirmed = await showConfirmModal({
             title: 'Delete cloud data',
             message: 'Wipe the gym tracker data stored in the cloud for this account. Your local data stays on this device.',
-            warning: 'This cannot be undone — other devices that sync will also lose this data on their next sync.',
+            warning: 'This cannot be undone. Other devices that sync will also lose this data on their next sync.',
             confirmText: 'Delete from cloud',
             cancelText: 'Cancel',
             isDangerous: true,
@@ -289,7 +289,7 @@ class SettingsView {
             showToast('Cloud data deleted. Sign out + back in to re-sync.', 'success', 5000);
         } catch (error) {
             console.error('Failed to delete cloud data:', error);
-            showToast('Could not delete cloud data — check your connection.', 'error', 5000);
+            showToast('Could not delete cloud data. Check your connection.', 'error', 5000);
         }
     }
 

--- a/apps/mario-kart/index.html
+++ b/apps/mario-kart/index.html
@@ -28,7 +28,7 @@
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:alt" content="Mario Kart Race Tracker — Mario Kart 8 Deluxe and Mario Kart World" />
+    <meta property="og:image:alt" content="Mario Kart Race Tracker for Mario Kart 8 Deluxe and Mario Kart World" />
     <meta property="og:site_name" content="Shevato" />
     <meta property="og:locale" content="en_US" />
 

--- a/apps/mario-kart/js/coursePicker.js
+++ b/apps/mario-kart/js/coursePicker.js
@@ -356,7 +356,7 @@
                     '<div class="cp-filters"></div>' +
                     '<span class="cp-count" hidden></span>' +
                 '</div>' +
-                '<div class="cp-hint">Search by <b>course</b>, <b>cup</b>, <b>game</b>, or <b>abbreviation</b> — try &ldquo;DK&rdquo;, &ldquo;Mushroom Cup&rdquo;, or &ldquo;MK8&rdquo;.</div>' +
+                '<div class="cp-hint">Search by <b>course</b>, <b>cup</b>, <b>game</b>, or <b>abbreviation</b>. Try &ldquo;DK&rdquo;, &ldquo;Mushroom Cup&rdquo;, or &ldquo;MK8&rdquo;.</div>' +
                 '<div class="cp-recent-searches" hidden></div>' +
                 '<div class="cp-modal-body">' +
                     '<div class="cp-results" role="listbox" aria-label="Courses"></div>' +

--- a/apps/rising-shows/js/app.js
+++ b/apps/rising-shows/js/app.js
@@ -762,7 +762,17 @@ function loadExtrasInBackground() {
   fetch('data/show-modal-extras.json')
     .then((res) => (res && res.ok ? res.json() : null))
     .then((extras) => {
-      if (!extras) return;
+      // The guard flag is set BEFORE the fetch settles (deliberately: it is
+      // what stops a second boot-time call racing the first), so a failure
+      // must hand the flag back or one flaky request means no cast strip and
+      // no episode titles for the rest of the session. Modal open retries via
+      // the loadExtrasInBackground() call there, i.e. exactly when the data
+      // is next wanted, so a dead network costs one failed request per open
+      // rather than a background retry loop.
+      if (!extras) {
+        extrasLoaded = false;
+        return;
+      }
       // Kept so applyDetail can enrich a show's episodes whenever its detail
       // file arrives. Detail and extras now load independently and in either
       // order, so whichever lands second does the joining.
@@ -794,7 +804,12 @@ function loadExtrasInBackground() {
         }
       } catch (e) { /* refresh is best-effort; the data is attached either way */ }
     })
-    .catch(() => { /* extras are optional: modals degrade, grid is unaffected */ });
+    .catch(() => {
+      // Network-level failure: hand the guard flag back (see above) so the
+      // next modal open retries. Extras stay optional either way: modals
+      // degrade, the grid is unaffected.
+      extrasLoaded = false;
+    });
 }
 
 /**
@@ -829,8 +844,14 @@ const detailCache = new Map();
 function ensureDetail(seriesId) {
   if (!seriesId) return Promise.resolve(null);
   if (detailCache.has(seriesId)) return detailCache.get(seriesId);
-  // An unsplit dataset already carries episodes; nothing to fetch.
-  const anyLoaded = dataset.matches.some((m) => m.seriesId === seriesId && Array.isArray(m.episodes));
+  // An unsplit dataset already carries episodes; nothing to fetch. The
+  // non-empty check matters: after a FAILED fetch the render paths coerce
+  // `m.episodes = []` so they can draw a degraded modal, and treating that
+  // empty array as "loaded" made this guard cache a resolved-null and defeat
+  // the retry the failure eviction just paid for. A genuinely loaded season
+  // always has at least one rated episode, so empty means "not loaded".
+  const anyLoaded = dataset.matches.some((m) => m.seriesId === seriesId
+    && Array.isArray(m.episodes) && m.episodes.length > 0);
   if (anyLoaded) {
     const done = Promise.resolve(null);
     detailCache.set(seriesId, done);
@@ -839,7 +860,15 @@ function ensureDetail(seriesId) {
   const p = fetch(`data/detail/${encodeURIComponent(seriesId)}.json`)
     .then((res) => (res && res.ok ? res.json() : null))
     .then((detail) => {
-      if (!detail || !detail.seasons) return null;
+      // A failed or empty fetch must NOT stay cached: the promise below is
+      // stored before it settles, so without this eviction one flaky request
+      // pinned "no episodes" for the rest of the session. Evicting means the
+      // next modal open simply retries; a repeat failure costs one request
+      // per open, which is bounded and beats permanently degraded detail.
+      if (!detail || !detail.seasons) {
+        detailCache.delete(seriesId);
+        return null;
+      }
       for (const m of dataset.matches) {
         if (m.seriesId !== seriesId) continue;
         const sRec = detail.seasons[String(m.season)];
@@ -854,7 +883,11 @@ function ensureDetail(seriesId) {
       }
       return detail;
     })
-    .catch(() => null);
+    .catch(() => {
+      // Same eviction on a network-level failure (offline, aborted).
+      detailCache.delete(seriesId);
+      return null;
+    });
   detailCache.set(seriesId, p);
   return p;
 }
@@ -1373,6 +1406,14 @@ function aboveImdbBadge(m) {
 // --- curve drawing (shared) ---
 
 function drawCurve(svg, episodes, W, H, opts) {
+  // No episodes, no curve. On the healthy path every caller has episode
+  // arrays by the time it draws, but a failed detail fetch leaves them
+  // undefined/empty, and the path math below indexes points[0] and
+  // points[length-1]: with zero points that is a TypeError which aborted
+  // openShowModal entirely, so a traveller on a flaky network got NO modal
+  // instead of a modal with blank sparklines. An empty svg degrades; a
+  // throw here takes the whole render down with it.
+  if (!Array.isArray(episodes) || episodes.length === 0) return;
   // Charts with hover dots need a small inset so the dots don't get
   // clipped at the viewport edge. Sparklines without dots (the list-view
   // row and the show-modal per-season mini-spark) pass padX=0 so the
@@ -1441,7 +1482,9 @@ function drawCurveAnnotations(svg, episodes, shapes) {
 
   const W = 600, H = 180;
   const padXLeft = 36, padXRight = 4, padY = 6;
-  const n = episodes.length;
+  // Same guard as drawCurve: episodes may be missing after a failed detail
+  // fetch, and annotations over no curve are meaningless anyway.
+  const n = Array.isArray(episodes) ? episodes.length : 0;
   if (n < 2) return;
   const ratings = episodes.map((e) => e.rating);
   const lo = Math.max(0, Math.min(...ratings) - 0.3);
@@ -1810,6 +1853,11 @@ function drawSeasonOverlay(svg, seasons, W, H) {
   // Wipe previous content — this SVG is reused across openShowModal calls.
   while (svg.firstChild) svg.removeChild(svg.firstChild);
   if (!seasons.length) return [];
+  // A failed detail fetch leaves every season's episodes empty; lo/hi would
+  // stay at +/-Infinity and the axis gridlines render with NaN coordinates
+  // (one console error per attribute). An empty overlay says the same thing
+  // more quietly, and the modal open retries the fetch.
+  if (!seasons.some((s) => Array.isArray(s.episodes) && s.episodes.length > 0)) return [];
 
   let lo = Infinity, hi = -Infinity;
   for (const s of seasons) for (const e of s.episodes) {
@@ -2035,7 +2083,7 @@ function drawCompareChart(svg, seriesEntries, W, H) {
       dot.style.left = `${xPct(x)}%`;
       dot.style.top = `${yPct(y)}%`;
       dot.style.background = color;
-      dot.title = `${title} — S${s.season}: avg ${s.avgRating.toFixed(1)}`;
+      dot.title = `${title}, S${s.season}: avg ${s.avgRating.toFixed(1)}`;
       overlay.appendChild(dot);
       // For a lone series, call out each season's value above its dot.
       if (single) {
@@ -2221,6 +2269,8 @@ function goBackModalView() {
 // await resolves instantly on a repeat open (memoised in detailCache) and on
 // an unsplit dataset. Callers are fire-and-forget and do not need the promise.
 async function openModal(m, opts = {}) {
+  // Extras retry point, same as openShowModal; no-op when already loaded.
+  loadExtrasInBackground();
   await ensureDetail(m.seriesId);
   if (!Array.isArray(m.episodes)) m.episodes = [];
   pushModalHistory(opts, `season:${m.seriesId}:${m.season}`);
@@ -2453,6 +2503,9 @@ async function openShowModal(seriesId, opts = {}) {
     .sort((a, b) => a.season - b.season);
   if (seasons.length === 0) return;
 
+  // The extras loader hands its guard flag back on failure; this is its retry
+  // point. A no-op in the common case where the boot-time load succeeded.
+  loadExtrasInBackground();
   // Awaited before any rendering so every season row has its episodes. One
   // fetch covers the whole series, and it is memoised, so reopening is free.
   await ensureDetail(seriesId);

--- a/apps/rising-shows/js/kometa.js
+++ b/apps/rising-shows/js/kometa.js
@@ -286,7 +286,7 @@
     const isYaml = f.filename.endsWith('.yml');
     const kind = state.outputMode === 'ids' ? 'IMDb IDs' : (state.outputMode === 'overlays' ? 'overlay shape buckets' : 'series');
     els.outputMeta.innerHTML = `
-      <span><strong>${f.filename}</strong> — ${f.metaCount.toLocaleString()} ${f.metaUnit}</span>
+      <span><strong>${f.filename}</strong>: ${f.metaCount.toLocaleString()} ${f.metaUnit}</span>
       <span>${isYaml ? 'Kometa YAML' : 'plain text'} • confidence ≥ ${state.confidence.toFixed(2)}</span>
     `;
   }

--- a/assets/css/back-to-top.css
+++ b/assets/css/back-to-top.css
@@ -33,8 +33,13 @@
 .back-to-top:active,
 .back-to-top:hover:active {
   position: fixed;
-  bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
-  right: calc(1.25rem + env(safe-area-inset-right, 0px));
+  /* px, not rem: this button renders on every page of the site, and the two
+     page families disagree on the root font size (main.css pages compute
+     14.67px, the generated static pages keep the 16px default), so a rem
+     offset put the button 18.33px from the corner on one family and 20px on
+     the other. One shared component gets one position. */
+  bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+  right: calc(20px + env(safe-area-inset-right, 0px));
   z-index: 9000;
   display: -webkit-flex;
   display: flex;

--- a/netlify/functions/lib/blob-cas.mjs
+++ b/netlify/functions/lib/blob-cas.mjs
@@ -1,0 +1,50 @@
+// Etag-conditional (compare-and-swap) updates for a shared JSON blob.
+// Used by BOTH functions' quota counters (tp-places and tp-assist).
+//
+// WHY THIS EXISTS: the quota counters are shared read-modify-write state, and
+// Netlify runs one function instance per request. A plain get + setJSON lets
+// two parallel batches read the same counters, and whichever write lands last
+// erases the other's reservation. Serial requests never see it; an abuser who
+// simply fires requests CONCURRENTLY walks through every cap, including the
+// monthly one that bounds real money. Netlify Blobs supports conditional
+// writes (@netlify/blobs >= 8.1: onlyIfMatch / onlyIfNew), which turns the
+// reservation into an atomic claim: the write lands only if the blob is
+// unchanged since it was read, and a lost race retries against fresh counters.
+//
+// The store is injected so node:test can drive genuine write collisions with
+// an in-memory etag store and no Blobs context.
+
+// Retries bound the work one request can be forced to do: burning through five
+// CAS rounds means many writers are fighting over one small blob, which only
+// happens under exactly the load the quota exists to stop, so the caller
+// fails closed (429) rather than reserving optimistically, which would be the
+// original race with extra steps.
+export const MAX_CAS_ATTEMPTS = 5;
+
+// updateUsage(store, key, compute) -> { ok, result }
+//
+// compute(usage) receives the freshest counters and returns { write, result }:
+//   write   the new usage object to store, or null/undefined to store nothing
+//           (a rejected reservation reads the counters but must not move them)
+//   result  passed through to the caller untouched
+//
+// Returns { ok: true, result } once the write lands (or none was needed), or
+// { ok: false } when every attempt lost its race. compute may run several
+// times, so it must be pure math over its argument; the quota helpers are.
+export async function updateUsage(store, key, compute) {
+  for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+    const cur = await store.getWithMetadata(key, { type: 'json' });
+    const usage = (cur && cur.data && typeof cur.data === 'object') ? cur.data : {};
+    const { write, result } = compute(usage);
+    if (!write) return { ok: true, result };
+    // A blob that does not exist yet has no etag to match; the equivalent
+    // claim is "still missing", so the first-ever write races on onlyIfNew.
+    const condition = (cur && cur.etag) ? { onlyIfMatch: cur.etag } : { onlyIfNew: true };
+    const res = await store.setJSON(key, write, condition);
+    // Conditional setJSON resolves { modified: false } when the precondition
+    // failed. Anything else (true, or an implementation that returns nothing)
+    // means the write landed.
+    if (!res || res.modified !== false) return { ok: true, result };
+  }
+  return { ok: false };
+}

--- a/netlify/functions/lib/tp-http.mjs
+++ b/netlify/functions/lib/tp-http.mjs
@@ -1,0 +1,36 @@
+// Request guards shared by every tp-* function. These were copy-pasted into
+// each function; a divergence here (say, one function forgetting the referer
+// fallback) would be an inconsistency an attacker could probe for, so there is
+// exactly one definition.
+
+// Only our own site and local dev. The referer fallback matters: some browsers
+// omit Origin on same-origin POSTs from older code paths, and a same-site
+// request must not be rejected for it.
+export function originAllowed(req) {
+  const src = req.headers.get('origin') || req.headers.get('referer') || '';
+  if (!src) return false;
+  try {
+    const u = new URL(src);
+    if (u.protocol === 'https:' && u.hostname === 'shevato.com') return true;
+    if (u.hostname === 'localhost' || u.hostname === '127.0.0.1') return true;
+    return false;
+  } catch { return false; }
+}
+
+export function json(obj, status) {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// Upstream calls get a deadline so a hung provider fails fast. The value must
+// sit UNDER Netlify's 10s synchronous-function ceiling: past that the platform
+// kills the invocation and the browser receives a gateway error page instead
+// of our JSON, so the UI's specific "try again / use Tier 1" handling never
+// runs. 9s leaves ~1s for our own error path; measured flash-lite turns run
+// 2-5s, so this only fires on a genuinely hung upstream.
+export const UPSTREAM_TIMEOUT_MS = 9000;
+export function upstreamSignal(ms = UPSTREAM_TIMEOUT_MS) {
+  return AbortSignal.timeout(ms);
+}

--- a/netlify/functions/lib/tp-places-usage.mjs
+++ b/netlify/functions/lib/tp-places-usage.mjs
@@ -1,49 +1,5 @@
-// Etag-conditional (compare-and-swap) updates for the tp-places usage blob.
-//
-// WHY THIS EXISTS: the quota counters are shared read-modify-write state, and
-// Netlify runs one function instance per request. A plain get + setJSON lets
-// two parallel batches read the same counters, and whichever write lands last
-// erases the other's reservation. Serial requests never see it; an abuser who
-// simply fires requests CONCURRENTLY walks through every cap, including the
-// monthly one that bounds real money. Netlify Blobs supports conditional
-// writes (@netlify/blobs >= 8.1: onlyIfMatch / onlyIfNew), which turns the
-// reservation into an atomic claim: the write lands only if the blob is
-// unchanged since it was read, and a lost race retries against fresh counters.
-//
-// The store is injected so node:test can drive genuine write collisions with
-// an in-memory etag store and no Blobs context.
-
-// Retries bound the work one request can be forced to do: burning through five
-// CAS rounds means many writers are fighting over one small blob, which only
-// happens under exactly the load the quota exists to stop, so the caller
-// fails closed (429) rather than reserving optimistically, which would be the
-// original race with extra steps.
-export const MAX_CAS_ATTEMPTS = 5;
-
-// updateUsage(store, key, compute) -> { ok, result }
-//
-// compute(usage) receives the freshest counters and returns { write, result }:
-//   write   the new usage object to store, or null/undefined to store nothing
-//           (a rejected reservation reads the counters but must not move them)
-//   result  passed through to the caller untouched
-//
-// Returns { ok: true, result } once the write lands (or none was needed), or
-// { ok: false } when every attempt lost its race. compute may run several
-// times, so it must be pure math over its argument; the quota helpers are.
-export async function updateUsage(store, key, compute) {
-  for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
-    const cur = await store.getWithMetadata(key, { type: 'json' });
-    const usage = (cur && cur.data && typeof cur.data === 'object') ? cur.data : {};
-    const { write, result } = compute(usage);
-    if (!write) return { ok: true, result };
-    // A blob that does not exist yet has no etag to match; the equivalent
-    // claim is "still missing", so the first-ever write races on onlyIfNew.
-    const condition = (cur && cur.etag) ? { onlyIfMatch: cur.etag } : { onlyIfNew: true };
-    const res = await store.setJSON(key, write, condition);
-    // Conditional setJSON resolves { modified: false } when the precondition
-    // failed. Anything else (true, or an implementation that returns nothing)
-    // means the write landed.
-    if (!res || res.modified !== false) return { ok: true, result };
-  }
-  return { ok: false };
-}
+// The CAS helper started life here, scoped to tp-places, and moved to
+// blob-cas.mjs when tp-assist picked up the same reservation pattern (its
+// plain get + setJSON had the exact race documented there). This re-export
+// keeps existing imports and the test file's name meaningful.
+export { updateUsage, MAX_CAS_ATTEMPTS } from './blob-cas.mjs';

--- a/netlify/functions/tests/tp-assist-cas.test.mjs
+++ b/netlify/functions/tests/tp-assist-cas.test.mjs
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { updateUsage } from '../lib/blob-cas.mjs';
+import { checkQuota, DEFAULT_LIMITS } from '../lib/tp-assist-quota.mjs';
+
+// tp-assist's reservation used to be a plain get + setJSON: two parallel
+// requests read the same counters, both passed checkQuota, and the later write
+// erased the earlier reservation, so a concurrent burst overran the daily
+// caps. The handler now composes checkQuota with the same etag-CAS helper
+// tp-places uses; these tests pin that composition (the handler's step 5,
+// reproduced verbatim in reserve() below) against deterministic collisions.
+
+function memStore() {
+  let seq = 0;
+  const map = new Map();
+  const store = {
+    gate: null,
+    async getWithMetadata(key) {
+      if (store.gate) await store.gate();
+      const e = map.get(key);
+      return e ? { data: JSON.parse(e.json), etag: e.etag, metadata: {} } : null;
+    },
+    async setJSON(key, value, cond = {}) {
+      const e = map.get(key);
+      if (cond.onlyIfNew && e) return { modified: false };
+      if (cond.onlyIfMatch !== undefined && (!e || e.etag !== cond.onlyIfMatch)) return { modified: false };
+      seq += 1;
+      const etag = '"e' + seq + '"';
+      map.set(key, { json: JSON.stringify(value), etag });
+      return { modified: true, etag };
+    },
+    peek(key) {
+      const e = map.get(key);
+      return e ? JSON.parse(e.json) : null;
+    },
+  };
+  return store;
+}
+
+// Holds every reader until n have arrived, so all n concurrent reservations
+// read the SAME counters and etag before any write: the interleaving the CAS
+// exists to survive, made deterministic. Retry rounds pass through freely.
+function collisionGate(n) {
+  const waiting = [];
+  let armed = true;
+  return () => {
+    if (!armed) return Promise.resolve();
+    return new Promise(resolve => {
+      waiting.push(resolve);
+      if (waiting.length === n) {
+        armed = false;
+        waiting.forEach(r => r());
+      }
+    });
+  };
+}
+
+const NOW = 1780000000000;
+
+// The handler's reservation, verbatim.
+function reserve(store, clientId) {
+  return updateUsage(store, 'usage', usage => {
+    const q = checkQuota(usage, clientId, NOW);
+    return { write: q.allowed ? q.usage : null, result: q };
+  });
+}
+
+test('colliding assist reservations all land: none is erased by the race', async () => {
+  const store = memStore();
+  store.gate = collisionGate(4);
+  const results = await Promise.all(['a', 'b', 'c', 'd'].map(id => reserve(store, id)));
+  assert.ok(results.every(r => r.ok && r.result.allowed));
+  // Every reservation must be visible in the final counters. Under the old
+  // plain write this ended at 1, with three grants unaccounted for.
+  assert.equal(store.peek('usage').globalDay, 4);
+});
+
+test('a client at its hourly cap is rejected without moving the counters', async () => {
+  const store = memStore();
+  for (let i = 0; i < DEFAULT_LIMITS.perClientHour; i++) {
+    const r = await reserve(store, 'greedy');
+    assert.ok(r.ok && r.result.allowed);
+  }
+  const before = store.peek('usage');
+  const rejected = await reserve(store, 'greedy');
+  assert.ok(rejected.ok);
+  assert.equal(rejected.result.allowed, false);
+  assert.equal(rejected.result.scope, 'client_hour');
+  // A rejection reads but must not write.
+  assert.deepEqual(store.peek('usage'), before);
+});
+
+test('concurrent burst cannot overrun the cap; every grant is accounted for', async () => {
+  const store = memStore();
+  const n = DEFAULT_LIMITS.perClientHour + 5;
+  store.gate = collisionGate(n);
+  const results = await Promise.all(Array.from({ length: n }, () => reserve(store, 'burst')));
+  const granted = results.filter(r => r.ok && r.result.allowed).length;
+  // Some writers exhaust their CAS retries against this much deliberate
+  // contention and fail closed (a 429 in the handler) rather than being
+  // granted optimistically. That is the designed trade: the invariants are
+  // that the cap is never overrun, and that every grant that was handed out
+  // is visible in the landed counters, with none erased by the race.
+  assert.ok(granted <= DEFAULT_LIMITS.perClientHour, `granted ${granted}`);
+  assert.ok(granted > 0, 'contention must not starve everyone');
+  assert.equal(store.peek('usage').clientHour.burst, granted);
+  assert.equal(store.peek('usage').globalDay, granted);
+});

--- a/netlify/functions/tp-assist.mjs
+++ b/netlify/functions/tp-assist.mjs
@@ -17,6 +17,8 @@
 // linked to any other project leaves this endpoint on 503.
 
 import { checkQuota } from './lib/tp-assist-quota.mjs';
+import { updateUsage } from './lib/blob-cas.mjs';
+import { originAllowed, json, upstreamSignal } from './lib/tp-http.mjs';
 // SINGLE SOURCE OF TRUTH for the assistant contract. This used to be a
 // hand-copied SYSTEM_PREAMBLE, which meant Tier 3 silently kept the old shape
 // every time the client contract changed. trip-logic.js is a classic script
@@ -129,15 +131,21 @@ export default async function handler(req) {
   if (!geminiKey) return json({ error: 'not_configured' }, 503);
 
   // (5) Quota check against the usage blob; rejected calls never hit upstream.
+  // The reservation is an etag-conditional write (lib/blob-cas.mjs), the same
+  // pattern tp-places uses: a plain get + setJSON let two PARALLEL requests
+  // read the same counters and the later write erase the earlier reservation,
+  // so a concurrent burst walked straight through the daily caps. A rejection
+  // reads the counters but writes nothing; sustained CAS contention fails
+  // closed, because many writers fighting over this one blob is exactly the
+  // load the quota exists to stop.
   const now = Date.now();
-  const usage = (await store.get(USAGE_KEY, { type: 'json' })) || {};
-  const q = checkQuota(usage, clamped.clientId, now);
+  const reserved = await updateUsage(store, USAGE_KEY, usage => {
+    const q = checkQuota(usage, clamped.clientId, now);
+    return { write: q.allowed ? q.usage : null, result: q };
+  });
+  if (!reserved.ok) return json({ error: 'quota_exceeded', scope: 'contention' }, 429);
+  const q = reserved.result;
   if (!q.allowed) return json({ error: 'quota_exceeded', scope: q.scope }, 429);
-
-  // Reserve the slot BEFORE the upstream call so a burst of parallel requests
-  // can't overrun the limit; the minor cost is that a failed upstream still
-  // counts against the quota.
-  await store.setJSON(USAGE_KEY, q.usage);
 
   // (6) Build the system instruction server-side from the pinned constant plus
   // the client-supplied trip context (messages were already role-filtered).
@@ -163,17 +171,6 @@ export default async function handler(req) {
 
   // (9) Success.
   return json({ reply }, 200);
-}
-
-function originAllowed(req) {
-  const src = req.headers.get('origin') || req.headers.get('referer') || '';
-  if (!src) return false;
-  try {
-    const u = new URL(src);
-    if (u.protocol === 'https:' && u.hostname === 'shevato.com') return true;
-    if (u.hostname === 'localhost' || u.hostname === '127.0.0.1') return true;
-    return false;
-  } catch { return false; }
 }
 
 function clampBody(body) {
@@ -233,6 +230,11 @@ async function callGemini(key, sys, contents) {
       contents,
       generationConfig: GENERATION_CONFIG,
     }),
+    // A hung upstream must fail inside Netlify's 10s ceiling so the browser
+    // gets our JSON error (and its "try again / Tier 1" fallback UI), not a
+    // platform gateway page. The abort surfaces as a TypeError from fetch and
+    // takes the same 502 path as any other upstream failure.
+    signal: upstreamSignal(),
   });
   if (!res.ok) {
     // function logs only; body helps diagnose, key never logged
@@ -254,11 +256,4 @@ async function callGemini(key, sys, contents) {
     console.error('tp-assist gemini truncated', JSON.stringify(data.usageMetadata || {}));
   }
   return out.text;
-}
-
-function json(obj, status) {
-  return new Response(JSON.stringify(obj), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  });
 }

--- a/netlify/functions/tp-places.mjs
+++ b/netlify/functions/tp-places.mjs
@@ -48,7 +48,8 @@
 
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { checkQuota, releaseQuota, DEFAULT_LIMITS, OWNER_LIMITS } from './lib/tp-places-quota.mjs';
-import { updateUsage } from './lib/tp-places-usage.mjs';
+import { updateUsage } from './lib/blob-cas.mjs';
+import { originAllowed, json, upstreamSignal } from './lib/tp-http.mjs';
 import { resolveQueries } from './lib/tp-places-lookup.mjs';
 import { isGenericQuery } from './lib/tp-places-match.mjs';
 
@@ -176,17 +177,6 @@ export default async function handler(req) {
   return json({ results, attribution: ATTRIBUTION }, 200);
 }
 
-function originAllowed(req) {
-  const src = req.headers.get('origin') || req.headers.get('referer') || '';
-  if (!src) return false;
-  try {
-    const u = new URL(src);
-    if (u.protocol === 'https:' && u.hostname === 'shevato.com') return true;
-    if (u.hostname === 'localhost' || u.hostname === '127.0.0.1') return true;
-    return false;
-  } catch { return false; }
-}
-
 // Exported for the unit tests. Duplicate queries collapse to one entry: a day
 // plan often proposes the same konbini or hotel bar twice, and every duplicate
 // would otherwise be a second billed lookup within the same request.
@@ -238,6 +228,10 @@ async function findPlaceId(key, query) {
       'X-Goog-FieldMask': SEARCH_FIELD_MASK,
     },
     body: JSON.stringify({ textQuery: query, pageSize: 1, languageCode: 'en' }),
+  
+    // Deadline under Netlify's 10s ceiling; see lib/tp-http.mjs. One hung
+    // lookup in a batch then costs 9s, not the whole invocation.
+    signal: upstreamSignal(),
   });
   if (!res.ok) {
     // function logs only; body helps diagnose, key never logged
@@ -254,6 +248,7 @@ async function findPlaceId(key, query) {
 async function fetchDetails(key, placeId) {
   const res = await fetch(PLACES_HOST + '/places/' + encodeURIComponent(placeId) + '?languageCode=en', {
     headers: { 'X-Goog-Api-Key': key, 'X-Goog-FieldMask': DETAILS_FIELD_MASK },
+    signal: upstreamSignal(),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => '');
@@ -274,11 +269,4 @@ async function fetchDetails(key, placeId) {
     lat: typeof loc.latitude === 'number' ? loc.latitude : null,
     lon: typeof loc.longitude === 'number' ? loc.longitude : null,
   };
-}
-
-function json(obj, status) {
-  return new Response(JSON.stringify(obj), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  });
 }

--- a/sync-system/storage-sync-robust.js
+++ b/sync-system/storage-sync-robust.js
@@ -27,7 +27,8 @@ import {
   sanitiseForFirestore,
   estimatePayloadBytes,
   sameKeySet,
-  decideRemoteChange
+  decideRemoteChange,
+  requeueFailedWrites
 } from './sync-helpers.mjs';
 
 // Configuration
@@ -702,10 +703,10 @@ class StorageSyncManager {
         state.retryCount++;
         console.log(`🔄 Retrying write flush (${state.retryCount}/${MAX_RETRY_ATTEMPTS})`);
         
-        // Re-queue failed writes
-        for (const [key, value] of writes) {
-          queue.set(key, value);
-        }
+        // Re-queue failed writes, but never OVER a newer entry the user made
+        // while this flush was in flight; see requeueFailedWrites for the
+        // data-loss race this guards against.
+        requeueFailedWrites(queue, writes);
         
         // Retry with exponential backoff
         setTimeout(() => this.flushWrites(state), RETRY_DELAY_MS * state.retryCount);

--- a/sync-system/sync-helpers.mjs
+++ b/sync-system/sync-helpers.mjs
@@ -207,3 +207,34 @@ export function decideRemoteChange(localRev, remoteInfo, lastRemoteUpdate) {
   if ((remoteInfo?.rev || 0) > (localRev.rev || 0)) return 'apply';
   return 'skip-older';
 }
+
+/**
+ * Re-queues the writes of a FAILED flush without clobbering newer work.
+ *
+ * flushWrites copies the queue and clears it before the network call, so a
+ * user edit made while the flush is in flight lands in the (now empty) queue
+ * as a higher revision of the same key. Blindly re-queuing the failed copy
+ * replaced that newer entry with the older one, and because localRevisions
+ * already records the newer hash, the newer value was never re-sent: silent
+ * data loss on the next successful flush. The failed copy is therefore only
+ * restored where no entry exists, or where the queued entry is OLDER (a rev
+ * the failed batch itself superseded, which cannot happen today but costs
+ * nothing to defend against).
+ *
+ * Pure so it is unit-testable outside the browser module.
+ *
+ * @param {Map<string, {rev?: number}>} queue live queue (mutated in place)
+ * @param {Map<string, {rev?: number}>} failedWrites the batch that failed
+ * @returns {number} how many entries were restored
+ */
+export function requeueFailedWrites(queue, failedWrites) {
+  let restored = 0;
+  for (const [key, value] of failedWrites) {
+    const queued = queue.get(key);
+    if (!queued || (queued.rev || 0) < (value.rev || 0)) {
+      queue.set(key, value);
+      restored++;
+    }
+  }
+  return restored;
+}

--- a/sync-system/tests/sync-helpers.test.mjs
+++ b/sync-system/tests/sync-helpers.test.mjs
@@ -15,7 +15,8 @@ import {
   sanitiseForFirestore,
   estimatePayloadBytes,
   sameKeySet,
-  decideRemoteChange
+  decideRemoteChange,
+  requeueFailedWrites
 } from '../sync-helpers.mjs';
 
 /* -------------------- hashValue -------------------- */
@@ -300,4 +301,43 @@ test('decideRemoteChange: missing remote.hash skips the dedupe path', () => {
         500
     );
     assert.equal(verdict, 'apply');
+});
+
+// ---------------------------------------------------------------------------
+// requeueFailedWrites: the failed-flush data-loss race
+// ---------------------------------------------------------------------------
+
+test('requeueFailedWrites restores failed writes into an empty queue', () => {
+    const queue = new Map();
+    const failed = new Map([
+        ['k1', { rev: 3, value: 'a' }],
+        ['k2', { rev: 1, value: 'b' }],
+    ]);
+    const restored = requeueFailedWrites(queue, failed);
+    assert.equal(restored, 2);
+    assert.equal(queue.get('k1').rev, 3);
+    assert.equal(queue.get('k2').rev, 1);
+});
+
+test('requeueFailedWrites never clobbers a NEWER write made during the flush', () => {
+    // THE RACE: flushWrites copied rev 3 and cleared the queue; while the
+    // network call was failing, the user edited the same key again and
+    // queueWrite stored rev 4. The old code re-queued rev 3 over it, and
+    // since localRevisions already held rev 4's hash, rev 4 was never sent.
+    const queue = new Map([['k1', { rev: 4, value: 'newer' }]]);
+    const failed = new Map([['k1', { rev: 3, value: 'older' }]]);
+    const restored = requeueFailedWrites(queue, failed);
+    assert.equal(restored, 0);
+    assert.equal(queue.get('k1').rev, 4);
+    assert.equal(queue.get('k1').value, 'newer');
+});
+
+test('requeueFailedWrites replaces an older queued entry and tolerates missing revs', () => {
+    const queue = new Map([['k1', { rev: 2, value: 'stale' }], ['k2', { value: 'no-rev' }]]);
+    const failed = new Map([['k1', { rev: 5, value: 'fresh' }], ['k2', { rev: 1, value: 'revved' }]]);
+    const restored = requeueFailedWrites(queue, failed);
+    assert.equal(restored, 2);
+    assert.equal(queue.get('k1').value, 'fresh');
+    // A queued entry with no rev counts as rev 0 and yields to any revved one.
+    assert.equal(queue.get('k2').value, 'revved');
 });


### PR DESCRIPTION
## TL;DR

Full-stack review round: one quota race in the assistant backend, one silent-data-loss race in the sync layer, a four-defect chain that broke Rising Shows' show modal on flaky networks (including an outright crash), a cached-failure bug in Arena, a cross-page positioning inconsistency in the back-to-top button, and small copy tightening across four apps. Six new unit tests pin the two races. 2,297 unit tests and 190 browser assertions pass; all fixes were also proven behaviourally with driven-browser probes.

---

### Backend

**`netlify/functions/tp-assist.mjs`** - The quota reservation was a plain `get` + `setJSON`: two parallel requests read the same counters, both passed `checkQuota`, and the later write erased the earlier reservation, so a concurrent burst walked straight through the daily caps. The reservation now goes through the same etag-conditional CAS helper tp-places already used, failing closed (429 `scope: contention`) if every CAS attempt loses its race. The Gemini call also gets a 9s `AbortSignal` deadline, and the local `originAllowed`/`json` duplicates are replaced by the shared module.

**`netlify/functions/lib/blob-cas.mjs`** (new) - `updateUsage`/`MAX_CAS_ATTEMPTS` moved here verbatim from `tp-places-usage.mjs`, since the helper was always store-agnostic and both functions now need it.

**`netlify/functions/lib/tp-places-usage.mjs`** - Now a documented two-line re-export of blob-cas, so existing imports and the test file's name keep working.

**`netlify/functions/lib/tp-http.mjs`** (new) - The `originAllowed` and `json` guards both functions had hand-copied, plus `upstreamSignal()`: a 9s deadline chosen to sit under Netlify's 10s synchronous-function ceiling, so a hung upstream produces our JSON error (which the client's fallback UI understands) rather than a platform gateway page.

**`netlify/functions/tp-places.mjs`** - Imports the shared guards and CAS helper; both Places calls (searchText, details) carry the upstream deadline.

**`netlify/functions/tests/tp-assist-cas.test.mjs`** (new) - Drives the handler's reservation composition against deterministic write collisions with an in-memory etag store: colliding reservations all land, a client at its cap is rejected without moving the counters, and a concurrent burst can never overrun the cap nor mint a grant that is missing from the landed counters.

### Sync system

**`sync-system/storage-sync-robust.js`** - `flushWrites`'s failure path re-queued the failed batch unconditionally. If the user edited the same key while the flush was in flight, the newer queued revision was replaced by the older failed copy, and because `localRevisions` already recorded the newer hash, the newer value was never re-sent: silent data loss on the next successful flush. The re-queue now keeps whichever revision is higher.

**`sync-system/sync-helpers.mjs`** - That logic extracted as pure `requeueFailedWrites` so it is genuinely unit-testable (the manager module imports Firebase from gstatic URLs Node cannot load).

**`sync-system/tests/sync-helpers.test.mjs`** - Three new tests, including the exact race: rev 4 queued mid-flight, failed rev 3 re-queued, rev 4 must survive.

### Rising Shows: the flaky-network chain

**`apps/rising-shows/js/app.js`** - Four defects found by rejecting the `data/detail/` fetch and clicking a show, fixed as a chain:

1. `drawCurve` with zero episodes indexed `points[-1][0]` and threw, aborting `openShowModal` entirely: a visitor on a flaky network got no modal at all. Guarded; the modal now opens with blank sparklines.
2. `ensureDetail` stored its promise before it settled and never evicted on failure, so one flaky request pinned "no episodes" for the rest of the session. Both failure paths (HTTP not-ok, network error) now evict, so the next open retries.
3. The render path coerces `m.episodes = []` for the degraded modal, and `ensureDetail`'s already-loaded guard counted an empty array as loaded, which re-defeated that retry. The guard now requires a non-empty array.
4. `drawSeasonOverlay` with all-empty seasons computed its axis from `lo = Infinity`, drawing 5 gridlines with NaN coordinates (10 console errors per open). It now renders an empty overlay.

`loadExtrasInBackground` had the same shape as (2): its once-flag was set before the fetch settled and never handed back, so a failed extras load meant no cast strip or episode titles all session. The flag resets on failure and both modal opens are its retry points.

End-to-end proof, driven with real coordinate clicks: block the detail fetch, click a show - modal opens degraded with zero console errors; unblock, reopen - detail refetched, 15 sparkline paths rendered.

### Arena

**`apps/arena/js/globe-drop-locations.js`** - `loadCountryMetaIndex` cached its promise before settling and returned `{}` on failure with the promise still cached, so difficulty scoring and area/population hints were absent for the whole session after one flaky request. The cache slot is now cleared on both failure paths.

**`apps/arena/index.html`** - The three difficulty `<option>` labels reworded to a colon form ("Medium: name + country + continent").

### Back-to-top

**`assets/css/back-to-top.css`** - Offset pinned from `1.25rem` to `20px`. The button renders on every page of the site, and the two page families disagree on root font size (main.css pages compute 14.67px, generated static pages keep 16px), so the same button sat 18.33px from the corner on one family and 20px on the other. Verified identical (computed `20px`) on both families after the change.

### Copy

User-visible strings tightened into plainer sentence forms: **`apps/gym-tracker/index.html`** (measurements empty state), **`apps/gym-tracker/js/app.js`** (two toasts), **`apps/gym-tracker/js/utils/sync-status.js`** (offline/online banners), **`apps/gym-tracker/js/views/calendar-view.js`** (rest-day line), **`apps/gym-tracker/js/views/settings-view.js`** (delete warning and toast), **`apps/mario-kart/index.html`** (og:image:alt), **`apps/mario-kart/js/coursePicker.js`** (search hint), **`apps/rising-shows/js/app.js`** (season-dot tooltip), **`apps/rising-shows/js/kometa.js`** (file summary line). Placeholder glyphs (the lone "no value" marker in `<dd>` cells and number inputs) are unchanged, as are code comments.
