### PR TITLE
feat(gym-tracker): rebuild the Edit Program editor - denser layout, one scroll area, clearer set controls

### DIFF
--- a/apps/gym-tracker/css/gym-tracker.css
+++ b/apps/gym-tracker/css/gym-tracker.css
@@ -1234,7 +1234,9 @@ body.modal-open {
     color: white;
 }
 
-.modal-close {
+/* The round X affordance. `.program-modal-cancel` also carries `.modal-close`
+   (it closes the editor) but is a labelled text button, so it opts out here. */
+.modal-close:not(.program-modal-cancel) {
     background: none;
     border: none;
     color: var(--text-primary);
@@ -1249,7 +1251,7 @@ body.modal-open {
     transition: all var(--transition-base);
 }
 
-.modal-close:hover {
+.modal-close:not(.program-modal-cancel):hover {
     background: var(--bg-hover);
     color: var(--text-primary);
 }
@@ -4365,709 +4367,6 @@ body.gym-tracker .rest-countdown-chip.rest-countdown-chip--idle i {
     }
 }
 
-/* Edit Program — compact exercise row */
-#program-exercises-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-}
-
-/* ---- Create/Edit Program modal — form polish ---- */
-#program-form .form-group {
-    margin-bottom: var(--spacing-md);
-}
-
-#program-form .form-group label {
-    margin-bottom: 0.4rem;
-    font-size: 0.85rem;
-    font-weight: 600;
-    text-transform: none;
-    letter-spacing: 0;
-    color: var(--text-secondary);
-}
-
-#program-form .form-group input[type="text"],
-#program-form .form-group textarea {
-    padding: 0.7rem 0.85rem;
-    background: var(--bg-elevated);
-    border: 1px solid var(--border-color);
-    color: var(--text-primary);
-    font-size: 0.95rem;
-    border-radius: var(--radius-md);
-}
-
-#program-form .form-group input::placeholder,
-#program-form .form-group textarea::placeholder {
-    color: rgba(184, 184, 209, 0.78);
-    opacity: 1;
-}
-
-#program-form .form-group input:focus,
-#program-form .form-group textarea:focus {
-    outline: none;
-    border-color: var(--accent-primary);
-    background: var(--bg-card);
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.18);
-}
-
-/* Modal body padding tightens slightly inside the program modal */
-#program-modal .modal-body {
-    padding: var(--spacing-md) var(--spacing-lg) var(--spacing-md);
-}
-
-/* ---- Create/Edit Program — Exercises section ---- */
-.program-exercises-section {
-    margin-top: var(--spacing-md);
-    padding: 0.85rem 0.85rem 0.7rem;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-}
-
-.program-exercises-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    padding-bottom: 0.4rem;
-    border-bottom: 1px solid var(--border-color);
-}
-
-.program-exercises-heading {
-    margin: 0;
-    font-size: 0.95rem;
-    font-weight: 700;
-    color: var(--text-primary);
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    letter-spacing: -0.005em;
-}
-
-.program-exercises-heading i {
-    color: var(--text-muted);
-    font-size: 0.8rem;
-}
-
-.program-exercises-count {
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    font-weight: 500;
-    text-transform: none;
-    letter-spacing: 0;
-}
-
-.program-exercises-count:empty { display: none; }
-
-#program-exercises-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-}
-
-.program-exercises-empty {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 1.4rem 1rem;
-    background: var(--bg-card);
-    border: 1px dashed var(--border-color);
-    border-radius: var(--radius-lg);
-    text-align: center;
-}
-
-.program-exercises-empty i {
-    font-size: 1.85rem;
-    color: var(--accent-primary);
-    opacity: 0.75;
-    margin-bottom: 0.25rem;
-}
-
-.program-exercises-empty p {
-    margin: 0;
-    color: var(--text-primary);
-    font-size: 0.95rem;
-    font-weight: 700;
-}
-
-.program-exercises-empty small {
-    color: var(--text-secondary);
-    font-size: 0.8rem;
-    line-height: 1.4;
-}
-
-/* Two-row layout at every breakpoint so exercise identity never competes with
-   the numeric controls. The drag handle + index badge span both rows so the
-   whole card reads as a single draggable unit; identity + delete occupy the
-   top row; the Sets/Reps/Rest cluster sits below as a secondary control row. */
-.program-exercise-row {
-    display: grid;
-    grid-template-columns: auto auto 1fr auto;
-    grid-template-areas:
-        "handle position name   delete"
-        "handle position targets targets";
-    align-items: center;
-    column-gap: 0.55rem;
-    row-gap: 0.45rem;
-    padding: 0.55rem 0.7rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-sm);
-    transition: transform var(--transition-fast), background var(--transition-fast),
-                border-color var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.program-exercise-row .pex-drag-handle { grid-area: handle; align-self: center; }
-.program-exercise-row .pex-position    { grid-area: position; align-self: center; }
-.program-exercise-row .pex-name        { grid-area: name; align-self: center; }
-.program-exercise-row .pex-delete      { grid-area: delete; align-self: center; justify-self: end; }
-
-/* Base = mobile. Keep the original flex-wrap row exactly as it was — the
- * desktop media query below swaps in the new vertical-block grid layout. */
-.pex-targets {
-    grid-area: targets;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    min-width: 0;
-}
-
-/* Desktop refinement — left-aligned card, tighter title/control connection,
-   and a structured CSS Grid for Sets / Reps / Rest. Each stepper lives
-   inside a bounded grid cell so siblings can NEVER overlap.
-   Mobile keeps its existing flex-wrap layout via the media query boundary. */
-@media (min-width: 641px) {
-    /* Wider program modal so there's real horizontal space for three
-       stepper cells + padding without crowding. */
-    #program-modal .modal-content { max-width: 760px; }
-
-    /* Left-aligned, full-width: the list fills the modal body instead of
-       centering a narrow column. */
-    #program-exercises-list {
-        max-width: none;
-        margin-inline: 0;
-    }
-
-    .program-exercise-row {
-        padding: 0.75rem 1rem;
-        column-gap: 0.75rem;
-        /* Tight row-gap + dashed divider = "title and controls are one unit." */
-        row-gap: 0.6rem;
-        border-radius: var(--radius-lg);
-        /* Desktop: targets get their own full-width row beneath the title row
-           so Sets/Reps/Rest can breathe across the entire card instead of
-           being squeezed into the name+delete columns. `minmax(0, 1fr)` on
-           the name column stops long exercise names from forcing the whole
-           card wider than the modal. */
-        grid-template-columns: auto auto minmax(0, 1fr) auto;
-        grid-template-areas:
-            "handle position name    delete"
-            "targets targets targets targets";
-    }
-
-    .program-exercise-row .pex-name-main { font-size: 1.05rem; }
-
-    .program-exercise-row .pex-name-sub {
-        font-size: 0.8rem;
-        opacity: 1;
-    }
-
-    /* Controls row: sets-block takes the majority of space; rest stepper
-       sits in a fixed-size right column when present (custom mode).
-       Spans all four outer-grid columns via redefined grid-template-areas. */
-    .pex-targets {
-        display: grid;
-        grid-template-columns: 1fr auto;
-        gap: 0.75rem;
-        padding-top: 0.5rem;
-        margin-top: 0;
-        border-top: 1px dashed var(--border-color);
-        min-width: 0;
-        width: 100%;
-        align-items: start;
-    }
-
-    .pex-targets > * {
-        min-width: 0;
-    }
-
-    /* Desktop-only: each control is a vertical block — label on top of
-       a full-width [-  value  +] pill. The outer .pex-stepper becomes a
-       transparent wrapper (all pill chrome moves to .pex-stepper-controls)
-       so the label isn't competing inside a crowded single row.
-       Mobile keeps the original horizontal pill via the base rules. */
-    .program-exercise-row .pex-stepper {
-        display: flex;
-        flex-direction: column;
-        align-items: stretch;
-        gap: 0.3rem;
-        width: 100%;
-        min-width: 0;
-        padding: 0;
-        background: transparent;
-        border: none;
-        border-radius: 0;
-        box-sizing: border-box;
-    }
-
-    .program-exercise-row .pex-stepper-label {
-        font-size: 0.76rem;
-        letter-spacing: 0;
-        padding-left: 0.1rem;
-    }
-
-    /* The pill now lives on .pex-stepper-controls on desktop. */
-    .program-exercise-row .pex-stepper-controls {
-        display: flex;
-        justify-content: space-between;
-        gap: 0.4rem;
-        padding: 0.4rem 0.65rem;
-        background: var(--bg-elevated);
-        border: 1px solid var(--border-color);
-        border-radius: var(--radius-sm);
-        min-width: 0;
-        box-sizing: border-box;
-    }
-
-    /* Slightly larger value floor so "2:15"/"10:30" sit cleanly without
-       crowding the +/- buttons. Tabular numerals keep widths stable. */
-    .program-exercise-row .pex-stepper-value {
-        min-width: 3ch;
-        font-size: 0.9rem;
-    }
-
-    .program-exercise-row .pex-stepper-controls {
-        gap: 0.4rem;
-    }
-
-    .program-exercise-row .pex-stepper-btn {
-        width: 26px;
-        height: 26px;
-        font-size: 0.75rem;
-    }
-
-    /* Drag handle + index badge — more presence on the taller card. */
-    .program-exercise-row .pex-drag-handle {
-        height: 28px;
-        font-size: 0.9rem;
-    }
-    .program-exercise-row .pex-position {
-        width: 22px;
-        height: 22px;
-        font-size: 0.8rem;
-    }
-
-    /* Delete stays tertiary at rest; aligned to the identity row's right edge. */
-    .program-exercise-row .pex-delete {
-        width: 28px !important;
-        height: 28px !important;
-        font-size: 0.82rem !important;
-    }
-}
-
-/* Between 641px and 900px keep the 2-column layout (sets-block + rest).
-   No special override needed — the 1fr auto grid already stacks gracefully. */
-
-/* Stepper — two zones separated by space-between:
-     [ LABEL ]                   [ - value + ]
-   The inner .pex-stepper-controls owns its own fixed inter-element gap so
-   the spacing between minus, value, and plus is ALWAYS identical, no matter
-   how long the value string is ("3", "10", "1:30", "2:15", "10:30"). */
-/* Base = mobile. Horizontal inline pill — label inside, [-  value  +]
- * sharing the same rounded container. Desktop media query above replaces
- * this with a vertical label-over-pill block layout. */
-.pex-stepper {
-    display: inline-flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    background: var(--bg-elevated);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
-    padding: 0.15rem 0.35rem;
-    font-size: 0.78rem;
-    min-width: 0;
-    box-sizing: border-box;
-}
-
-.pex-stepper-label {
-    flex-shrink: 0;
-    font-weight: 600;
-    color: var(--text-secondary);
-    text-transform: none;
-    letter-spacing: 0;
-    font-size: 0.78rem;
-    white-space: nowrap;
-}
-
-/* Right-side cluster: [-] value [+]. Inline, no background of its own —
- * the outer .pex-stepper provides the pill chrome on mobile. */
-.pex-stepper-controls {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    flex-shrink: 0;
-}
-
-.pex-stepper-value {
-    min-width: 2.6ch;
-    padding: 0 0.1rem;
-    text-align: center;
-    color: var(--text-primary);
-    font-variant-numeric: tabular-nums;
-    font-weight: 600;
-    letter-spacing: -0.005em;
-    white-space: nowrap;
-}
-
-.pex-stepper-btn {
-    flex-shrink: 0;
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    width: 22px;
-    height: 22px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--radius-sm);
-    font-size: 0.7rem;
-    transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.pex-stepper-btn:hover:not(:disabled) {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-}
-
-.pex-stepper-btn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-}
-
-.pex-stepper-btn:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(91, 155, 255, 0.45);
-}
-
-/* Tighter gap specifically between the number badge and the exercise name,
-   so the badge reads as attached to the name it belongs to. */
-.program-exercise-row .pex-position + .pex-name {
-    margin-left: -0.15rem;
-}
-
-.program-exercise-row:hover {
-    background: var(--bg-elevated);
-    border-color: var(--border-light);
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-md);
-}
-
-/* Neutral, low-emphasis index marker (not a bold blue circle). */
-.pex-position {
-    width: 20px;
-    height: 20px;
-    flex-shrink: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: transparent;
-    border: none;
-    color: var(--text-muted);
-    font-size: 0.78rem;
-    font-weight: 600;
-    font-variant-numeric: tabular-nums;
-}
-
-/* Drag handle — low-emphasis grip icon; the whole row is draggable, this is
-   just the visual affordance. Brightens on row hover. */
-.pex-drag-handle {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 26px;
-    color: var(--text-muted);
-    opacity: 0.85;
-    cursor: grab;
-    font-size: 0.95rem;
-    transition: color var(--transition-fast), opacity var(--transition-fast);
-    flex-shrink: 0;
-}
-
-.program-exercise-row:hover .pex-drag-handle {
-    color: var(--text-secondary);
-    opacity: 1;
-}
-
-.pex-drag-handle:active {
-    cursor: grabbing;
-}
-
-/* Row drag states */
-.program-exercise-row {
-    cursor: grab;
-}
-
-.program-exercise-row:active {
-    cursor: grabbing;
-}
-
-.program-exercise-row.is-dragging {
-    opacity: 0.4;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-    border-color: var(--accent-primary);
-}
-
-/* Drop indicator — accent bar on the edge the dragged row would land on */
-.program-exercise-row.is-drop-above {
-    box-shadow: 0 -2px 0 0 var(--accent-primary);
-}
-
-.program-exercise-row.is-drop-below {
-    box-shadow: 0 2px 0 0 var(--accent-primary);
-}
-
-.pex-name {
-    font-size: 0.95rem;
-    color: var(--text-primary);
-    letter-spacing: -0.005em;
-    min-width: 0;
-    overflow: hidden;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 0.35rem;
-    line-height: 1.25;
-}
-
-.pex-name-main {
-    font-weight: 700;
-    font-size: 1rem;
-    color: var(--text-primary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    min-width: 0;
-    letter-spacing: -0.01em;
-}
-
-.pex-name-sub {
-    font-weight: 500;
-    color: var(--text-secondary);
-    font-size: 0.78rem;
-    opacity: 1;
-    white-space: nowrap;
-}
-
-/* Delete — small, low-contrast at rest; clear red on hover without heavy glow */
-.pex-delete {
-    width: 26px !important;
-    height: 26px !important;
-    padding: 0 !important;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: transparent;
-    border: 1px solid transparent !important;
-    color: var(--text-muted) !important;
-    opacity: 0.65;
-    border-radius: var(--radius-sm);
-    font-size: 0.78rem !important;
-    font-weight: 500 !important;
-    line-height: 1 !important;
-    cursor: pointer;
-    box-shadow: none !important;
-    font-family: inherit !important;
-    transition: color var(--transition-fast), background var(--transition-fast),
-                border-color var(--transition-fast), opacity var(--transition-fast),
-                transform var(--transition-fast);
-}
-
-.program-exercise-row:hover .pex-delete {
-    opacity: 1;
-    border-color: var(--border-color) !important;
-}
-
-.pex-delete:hover,
-.pex-delete:focus-visible {
-    color: var(--accent-error) !important;
-    background: var(--bg-elevated);
-    border-color: var(--accent-error) !important;
-    opacity: 1;
-    outline: none;
-}
-
-.pex-delete:focus-visible {
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
-}
-
-.pex-delete:active {
-    transform: scale(0.96);
-}
-
-/* Add Exercise — full-width secondary action. Subtle tinted surface at rest,
-   brightens on hover. !important beats the global button overrides. */
-.btn-add-exercise {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    width: 100%;
-    margin: 0;
-    height: auto !important;
-    min-height: 0 !important;
-    padding: 0.6rem 1rem !important;
-    background: var(--bg-elevated) !important;
-    border: 1px dashed var(--border-light) !important;
-    border-radius: var(--radius-lg);
-    color: var(--text-secondary) !important;
-    font-family: inherit !important;
-    font-weight: 600 !important;
-    font-size: 0.85rem !important;
-    line-height: 1 !important;
-    cursor: pointer;
-    box-shadow: none !important;
-    transition: background var(--transition-base), border-color var(--transition-base),
-                color var(--transition-base), box-shadow var(--transition-base);
-}
-
-.btn-add-exercise:hover {
-    background: var(--bg-hover) !important;
-    border-color: var(--border-light) !important;
-    color: var(--text-primary) !important;
-    box-shadow: none !important;
-}
-
-.btn-add-exercise:active {
-    background: var(--bg-hover) !important;
-    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.25) !important;
-}
-
-.btn-add-exercise:focus-visible {
-    outline: none;
-    color: var(--text-primary) !important;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
-}
-
-.btn-add-exercise i {
-    font-size: 0.78rem;
-    color: inherit !important;
-    transition: color var(--transition-base);
-}
-
-.btn-add-exercise:hover i {
-    color: inherit !important;
-}
-
-/* Bottom action row — anchored footer with clear Cancel/Save hierarchy. */
-.program-form-actions {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 0.75rem;
-    margin-top: 1.5rem;
-    padding-top: 1.25rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.program-form-actions .btn {
-    height: 44px !important;
-    min-height: 0 !important;
-    min-width: 120px;
-    padding: 0 1.25rem !important;
-    border-radius: 10px;
-    font-size: 0.9rem !important;
-    font-weight: 600 !important;
-    font-family: inherit !important;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.4rem;
-    line-height: 1 !important;
-    transition: background var(--transition-base), border-color var(--transition-base),
-                color var(--transition-base), box-shadow var(--transition-base),
-                transform var(--transition-base), filter var(--transition-base);
-}
-
-/* Cancel — transparent/outline, tuned down so Save dominates. */
-.program-form-actions .btn-ghost {
-    background: transparent !important;
-    border: 1px solid rgba(255, 255, 255, 0.15) !important;
-    color: rgba(255, 255, 255, 0.7) !important;
-    box-shadow: none !important;
-}
-
-.program-form-actions .btn-ghost:hover {
-    background: rgba(255, 255, 255, 0.04) !important;
-    border-color: rgba(255, 255, 255, 0.25) !important;
-    color: var(--text-primary) !important;
-}
-
-.program-form-actions .btn-ghost:active {
-    background: var(--bg-hover) !important;
-    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.25) !important;
-}
-
-.program-form-actions .btn-ghost:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.25) !important;
-}
-
-/* Save — primary CTA. Strong gradient + glow so it's the obvious action. */
-/* Calmer azure primary: flat fill, standard height, no glow/heavy shadow. */
-.btn-save-program {
-    background: var(--accent-primary) !important;
-    border: 1px solid transparent !important;
-    color: #ffffff !important;
-    box-shadow: none !important;
-    padding: 0.5rem 1rem !important;
-    height: auto !important;
-    min-height: 0 !important;
-    font-size: 0.85rem !important;
-}
-
-.btn-save-program i {
-    color: #ffffff !important;
-    font-size: 0.82rem;
-}
-
-.btn-save-program:hover {
-    filter: brightness(1.08);
-    box-shadow: none !important;
-}
-
-.btn-save-program:active {
-    filter: brightness(0.95);
-    box-shadow: none !important;
-}
-
-.btn-save-program:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
-}
-
-@media (max-width: 520px) {
-    .program-form-actions { flex-direction: column-reverse; align-items: stretch; gap: 0.5rem; }
-    .program-form-actions .btn { width: 100%; min-width: 0; }
-}
-
-@media (max-width: 520px) {
-    .program-exercise-row {
-        gap: 0.5rem;
-        padding: 0.5rem 0.6rem;
-    }
-    .pex-position { width: 22px; height: 22px; font-size: 0.65rem; }
-}
 
 /* Workout Day Exercise Items */
 .exercise-day-item {
@@ -8440,48 +7739,6 @@ button.calendar-day {
 }
 
 /* ------------------------------------------------------------------
-   Keyboard reorder buttons — sit alongside the drag handle on programs
-   and program-exercise rows (in the Program edit modal). The card-
-   level arrows on the Programs grid were removed in favour of drag-
-   only reorder; the in-modal exercise-row arrows stay because there's
-   no drag handle inside the modal.
-   ------------------------------------------------------------------ */
-.pex-move-buttons {
-    display: inline-flex;
-    flex-direction: column;
-    gap: 2px;
-    margin-right: 4px;
-}
-.btn-icon-move {
-    width: 28px;
-    height: 22px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 6px;
-    color: rgba(255, 255, 255, 0.7);
-    cursor: pointer;
-    transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
-}
-.btn-icon-move:hover:not(:disabled),
-.btn-icon-move:focus-visible {
-    background: rgba(91, 155, 255, 0.18);
-    border-color: rgba(91, 155, 255, 0.45);
-    color: #fff;
-}
-.btn-icon-move:disabled {
-    opacity: 0.3;
-    cursor: not-allowed;
-}
-.btn-icon-move-mini {
-    width: 24px;
-    height: 18px;
-    font-size: 10px;
-}
-
-/* ------------------------------------------------------------------
    Plate calculator UI — Settings input stack + per-row inline hint.
    ------------------------------------------------------------------ */
 .setting-item-stack {
@@ -8584,76 +7841,6 @@ button.calendar-day {
     .plate-hint-label-text { display: none; }
     .plate-hint { font-size: 0.78rem; }
 }
-
-/* ------------------------------------------------------------------
-   Supersets — Program edit link button + workout-view group card.
-   ------------------------------------------------------------------ */
-
-/* Row-level link/unlink button in the program-edit modal. Sits in the
-   same trailing actions cluster as the delete (×) button. */
-.pex-row-actions {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    margin-left: auto;
-}
-.btn-icon-link {
-    width: 30px;
-    height: 30px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 6px;
-    color: rgba(255, 255, 255, 0.7);
-    cursor: pointer;
-    transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
-}
-.btn-icon-link:hover,
-.btn-icon-link:focus-visible {
-    background: rgba(91, 155, 255, 0.18);
-    border-color: rgba(91, 155, 255, 0.45);
-    color: #fff;
-}
-.btn-icon-link.is-on {
-    background: rgba(91, 155, 255, 0.28);
-    border-color: rgba(91, 155, 255, 0.7);
-    color: #fff;
-}
-
-/* Visual cohesion for adjacent rows in the same superset: collapse the
-   bottom border of the row above and the top border of the row below
-   so they read as one unit, plus a subtle accent stripe. */
-.program-exercise-row.is-grouped {
-    border-color: rgba(91, 155, 255, 0.45);
-    background: rgba(91, 155, 255, 0.05);
-}
-.program-exercise-row.is-linked-above {
-    border-top-color: transparent;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-    margin-top: 0;
-}
-.program-exercise-row.is-linked-below {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-    margin-bottom: 0;
-}
-.pex-superset-tag {
-    position: absolute;
-    top: -8px;
-    left: 12px;
-    padding: 1px 7px;
-    background: var(--bg-elevated);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
-    color: var(--text-secondary);
-    font-size: 0.65rem;
-    font-weight: 600;
-    letter-spacing: 0;
-}
-.program-exercise-row { position: relative; }
 
 /* Workout-view group card — wraps consecutive .exercise-entry blocks
    that share a groupId. The wrapper provides the outer purple frame +
@@ -8932,319 +8119,10 @@ button.calendar-day {
     }
 }
 
-/* ------------------------------------------------------------------
-   Rest mode toggle (program modal)
-   ------------------------------------------------------------------ */
-
-.rest-mode-group {
-    margin-bottom: 0.75rem;
-}
-
-.rest-mode-toggle-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.55rem 0.75rem;
-    background: var(--bg-elevated);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-}
-
-.rest-mode-label {
-    display: flex;
-    align-items: center;
-    gap: 0.45rem;
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--text-secondary);
-    cursor: pointer;
-    user-select: none;
-}
-
-.rest-mode-label i {
-    color: var(--text-muted);
-    font-size: 0.9rem;
-}
-
-.rest-mode-uniform-section {
-    margin-top: 0.6rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-}
-
-.rest-mode-uniform-label {
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--text-secondary);
-    text-transform: none;
-    letter-spacing: 0;
-}
-
-.rest-mode-uniform-input {
-    width: 100%;
-    max-width: 140px;
-    padding: 0.4rem 0.6rem;
-    background: var(--bg-input, var(--bg-elevated));
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
-    color: var(--text-primary);
-    font-size: 0.9rem;
-    font-variant-numeric: tabular-nums;
-}
-
-.rest-mode-uniform-input:focus {
-    outline: none;
-    border-color: var(--accent-primary);
-    box-shadow: 0 0 0 2px rgba(91, 155, 255, 0.25);
-}
-
 .form-hint {
     font-size: 0.75rem;
     color: var(--text-muted);
     margin: 0;
-}
-
-/* ------------------------------------------------------------------
-   Per-set rep rows in the program builder
-   ------------------------------------------------------------------ */
-
-/* The sets-block replaces the old Sets + Reps steppers. */
-.pex-sets-block {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    min-width: 0;
-}
-
-.pex-sets-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-}
-
-/* Reuse the existing .pex-stepper-label for the "Sets / Reps" heading.
-   Reduced emphasis: smaller, lighter, Title Case. */
-.pex-sets-header .pex-stepper-label {
-    font-size: 0.76rem;
-    letter-spacing: 0;
-    font-weight: 600;
-    text-transform: none;
-    color: var(--text-secondary);
-}
-
-/* Add set: a quiet neutral chip that reads as part of the sets block.
-   Clearly clickable (filled elevated surface) without a blue border. */
-.pex-add-set-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3rem;
-    padding: 0.25rem 0.6rem;
-    background: var(--bg-elevated) !important;
-    border: 1px solid transparent !important;
-    border-radius: var(--radius-sm);
-    color: var(--text-secondary) !important;
-    font-size: 0.72rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 120ms ease, color 120ms ease;
-    white-space: nowrap;
-}
-
-.pex-add-set-btn i { color: inherit !important; }
-
-.pex-add-set-btn:hover {
-    background: var(--bg-hover) !important;
-    color: var(--text-primary) !important;
-    outline: none;
-}
-
-.pex-add-set-btn:focus-visible {
-    color: var(--text-primary) !important;
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
-}
-
-.pex-set-rows {
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-}
-
-.pex-set-row {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    min-width: 0;
-}
-
-.pex-set-label {
-    flex: 0 0 auto;
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--text-secondary);
-    text-transform: none;
-    letter-spacing: 0;
-    min-width: 3.2rem;
-}
-
-.pex-set-reps {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    flex: 1 1 auto;
-    min-width: 0;
-}
-
-.pex-reps-input {
-    width: 3.2rem;
-    padding: 0.25rem 0.3rem;
-    background: var(--bg-input, var(--bg-elevated));
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
-    color: var(--text-primary);
-    font-size: 0.85rem;
-    font-variant-numeric: tabular-nums;
-    text-align: center;
-    -moz-appearance: textfield;
-}
-
-.pex-reps-input::-webkit-inner-spin-button,
-.pex-reps-input::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-}
-
-.pex-reps-input:focus {
-    outline: none;
-    border-color: var(--accent-primary);
-    box-shadow: 0 0 0 2px rgba(91, 155, 255, 0.22);
-}
-
-.pex-reps-sep {
-    flex: 0 0 auto;
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    font-weight: 700;
-}
-
-.pex-reps-sep-hidden,
-.pex-reps-max-hidden {
-    display: none;
-}
-
-/* Single/Range selector: a quiet neutral segmented-style toggle, not a
-   bordered blue button. Borderless quiet fill at rest; subtle elevated fill
-   when on. */
-.pex-range-toggle {
-    flex: 0 0 auto;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.3rem;
-    min-width: 64px;
-    height: 32px;
-    padding: 0 0.55rem;
-    background: var(--bg-elevated) !important;
-    border: 1px solid transparent !important;
-    border-radius: var(--radius-sm);
-    color: var(--text-secondary) !important;
-    cursor: pointer;
-    font-size: 0.7rem;
-    transition: background 100ms ease, color 100ms ease, border-color 100ms ease;
-}
-
-.pex-range-toggle:hover {
-    background: var(--bg-hover) !important;
-    color: var(--text-primary) !important;
-}
-
-.pex-range-toggle:focus-visible {
-    color: var(--text-primary) !important;
-    border-color: transparent !important;
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
-}
-
-.pex-range-toggle:hover:active {
-    background: var(--bg-hover) !important;
-}
-
-.pex-range-toggle.is-on {
-    background: var(--bg-hover) !important;
-    border-color: transparent !important;
-    color: var(--text-primary) !important;
-}
-
-.pex-range-toggle.is-on:hover {
-    background: var(--bg-hover) !important;
-    color: var(--text-primary) !important;
-}
-
-.pex-range-toggle-label {
-    font-size: 0.72rem;
-    font-weight: 600;
-    letter-spacing: 0;
-    line-height: 1;
-    color: inherit;
-}
-
-/* Per-exercise hint below the sets/reps header */
-.pex-range-hint {
-    margin: 0.15rem 0 0.35rem;
-    font-size: 0.72rem;
-    color: var(--text-muted);
-    line-height: 1.3;
-}
-
-/* At mobile widths refresh.css forces width:32px on .pex-range-toggle which
-   would clip the text label — override to auto-width with a sensible minimum. */
-@media (max-width: 640px) {
-    body.gym-tracker .pex-range-toggle {
-        width: auto;
-        min-width: 58px;
-        height: 32px;
-        padding: 0 0.4rem;
-    }
-}
-
-.pex-set-remove {
-    flex: 0 0 auto;
-    width: 22px;
-    height: 22px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: transparent;
-    border: none;
-    border-radius: var(--radius-sm);
-    color: var(--text-disabled);
-    cursor: pointer;
-    font-size: 0.72rem;
-    transition: color 100ms ease, background 100ms ease;
-}
-
-.pex-set-remove:hover:not(:disabled) {
-    color: var(--accent-error);
-    background: var(--bg-elevated);
-    outline: none;
-}
-
-.pex-set-remove:focus-visible:not(:disabled) {
-    color: var(--accent-error);
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4);
-}
-
-.pex-set-remove:disabled {
-    opacity: 0.25;
-    cursor: default;
-}
-
-/* When rest stepper is absent (uniform mode), sets-block spans full width. */
-.pex-targets:not(:has(.pex-stepper)) .pex-sets-block {
-    grid-column: 1 / -1;
 }
 
 /* ---- Finish Workout Modal — premium redesign ---- */
@@ -9926,66 +8804,6 @@ button.calendar-day {
     border-radius: var(--radius-lg);
 }
 
-/* Item 9: weekday chips in the program editor. */
-.program-schedule-days {
-    display: flex;
-    gap: 0.4rem;
-    margin-top: 0.35rem;
-}
-.schedule-day-chip {
-    appearance: none;
-    /* Every day is an identical cell: equal width (flex share) + fixed height,
-       border-box so the 1px border never shifts size. Selection changes ONLY
-       background/border/text color, never the box dimensions. */
-    flex: 1 1 0;
-    min-width: 0;
-    box-sizing: border-box;
-    height: 40px;
-    padding: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid var(--border-light);
-    background: var(--bg-elevated);
-    /* Pin colour !important across states: these chips are <button>s, so the
-       sitewide main.css `button{color:#555!important}` / `:hover{#ce1b28}` trap
-       would otherwise dim them to a disabled-looking gray. */
-    color: var(--text-primary) !important;
-    font: inherit;
-    font-size: 0.82rem;
-    font-weight: 600;
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: background var(--transition-base), border-color var(--transition-base),
-                color var(--transition-base);
-}
-.schedule-day-chip:hover {
-    background: var(--bg-hover);
-    border-color: var(--accent-primary);
-    color: var(--text-primary) !important;
-}
-.schedule-day-chip.is-on,
-.schedule-day-chip.is-on:hover {
-    background: #2563eb;
-    border-color: #2563eb;
-    color: #ffffff !important;
-}
-.schedule-day-chip.is-on:hover {
-    background: #1d4ed8;
-    border-color: #1d4ed8;
-}
-.schedule-day-chip:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.35);
-}
-.program-schedule-label {
-    display: block;
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--text-secondary);
-    margin-bottom: 0.2rem;
-}
-
 /* Item 9: calendar schedule marker (distinct from the workout dot/PR star).
    Positioned bottom-left to avoid overlapping the day number (top-right),
    PR star (top-left) and workout dot (bottom-center). */
@@ -10247,146 +9065,6 @@ button.calendar-day {
         width: auto;
         flex: 0 0 auto;
     }
-}
-
-/* Item R2-7: mid-workout program editor sticky header action bar. */
-.program-modal-workout-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-}
-.program-modal-workout-actions[hidden] { display: none; }
-.program-modal-workout-actions .btn { white-space: nowrap; }
-
-/* In workout mode: pin the header to the top of the scrolling modal content,
-   hide the footer save/return cluster and the corner X (the two header actions
-   are the only controls). */
-#program-modal.program-editor-workout-mode .program-modal-header {
-    position: sticky;
-    top: 0;
-    z-index: 5;
-    background: var(--bg-secondary);
-    border-bottom: 1px solid var(--border-color);
-    box-shadow: none;
-}
-#program-modal.program-editor-workout-mode .modal-close {
-    display: none;
-}
-#program-modal.program-editor-workout-mode .program-form-actions {
-    display: none;
-}
-/* Pin the header action button colors so the sitewide button red can't bleed. */
-#program-modal-save-resume,
-#program-modal-save-resume:hover,
-#program-modal-save-resume:focus {
-    background: var(--accent-primary) !important;
-    color: #ffffff !important;
-}
-#program-modal-save-resume:hover {
-    filter: brightness(1.08);
-}
-#program-modal-cancel-workout:hover,
-#program-modal-cancel-workout:focus {
-    color: var(--text-primary) !important;
-    background: var(--bg-hover) !important;
-}
-
-/* Feature B: normal create/edit mode also pins Save + Cancel in a sticky
-   header at the top of the scrolling modal. Mirrors the R2-7 workout-mode
-   layout for normal entry. */
-.program-modal-normal-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-}
-.program-modal-normal-actions[hidden] { display: none; }
-.program-modal-normal-actions .btn { white-space: nowrap; }
-
-/* Pin the header in normal mode too (the R2-7 rule only stickies workout mode).
-   Both modes now use the header for actions, so the header is always sticky.
-   Reads as a flat navigation bar: title left, actions right, a single bottom
-   border (no card elevation / drop shadow). */
-#program-modal .program-modal-header {
-    position: sticky;
-    top: 0;
-    z-index: 5;
-    background: var(--bg-secondary);
-    border-bottom: 1px solid var(--border-color);
-    box-shadow: none;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.85rem var(--spacing-lg);
-}
-
-/* Title is the focal point of the bar: larger + stronger than the generic
-   modal-header h2. Stays on one line; actions (Cancel + Save) sit on the right. */
-#program-modal-title {
-    font-size: 1.25rem;
-    font-weight: 700;
-    letter-spacing: -0.01em;
-    line-height: 1.15;
-    white-space: nowrap;
-    margin: 0;
-    margin-right: auto;
-}
-
-/* Cancel: a plain muted text button (no border/fill), pairs with the blue Save. */
-#program-modal .program-modal-cancel,
-#program-modal .program-modal-cancel:hover,
-#program-modal .program-modal-cancel:focus-visible {
-    background: transparent !important;
-    border: none !important;
-    box-shadow: none !important;
-    color: var(--text-secondary) !important;
-    padding: 0.5rem 0.6rem;
-    font-weight: 600;
-}
-#program-modal .program-modal-cancel:hover { color: var(--text-primary) !important; }
-
-/* The bottom form actions are now redundant in both modes — the header carries
-   Save + Cancel. Hide the footer cluster for this modal entirely. */
-#program-modal .program-form-actions {
-    display: none;
-}
-
-/* Pin the header Save button accent color against the sitewide red button bleed
-   (mirrors #program-modal-save-resume). .btn-save-program already gets the
-   primary gradient, but assert it here in the header context too. */
-.program-modal-normal-actions .btn-save-program,
-.program-modal-normal-actions .btn-save-program:hover,
-.program-modal-normal-actions .btn-save-program:focus {
-    background: var(--accent-primary) !important;
-    color: #ffffff !important;
-}
-
-/* Cancel: small, quiet ghost text, not a heavy button. Applies to both the
-   normal and workout header action clusters. */
-.program-modal-normal-actions .btn-ghost,
-.program-modal-workout-actions .btn-ghost {
-    padding: 0.5rem 0.65rem !important;
-    height: auto !important;
-    min-height: 0 !important;
-    font-size: 0.85rem !important;
-    font-weight: 500 !important;
-    background: transparent !important;
-    border: 1px solid transparent !important;
-    color: var(--text-secondary) !important;
-    box-shadow: none !important;
-}
-.program-modal-normal-actions .btn-ghost:hover,
-.program-modal-normal-actions .btn-ghost:focus-visible,
-.program-modal-workout-actions .btn-ghost:hover,
-.program-modal-workout-actions .btn-ghost:focus-visible {
-    background: var(--bg-hover) !important;
-    color: var(--text-primary) !important;
-    border-color: transparent !important;
-    outline: none;
-}
-.program-modal-normal-actions .btn-ghost:focus-visible,
-.program-modal-workout-actions .btn-ghost:focus-visible {
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.4) !important;
 }
 
 /* =========================================================================
@@ -10926,4 +9604,1196 @@ button.calendar-day {
     /* Full 44px tap target on phones. */
     .history-program-wrap .dark-select-trigger { height: 44px !important; }
     .history-program-wrap .dark-select-option { min-height: 44px; }
+}
+
+/* =========================================================================
+   EDIT PROGRAM EDITOR — 2026-08-10 UI/UX polish round.
+
+   Single source of truth for the Create/Edit Program modal (#program-modal).
+   Before this round the same controls were sized in four places in this file
+   plus two override blocks in refresh.css, at three different values; that
+   scatter is why the editor read as "many slightly different rectangles".
+   Everything now derives from the --pe-* tokens below.
+
+   Every selector is #program-modal-scoped on purpose. The ID beats both the
+   sitewide assets/css/main.css button trap (`button { color:#555 !important;
+   box-shadow: inset 0 0 0 1px #555 }`, `button:hover { color:#ce1b28 }`,
+   `button:hover:active { background: rgba(206,27,40,.25) }`) and the
+   `body.gym-tracker`-scoped rules in refresh.css, so no editor rule can be
+   silently reverted by a later file. `color` still needs !important because
+   main.css declares it !important.
+   ========================================================================= */
+
+#program-modal {
+    /* One height for every icon button, input, chip and segment. */
+    --pe-control-h: 32px;
+    --pe-radius: 8px;
+    --pe-gap: 6px;
+    --pe-card-pad-x: 0.7rem;
+    --pe-card-pad-y: 0.4rem;
+    --pe-card-gap: 6px;
+    --pe-rest-col: 248px;
+    /* One readable measure for every top-level form block, so name, description,
+       scheduled days and the rest-mode box share a right edge. The exercises
+       section is deliberately outside the cap: its cards need the full dialog. */
+    --pe-field-max: 720px;
+    /* The single muted tone for every piece of secondary text in the editor. */
+    --pe-text-muted: #a4adbd;
+    --pe-surface-2: var(--bg-elevated);
+    --pe-surface-3: var(--bg-hover);
+    /* Exercise-card hover. It cannot be --pe-surface-2: that is the exact fill
+       of the reps inputs and the rest steppers sitting inside the card, so
+       hovering painted the card the controls' own colour and they dissolved
+       (their border is 2/255 off that fill, so it rescues nothing). The card
+       is squeezed between the section behind it (#12151d) and those controls
+       (#232836), and the app's own proven minimum surface step is the 6/7/9
+       between a resting card and the section. This sits ~45% up the card ->
+       control ramp, which keeps 6/7/10 to the controls and widens the gap to
+       the section to 11/12/15. The lift is deliberately small; :hover also
+       swaps border-color to --border-light, a 17/18/23 jump. */
+    --pe-card-hover: #1d212c;
+    --pe-focus: 0 0 0 3px rgba(91, 155, 255, 0.45);
+    --pe-accent-soft: rgba(91, 155, 255, 0.22);
+}
+
+/* ---- 1. One scroll container -------------------------------------------
+   .modal-content is the only thing that scrolls; the overlay never does, so
+   a wheel/touch gesture cannot move two surfaces depending on where the
+   pointer sits and the dialog can never land above the viewport. Scoped to
+   this modal so the picker and confirm dialogs keep their own behaviour. */
+#program-modal {
+    overflow: hidden;
+}
+
+#program-modal .modal-content {
+    max-width: min(760px, 94vw);
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    /* Fade, don't slide. The shared `slideUp` starts 50px low, and with the
+       overlay no longer scrolling that put the bottom of a 90vh dialog past
+       the viewport for the length of the animation. */
+    animation: peModalIn 0.22s ease;
+}
+
+@keyframes peModalIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+#program-modal .modal-body {
+    padding: 0.9rem 1.25rem 1.1rem;
+    overflow: visible;
+}
+
+/* ---- 2. Sticky header that fits ---------------------------------------- */
+#program-modal .program-modal-header {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.7rem 1.25rem;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    box-shadow: none;
+}
+
+#program-modal-title {
+    flex: 0 1 auto;
+    min-width: 0;
+    margin: 0 auto 0 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* The action cluster never shrinks; the title absorbs the squeeze instead.
+   Letting these shrink is half of what clipped "Cancel" down to "Cance". */
+#program-modal .program-modal-normal-actions,
+#program-modal .program-modal-workout-actions {
+    display: flex;
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+#program-modal .program-modal-normal-actions[hidden],
+#program-modal .program-modal-workout-actions[hidden] {
+    display: none;
+}
+
+#program-modal .program-modal-header .btn {
+    flex: 0 0 auto;
+    width: auto;
+    height: 34px;
+    min-width: 0;
+    min-height: 0;
+    padding: 0 0.85rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    border-radius: var(--pe-radius);
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+    box-shadow: none;
+}
+
+/* Cancel: quiet ghost text. Rest AND hover colours are pinned so the sitewide
+   grey/red button rules cannot bleed through. */
+#program-modal .program-modal-cancel {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--pe-text-muted) !important;
+}
+
+#program-modal .program-modal-cancel:hover,
+#program-modal .program-modal-cancel:hover:active,
+#program-modal .program-modal-cancel:focus-visible {
+    background: var(--pe-surface-3);
+    border-color: transparent;
+    color: var(--text-primary) !important;
+}
+
+#program-modal .program-modal-cancel:focus-visible {
+    outline: none;
+    box-shadow: var(--pe-focus);
+}
+
+#program-modal .btn-save-program {
+    background: var(--accent-primary);
+    border: 1px solid transparent;
+    color: #ffffff !important;
+}
+
+#program-modal .btn-save-program i {
+    color: #ffffff !important;
+    font-size: 0.8rem;
+}
+
+#program-modal .btn-save-program:hover,
+#program-modal .btn-save-program:hover:active {
+    background: var(--accent-primary);
+    color: #ffffff !important;
+    filter: brightness(1.08);
+}
+
+#program-modal .btn-save-program:focus-visible {
+    outline: none;
+    box-shadow: var(--pe-focus);
+}
+
+/* The footer cluster is redundant: the sticky header carries Save + Cancel. */
+#program-modal .program-form-actions {
+    display: none;
+}
+
+#program-modal.program-editor-workout-mode .modal-close:not(.program-modal-cancel) {
+    display: none;
+}
+
+/* ---- 3. Program form fields -------------------------------------------- */
+#program-form .form-group {
+    max-width: var(--pe-field-max);
+    margin-bottom: 0.75rem;
+}
+
+#program-form .form-group label,
+#program-modal .program-schedule-label {
+    display: block;
+    margin-bottom: 0.3rem;
+    color: var(--pe-text-muted);
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+/* The readable-line-length cap lives on .form-group above, so the fields and
+   the blocks around them end on the same edge instead of the input alone. */
+#program-form .form-group input[type="text"],
+#program-form .form-group textarea {
+    padding: 0.55rem 0.75rem;
+    background: var(--pe-surface-2);
+    border: 1px solid var(--border-color);
+    border-radius: var(--pe-radius);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.92rem;
+}
+
+#program-form .form-group textarea {
+    resize: none;
+    line-height: 1.4;
+}
+
+#program-form .form-group input::placeholder,
+#program-form .form-group textarea::placeholder {
+    color: rgba(184, 184, 209, 0.7);
+    opacity: 1;
+}
+
+#program-form .form-group input:focus,
+#program-form .form-group textarea:focus {
+    outline: none;
+    border-color: var(--accent-primary);
+    background: var(--bg-card);
+    box-shadow: var(--pe-focus);
+}
+
+#program-modal .form-hint {
+    margin: 0.3rem 0 0;
+    color: var(--pe-text-muted);
+    font-size: 0.75rem;
+    line-height: 1.35;
+}
+
+/* ---- 4. Scheduled days: seven equal columns, never overflowing ---------- */
+#program-modal .program-schedule-days {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    justify-content: start;
+    gap: 4px;
+    margin-top: 0.1rem;
+}
+
+/* Above phone widths the strip stops stretching: seven fixed 72px columns
+   left-aligned inside the (full-width) block, so the chips read as controls
+   instead of dominating the form at 125px each. */
+@media (min-width: 641px) {
+    #program-modal .program-schedule-days {
+        grid-template-columns: repeat(7, 72px);
+    }
+}
+
+#program-modal .schedule-day-chip {
+    appearance: none;
+    box-sizing: border-box;
+    width: 100%;
+    min-width: 0;
+    height: 36px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--pe-surface-2);
+    border: 1px solid var(--border-color);
+    border-radius: var(--pe-radius);
+    color: var(--pe-text-muted) !important;
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: none;
+    transition: background var(--transition-base), border-color var(--transition-base),
+                color var(--transition-base);
+}
+
+#program-modal .schedule-day-chip:hover,
+#program-modal .schedule-day-chip:hover:active {
+    background: var(--pe-surface-3);
+    border-color: var(--accent-primary);
+    color: var(--text-primary) !important;
+}
+
+/* Selected differs from unselected in BOTH background and text colour. */
+#program-modal .schedule-day-chip.is-on,
+#program-modal .schedule-day-chip.is-on:hover,
+#program-modal .schedule-day-chip.is-on:hover:active {
+    background: #2563eb;
+    border-color: #2563eb;
+    color: #ffffff !important;
+}
+
+#program-modal .schedule-day-chip:focus-visible {
+    outline: none;
+    box-shadow: var(--pe-focus);
+}
+
+/* ---- 5. Program-level rest block --------------------------------------- */
+#program-modal .rest-mode-group {
+    margin-bottom: 0.75rem;
+}
+
+/* Toggle and duration share one bordered container so the stepper reads as
+   nested under the switch that reveals it. */
+#program-modal .rest-mode-box {
+    background: var(--pe-surface-2);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+}
+
+#program-modal .rest-mode-toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    min-height: 40px;
+    padding: 0.35rem 0.7rem;
+}
+
+#program-modal .rest-mode-label {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    min-width: 0;
+    margin: 0;
+    color: var(--pe-text-muted);
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+}
+
+#program-modal .rest-mode-label i {
+    flex-shrink: 0;
+    color: var(--pe-text-muted);
+    font-size: 0.85rem;
+}
+
+#program-modal .rest-mode-group .toggle-switch {
+    flex-shrink: 0;
+}
+
+/* The switch's real checkbox is transparent but still inherits the sitewide
+   `color: #555 !important`; pin it so nothing in the editor resolves grey. */
+#program-modal .toggle-switch input[type="checkbox"] {
+    color: var(--pe-text-muted) !important;
+}
+
+#program-modal .rest-mode-uniform-section {
+    padding: 0 0.7rem 0.45rem 1.55rem;
+}
+
+#program-modal .rest-mode-uniform-section[hidden] {
+    display: none;
+}
+
+#program-modal #rest-mode-uniform-stepper .pex-stepper {
+    width: 100%;
+    max-width: 320px;
+    background: var(--bg-card);
+}
+
+/* ---- 6. Exercises section ---------------------------------------------- */
+#program-modal .program-exercises-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    margin-top: 0.9rem;
+    padding: 0.7rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+}
+
+#program-modal .program-exercises-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+#program-modal .program-exercises-heading {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: -0.005em;
+}
+
+#program-modal .program-exercises-heading i {
+    color: var(--pe-text-muted);
+    font-size: 0.8rem;
+}
+
+#program-modal .program-exercises-count {
+    color: var(--pe-text-muted);
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+#program-modal .program-exercises-count:empty {
+    display: none;
+}
+
+#program-modal .program-exercises-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 1.3rem 1rem;
+    background: var(--bg-card);
+    border: 1px dashed var(--border-light);
+    border-radius: 10px;
+    text-align: center;
+}
+
+#program-modal .program-exercises-empty i {
+    margin-bottom: 0.2rem;
+    color: var(--accent-primary);
+    font-size: 1.7rem;
+    opacity: 0.75;
+}
+
+#program-modal .program-exercises-empty p {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-weight: 700;
+}
+
+#program-modal .program-exercises-empty small {
+    color: var(--pe-text-muted);
+    font-size: 0.8rem;
+    line-height: 1.4;
+}
+
+#program-modal .btn-add-exercise {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    height: 36px;
+    min-height: 0;
+    margin: 0;
+    padding: 0 1rem;
+    background: var(--pe-surface-2);
+    border: 1px dashed var(--border-light);
+    border-radius: 10px;
+    color: var(--pe-text-muted) !important;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: none;
+    transition: background var(--transition-base), border-color var(--transition-base),
+                color var(--transition-base);
+}
+
+#program-modal .btn-add-exercise i {
+    color: inherit !important;
+    font-size: 0.78rem;
+}
+
+#program-modal .btn-add-exercise:hover,
+#program-modal .btn-add-exercise:hover:active {
+    background: var(--pe-surface-3);
+    border-color: var(--accent-primary);
+    color: var(--text-primary) !important;
+}
+
+#program-modal .btn-add-exercise:focus-visible {
+    outline: none;
+    color: var(--text-primary) !important;
+    box-shadow: var(--pe-focus);
+}
+
+#program-exercises-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pe-card-gap);
+}
+
+/* ---- 7. Exercise card shell -------------------------------------------- */
+#program-modal .program-exercise-row {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: var(--pe-gap);
+    /* The card's top inset lives on .pex-head, not here: it keeps the header
+       row flush with the card's top edge so every header control measures
+       inside the header band. */
+    padding: 0 var(--pe-card-pad-x) var(--pe-card-pad-y);
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    box-shadow: var(--shadow-sm);
+    cursor: grab;
+    transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+#program-modal .program-exercise-row:hover {
+    background: var(--pe-card-hover);
+    border-color: var(--border-light);
+}
+
+#program-modal .program-exercise-row:active {
+    cursor: grabbing;
+}
+
+#program-modal .program-exercise-row.is-dragging {
+    opacity: 0.4;
+    border-color: var(--accent-primary);
+}
+
+#program-modal .program-exercise-row.is-drop-above {
+    box-shadow: 0 -2px 0 0 var(--accent-primary);
+}
+
+#program-modal .program-exercise-row.is-drop-below {
+    box-shadow: 0 2px 0 0 var(--accent-primary);
+}
+
+/* Fires once when a card arrives from the exercise picker. */
+#program-modal .program-exercise-row.gt-exercise-added {
+    animation: gt-exercise-added-glow 1.5s ease forwards;
+}
+
+@keyframes gt-exercise-added-glow {
+    0%   { box-shadow: 0 0 0 2px var(--accent-primary), 0 0 14px rgba(91, 155, 255, 0.45); }
+    60%  { box-shadow: 0 0 0 2px var(--accent-primary), 0 0 10px rgba(91, 155, 255, 0.3); }
+    100% { box-shadow: none; }
+}
+
+/* Superset members sit flush with squared shared edges and rounded outer
+   ones; the linked card carries extra top padding so the tag gets its own
+   band instead of overlapping the header. */
+#program-modal .program-exercise-row.is-grouped {
+    background: rgba(91, 155, 255, 0.06);
+    border-color: rgba(91, 155, 255, 0.45);
+}
+
+#program-modal .program-exercise-row.is-linked-above {
+    margin-top: calc(-1 * var(--pe-card-gap));
+    border-top-color: transparent;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
+#program-modal .program-exercise-row.is-linked-above .pex-head {
+    padding-top: calc(var(--pe-card-pad-y) + 15px);
+}
+
+#program-modal .program-exercise-row.is-linked-below {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+#program-modal .pex-superset-tag {
+    position: absolute;
+    top: 3px;
+    left: 10px;
+    padding: 0 7px;
+    background: var(--bg-card);
+    border: 1px solid rgba(91, 155, 255, 0.5);
+    border-radius: 999px;
+    color: var(--accent-primary);
+    font-size: 0.62rem;
+    font-weight: 700;
+    line-height: 15px;
+}
+
+/* ---- 8. Card header: handle, number, name, muscle, action cluster ------- */
+#program-modal .pex-head {
+    display: flex;
+    align-items: center;
+    gap: var(--pe-gap);
+    padding-top: var(--pe-card-pad-y);
+    min-width: 0;
+    min-height: calc(var(--pe-control-h) + var(--pe-card-pad-y));
+}
+
+#program-modal .pex-drag-handle {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: var(--pe-control-h);
+    color: var(--pe-text-muted);
+    font-size: 0.9rem;
+    opacity: 0.7;
+    cursor: grab;
+    transition: opacity var(--transition-fast);
+}
+
+#program-modal .program-exercise-row:hover .pex-drag-handle {
+    opacity: 1;
+}
+
+#program-modal .pex-drag-handle:active {
+    cursor: grabbing;
+}
+
+#program-modal .pex-position {
+    flex: 0 0 auto;
+    min-width: 15px;
+    color: var(--pe-text-muted);
+    font-size: 0.78rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+}
+
+#program-modal .pex-name {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    min-width: 0;
+    overflow: hidden;
+}
+
+/* Name is the strongest element in the card and truncates rather than
+   wrapping the header onto a third line. */
+#program-modal .pex-name-main {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: 1.3;
+}
+
+#program-modal .pex-name-sub {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--pe-text-muted);
+    font-size: 0.78rem;
+    font-weight: 500;
+    line-height: 1.3;
+}
+
+#program-modal .pex-head-actions {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-left: auto;
+}
+
+#program-modal .pex-move-buttons {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+}
+
+/* ---- 9. The one icon button -------------------------------------------- */
+#program-modal .pex-icon-btn {
+    flex: 0 0 auto;
+    width: var(--pe-control-h);
+    height: var(--pe-control-h);
+    min-width: 0;
+    min-height: 0;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--pe-radius);
+    color: var(--pe-text-muted) !important;
+    font-family: inherit;
+    font-size: 0.78rem;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: none;
+    transition: background var(--transition-fast), color var(--transition-fast),
+                border-color var(--transition-fast);
+}
+
+#program-modal .pex-icon-btn i {
+    color: inherit !important;
+}
+
+#program-modal .pex-icon-btn:hover,
+#program-modal .pex-icon-btn:hover:active {
+    background: var(--pe-surface-3);
+    border-color: var(--border-light);
+    color: var(--text-primary) !important;
+}
+
+#program-modal .pex-icon-btn:focus-visible {
+    outline: none;
+    color: var(--text-primary) !important;
+    box-shadow: var(--pe-focus);
+}
+
+#program-modal .pex-icon-btn:disabled {
+    background: transparent;
+    border-color: transparent;
+    color: var(--pe-text-muted) !important;
+    opacity: 0.28;
+    cursor: not-allowed;
+}
+
+/* Destructive controls stay muted at rest and only take the danger colour on
+   hover/focus, pinned here so the sitewide red hover can't claim them. */
+#program-modal .pex-icon-btn-danger:hover:not(:disabled),
+#program-modal .pex-icon-btn-danger:hover:active:not(:disabled),
+#program-modal .pex-icon-btn-danger:focus-visible:not(:disabled) {
+    background: rgba(248, 113, 113, 0.12);
+    border-color: rgba(248, 113, 113, 0.5);
+    color: var(--accent-error) !important;
+}
+
+#program-modal .pex-icon-btn-link.is-on {
+    background: var(--pe-accent-soft);
+    border-color: rgba(91, 155, 255, 0.65);
+    color: #ffffff !important;
+}
+
+#program-modal .pex-icon-btn-link.is-on:hover,
+#program-modal .pex-icon-btn-link.is-on:hover:active {
+    background: rgba(91, 155, 255, 0.34);
+    border-color: var(--accent-primary);
+    color: #ffffff !important;
+}
+
+/* ---- 10. Card body: sets on the left, rest in a fixed right column ------ */
+#program-modal .pex-body {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) var(--pe-rest-col);
+    grid-template-areas:
+        "sets   rest"
+        "addset rest";
+    gap: var(--pe-gap) 0.75rem;
+    align-items: start;
+    min-width: 0;
+}
+
+#program-modal .pex-sets-block {
+    grid-area: sets;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+#program-modal .pex-add-set-btn {
+    grid-area: addset;
+    justify-self: start;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3rem;
+    width: auto;
+    max-width: 110px;
+    height: 28px;
+    min-height: 0;
+    padding: 0 0.6rem;
+    background: transparent;
+    border: 1px dashed var(--border-light);
+    border-radius: var(--pe-radius);
+    color: var(--pe-text-muted) !important;
+    font-family: inherit;
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+    box-shadow: none;
+    transition: background var(--transition-fast), color var(--transition-fast),
+                border-color var(--transition-fast);
+}
+
+#program-modal .pex-add-set-btn i {
+    color: inherit !important;
+    font-size: 0.66rem;
+}
+
+#program-modal .pex-add-set-btn:hover,
+#program-modal .pex-add-set-btn:hover:active {
+    background: var(--pe-surface-3);
+    border-color: var(--accent-primary);
+    color: var(--text-primary) !important;
+}
+
+#program-modal .pex-add-set-btn:focus-visible {
+    outline: none;
+    color: var(--text-primary) !important;
+    box-shadow: var(--pe-focus);
+}
+
+#program-modal .pex-rest-block {
+    grid-area: rest;
+    display: flex;
+    flex-direction: column;
+    gap: var(--pe-gap);
+    min-width: 0;
+}
+
+/* ---- 11. Set row: Set N | reps | Single|Range | remove ------------------ */
+#program-modal .pex-set-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+}
+
+#program-modal .pex-set-label {
+    flex: 0 0 auto;
+    min-width: 2.6rem;
+    color: var(--pe-text-muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0;
+    white-space: nowrap;
+}
+
+#program-modal .pex-set-reps {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+}
+
+#program-modal .pex-reps-input {
+    flex: 0 0 auto;
+    width: 46px;
+    height: var(--pe-control-h);
+    padding: 0 2px;
+    background: var(--pe-surface-2);
+    border: 1px solid var(--border-color);
+    border-radius: var(--pe-radius);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    box-shadow: none;
+    -moz-appearance: textfield;
+}
+
+#program-modal .pex-reps-input::-webkit-inner-spin-button,
+#program-modal .pex-reps-input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+#program-modal .pex-reps-input:focus {
+    outline: none;
+    border-color: var(--accent-primary);
+    background: var(--bg-card);
+    box-shadow: var(--pe-focus);
+}
+
+#program-modal .pex-reps-sep {
+    flex: 0 0 auto;
+    color: var(--pe-text-muted);
+    font-size: 0.8rem;
+    font-weight: 700;
+}
+
+/* Single mode really removes the second input from layout, it isn't just
+   faded out, so the row reads as one target. */
+#program-modal .pex-reps-sep-hidden,
+#program-modal .pex-reps-max-hidden {
+    display: none;
+}
+
+/* Segmented control showing the CURRENT mode as selected. It shrinks before
+   the row can ever overflow at narrow widths. */
+#program-modal .pex-mode-seg {
+    flex: 0 1 auto;
+    display: inline-flex;
+    align-items: stretch;
+    height: var(--pe-control-h);
+    min-width: 0;
+    max-width: 120px;
+    padding: 0;
+    background: var(--pe-surface-2);
+    border: none;
+    border-radius: var(--pe-radius);
+}
+
+#program-modal .pex-mode-opt {
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 100%;
+    padding: 0 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: var(--pe-radius);
+    color: var(--pe-text-muted) !important;
+    font-family: inherit;
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+    box-shadow: none;
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+#program-modal .pex-mode-opt:hover,
+#program-modal .pex-mode-opt:hover:active {
+    background: var(--pe-surface-3);
+    color: var(--text-primary) !important;
+}
+
+/* Selected reads as a raised chip with accent text, not a saturated fill: the
+   mode control is chrome and repeats on every set row, so a solid blue block
+   per row out-shouted the rep numbers, which are the actual data. The inset
+   ring keeps the box the same size as every other editor control. */
+#program-modal .pex-mode-opt.is-on,
+#program-modal .pex-mode-opt.is-on:hover,
+#program-modal .pex-mode-opt.is-on:hover:active {
+    background: var(--pe-surface-3);
+    color: var(--accent-primary) !important;
+    box-shadow: inset 0 0 0 1px rgba(91, 155, 255, 0.55);
+}
+
+#program-modal .pex-mode-opt.is-on:focus-visible {
+    box-shadow: inset 0 0 0 1px rgba(91, 155, 255, 0.55), var(--pe-focus);
+}
+
+#program-modal .pex-mode-opt:focus-visible {
+    outline: none;
+    box-shadow: var(--pe-focus);
+}
+
+/* ---- 12. Rest steppers: label - value + on one line --------------------- */
+#program-modal .pex-stepper {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+    min-width: 0;
+    padding: 0 0.15rem 0 0.6rem;
+    background: var(--pe-surface-2);
+    border: 1px solid var(--border-color);
+    border-radius: var(--pe-radius);
+    box-sizing: border-box;
+}
+
+#program-modal .pex-stepper-label {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--pe-text-muted);
+    font-size: 0.74rem;
+    font-weight: 600;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+#program-modal .pex-label-short {
+    display: none;
+}
+
+#program-modal .pex-stepper-controls {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+}
+
+#program-modal .pex-stepper-value {
+    min-width: 3.2ch;
+    padding: 0 0.15rem;
+    color: var(--text-primary);
+    font-size: 0.82rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    white-space: nowrap;
+}
+
+#program-modal .pex-stepper-btn {
+    font-size: 0.68rem;
+}
+
+/* ---- 13. Desktop (>= 1024px): a wider dialog --------------------------- */
+@media (min-width: 1024px) {
+    #program-modal .modal-content {
+        max-width: min(940px, 92vw);
+    }
+}
+
+/* ---- 14. Mobile (<= 640px) --------------------------------------------- */
+@media (max-width: 640px) {
+    #program-modal {
+        --pe-control-h: 36px;
+        --pe-card-pad-x: 0.55rem;
+    }
+
+    #program-modal .modal-content {
+        max-width: 100%;
+    }
+
+    #program-modal .modal-body {
+        padding: 0.7rem 0.7rem 0.9rem;
+    }
+
+    #program-modal .program-modal-header {
+        padding: 0.6rem 0.75rem;
+    }
+
+    #program-modal .program-exercises-section {
+        padding: 0.55rem;
+    }
+
+    /* Sets span the full width; "+ Add set" and the rest controls share the
+       row below, which is what keeps a five-set card inside the height budget. */
+    #program-modal .pex-body {
+        grid-template-columns: auto minmax(0, 1fr);
+        grid-template-areas:
+            "sets   sets"
+            "addset rest";
+        gap: var(--pe-gap) 0.5rem;
+    }
+
+    #program-modal .pex-add-set-btn {
+        height: 36px;
+        font-size: 0.75rem;
+    }
+
+    #program-modal .pex-label-full {
+        display: none;
+    }
+
+    #program-modal .pex-label-short {
+        display: inline;
+    }
+
+    #program-modal .pex-stepper {
+        padding-left: 0.5rem;
+    }
+
+    #program-modal .pex-drag-handle {
+        width: 12px;
+    }
+
+    /* Name over muscle group: sharing one line here left the name at ~90px
+       and the muscle group at ~20px, so both were ellipsis. Two short lines
+       still fit inside the 36px action row. */
+    #program-modal .pex-name {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0;
+    }
+
+    /* Touch targets: header actions and the uniform-rest switch both sat
+       under 36px on their short axis. */
+    #program-modal .program-modal-header .btn {
+        height: 36px;
+    }
+
+    #program-modal .rest-mode-group .toggle-switch {
+        width: 60px;
+        height: 36px;
+    }
+
+    #program-modal .rest-mode-group .toggle-slider::before {
+        top: 3px;
+        left: 3px;
+        width: 28px;
+        height: 28px;
+    }
+
+    #program-modal .rest-mode-group .toggle-switch input[type="checkbox"]:checked + .toggle-slider::before {
+        transform: translateX(24px);
+    }
+}
+
+/* ---- 15. Narrow (<= 380px): everything stacks -------------------------- */
+@media (max-width: 380px) {
+    #program-modal {
+        --pe-card-pad-x: 0.45rem;
+        padding: 0.35rem;
+    }
+
+    #program-modal .modal-body {
+        padding: 0.6rem 0.5rem 0.8rem;
+    }
+
+    #program-modal .program-exercises-section {
+        padding: 0.45rem;
+    }
+
+    #program-modal .pex-body {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-areas:
+            "sets"
+            "addset"
+            "rest";
+    }
+
+    /* The header's action cluster (4 x 36px), the drag handle and the position
+       badge consume this width, leaving the name 65px: every name ellipsised,
+       "Hex Press" included. Unwrap .pex-name so the name takes a full-width
+       line of its own and the meta row below it carries
+       [handle] [position] [muscle group] ... [actions]. */
+    #program-modal .pex-head {
+        flex-wrap: wrap;
+        row-gap: 0;
+    }
+
+    #program-modal .pex-name {
+        display: contents;
+    }
+
+    #program-modal .pex-name-main {
+        order: -1;
+        flex: 1 0 100%;
+        width: 100%;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        white-space: normal;
+        line-height: 1.25;
+    }
+
+    /* Basis 0 so a long muscle group ("Upper Chest") can never push the action
+       cluster onto a third line: with wrapping on, flex line-breaking happens
+       before shrinking, so an auto basis would break the row. */
+    #program-modal .pex-name-sub {
+        flex: 1 1 0;
+    }
+
+    #program-modal .pex-set-label {
+        min-width: 0;
+        font-size: 0.7rem;
+    }
+
+    #program-modal .pex-reps-input {
+        width: 44px;
+    }
+
+    #program-modal .pex-mode-opt {
+        padding: 0 0.35rem;
+        font-size: 0.66rem;
+    }
+
+    #program-modal .schedule-day-chip {
+        font-size: 0.72rem;
+    }
 }

--- a/apps/gym-tracker/css/refresh.css
+++ b/apps/gym-tracker/css/refresh.css
@@ -492,7 +492,10 @@ body.gym-tracker .modal-header h2 {
     text-transform: none;
 }
 
-body.gym-tracker .modal-close {
+/* `.modal-close` is the round X affordance. The program editor's header
+   Cancel also carries the class (it is a close path), so it must be excluded
+   or it renders as a 30px circle with its label clipped to "Cance". */
+body.gym-tracker .modal-close:not(.program-modal-cancel) {
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid var(--gt-border);
     color: var(--gt-text) !important;
@@ -509,7 +512,7 @@ body.gym-tracker .modal-close:hover,
 body.gym-tracker .modal-close:hover:active {
     box-shadow: none !important;
 }
-body.gym-tracker .modal-close:hover {
+body.gym-tracker .modal-close:not(.program-modal-cancel):hover {
     background: var(--gt-surface-2);
     border-color: var(--gt-border-strong);
 }
@@ -1850,60 +1853,6 @@ body.gym-tracker .modal-header h2 {
     letter-spacing: -0.01em;
 }
 
-/* Program form inside modal — Title Case, consistent label sizing. */
-body.gym-tracker #program-form .form-group label {
-    color: var(--gt-muted);
-    font-size: 0.85rem;
-    letter-spacing: 0;
-    text-transform: none;
-}
-
-/* Program exercises section */
-body.gym-tracker .program-exercises-section {
-    background: var(--gt-surface-2);
-    border: 1px solid var(--gt-border);
-    border-radius: var(--gt-radius-inner);
-}
-
-body.gym-tracker .program-exercises-empty {
-    background: var(--gt-surface);
-    border: 1px dashed var(--gt-border-strong);
-    border-radius: var(--gt-radius-inner);
-}
-
-body.gym-tracker .program-exercises-empty i {
-    color: var(--gt-accent);
-    opacity: 0.7;
-}
-
-body.gym-tracker .program-exercises-empty p {
-    color: var(--gt-text) !important;
-    font-weight: 600;
-}
-
-body.gym-tracker .program-exercises-empty small {
-    color: var(--gt-muted) !important;
-}
-
-/* Individual exercise row in program editor */
-body.gym-tracker .program-exercise-row {
-    background: var(--gt-surface);
-    border: 1px solid var(--gt-border);
-    border-radius: var(--gt-radius-inner);
-}
-
-body.gym-tracker .program-exercise-row:hover {
-    background: var(--gt-surface-2);
-    border-color: var(--gt-border-strong);
-}
-
-/* Rest mode toggle row */
-body.gym-tracker .rest-mode-toggle-row {
-    background: var(--gt-surface-2);
-    border: 1px solid var(--gt-border);
-    border-radius: var(--gt-radius-inner);
-}
-
 /* ============================================================
    10. GENERAL TYPOGRAPHY + EMPTY STATES REFINEMENT
    ============================================================ */
@@ -2222,197 +2171,6 @@ body.gym-tracker .gt-exercise-dir-link:focus-visible {
     outline: 2px solid var(--gt-accent);
     outline-offset: 2px;
     text-decoration: none !important;
-}
-
-/* ============================================================
-   18. PROGRAM MODAL MOBILE ALIGNMENT (max-width: 640px)
-   Fixes alignment of all controls in the Create/Edit Program modal
-   at 390px: consistent gutters, touch targets >=40px, no overflow.
-   ============================================================ */
-
-@media (max-width: 640px) {
-
-    /* Modal body padding — tighter on mobile */
-    body.gym-tracker #program-modal .modal-body {
-        padding: 0.85rem 0.75rem !important;
-    }
-
-    /* Name + description inputs: full width, readable height */
-    body.gym-tracker #program-form .form-group input[type="text"],
-    body.gym-tracker #program-form .form-group textarea {
-        width: 100%;
-        box-sizing: border-box;
-    }
-
-    /* Uniform rest toggle row: fix label wrapping — icon + text shrink,
-       toggle stays on same line */
-    body.gym-tracker .rest-mode-toggle-row {
-        align-items: flex-start;
-        flex-wrap: nowrap;
-        gap: 0.5rem;
-        padding: 0.65rem 0.75rem;
-        min-height: 48px;
-    }
-
-    body.gym-tracker .rest-mode-label {
-        font-size: 0.82rem;
-        flex: 1 1 auto;
-        min-width: 0;
-        flex-wrap: wrap;
-        align-items: flex-start;
-        gap: 0.35rem;
-        padding-top: 0.1rem;
-    }
-
-    body.gym-tracker .rest-mode-label i {
-        flex-shrink: 0;
-        margin-top: 0.1rem;
-    }
-
-    body.gym-tracker .rest-mode-group .toggle-switch {
-        flex-shrink: 0;
-    }
-
-    /* Uniform rest stepper — full width on mobile */
-    body.gym-tracker .rest-mode-uniform-section {
-        padding: 0.5rem 0 0;
-    }
-
-    body.gym-tracker #rest-mode-uniform-stepper .pex-stepper {
-        width: 100%;
-        box-sizing: border-box;
-        display: flex;
-        justify-content: space-between;
-    }
-
-    /* Exercise list section — full-width, no side overflow */
-    body.gym-tracker .program-exercises-section {
-        padding: 0.65rem 0.65rem 0.65rem;
-        overflow: hidden;
-    }
-
-    /* Each exercise row: single-column layout on narrow screens.
-       Stack handle+position+name on top, then targets below. */
-    body.gym-tracker .program-exercise-row {
-        grid-template-columns: auto auto 1fr auto auto;
-        grid-template-areas:
-            "handle position name   actions actions"
-            "targets targets targets targets targets";
-        padding: 0.55rem 0.6rem;
-        gap: 0.4rem;
-        overflow: hidden;
-    }
-
-    body.gym-tracker .program-exercise-row .pex-row-actions {
-        grid-area: actions;
-        align-self: center;
-        justify-self: end;
-        margin-left: 0;
-    }
-
-    /* Targets row spans full width and lays out as a column */
-    body.gym-tracker .program-exercise-row .pex-targets {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        width: 100%;
-        padding-top: 0.4rem;
-        border-top: 1px dashed var(--gt-border);
-        align-items: stretch;
-    }
-
-    /* Sets/reps block fills full width */
-    body.gym-tracker .pex-sets-block {
-        width: 100%;
-    }
-
-    /* Sets header: label + add button on same row, full width */
-    body.gym-tracker .pex-sets-header {
-        width: 100%;
-    }
-
-    /* Each set row: align controls on one line, ensure min touch target */
-    body.gym-tracker .pex-set-row {
-        gap: 0.4rem;
-        min-height: 40px;
-    }
-
-    /* Set label: consistent width */
-    body.gym-tracker .pex-set-label {
-        min-width: 2.8rem;
-        flex-shrink: 0;
-    }
-
-    /* Reps inputs: slightly larger for fat-finger accuracy */
-    body.gym-tracker .pex-reps-input {
-        width: 3rem;
-        min-height: 36px;
-        padding: 0.3rem 0.25rem;
-        font-size: 0.9rem;
-    }
-
-    /* Range toggle + remove set: explicit touch target */
-    body.gym-tracker .pex-range-toggle,
-    body.gym-tracker .pex-set-remove {
-        width: 32px;
-        height: 32px;
-        flex-shrink: 0;
-    }
-
-    /* Rest stepper: full width pill on mobile */
-    body.gym-tracker .program-exercise-row .pex-stepper {
-        width: 100%;
-        box-sizing: border-box;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0.35rem 0.6rem;
-        min-height: 40px;
-    }
-
-    body.gym-tracker .program-exercise-row .pex-stepper-btn {
-        width: 32px;
-        height: 32px;
-        font-size: 0.75rem;
-    }
-
-    /* Move buttons: ensure they don't overflow */
-    body.gym-tracker .pex-move-buttons {
-        flex-shrink: 0;
-    }
-
-    /* Delete button: proper touch target */
-    body.gym-tracker .pex-delete {
-        width: 32px !important;
-        height: 32px !important;
-    }
-
-    /* Form footer buttons — full width stack, already handled by gym-tracker.css
-       @media (max-width: 520px) rule, but reinforce for 640px breakpoint */
-    body.gym-tracker .program-form-actions {
-        flex-direction: column-reverse;
-        align-items: stretch;
-        gap: 0.5rem;
-        margin-top: 1rem;
-    }
-
-    body.gym-tracker .program-form-actions .btn {
-        width: 100%;
-        min-width: 0;
-    }
-}
-
-/* Exercise card highlight animation — fires once when a new card is
-   added from the picker. JS adds .gt-exercise-added class immediately,
-   removes it after the animation duration. */
-@keyframes gt-exercise-added-glow {
-    0%   { box-shadow: 0 0 0 2px var(--gt-accent), 0 0 14px rgba(91, 155, 255,0.45); }
-    60%  { box-shadow: 0 0 0 2px var(--gt-accent), 0 0 10px rgba(91, 155, 255,0.3); }
-    100% { box-shadow: none; }
-}
-
-body.gym-tracker .program-exercise-row.gt-exercise-added {
-    animation: gt-exercise-added-glow 1.5s ease forwards;
 }
 
 /* Shared back-to-top button: on mobile it tucks LOW, hugging just above the
@@ -3063,23 +2821,6 @@ body.gym-tracker .set-toggle:hover:active {
 }
 body.gym-tracker .set-toggle[aria-pressed="true"]:hover:active {
     background: var(--accent-success) padding-box;
-}
-
-/* Program-modal weekday chips: they use a real 1px border, so the leaked
-   inset ring double-strokes them gray and turns red on hover. */
-body.gym-tracker .schedule-day-chip,
-body.gym-tracker .schedule-day-chip:hover,
-body.gym-tracker .schedule-day-chip:hover:active {
-    box-shadow: none !important;
-}
-body.gym-tracker .schedule-day-chip:focus-visible {
-    box-shadow: 0 0 0 3px rgba(91, 155, 255, 0.35) !important;
-}
-body.gym-tracker .schedule-day-chip:hover:active {
-    background: var(--bg-hover);
-}
-body.gym-tracker .schedule-day-chip.is-on:hover:active {
-    background: #1d4ed8;
 }
 
 /* Desktop workout FAB and mobile More-menu rows: their labels/icons are

--- a/apps/gym-tracker/index.html
+++ b/apps/gym-tracker/index.html
@@ -281,103 +281,6 @@
                     <!-- Will be populated by JS -->
                 </div>
 
-                <!-- Create/Edit Program Modal -->
-                <div id="program-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="program-modal-title">
-                    <div class="modal-content" data-back-to-top>
-                        <div class="modal-header program-modal-header">
-                            <h2 id="program-modal-title">Create Program</h2>
-                            <!-- Item R2-7: in workout mode these two actions live in
-                                 the sticky header; the footer save/return are hidden. -->
-                            <div class="program-modal-workout-actions" id="program-modal-workout-actions" hidden>
-                                <button type="button" class="btn btn-ghost program-modal-cancel" id="program-modal-cancel-workout">Cancel</button>
-                                <button type="button" class="btn btn-primary" id="program-modal-save-resume">
-                                    <i class="fas fa-check"></i> Save &amp; resume
-                                </button>
-                            </div>
-                            <!-- Normal create/edit actions, pinned in the sticky header:
-                                 a plain Cancel (dismisses) + a blue Save. No separate X. -->
-                            <div class="program-modal-normal-actions" id="program-modal-normal-actions" hidden>
-                                <button type="button" class="btn btn-ghost modal-close program-modal-cancel">Cancel</button>
-                                <button type="submit" class="btn btn-primary btn-save-program" form="program-form">
-                                    <i class="fas fa-check"></i> Save
-                                </button>
-                            </div>
-                        </div>
-                        <div class="modal-body">
-                            <form id="program-form" novalidate>
-                                <div class="form-group" id="program-name-group">
-                                    <label for="program-name">Program Name</label>
-                                    <input type="text" id="program-name"
-                                        placeholder="e.g., Full Body Workout"
-                                        aria-describedby="program-name-error"
-                                        aria-invalid="false">
-                                    <p id="program-name-error" class="form-error" hidden>
-                                        <i class="fas fa-circle-exclamation" aria-hidden="true"></i>
-                                        <span>Enter a name for this program.</span>
-                                    </p>
-                                </div>
-                                <div class="form-group">
-                                    <label for="program-description">Description (Optional)</label>
-                                    <textarea id="program-description" placeholder="Program details..." rows="3"></textarea>
-                                </div>
-
-                                <div class="form-group program-schedule-group">
-                                    <span class="program-schedule-label">Scheduled days (optional)</span>
-                                    <div id="program-schedule-days" class="program-schedule-days" role="group" aria-label="Scheduled days of the week"></div>
-                                    <p class="form-hint">Pick the days you plan to run this program. They show as markers in the calendar.</p>
-                                </div>
-
-                                <div class="form-group rest-mode-group">
-                                    <div class="rest-mode-toggle-row">
-                                        <label class="rest-mode-label" for="rest-mode-toggle">
-                                            <i class="fas fa-stopwatch" aria-hidden="true"></i>
-                                            Uniform rest between exercises
-                                        </label>
-                                        <label class="toggle-switch" aria-label="Use a single rest duration between all exercises">
-                                            <input type="checkbox" id="rest-mode-toggle" role="switch">
-                                            <span class="toggle-slider" aria-hidden="true"></span>
-                                        </label>
-                                    </div>
-                                    <div id="rest-mode-uniform-section" hidden class="rest-mode-uniform-section">
-                                        <span class="rest-mode-uniform-label">Rest duration</span>
-                                        <div id="rest-mode-uniform-stepper"></div>
-                                        <p id="rest-mode-uniform-hint" class="form-hint">Applied after each exercise. Rest between sets stays per exercise.</p>
-                                    </div>
-                                </div>
-
-                                <section class="program-exercises-section" id="program-exercises-section">
-                                    <header class="program-exercises-header">
-                                        <h3 class="program-exercises-heading">
-                                            <i class="fas fa-dumbbell"></i> Exercises
-                                        </h3>
-                                        <span id="program-exercises-count" class="program-exercises-count"></span>
-                                    </header>
-                                    <div id="program-exercises-list">
-                                        <!-- Exercises will be added here -->
-                                    </div>
-                                    <button type="button" class="btn-add-exercise" id="add-exercise-to-program-btn">
-                                        <i class="fas fa-plus"></i> Add Exercise
-                                    </button>
-                                    <p id="program-exercises-error" class="form-error form-error-section" hidden>
-                                        <i class="fas fa-circle-exclamation" aria-hidden="true"></i>
-                                        <span>Add at least one exercise before saving this program.</span>
-                                    </p>
-                                </section>
-
-                                <div class="form-actions program-form-actions">
-                                    <button type="button" class="btn btn-ghost modal-close">Cancel</button>
-                                    <button type="button" class="btn btn-return-workout" id="return-to-workout-btn" hidden>
-                                        <i class="fas fa-circle-arrow-left"></i> Return to workout
-                                    </button>
-                                    <button type="submit" class="btn btn-primary btn-save-program">
-                                        <i class="fas fa-check"></i> Save Program
-                                    </button>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-
                 <!-- Exercise Picker Modal -->
                 <div id="exercise-picker-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="exercise-picker-title">
                     <div class="modal-content large" data-back-to-top>
@@ -1657,6 +1560,108 @@
                     </button>
                     <button type="button" class="btn btn-ghost feel-modal-skip-secondary" id="feel-modal-skip-btn">Not yet</button>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Create/Edit Program Modal.
+         Lives at document level, NOT inside #programs-view: `.view` animates
+         `fadeIn` with a transform, and a transformed ancestor becomes the
+         containing block for `position: fixed`, which pinned this overlay to
+         the view box (taller than the viewport) instead of the screen. -->
+    <div id="program-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="program-modal-title">
+        <div class="modal-content" data-back-to-top>
+            <div class="modal-header program-modal-header">
+                <h2 id="program-modal-title">Create Program</h2>
+                <!-- Item R2-7: in workout mode these two actions live in
+                     the sticky header; the footer save/return are hidden. -->
+                <div class="program-modal-workout-actions" id="program-modal-workout-actions" hidden>
+                    <button type="button" class="btn btn-ghost program-modal-cancel" id="program-modal-cancel-workout">Cancel</button>
+                    <button type="button" class="btn btn-primary btn-save-program" id="program-modal-save-resume">
+                        <i class="fas fa-check" aria-hidden="true"></i> Save &amp; resume
+                    </button>
+                </div>
+                <!-- Normal create/edit actions, pinned in the sticky header:
+                     a plain Cancel (dismisses) + a blue Save. No separate X. -->
+                <div class="program-modal-normal-actions" id="program-modal-normal-actions" hidden>
+                    <button type="button" class="btn btn-ghost modal-close program-modal-cancel">Cancel</button>
+                    <button type="submit" class="btn btn-primary btn-save-program" form="program-form">
+                        <i class="fas fa-check" aria-hidden="true"></i> Save
+                    </button>
+                </div>
+            </div>
+            <div class="modal-body">
+                <form id="program-form" novalidate>
+                    <div class="form-group" id="program-name-group">
+                        <label for="program-name">Program Name</label>
+                        <input type="text" id="program-name"
+                            placeholder="e.g., Full Body Workout"
+                            aria-describedby="program-name-error"
+                            aria-invalid="false">
+                        <p id="program-name-error" class="form-error" hidden>
+                            <i class="fas fa-circle-exclamation" aria-hidden="true"></i>
+                            <span>Enter a name for this program.</span>
+                        </p>
+                    </div>
+                    <div class="form-group">
+                        <label for="program-description">Description (Optional)</label>
+                        <textarea id="program-description" placeholder="Program details..." rows="2"></textarea>
+                    </div>
+
+                    <div class="form-group program-schedule-group">
+                        <span class="program-schedule-label">Scheduled days (optional)</span>
+                        <div id="program-schedule-days" class="program-schedule-days" role="group" aria-label="Scheduled days of the week"></div>
+                        <p class="form-hint">Pick the days you plan to run this program. They show as markers in the calendar.</p>
+                    </div>
+
+                    <div class="form-group rest-mode-group">
+                        <div class="rest-mode-box">
+                            <div class="rest-mode-toggle-row">
+                                <label class="rest-mode-label" for="rest-mode-toggle">
+                                    <i class="fas fa-stopwatch" aria-hidden="true"></i>
+                                    Uniform rest between exercises
+                                </label>
+                                <label class="toggle-switch" aria-label="Use a single rest duration between all exercises">
+                                    <input type="checkbox" id="rest-mode-toggle" role="switch">
+                                    <span class="toggle-slider" aria-hidden="true"></span>
+                                </label>
+                            </div>
+                            <div id="rest-mode-uniform-section" hidden class="rest-mode-uniform-section">
+                                <div id="rest-mode-uniform-stepper"></div>
+                            </div>
+                        </div>
+                        <p id="rest-mode-hint" class="form-hint">Rest between exercises is set on each exercise below.</p>
+                    </div>
+
+                    <section class="program-exercises-section" id="program-exercises-section">
+                        <header class="program-exercises-header">
+                            <h3 class="program-exercises-heading">
+                                <i class="fas fa-dumbbell" aria-hidden="true"></i> Exercises
+                            </h3>
+                            <span id="program-exercises-count" class="program-exercises-count"></span>
+                        </header>
+                        <div id="program-exercises-list">
+                            <!-- Exercises will be added here -->
+                        </div>
+                        <button type="button" class="btn-add-exercise" id="add-exercise-to-program-btn">
+                            <i class="fas fa-plus" aria-hidden="true"></i> Add Exercise
+                        </button>
+                        <p id="program-exercises-error" class="form-error form-error-section" hidden>
+                            <i class="fas fa-circle-exclamation" aria-hidden="true"></i>
+                            <span>Add at least one exercise before saving this program.</span>
+                        </p>
+                    </section>
+
+                    <div class="form-actions program-form-actions">
+                        <button type="button" class="btn btn-ghost modal-close">Cancel</button>
+                        <button type="button" class="btn btn-return-workout" id="return-to-workout-btn" hidden>
+                            <i class="fas fa-circle-arrow-left" aria-hidden="true"></i> Return to workout
+                        </button>
+                        <button type="submit" class="btn btn-primary btn-save-program">
+                            <i class="fas fa-check" aria-hidden="true"></i> Save Program
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>

--- a/apps/gym-tracker/js/views/programs-view.js
+++ b/apps/gym-tracker/js/views/programs-view.js
@@ -85,6 +85,7 @@ class ProgramsView {
                         this.renderUniformStepper(stepperContainer, this.currentProgram.uniformRestSeconds ?? 90);
                     }
                 }
+                this.syncRestModeHint(restModeToggle.checked);
                 this.renderProgramExercises();
                 this.renderExercisePickerTray();
             });
@@ -529,6 +530,20 @@ class ProgramsView {
         if (isUniform && this.currentProgram) {
             this.renderUniformStepper(stepperContainer, this.currentProgram.uniformRestSeconds ?? 90);
         }
+        this.syncRestModeHint(isUniform);
+    }
+
+    /**
+     * Item 9: one hint line, in both states. OFF has to say what actually
+     * happens (rest lives on each exercise), which the old markup never did
+     * because the only hint lived inside the uniform-only section.
+     */
+    syncRestModeHint(isUniform) {
+        const hint = document.getElementById('rest-mode-hint');
+        if (!hint) return;
+        hint.textContent = isUniform
+            ? 'This rest is used after every exercise. Rest between sets stays per exercise.'
+            : 'Rest between exercises is set on each exercise below.';
     }
 
     /**
@@ -538,14 +553,17 @@ class ProgramsView {
      */
     renderUniformStepper(container, seconds) {
         const label = formatRestLabel(seconds);
-        container.innerHTML = stepperHTML('uniformRest', 0, seconds, 0, 900, 'Rest', 15, label);
+        container.innerHTML = stepperHTML('uniformRest', 0, seconds, 0, 900, 'Rest duration', 15, label);
         container.querySelectorAll('[data-stepper]').forEach(btn => {
             btn.addEventListener('click', () => {
                 if (!this.currentProgram) return;
                 const cur = this.currentProgram.uniformRestSeconds ?? 90;
                 const next = Math.max(0, Math.min(900, cur + Number(btn.dataset.delta)));
                 this.currentProgram.uniformRestSeconds = next;
-                this.renderUniformStepper(container, next);
+                // Same rule as the per-exercise steppers: update the value and
+                // the bound states in place. Re-rendering here rebuilt the
+                // container and threw away the button being clicked.
+                syncStepperUI(container.querySelector('.pex-stepper'), next, 0, 900, formatRestLabel(next));
             });
         });
     }
@@ -599,7 +617,7 @@ class ProgramsView {
             const linkBtnIcon = linkedAbove ? 'fa-link-slash' : 'fa-link';
             // First row can't link upward — there's nothing above it.
             const linkBtnHTML = index === 0 ? '' : `
-                <button type="button" class="btn-icon btn-icon-link${linkedAbove ? ' is-on' : ''}"
+                <button type="button" class="pex-icon-btn pex-icon-btn-link${linkedAbove ? ' is-on' : ''}"
                     data-action="${linkedAbove ? 'unlink-superset' : 'link-superset'}"
                     data-index="${index}"
                     aria-pressed="${linkedAbove ? 'true' : 'false'}"
@@ -613,10 +631,23 @@ class ProgramsView {
             const setRowsHTML = exercise.sets.map((setRow, si) => {
                 const isSingle = setRow.repsMin === setRow.repsMax;
                 const canRemove = exercise.sets.length > 1;
+                // Item 5: a two-option segmented control showing the CURRENT
+                // mode as selected. Both options carry the existing
+                // `toggle-rep-range` action; `data-mode` makes re-picking the
+                // active option a no-op instead of a toggle-away.
+                const modeOpt = (mode, label, on) => `
+                        <button type="button" class="pex-mode-opt${on ? ' is-on' : ''}"
+                            data-action="toggle-rep-range"
+                            data-mode="${mode}"
+                            data-exercise-index="${index}"
+                            data-set-index="${si}"
+                            aria-pressed="${on ? 'true' : 'false'}"
+                            aria-label="Set ${si + 1}: ${mode === 'single' ? 'single rep target' : 'rep range'}"
+                            title="Set ${si + 1}: ${mode === 'single' ? 'single rep target' : 'rep range'}">${label}</button>`;
                 return `
                 <div class="pex-set-row" data-set-index="${si}">
                     <span class="pex-set-label">Set ${si + 1}</span>
-                    <div class="pex-set-reps">
+                    <span class="pex-set-reps">
                         <input type="number" class="pex-reps-input"
                             data-action="set-reps-min"
                             data-exercise-index="${index}"
@@ -632,24 +663,19 @@ class ProgramsView {
                             value="${setRow.repsMax}"
                             min="1" max="100"
                             aria-label="Set ${si + 1} max reps">
-                        <button type="button" class="pex-range-toggle${isSingle ? '' : ' is-on'}"
-                            data-action="toggle-rep-range"
-                            data-exercise-index="${index}"
-                            data-set-index="${si}"
-                            title="${isSingle ? 'Add rep range' : 'Remove rep range'}"
-                            aria-label="${isSingle ? 'Add rep range' : 'Remove rep range'}">
-                            <i class="fas ${isSingle ? 'fa-arrows-left-right' : 'fa-minus'}"></i>
-                            <span class="pex-range-toggle-label">${isSingle ? 'Range' : 'Single'}</span>
-                        </button>
-                    </div>
-                    <button type="button" class="pex-set-remove"
+                    </span>
+                    <span class="pex-mode-seg" role="group" aria-label="Set ${si + 1} rep mode">
+                        ${modeOpt('single', 'Single', isSingle)}
+                        ${modeOpt('range', 'Range', !isSingle)}
+                    </span>
+                    <button type="button" class="pex-icon-btn pex-icon-btn-danger pex-set-remove"
                         data-action="remove-set-row"
                         data-exercise-index="${index}"
                         data-set-index="${si}"
-                        title="Remove set"
+                        title="Remove set ${si + 1}"
                         aria-label="Remove set ${si + 1}"
                         ${canRemove ? '' : 'disabled'}>
-                        <i class="fas fa-xmark"></i>
+                        <i class="fas fa-trash-can" aria-hidden="true"></i>
                     </button>
                 </div>`;
             }).join('');
@@ -657,59 +683,58 @@ class ProgramsView {
             return `
             <div class="program-exercise-row ${groupClasses}" draggable="true" data-exercise-index="${index}">
                 ${linkedAbove ? `<span class="pex-superset-tag" aria-hidden="true">Superset</span>` : ''}
-                <span class="pex-drag-handle" aria-hidden="true" title="Drag to reorder">
-                    <i class="fas fa-grip-vertical"></i>
-                </span>
-                <div class="pex-move-buttons" role="group" aria-label="Reorder exercise">
-                    <button type="button" class="btn-icon btn-icon-move btn-icon-move-mini"
-                        data-action="move-exercise-up"
-                        data-index="${index}"
-                        ${index === 0 ? 'disabled' : ''}
-                        aria-label="Move ${escapeHtml(exercise.exerciseName)} up"
-                        title="Move up">
-                        <i class="fas fa-chevron-up"></i>
-                    </button>
-                    <button type="button" class="btn-icon btn-icon-move btn-icon-move-mini"
-                        data-action="move-exercise-down"
-                        data-index="${index}"
-                        ${index === this.currentProgram.exercises.length - 1 ? 'disabled' : ''}
-                        aria-label="Move ${escapeHtml(exercise.exerciseName)} down"
-                        title="Move down">
-                        <i class="fas fa-chevron-down"></i>
-                    </button>
-                </div>
-                <div class="pex-position" aria-hidden="true">${index + 1}</div>
-                <div class="pex-name">
-                    <span class="pex-name-main">${escapeHtml(exercise.exerciseName)}</span>${muscle ? `
-                    <span class="pex-name-sub">(${muscle})</span>` : ''}
-                </div>
-                <div class="pex-targets">
-                    <div class="pex-sets-block">
-                        <div class="pex-sets-header">
-                            <span class="pex-stepper-label">Sets / Reps</span>
-                            <button type="button" class="pex-add-set-btn"
-                                data-action="add-set-row"
+                <div class="pex-head">
+                    <span class="pex-drag-handle" aria-hidden="true" title="Drag to reorder">
+                        <i class="fas fa-grip-vertical"></i>
+                    </span>
+                    <span class="pex-position" aria-hidden="true">${index + 1}</span>
+                    <span class="pex-name">
+                        <span class="pex-name-main">${escapeHtml(exercise.exerciseName)}</span>${muscle ? `
+                        <span class="pex-name-sub">${escapeHtml(muscle)}</span>` : ''}
+                    </span>
+                    <span class="pex-head-actions">
+                        ${linkBtnHTML}
+                        <span class="pex-move-buttons" role="group" aria-label="Reorder exercise">
+                            <button type="button" class="pex-icon-btn pex-icon-btn-move"
+                                data-action="move-exercise-up"
                                 data-index="${index}"
-                                aria-label="Add set to ${escapeHtml(exercise.exerciseName)}">
-                                <i class="fas fa-plus"></i> Add set
+                                ${index === 0 ? 'disabled' : ''}
+                                aria-label="Move ${escapeHtml(exercise.exerciseName)} up"
+                                title="Move up">
+                                <i class="fas fa-chevron-up" aria-hidden="true"></i>
                             </button>
-                        </div>
-                        <p class="pex-range-hint">Each set can be a single target or a range.</p>
-                        <div class="pex-set-rows">
-                            ${setRowsHTML}
-                        </div>
-                    </div>
-                    ${stepperHTML('rest', index, exercise.restSeconds, 0, 900, 'Rest between sets', 15, restLabel)}
-                    ${isUniform ? '' : stepperHTML('restAfter', index, exercise.restAfterSeconds, 0, 900, 'Rest after exercise', 15, restAfterLabel)}
+                            <button type="button" class="pex-icon-btn pex-icon-btn-move"
+                                data-action="move-exercise-down"
+                                data-index="${index}"
+                                ${index === this.currentProgram.exercises.length - 1 ? 'disabled' : ''}
+                                aria-label="Move ${escapeHtml(exercise.exerciseName)} down"
+                                title="Move down">
+                                <i class="fas fa-chevron-down" aria-hidden="true"></i>
+                            </button>
+                        </span>
+                        <button type="button" class="pex-icon-btn pex-icon-btn-danger pex-delete"
+                            data-action="remove-exercise"
+                            data-index="${index}"
+                            title="Remove ${escapeHtml(exercise.exerciseName)}"
+                            aria-label="Remove ${escapeHtml(exercise.exerciseName)}">
+                            <i class="fas fa-trash-can" aria-hidden="true"></i>
+                        </button>
+                    </span>
                 </div>
-                <div class="pex-row-actions">
-                    ${linkBtnHTML}
-                    <button class="pex-delete"
-                        data-action="remove-exercise"
+                <div class="pex-body">
+                    <div class="pex-sets-block">
+                        ${setRowsHTML}
+                    </div>
+                    <button type="button" class="pex-add-set-btn"
+                        data-action="add-set-row"
                         data-index="${index}"
-                        title="Remove exercise" type="button" aria-label="Remove exercise">
-                        <i class="fas fa-xmark"></i>
+                        aria-label="Add set to ${escapeHtml(exercise.exerciseName)}">
+                        <i class="fas fa-plus" aria-hidden="true"></i> Add set
                     </button>
+                    <div class="pex-rest-block">
+                        ${stepperHTML('rest', index, exercise.restSeconds, 0, 900, 'Rest between sets', 15, restLabel, 'Between sets')}
+                        ${isUniform ? '' : stepperHTML('restAfter', index, exercise.restAfterSeconds, 0, 900, 'Rest after exercise', 15, restAfterLabel, 'After exercise')}
+                    </div>
                 </div>
             </div>
         `;}).join('');
@@ -778,13 +803,21 @@ class ProgramsView {
             });
         });
 
-        // Toggle rep range on/off for a set
+        // Rep mode segmented control (Single / Range) for a set
         container.querySelectorAll('[data-action="toggle-rep-range"]').forEach(btn => {
             btn.addEventListener('click', () => {
-                this.toggleRepRange(
-                    Number(btn.dataset.exerciseIndex),
-                    Number(btn.dataset.setIndex)
-                );
+                const ei = Number(btn.dataset.exerciseIndex);
+                const si = Number(btn.dataset.setIndex);
+                const mode = btn.dataset.mode || null;
+                this.toggleRepRange(ei, si, mode);
+                // Collapsing to Single doesn't move focus into an input, so
+                // put it back on the option the user just pressed (the click
+                // re-rendered the row and destroyed the original node).
+                if (mode === 'single') {
+                    document.querySelector(
+                        `#program-exercises-list [data-action="toggle-rep-range"][data-mode="single"][data-exercise-index="${ei}"][data-set-index="${si}"]`
+                    )?.focus();
+                }
             });
         });
 
@@ -874,13 +907,23 @@ class ProgramsView {
         if (!this.currentProgram) return;
         const ex = this.currentProgram.exercises[index];
         if (!ex) return;
-        if (field === 'rest') {
-            this.currentProgram.updateExercise(index, { restSeconds: ex.restSeconds + delta });
-            this.renderProgramExercises();
-        } else if (field === 'restAfter') {
-            this.currentProgram.updateExercise(index, { restAfterSeconds: ex.restAfterSeconds + delta });
-            this.renderProgramExercises();
-        }
+        const key = field === 'rest' ? 'restSeconds' : field === 'restAfter' ? 'restAfterSeconds' : null;
+        if (!key) return;
+        // #16 again, this time for the steppers: a +/- click changes one number,
+        // so it must NOT re-render #program-exercises-list. The rebuild replaced
+        // every card, which destroyed the button under the pointer (focus fell to
+        // <body>, so holding position for a second click was luck) and repainted
+        // the whole list for a two-character change.
+        // Clamping still belongs to the model: hand updateExercise the raw sum
+        // and read the normalized value back out for the display.
+        this.currentProgram.updateExercise(index, { [key]: ex[key] + delta });
+        const value = this.currentProgram.exercises[index][key];
+        syncStepperUI(
+            document.querySelector(
+                `#program-exercises-list .program-exercise-row[data-exercise-index="${index}"] .pex-stepper[data-field="${field}"]`
+            ),
+            value, 0, 900, formatRestLabel(value)
+        );
     }
 
     addSetRow(exerciseIndex) {
@@ -903,13 +946,21 @@ class ProgramsView {
         this.renderProgramExercises();
     }
 
-    toggleRepRange(exerciseIndex, setIndex) {
+    /**
+     * Switch a set between a single rep target and a rep range.
+     * `mode` ('single' | 'range') comes from the segmented control and makes
+     * clicking the already-selected option a no-op; called without it the
+     * function still flips whichever state the set is in.
+     */
+    toggleRepRange(exerciseIndex, setIndex, mode = null) {
         if (!this.currentProgram) return;
         const ex = this.currentProgram.exercises[exerciseIndex];
         if (!ex || !Array.isArray(ex.sets)) return;
         const row = ex.sets[setIndex];
         if (!row) return;
         const activating = row.repsMin === row.repsMax;
+        if (mode === 'single' && activating) return;
+        if (mode === 'range' && !activating) return;
         if (activating) {
             // Activate range: default max to min+2 (capped at 100)
             row.repsMax = Math.min(100, row.repsMin + 2);
@@ -942,8 +993,9 @@ class ProgramsView {
         // The change event fires on TAB-out (blur); a full re-render destroys
         // and rebuilds the input being left, so the browser's native "focus the
         // next tabbable element" lands on a detached node and jumps elsewhere.
-        // Update the model in place; if clamping moved the SIBLING field, write
-        // only that sibling's input value via a targeted selector — no rebuild.
+        // Update the model in place; write the clamped value back into the
+        // edited input, and into the SIBLING input when clamping moved it, via
+        // targeted selectors, no rebuild.
         let siblingChanged = null; // 'min' | 'max' when the other field was clamped
         if (minOrMax === 'min') {
             const wasSingle = row.repsMin === row.repsMax;
@@ -965,15 +1017,20 @@ class ProgramsView {
         }
         this.currentProgram.updatedAt = new Date().toISOString();
 
+        const repsInput = (kind) => document.querySelector(
+            `#program-exercises-list [data-action="set-reps-${kind}"][data-exercise-index="${exerciseIndex}"][data-set-index="${setIndex}"]`
+        );
+        // The field the user just left keeps whatever they typed unless we
+        // rewrite it, so typing 250 left "250" on screen against a model of 100
+        // and the next open of the editor showed a different number.
+        const edited = repsInput(minOrMax);
+        if (edited) edited.value = minOrMax === 'min' ? row.repsMin : row.repsMax;
+
         if (siblingChanged === 'max') {
-            const maxInput = document.querySelector(
-                `#program-exercises-list [data-action="set-reps-max"][data-exercise-index="${exerciseIndex}"][data-set-index="${setIndex}"]`
-            );
+            const maxInput = repsInput('max');
             if (maxInput) maxInput.value = row.repsMax;
         } else if (siblingChanged === 'min') {
-            const minInput = document.querySelector(
-                `#program-exercises-list [data-action="set-reps-min"][data-exercise-index="${exerciseIndex}"][data-set-index="${setIndex}"]`
-            );
+            const minInput = repsInput('min');
             if (minInput) minInput.value = row.repsMin;
         }
     }
@@ -1098,11 +1155,10 @@ class ProgramsView {
     }
 
     editProgram(programId) {
-        // The program modal lives inside #programs-view, which is `display: none`
-        // when another view is active. If the user triggered this from elsewhere
-        // (e.g. the Dashboard's empty-program row), switch to the Programs view
-        // first so the modal can actually render — and remember where they came
-        // from so we can return them on close.
+        // If the user triggered this from elsewhere (e.g. the Dashboard's
+        // empty-program row), switch to the Programs view first so closing the
+        // editor lands on the program list, and remember where they came from
+        // so we can return them there.
         if (this.app.currentView !== 'programs') {
             this.returnToView = this.app.currentView;
             this.app.showView('programs');
@@ -1183,6 +1239,30 @@ class ProgramsView {
             this.returnToView = null;
             this.app.showView(target);
         }
+    }
+
+    /**
+     * Item R2-9 hook. #program-modal is a document-level element (a `.view`
+     * animates, which would make its `position: fixed` resolve against the
+     * view box), so showView()'s display:none sweep over `.view` no longer
+     * hides it. Dismiss the editor whenever the user leaves Programs by any
+     * route, including the Back button (popstate routes through showView too).
+     * The staged clone is simply dropped, exactly like Cancel. The exercise
+     * picker lives inside #programs-view and so is hidden with it, but its
+     * `active` class also holds the body scroll lock, so clear that as well.
+     * Navigation always proceeds: this hook never defers.
+     */
+    beforeLeave() {
+        const modal = document.getElementById('program-modal');
+        if (modal && modal.classList.contains('active')) {
+            // Cleared first: closeProgramModal() would otherwise call
+            // showView() from inside the showView() that invoked us.
+            this.returnToView = null;
+            this.closeProgramModal();
+        }
+        const picker = document.getElementById('exercise-picker-modal');
+        if (picker) picker.classList.remove('active');
+        return true;
     }
 
     duplicateProgram(programId) {
@@ -1558,35 +1638,59 @@ class ProgramsView {
 }
 
 /**
- * Compact +/- stepper for program-exercise target values.
- * `valueLabel` overrides the displayed label (used by rest which shows "1:30").
+ * Compact single-line `label − value +` stepper for program-exercise values.
+ * `valueLabel` overrides the displayed value (rest shows "1:30" for 90).
+ * `shortLabel` is a narrow-screen alias for the visible caption; the full
+ * `label` always drives the +/- aria-labels so screen readers keep the
+ * unambiguous wording ("Decrease rest between sets").
  */
-function stepperHTML(field, index, value, min, max, label, step = 1, valueLabel = null) {
+function stepperHTML(field, index, value, min, max, label, step = 1, valueLabel = null, shortLabel = null) {
     const displayed = valueLabel ?? String(value);
     const atMin = value <= min;
     const atMax = value >= max;
+    const caption = shortLabel
+        ? `<span class="pex-label-full">${label}</span><span class="pex-label-short">${shortLabel}</span>`
+        : label;
     return `
         <div class="pex-stepper" data-field="${field}">
-            <span class="pex-stepper-label">${label}</span>
+            <span class="pex-stepper-label" title="${label}">${caption}</span>
             <span class="pex-stepper-controls">
-                <button type="button" class="pex-stepper-btn"
+                <button type="button" class="pex-icon-btn pex-stepper-btn"
                     data-stepper data-index="${index}" data-field="${field}" data-delta="${-step}"
                     ${atMin ? 'disabled' : ''}
                     aria-label="Decrease ${label.toLowerCase()}">
-                    <i class="fas fa-minus"></i>
+                    <i class="fas fa-minus" aria-hidden="true"></i>
                 </button>
                 <span class="pex-stepper-value">${displayed}</span>
-                <button type="button" class="pex-stepper-btn"
+                <button type="button" class="pex-icon-btn pex-stepper-btn"
                     data-stepper data-index="${index}" data-field="${field}" data-delta="${step}"
                     ${atMax ? 'disabled' : ''}
                     aria-label="Increase ${label.toLowerCase()}">
-                    <i class="fas fa-plus"></i>
+                    <i class="fas fa-plus" aria-hidden="true"></i>
                 </button>
             </span>
         </div>
     `;
 }
 
+
+/**
+ * In-place refresh of one stepper built by stepperHTML(). A +/- click can only
+ * change two things: the displayed value, and whether the buttons are at a
+ * bound. Everything else in the markup (labels, aria-labels, the data-* the
+ * delegated handlers read) is a function of the field, not the value, so it is
+ * left alone and the listeners already on these buttons keep working.
+ */
+function syncStepperUI(stepper, value, min, max, valueLabel = null) {
+    if (!stepper) return;
+    // Write into the existing text node rather than assigning textContent:
+    // textContent throws the node away and inserts a new one, which is a real
+    // childList removal, i.e. a smaller version of the teardown this avoids.
+    stepper.querySelector('.pex-stepper-value').firstChild.data = valueLabel ?? String(value);
+    stepper.querySelectorAll('[data-stepper]').forEach(btn => {
+        btn.disabled = Number(btn.dataset.delta) < 0 ? value <= min : value >= max;
+    });
+}
 
 /** "1:30", "45s", "0s" — short display optimized for the stepper pill. */
 function formatRestLabel(seconds) {

--- a/apps/gym-tracker/sw.js
+++ b/apps/gym-tracker/sw.js
@@ -18,7 +18,7 @@
  * Old caches are pruned automatically on activate.
  */
 
-const CACHE_VERSION = '1.8.2';
+const CACHE_VERSION = '1.8.3';
 const PRECACHE = `gym-precache-${CACHE_VERSION}`;
 const RUNTIME = `gym-runtime-${CACHE_VERSION}`;
 

--- a/apps/gym-tracker/tests/programs-view-before-leave.test.mjs
+++ b/apps/gym-tracker/tests/programs-view-before-leave.test.mjs
@@ -1,0 +1,135 @@
+// ProgramsView.beforeLeave: the navigation hook that dismisses the program
+// editor when the user leaves the Programs view.
+//
+// Why it exists: #program-modal is a document-level element (a `.view` animates,
+// which would make its `position: fixed` resolve against the view box and render
+// the dialog off-screen). app.showView() hides views by setting display:none on
+// every `.view`, so a modal outside the view tree survives a view change and
+// floats over whatever view you land on. Pressing Back with the editor open left
+// it on top of the Dashboard.
+//
+// The methods are lifted from the real source text (they hang off a DOM-bound
+// class that cannot be imported under node) and run against a stub document, so
+// these tests fail if programs-view.js drifts.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const src = readFileSync(new URL('../js/views/programs-view.js', import.meta.url), 'utf8');
+
+function methodSource(name) {
+    const start = src.indexOf(`\n    ${name}(`);
+    assert.notEqual(start, -1, `${name}() not found in programs-view.js`);
+    let depth = 0;
+    let i = src.indexOf('{', start);
+    const bodyStart = i;
+    for (; i < src.length; i++) {
+        if (src[i] === '{') depth++;
+        else if (src[i] === '}' && --depth === 0) break;
+    }
+    return src.slice(start + 1, i + 1).trim();
+}
+
+// Object-literal shorthand matches the class-method syntax exactly, so the
+// extracted text can be evaluated as-is with `document` shadowed by a stub.
+const buildMethods = new Function(
+    'document',
+    `"use strict"; return { ${methodSource('beforeLeave')}, ${methodSource('closeProgramModal')} };`
+);
+
+function makeEl(id, classes = []) {
+    const set = new Set(classes);
+    return {
+        id,
+        hidden: false,
+        classList: {
+            add: c => set.add(c),
+            remove: c => set.delete(c),
+            contains: c => set.has(c),
+        },
+        classes: set,
+    };
+}
+
+// `open` mirrors the DOM after openProgramModal(): editor active, picker closed.
+function makeView({ open = true, workoutMode = false, pickerOpen = false, returnToView = null } = {}) {
+    const els = {
+        'program-modal': makeEl('program-modal', [
+            ...(open ? ['modal', 'active'] : ['modal']),
+            ...(workoutMode ? ['program-editor-workout-mode'] : []),
+        ]),
+        'exercise-picker-modal': makeEl('exercise-picker-modal', pickerOpen ? ['modal', 'active'] : ['modal']),
+        'return-to-workout-btn': makeEl('return-to-workout-btn'),
+        'program-modal-workout-actions': makeEl('program-modal-workout-actions'),
+    };
+    els['program-modal-workout-actions'].hidden = !workoutMode;
+    els['return-to-workout-btn'].hidden = true;
+
+    const document = { getElementById: id => els[id] || null };
+    const shown = [];
+    const stored = [{ id: 1, name: 'Push Day A', exercises: [{ sets: [{ repsMin: 6, repsMax: 8 }] }] }];
+    const view = Object.create(buildMethods(document));
+    view.app = { showView: v => shown.push(v), programs: stored };
+    view.returnToView = returnToView;
+    view.enteredFromWorkout = workoutMode;
+    // The staged deep clone the editor mutates; Cancel and this hook discard it.
+    view.currentProgram = { id: 1, name: 'Push Day A EDITED', exercises: [{ sets: [{ repsMin: 3, repsMax: 3 }] }] };
+
+    return { view, els, shown, stored };
+}
+
+test('beforeLeave dismisses the open editor so it cannot float over the next view', () => {
+    const { view, els } = makeView();
+    view.beforeLeave('home');
+    assert.equal(els['program-modal'].classList.contains('active'), false);
+});
+
+test('beforeLeave lets navigation proceed (never returns false)', () => {
+    const open = makeView();
+    assert.notEqual(open.view.beforeLeave('home'), false, 'an open editor must not defer navigation');
+    const closed = makeView({ open: false });
+    assert.notEqual(closed.view.beforeLeave('home'), false, 'no editor open is still a clean pass');
+});
+
+test('beforeLeave does not re-enter showView via returnToView', () => {
+    // closeProgramModal() calls app.showView(returnToView); beforeLeave is itself
+    // called from inside showView, so the field has to be cleared first.
+    const { view, shown } = makeView({ returnToView: 'home' });
+    view.beforeLeave('home');
+    assert.deepEqual(shown, [], 'no nested showView call');
+    assert.equal(view.returnToView, null);
+});
+
+test('beforeLeave resets workout-edit state exactly as closing the editor does', () => {
+    const { view, els } = makeView({ workoutMode: true });
+    view.beforeLeave('workout');
+    assert.equal(els['program-modal'].classList.contains('program-editor-workout-mode'), false);
+    assert.equal(els['program-modal-workout-actions'].hidden, true);
+    assert.equal(els['return-to-workout-btn'].hidden, true);
+    assert.equal(view.enteredFromWorkout, false, 'the next open must not inherit workout mode');
+});
+
+test('beforeLeave also closes the exercise picker', () => {
+    // The picker is inside #programs-view so it is hidden with the view, but its
+    // `active` class holds the shared modal scroll lock on <body>.
+    const { view, els } = makeView({ pickerOpen: true });
+    view.beforeLeave('home');
+    assert.equal(els['exercise-picker-modal'].classList.contains('active'), false);
+});
+
+test('beforeLeave discards the staged edits instead of committing them', () => {
+    const { view, stored } = makeView();
+    view.beforeLeave('home');
+    assert.equal(stored.length, 1);
+    assert.equal(stored[0].name, 'Push Day A', 'the stored program keeps its original name');
+    assert.equal(stored[0].exercises[0].sets[0].repsMin, 6, 'and its original reps');
+});
+
+test('beforeLeave with the editor already closed touches nothing', () => {
+    const { view, shown, els } = makeView({ open: false, returnToView: 'home' });
+    view.beforeLeave('home');
+    assert.deepEqual(shown, []);
+    assert.equal(els['program-modal'].classList.contains('active'), false);
+    assert.equal(view.returnToView, 'home', 'a pending return target is left for closeProgramModal');
+});

--- a/apps/gym-tracker/tests/programs-view-range-label.test.mjs
+++ b/apps/gym-tracker/tests/programs-view-range-label.test.mjs
@@ -1,103 +1,122 @@
-// Mirror of the range-toggle and hint markup from ProgramsView.renderProgramExercises.
+// Mirror of the rep-mode segmented control from ProgramsView.renderProgramExercises.
 // If the template changes in programs-view.js, update this file too.
-// These tests assert the discoverability improvements added 2026-06-04:
-//   - .pex-range-toggle-label shows "Range" for single sets and "Single" for ranges.
-//   - .pex-range-hint caption is rendered once per exercise, below the sets header.
+// These tests pin the 2026-08-10 editor round's discoverability contract:
+//   - the control shows BOTH modes at once and marks the CURRENT one selected,
+//     replacing the old single button whose label was the mode you'd switch TO
+//     ("Range" while the set was single), which read as a value, not a mode;
+//   - re-picking the already-selected mode is a no-op, so both options carry
+//     data-mode and the handler compares it against the set's state;
+//   - the per-card "Each set can be a single target or a range." caption is
+//     gone: the two visible options say the same thing without costing a line
+//     of height in every exercise card.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-// Reproduce the set-row HTML fragment (only the toggle portion) from programs-view.js.
-function setRowHTML(setRow) {
+// Reproduce the mode-toggle fragment from programs-view.js.
+function modeSegHTML(setRow, si = 0, index = 0) {
     const isSingle = setRow.repsMin === setRow.repsMax;
+    const modeOpt = (mode, label, on) => `
+                        <button type="button" class="pex-mode-opt${on ? ' is-on' : ''}"
+                            data-action="toggle-rep-range"
+                            data-mode="${mode}"
+                            data-exercise-index="${index}"
+                            data-set-index="${si}"
+                            aria-pressed="${on ? 'true' : 'false'}"
+                            aria-label="Set ${si + 1}: ${mode === 'single' ? 'single rep target' : 'rep range'}"
+                            title="Set ${si + 1}: ${mode === 'single' ? 'single rep target' : 'rep range'}">${label}</button>`;
     return `
-        <button type="button" class="pex-range-toggle${isSingle ? '' : ' is-on'}"
-            data-action="toggle-rep-range"
-            title="${isSingle ? 'Add rep range' : 'Remove rep range'}"
-            aria-label="${isSingle ? 'Add rep range' : 'Remove rep range'}">
-            <i class="fas ${isSingle ? 'fa-arrows-left-right' : 'fa-minus'}"></i>
-            <span class="pex-range-toggle-label">${isSingle ? 'Range' : 'Single'}</span>
-        </button>`;
+                    <span class="pex-mode-seg" role="group" aria-label="Set ${si + 1} rep mode">
+                        ${modeOpt('single', 'Single', isSingle)}
+                        ${modeOpt('range', 'Range', !isSingle)}
+                    </span>`;
 }
 
 // Reproduce the per-exercise sets block wrapper from programs-view.js.
 function setsBlockHTML(sets) {
-    const setRowsHTML = sets.map(setRow => setRowHTML(setRow)).join('');
+    const rows = sets.map((setRow, si) => `
+                <div class="pex-set-row" data-set-index="${si}">
+                    <span class="pex-set-label">Set ${si + 1}</span>
+                    ${modeSegHTML(setRow, si)}
+                </div>`).join('');
     return `
         <div class="pex-sets-block">
-            <div class="pex-sets-header">
-                <span class="pex-stepper-label">Sets / Reps</span>
-                <button type="button" class="pex-add-set-btn" data-action="add-set-row">
-                    <i class="fas fa-plus"></i> Add set
-                </button>
-            </div>
-            <p class="pex-range-hint">Each set can be a single target or a range.</p>
-            <div class="pex-set-rows">
-                ${setRowsHTML}
-            </div>
-        </div>`;
+            ${rows}
+        </div>
+        <button type="button" class="pex-add-set-btn" data-action="add-set-row">
+            <i class="fas fa-plus" aria-hidden="true"></i> Add set
+        </button>`;
 }
 
+const pressed = (html) => [...html.matchAll(/aria-pressed="(true|false)"/g)].map(m => m[1]);
+
 // -------------------------------------------------------
-// Range toggle label: single set
+// Both modes are always on screen
 // -------------------------------------------------------
 
-test('pex-range-toggle-label: shows "Range" for a single-value set (repsMin === repsMax)', () => {
-    const html = setRowHTML({ repsMin: 10, repsMax: 10 });
-    assert.ok(html.includes('class="pex-range-toggle-label"'), 'label span is present');
-    assert.ok(html.includes('>Range<'), 'label text is "Range"');
-    assert.ok(!html.includes('>Single<'), 'label text is not "Single"');
+test('mode control: renders exactly two options, labelled Single and Range', () => {
+    const html = modeSegHTML({ repsMin: 10, repsMax: 10 });
+    const options = [...html.matchAll(/class="pex-mode-opt/g)];
+    assert.equal(options.length, 2, 'exactly two mode options per set row');
+    assert.ok(html.includes('>Single<'), '"Single" option is present');
+    assert.ok(html.includes('>Range<'), '"Range" option is present');
 });
 
-test('pex-range-toggle: has no "is-on" class for a single-value set', () => {
-    const html = setRowHTML({ repsMin: 8, repsMax: 8 });
-    assert.ok(!html.includes('is-on'), 'is-on class absent for single set');
+test('mode control: a single-value set marks Single selected, Range unselected', () => {
+    const html = modeSegHTML({ repsMin: 8, repsMax: 8 });
+    assert.deepEqual(pressed(html), ['true', 'false'], 'Single is pressed, Range is not');
+    assert.ok(html.includes('pex-mode-opt is-on'), 'the selected option carries is-on');
+    assert.equal([...html.matchAll(/is-on/g)].length, 1, 'only one option is selected');
 });
 
-// -------------------------------------------------------
-// Range toggle label: range set
-// -------------------------------------------------------
-
-test('pex-range-toggle-label: shows "Single" for a range set (repsMin !== repsMax)', () => {
-    const html = setRowHTML({ repsMin: 8, repsMax: 12 });
-    assert.ok(html.includes('class="pex-range-toggle-label"'), 'label span is present');
-    assert.ok(html.includes('>Single<'), 'label text is "Single"');
-    assert.ok(!html.includes('>Range<'), 'label text is not "Range"');
-});
-
-test('pex-range-toggle: has "is-on" class for a range set', () => {
-    const html = setRowHTML({ repsMin: 6, repsMax: 10 });
-    assert.ok(html.includes('pex-range-toggle is-on'), 'is-on class present for range set');
+test('mode control: a range set marks Range selected, Single unselected', () => {
+    const html = modeSegHTML({ repsMin: 8, repsMax: 12 });
+    assert.deepEqual(pressed(html), ['false', 'true'], 'Range is pressed, Single is not');
+    assert.equal([...html.matchAll(/is-on/g)].length, 1, 'only one option is selected');
 });
 
 // -------------------------------------------------------
-// Per-exercise hint caption
+// The handler can tell "switch mode" from "re-pick current mode"
 // -------------------------------------------------------
 
-test('pex-range-hint: rendered once per exercise, below the sets header', () => {
-    const sets = [
+test('mode control: both options carry data-mode so re-picking the current one is a no-op', () => {
+    const html = modeSegHTML({ repsMin: 10, repsMax: 10 });
+    assert.ok(html.includes('data-mode="single"'), 'Single option declares its mode');
+    assert.ok(html.includes('data-mode="range"'), 'Range option declares its mode');
+    const actions = [...html.matchAll(/data-action="toggle-rep-range"/g)];
+    assert.equal(actions.length, 2, 'both options reuse the existing toggle-rep-range action');
+});
+
+test('mode control: every option names its set number for screen readers', () => {
+    const html = modeSegHTML({ repsMin: 6, repsMax: 10 }, 2);
+    assert.ok(html.includes('aria-label="Set 3: single rep target"'), 'Single names its set');
+    assert.ok(html.includes('aria-label="Set 3: rep range"'), 'Range names its set');
+    assert.ok(html.includes('aria-label="Set 3 rep mode"'), 'the group names its set');
+});
+
+// -------------------------------------------------------
+// The per-card helper caption is gone
+// -------------------------------------------------------
+
+test('sets block: no per-exercise range hint caption is rendered', () => {
+    const html = setsBlockHTML([
         { repsMin: 10, repsMax: 10 },
         { repsMin: 10, repsMax: 10 },
         { repsMin: 10, repsMax: 10 },
-    ];
-    const html = setsBlockHTML(sets);
-
-    // Appears exactly once per exercise block
-    const matches = [...html.matchAll(/class="pex-range-hint"/g)];
-    assert.equal(matches.length, 1, 'hint appears exactly once per exercise');
-
-    // Contains expected text (no em dashes)
+    ]);
+    assert.ok(!html.includes('pex-range-hint'), 'the hint element is gone');
     assert.ok(
-        html.includes('Each set can be a single target or a range.'),
-        'hint text is correct and contains no em dashes'
+        !html.includes('Each set can be a single target or a range.'),
+        'the hint sentence is gone; the segmented control states both options'
     );
 });
 
-test('pex-range-hint: is inside pex-sets-block, after pex-sets-header', () => {
-    const html = setsBlockHTML([{ repsMin: 5, repsMax: 5 }]);
-    const headerIdx = html.indexOf('pex-sets-header');
-    const hintIdx = html.indexOf('pex-range-hint');
-    assert.ok(headerIdx !== -1, 'pex-sets-header present');
-    assert.ok(hintIdx !== -1, 'pex-range-hint present');
-    assert.ok(hintIdx > headerIdx, 'hint appears after the sets header');
+test('sets block: "+ Add set" follows the set rows instead of sitting in a header', () => {
+    const html = setsBlockHTML([{ repsMin: 5, repsMax: 5 }, { repsMin: 5, repsMax: 5 }]);
+    const lastRowIdx = html.lastIndexOf('pex-set-row');
+    const addSetIdx = html.indexOf('pex-add-set-btn');
+    assert.ok(lastRowIdx !== -1, 'set rows are present');
+    assert.ok(addSetIdx !== -1, 'add-set button is present');
+    assert.ok(addSetIdx > lastRowIdx, 'add-set comes after the last set row');
+    assert.ok(!html.includes('pex-sets-header'), 'the old sets header no longer exists');
 });

--- a/apps/gym-tracker/tests/programs-view-rep-clamp.test.mjs
+++ b/apps/gym-tracker/tests/programs-view-rep-clamp.test.mjs
@@ -1,0 +1,144 @@
+// Mirror of ProgramsView.setRepValue (js/views/programs-view.js). Kept in sync
+// by hand: the real method hangs off a DOM-bound class.
+//
+// What these tests pin: a rep value the user types is clamped to 1..100 before
+// it reaches the model, and the FIELD the user just left must be rewritten with
+// the clamped number. Before this fix only the sibling field was refreshed, so
+// typing 250 and tabbing out left "250" on screen while the model held 100; the
+// save wrote 100 and the next open of the editor showed a number the user had
+// never seen. The rewrite is a targeted .value assignment on purpose: the change
+// event fires on tab-out, and re-rendering #program-exercises-list would destroy
+// the input being blurred and strand the browser's focus advance on a detached
+// node.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Fake inputs keyed the way the real selectors address them:
+// [data-action="set-reps-min|max"][data-exercise-index][data-set-index]
+function makeInputs(sets) {
+    const inputs = {};
+    sets.forEach((row, si) => {
+        inputs[`min:0:${si}`] = { value: String(row.repsMin) };
+        inputs[`max:0:${si}`] = { value: String(row.repsMax) };
+    });
+    return inputs;
+}
+
+function makeEditor(sets) {
+    const program = { exercises: [{ sets: sets.map(s => ({ ...s })) }], updatedAt: null };
+    const inputs = makeInputs(sets);
+
+    function setRepValue(exerciseIndex, setIndex, minOrMax, rawValue) {
+        const ex = program.exercises[exerciseIndex];
+        if (!ex || !Array.isArray(ex.sets)) return;
+        const row = ex.sets[setIndex];
+        if (!row) return;
+        const val = Math.max(1, Math.min(100, Math.round(Number(rawValue) || 1)));
+        let siblingChanged = null;
+        if (minOrMax === 'min') {
+            const wasSingle = row.repsMin === row.repsMax;
+            row.repsMin = val;
+            if (wasSingle) {
+                row.repsMax = val;
+                siblingChanged = 'max';
+            } else if (row.repsMax < row.repsMin) {
+                row.repsMax = row.repsMin;
+                siblingChanged = 'max';
+            }
+        } else {
+            row.repsMax = val;
+            if (row.repsMin > row.repsMax) {
+                row.repsMin = row.repsMax;
+                siblingChanged = 'min';
+            }
+        }
+        program.updatedAt = new Date().toISOString();
+
+        const repsInput = (kind) => inputs[`${kind}:${exerciseIndex}:${setIndex}`];
+        const edited = repsInput(minOrMax);
+        if (edited) edited.value = minOrMax === 'min' ? row.repsMin : row.repsMax;
+
+        if (siblingChanged === 'max') {
+            const maxInput = repsInput('max');
+            if (maxInput) maxInput.value = row.repsMax;
+        } else if (siblingChanged === 'min') {
+            const minInput = repsInput('min');
+            if (minInput) minInput.value = row.repsMin;
+        }
+    }
+
+    // Simulate the user typing into a field and tabbing out (the change event).
+    const type = (kind, si, typed) => {
+        inputs[`${kind}:0:${si}`].value = String(typed);
+        setRepValue(0, si, kind, Number(typed));
+    };
+    const shown = (kind, si = 0) => Number(inputs[`${kind}:0:${si}`].value);
+    const model = (si = 0) => program.exercises[0].sets[si];
+
+    return { type, shown, model };
+}
+
+test('rep clamp: a value over the max lands at 100 in the model AND in the field', () => {
+    const ed = makeEditor([{ repsMin: 8, repsMax: 12 }]);
+    ed.type('max', 0, 250);
+    assert.equal(ed.model().repsMax, 100, 'model clamps to the max of 100');
+    assert.equal(ed.shown('max'), 100, 'the edited field shows the clamped value, not "250"');
+    assert.equal(ed.model().repsMin, 8, 'the untouched min is left alone');
+});
+
+test('rep clamp: a value under the min lands at 1 in the model AND in the field', () => {
+    const ed = makeEditor([{ repsMin: 8, repsMax: 12 }]);
+    ed.type('min', 0, 0);
+    assert.equal(ed.model().repsMin, 1, 'model clamps up to the min of 1');
+    assert.equal(ed.shown('min'), 1, 'the edited field shows 1, not "0"');
+});
+
+test('rep clamp: empty / non-numeric input falls back to 1 in the field', () => {
+    const ed = makeEditor([{ repsMin: 8, repsMax: 12 }]);
+    ed.type('min', 0, '');
+    assert.equal(ed.model().repsMin, 1);
+    assert.equal(ed.shown('min'), 1, 'a blanked field is refilled rather than left empty');
+});
+
+test('rep clamp: single mode keeps min and max in sync, in the model and both fields', () => {
+    const ed = makeEditor([{ repsMin: 10, repsMax: 10 }]);
+    ed.type('min', 0, 250);
+    assert.equal(ed.model().repsMin, 100, 'min clamps');
+    assert.equal(ed.model().repsMax, 100, 'max follows so the row stays a single target');
+    assert.equal(ed.shown('min'), 100, 'the edited field shows the clamped value');
+    assert.equal(ed.shown('max'), 100, 'the hidden sibling field stays in sync');
+});
+
+test('rep clamp: single mode with an in-range value still syncs both fields', () => {
+    const ed = makeEditor([{ repsMin: 10, repsMax: 10 }]);
+    ed.type('min', 0, 6);
+    assert.equal(ed.model().repsMin, 6);
+    assert.equal(ed.model().repsMax, 6);
+    assert.equal(ed.shown('min'), 6);
+    assert.equal(ed.shown('max'), 6);
+});
+
+test('rep clamp: a max dropped below the min pulls the min down in both places', () => {
+    const ed = makeEditor([{ repsMin: 8, repsMax: 12 }]);
+    ed.type('max', 0, 5);
+    assert.equal(ed.model().repsMin, 5, 'min follows the lowered max');
+    assert.equal(ed.model().repsMax, 5);
+    assert.equal(ed.shown('min'), 5, 'the sibling field is refreshed');
+    assert.equal(ed.shown('max'), 5, 'the edited field keeps the accepted value');
+});
+
+test('rep clamp: an in-range edit leaves the typed value untouched', () => {
+    const ed = makeEditor([{ repsMin: 8, repsMax: 12 }]);
+    ed.type('max', 0, 15);
+    assert.equal(ed.model().repsMax, 15);
+    assert.equal(ed.shown('max'), 15, 'no needless rewrite of a valid entry');
+    assert.equal(ed.shown('min'), 8);
+});
+
+test('rep clamp: only the edited set row is touched', () => {
+    const ed = makeEditor([{ repsMin: 8, repsMax: 12 }, { repsMin: 5, repsMax: 5 }]);
+    ed.type('min', 0, 250);
+    assert.equal(ed.model(1).repsMin, 5, 'the second set row is unchanged');
+    assert.equal(ed.shown('min', 1), 5);
+});

--- a/apps/gym-tracker/tests/programs-view-stepper.test.mjs
+++ b/apps/gym-tracker/tests/programs-view-stepper.test.mjs
@@ -1,0 +1,227 @@
+// Rest steppers in the Edit Program modal.
+//
+// What these tests pin: a +/- click updates ONE stepper in place. It used to
+// call renderProgramExercises(), which reassigns the whole
+// #program-exercises-list innerHTML, so a single click on one card's rest "+"
+// destroyed all seven cards and every control in them, and focus fell from the
+// clicked button to <body>, so a user could not press "+" twice without
+// re-aiming. Same story for the program-level "Rest duration" stepper, which
+// rebuilt its own container. So:
+//   - the model still does the clamping (Program.updateExercise -> 0..900),
+//     the view only reads the normalized value back and displays it;
+//   - repeated clicks must accumulate (five * +15 from 3m lands on 4:15, which
+//     is only true if each click reads the CURRENT model value);
+//   - the only DOM writes allowed are the value text and the disabled state of
+//     the two buttons at the bounds. The value text node is mutated, never
+//     replaced, so nothing under the pointer is torn down.
+//
+// syncStepperUI / adjustExerciseTarget / formatRestLabel are mirrored from
+// js/views/programs-view.js by hand (the real ones hang off a DOM-bound class);
+// keep them in sync. The clamping is NOT mirrored: the real Program model is
+// imported so a change to its bounds fails here.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { Program } = await import('../js/models/Program.js');
+
+// ---- mirrors of programs-view.js ---------------------------------------
+
+function formatRestLabel(seconds) {
+    if (!Number.isFinite(seconds) || seconds <= 0) return '0s';
+    if (seconds < 60) return `${seconds}s`;
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return s === 0 ? `${m}m` : `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function syncStepperUI(stepper, value, min, max, valueLabel = null) {
+    if (!stepper) return;
+    stepper.querySelector('.pex-stepper-value').firstChild.data = valueLabel ?? String(value);
+    stepper.querySelectorAll('[data-stepper]').forEach(btn => {
+        btn.disabled = Number(btn.dataset.delta) < 0 ? value <= min : value >= max;
+    });
+}
+
+// ---- the stepper markup stepperHTML() emits, as objects ----------------
+
+function fakeStepper(field, value, step = 15) {
+    // <span class="pex-stepper-value">3m</span> is a single text node; the
+    // buttons carry data-stepper / data-field / data-delta and start disabled
+    // at the bounds.
+    const textNode = { data: formatRestLabel(value) };
+    const valueSpan = { firstChild: textNode, get textContent() { return textNode.data; } };
+    const buttons = [-step, step].map(delta => ({
+        dataset: { stepper: '', index: '0', field, delta: String(delta) },
+        disabled: delta < 0 ? value <= 0 : value >= 900,
+    }));
+    return {
+        field,
+        textNode,
+        buttons,
+        minus: buttons[0],
+        plus: buttons[1],
+        shown: () => valueSpan.textContent,
+        querySelector: (sel) => (sel === '.pex-stepper-value' ? valueSpan : null),
+        querySelectorAll: (sel) => (sel === '[data-stepper]' ? buttons : []),
+    };
+}
+
+// ---- the editor: one program, one stepper per rest field per exercise ---
+
+function makeEditor(exercises) {
+    const program = new Program({ name: 'Push', exercises });
+    const steppers = program.exercises.flatMap((ex, i) => [
+        Object.assign(fakeStepper('rest', ex.restSeconds), { index: i }),
+        Object.assign(fakeStepper('restAfter', ex.restAfterSeconds), { index: i }),
+    ]);
+    const stepperFor = (index, field) => steppers.find(s => s.index === index && s.field === field);
+
+    // Mirror of ProgramsView.adjustExerciseTarget.
+    function adjustExerciseTarget(index, field, delta) {
+        const ex = program.exercises[index];
+        if (!ex) return;
+        const key = field === 'rest' ? 'restSeconds' : field === 'restAfter' ? 'restAfterSeconds' : null;
+        if (!key) return;
+        program.updateExercise(index, { [key]: ex[key] + delta });
+        const value = program.exercises[index][key];
+        syncStepperUI(stepperFor(index, field), value, 0, 900, formatRestLabel(value));
+    }
+
+    // What a user click does: read the delta off the button that was pressed.
+    const click = (index, field, sign, times = 1) => {
+        for (let i = 0; i < times; i++) {
+            const st = stepperFor(index, field);
+            const btn = sign === '-' ? st.minus : st.plus;
+            if (btn.disabled) continue; // a disabled button eats the click
+            adjustExerciseTarget(index, field, Number(btn.dataset.delta));
+        }
+    };
+
+    return {
+        click,
+        adjust: adjustExerciseTarget,
+        stepper: stepperFor,
+        shown: (index, field) => stepperFor(index, field).shown(),
+        model: (index, field) => program.exercises[index][field === 'rest' ? 'restSeconds' : 'restAfterSeconds'],
+    };
+}
+
+const oneExercise = [{ exerciseId: 'e1', exerciseName: 'Bench', restSeconds: 180, restAfterSeconds: 180, sets: [{ repsMin: 6, repsMax: 8 }] }];
+
+// -------------------------------------------------------
+// The value moves, and it accumulates across clicks
+// -------------------------------------------------------
+
+test('rest stepper: one "+" advances the model and the label together', () => {
+    const ed = makeEditor(oneExercise);
+    assert.equal(ed.shown(0, 'rest'), '3m');
+    ed.click(0, 'rest', '+');
+    assert.equal(ed.model(0, 'rest'), 195);
+    assert.equal(ed.shown(0, 'rest'), '3:15', 'the displayed label is refreshed from the model');
+});
+
+test('rest stepper: five "+" clicks accumulate to 4:15, not 3:15', () => {
+    // The regression this guards: each click must read the CURRENT model value.
+    const ed = makeEditor(oneExercise);
+    ed.click(0, 'rest', '+', 5);
+    assert.equal(ed.model(0, 'rest'), 255);
+    assert.equal(ed.shown(0, 'rest'), '4:15');
+});
+
+test('rest stepper: "-" walks back down through the same values', () => {
+    const ed = makeEditor(oneExercise);
+    ed.click(0, 'rest', '+', 2);
+    ed.click(0, 'rest', '-', 3);
+    assert.equal(ed.model(0, 'rest'), 165);
+    assert.equal(ed.shown(0, 'rest'), '2:45');
+});
+
+// -------------------------------------------------------
+// Bounds: clamped by the model, reflected by the buttons
+// -------------------------------------------------------
+
+test('rest stepper: the floor is the model\'s 0, and "-" disables there', () => {
+    const ed = makeEditor(oneExercise);
+    ed.click(0, 'rest', '-', 40); // 180 / 15 = 12 clicks reach 0, the rest are eaten
+    assert.equal(ed.model(0, 'rest'), 0, 'Program.updateExercise clamps at 0');
+    assert.equal(ed.shown(0, 'rest'), '0s');
+    assert.equal(ed.stepper(0, 'rest').minus.disabled, true, 'cannot go lower');
+    assert.equal(ed.stepper(0, 'rest').plus.disabled, false, 'can still go up');
+});
+
+test('rest stepper: the ceiling is the model\'s 900, and "+" disables there', () => {
+    const ed = makeEditor(oneExercise);
+    ed.click(0, 'rest', '+', 70);
+    assert.equal(ed.model(0, 'rest'), 900, 'Program.updateExercise clamps at 900');
+    assert.equal(ed.shown(0, 'rest'), '15m');
+    assert.equal(ed.stepper(0, 'rest').plus.disabled, true, 'cannot go higher');
+    assert.equal(ed.stepper(0, 'rest').minus.disabled, false);
+});
+
+test('rest stepper: stepping back off a bound re-enables the button', () => {
+    const ed = makeEditor(oneExercise);
+    ed.click(0, 'rest', '+', 70);
+    ed.click(0, 'rest', '-');
+    assert.equal(ed.model(0, 'rest'), 885);
+    assert.equal(ed.shown(0, 'rest'), '14:45');
+    assert.equal(ed.stepper(0, 'rest').plus.disabled, false, '"+" comes back as soon as there is room');
+});
+
+// -------------------------------------------------------
+// Nothing beyond the one stepper is touched
+// -------------------------------------------------------
+
+test('rest stepper: the value text node is mutated, never replaced', () => {
+    // Replacing it is what re-rendering did, and that is what dropped focus.
+    const ed = makeEditor(oneExercise);
+    const node = ed.stepper(0, 'rest').textNode;
+    ed.click(0, 'rest', '+', 3);
+    assert.equal(ed.stepper(0, 'rest').textNode, node, 'same text node instance');
+    assert.equal(node.data, '3:45', 'and it carries the new label');
+});
+
+test('rest stepper: "Rest between sets" and "Rest after exercise" move independently', () => {
+    const ed = makeEditor(oneExercise);
+    ed.click(0, 'rest', '+', 2);
+    ed.click(0, 'restAfter', '-', 2);
+    assert.equal(ed.model(0, 'rest'), 210);
+    assert.equal(ed.shown(0, 'rest'), '3:30');
+    assert.equal(ed.model(0, 'restAfter'), 150);
+    assert.equal(ed.shown(0, 'restAfter'), '2:30');
+});
+
+test('rest stepper: a click on one exercise leaves the other exercises alone', () => {
+    const ed = makeEditor([
+        ...oneExercise,
+        { exerciseId: 'e2', exerciseName: 'Fly', restSeconds: 90, restAfterSeconds: 90, sets: [{ repsMin: 10, repsMax: 10 }] },
+    ]);
+    ed.click(1, 'rest', '+', 2);
+    assert.equal(ed.model(1, 'rest'), 120);
+    assert.equal(ed.shown(1, 'rest'), '2m');
+    assert.equal(ed.model(0, 'rest'), 180, 'exercise 1 is untouched');
+    assert.equal(ed.shown(0, 'rest'), '3m', 'and its stepper was never rewritten');
+});
+
+test('rest stepper: only the two rest fields are writable, and only real rows', () => {
+    // The handler is delegated off data-field, so it must ignore anything that
+    // is not one of the two rest fields instead of writing a junk key.
+    const ed = makeEditor(oneExercise);
+    ed.adjust(0, 'targetSets', 15);
+    ed.adjust(9, 'rest', 15);
+    assert.equal(ed.model(0, 'rest'), 180);
+    assert.equal(ed.model(0, 'restAfter'), 180);
+    assert.equal(ed.shown(0, 'rest'), '3m');
+});
+
+// -------------------------------------------------------
+// Label formatting the stepper depends on
+// -------------------------------------------------------
+
+test('formatRestLabel: seconds, whole minutes, and m:ss', () => {
+    assert.equal(formatRestLabel(0), '0s');
+    assert.equal(formatRestLabel(45), '45s');
+    assert.equal(formatRestLabel(60), '1m');
+    assert.equal(formatRestLabel(90), '1:30');
+    assert.equal(formatRestLabel(900), '15m');
+});


### PR DESCRIPTION
## TL;DR

A layout and density pass on the Gym Tracker Create/Edit Program modal. Every
control that existed still exists and still works; what changed is how it is laid
out, sized, and grouped. For a 7-exercise program the form drops from **3187px to
1823px** on desktop and **3628px to 2333px** on mobile, the mean exercise card
from **382px to 193px** (desktop) and **431px to 263px** (mobile), and the editor
now has **one** vertical scroll container instead of two.

Five defects were found and fixed while doing it: a clipped Cancel label, a rep
clamp that never reached the field, a modal that survived navigation, a scroll
lock leaked by the exercise picker, and rest steppers that rebuilt the entire
exercise list on every click.

## apps/gym-tracker/index.html

The `#program-modal` markup moved out of `#programs-view` to document level.
`.view` animates, and an animated ancestor becomes the containing block for
`position: fixed`, which is why the dialog rendered partly above the viewport
(its header measured at `y = -62`). Also in this file: the program description
textarea drops from `rows="3"` to `rows="2"`; the uniform-rest toggle and its
duration stepper are wrapped in a new `.rest-mode-box` so the stepper reads as
belonging to the toggle; the two rest hint paragraphs collapse into a single
`#rest-mode-hint` whose text is swapped per state; and the workout-mode
"Save & resume" button gains `.btn-save-program` so it shares the primary-button
sizing.

## apps/gym-tracker/js/views/programs-view.js

`renderProgramExercises()` emits a new card structure: a `.pex-head` row carrying
the drag handle, position number, name, muscle group and a right-aligned
`.pex-head-actions` cluster (link, move up, move down, delete), over a `.pex-body`
holding `.pex-sets-block`, the add-set button and `.pex-rest-block`. Previously
the move buttons sat in the header on desktop but at the card's bottom on mobile,
and the link and delete buttons sat in a loose strip at the bottom-left where a
bare `x` read as "remove this set".

Each set row's mode control becomes a two-option segmented control
(`.pex-mode-seg` with two `.pex-mode-opt`) that shows the *current* mode as
selected. It previously rendered one button labelled with the mode you would
switch **to**, so a single-target set displayed the word "Range". Both options
carry `data-mode`, and `toggleRepRange(exerciseIndex, setIndex, mode = null)` uses
it to make re-picking the active option a no-op while keeping the old
argument-less flip working. The per-card "Each set can be a single target or a
range." caption is gone; with both options on screen it had no work left to do.

`setRepValue()` now writes the clamped value back into the input the user just
edited. It only ever refreshed the *sibling* field, so typing `250` and tabbing
out left "250" on screen against a stored 100, and the next open showed a
different number. The fix writes through a targeted selector and deliberately does
not re-render, preserving the tab-out focus fix documented in the `#16` comment.

`adjustExerciseTarget()` and `renderUniformStepper()` call a new module-level
`syncStepperUI()` that updates the stepper's value text and the two buttons'
`disabled` state in place. Both previously called `renderProgramExercises()`,
which reassigns `container.innerHTML`: a single click on one card's rest `+`
produced 15 removed nodes, destroyed every card including controls in exercises
the user never touched, and dropped focus to `<body>`. `addSetRow`,
`removeSetRow` and `toggleRepRange` still re-render, since those genuinely change
row structure.

`beforeLeave()` is new. `showView()` hides views by setting `display: none` on
each `.view`, so once the modal became a `body` child it survived a view change
and floated over the destination view; pressing browser Back left the editor on
top of the Dashboard, and returning to Programs resurrected it still holding the
staged edit. It clears `returnToView` before calling `closeProgramModal()` to
avoid re-entering the `showView()` that invoked it, and returns `true` so it never
defers navigation. It also clears `.active` on `#exercise-picker-modal`, not
because the picker floats (it is still inside `#programs-view`) but because that
class holds the shared body scroll lock, so navigating away with it open stranded
`<body class="modal-open">` and a `body.style.top` offset on the next view.

`syncRestModeHint()` is new, driving the single rest hint's text from the toggle
state. `stepperHTML()` gains a `shortLabel` parameter so the rest steppers can
render "Between sets" / "After exercise" at narrow widths.

## apps/gym-tracker/css/gym-tracker.css

The editor's rules were spread from line ~4360 to ~10900 in four regions, which is
why the same control was sized in three places at three values. They are now one
contiguous `#program-modal`-scoped block driven by `--pe-*` tokens
(`--pe-control-h`, `--pe-radius`, `--pe-gap`, `--pe-card-pad-*`, `--pe-rest-col`,
`--pe-field-max`, `--pe-text-muted`, `--pe-surface-2/3`, `--pe-focus`). Every icon
button, stepper button, reps input and mode option now resolves to one computed
height and one border-radius per breakpoint (32px desktop, 36px mobile).

Layout: the modal widens from 760px to 940px; each card puts its sets block and a
fixed-width rest column side by side on desktop, aligned to 0px spread across all
cards; text inputs cap at `--pe-field-max` for line length; the weekday chips
become 7 equal columns at 72px (they were 125px, stretching 901px). At <=380px the
exercise name takes its own full-width line above a meta row, because the action
cluster had squeezed the name column to 65px and was ellipsising even "Hex Press".

`--pe-card-hover: #1d212c` is a new token for the card hover background. The hover
state used `--pe-surface-2`, `rgb(35,40,54)`, which is the exact background of
`.pex-reps-input` and `.pex-stepper`, whose border is `rgb(35,40,56)`; hovering a
card made its own inputs and rest pills mathematically invisible. The new value
holds a `6,7,10` channel delta to those controls, matching the app's own proven
minimum surface step, while the border swap to `--border-light` carries the state
change.

`.modal-close` is narrowed to `.modal-close:not(.program-modal-cancel)` so the
editor's labelled text Cancel stops inheriting the round X affordance's 30px
width, which was clipping its label to "Cance" at every viewport.

## apps/gym-tracker/css/refresh.css

The `body.gym-tracker` editor overrides are removed. They existed only to fight
`gym-tracker.css`, and being higher-specificity they silently defeated the new base
rules. The `.modal-close` counter-pin against the sitewide
`main.css button { color: #555 !important }` and its inset ring is retained,
narrowed to `:not(.program-modal-cancel)` to match.

## apps/gym-tracker/sw.js

`CACHE_VERSION` 1.8.2 -> 1.8.3, since both precached editor assets changed.

## apps/gym-tracker/tests/

`programs-view-range-label.test.mjs` is rewritten for the segmented control: the
old assertions checked that a single-value set rendered the label "Range", which
is the behaviour this PR removes. New cases cover both options rendering, the
correct one being marked selected in each direction, `data-mode` being present,
per-set aria labels, the absence of the range caption, and "+ Add set" following
the set rows.

Three new suites: `programs-view-rep-clamp.test.mjs` (8 tests, over-max, under-min,
blank, single-mode sync, max-below-min, in-range untouched, neighbouring rows
untouched), `programs-view-before-leave.test.mjs` (7 tests, lifting the real
`beforeLeave` and `closeProgramModal` source out of the view so it fails on
drift), and `programs-view-stepper.test.mjs` (11 tests, bounds clamping and
accumulation across clicks against the real `Program` model).
