### PR TITLE
gym-tracker: serve precached URLs offline (SW precache fallback)

### DIFF
--- a/TESTING-AUDIT.md
+++ b/TESTING-AUDIT.md
@@ -378,13 +378,15 @@ Severity: H high, M medium, L low.
 
 ### Offline / platform
 
-16. **[H] Gym Tracker: the service worker never consults its precache.** The
-    fetch handler matches only the RUNTIME cache (sw.js:113-121), so an
-    offline request for a precached-but-never-visited URL gets
-    `respondWith(undefined)` and fails; all install-time precaching is
-    currently dead weight, and the README's offline promise holds only for
-    URLs already visited in the session. Pinned at both the vm and browser
-    layers.
+16. **[H] Gym Tracker: the service worker never consults its precache.**
+    **RESOLVED 2026-08-15** (fix/gym-sw-precache-fallback): the fetch handler
+    now falls back to the gym precache on a runtime-cache miss and
+    `CACHE_VERSION` moved to 1.9.0; the former quarantines are plain
+    regression tests (`sw-offline-behavior.test.mjs`, pwa-gym browser
+    suite). Original finding: the handler matched only the RUNTIME cache
+    (sw.js:113-121), so an offline request for a precached-but-never-visited
+    URL got `respondWith(undefined)` and failed, making all install-time
+    precaching dead weight.
 17. **[L] Gym Tracker: rest-timer ids collide** when two timers start in the
     same millisecond (TimerService.js:21); first interval becomes
     unclearable.
@@ -526,7 +528,8 @@ failure.
 
 ## Recommended next steps (each is a product-code decision, not a test gap)
 
-1. Fix the HIGH defect: make the gym service worker consult its precache.
+1. ~~Fix the HIGH defect: make the gym service worker consult its
+   precache.~~ Done 2026-08-15 (see defect 16).
 2. Stand up the Firebase emulator harness for Arena + rules tests
    (`firebase.json` already declares the ports); then delete the
    blocked-backend compromise checks.

--- a/apps/gym-tracker/FINDINGS.md
+++ b/apps/gym-tracker/FINDINGS.md
@@ -132,7 +132,6 @@ Each is asserted at its CORRECT behavior with `{ todo: 'KNOWN DEFECT: ...' }`
 so `node --test` reports it without failing; fixing the code flips the todo
 into a pass (then remove the todo option). Current list:
 
-- **sw.js offline precache miss** (above) - `sw-offline-behavior.test.mjs`.
 - **Four `===` id comparisons in StorageService** violating the sameId rule
   (next section): `saveProgram` ~99 (duplicates instead of updating),
   `deleteProgram` ~112 (no-op), `deleteCustomExercise` ~222 (no-op),
@@ -209,13 +208,21 @@ lone exercise in superset chrome during a workout (fixed 2026-08-12,
 - `data/exercises-db.json` is precached; **any catalog edit needs a
   `CACHE_VERSION` PATCH bump in `sw.js`** or existing installs keep serving
   the old catalog until the next unrelated bump.
-- **KNOWN DEFECT: the fetch handler never consults the precache.** It opens
-  only the RUNTIME cache (sw.js ~113-121), so a URL that was precached at
-  install but never fetched while online in this SW generation gets
-  `respondWith(undefined)` offline and fails. The entire install-time
-  precaching buys nothing until the handler falls back to the PRECACHE cache
-  (or `caches.match`). Pinned by a `todo` test in
-  `tests/sw-offline-behavior.test.mjs`.
+- **The fetch handler falls back to the gym precache on a runtime miss**
+  (fixed 2026-08-15, `CACHE_VERSION` 1.9.0; was TESTING-AUDIT.md defect 16:
+  it used to open only the RUNTIME cache, so a URL precached at install but
+  never fetched online in that SW generation got `respondWith(undefined)`
+  offline, and the install-time precaching bought nothing). Semantics since
+  the fix: stale-while-revalidate treats "cached" as runtime-first then OWN
+  precache, so a precached URL is served from the precache even online while
+  the background refresh updates RUNTIME. Only `gym-precache-*` is searched,
+  never other apps' caches on this shared origin. Regression tests:
+  `tests/sw-offline-behavior.test.mjs` (vm) and the pwa-gym browser suite.
+- Same-origin assets OUTSIDE the app dir (`../../assets/*`, sync-system, the
+  two shared mario-kart CSS files) are intercepted but deliberately NOT
+  precached; they ride the runtime cache only, so a fully cold offline first
+  visit still lacks them. Widening the precache to cross-app paths is a
+  product decision, not part of the fallback fix.
 - Two failure modes are pinned by `tests/sw-precache-completeness.test.mjs`:
   a new `js/` module missing from `PRECACHE_URLS` breaks OFFLINE ONLY, and a
   listed-but-deleted file fails the whole install (cache.addAll is atomic),

--- a/apps/gym-tracker/sw.js
+++ b/apps/gym-tracker/sw.js
@@ -18,7 +18,7 @@
  * Old caches are pruned automatically on activate.
  */
 
-const CACHE_VERSION = '1.8.4';
+const CACHE_VERSION = '1.9.0';
 const PRECACHE = `gym-precache-${CACHE_VERSION}`;
 const RUNTIME = `gym-runtime-${CACHE_VERSION}`;
 
@@ -109,10 +109,17 @@ self.addEventListener('fetch', (event) => {
   if (url.origin !== self.location.origin) return;
 
   // Stale-while-revalidate: serve cached if present, kick off a fresh
-  // fetch in the background to update the cache.
+  // fetch in the background to update the cache. The runtime cache is
+  // consulted first (it holds the freshest copy), then OUR OWN precache:
+  // without that fallback, a precached URL the page had never fetched
+  // online produced respondWith(undefined) offline, so the install-time
+  // precache was dead weight and a cold offline start failed. Only the
+  // gym precache is searched, never other apps' caches on this shared
+  // origin.
   event.respondWith((async () => {
     const cache = await caches.open(RUNTIME);
-    const cached = await cache.match(req);
+    const cached = (await cache.match(req))
+      || (await (await caches.open(PRECACHE)).match(req));
     const networkPromise = fetch(req).then((res) => {
       if (res && res.ok) cache.put(req, res.clone()).catch(() => {});
       return res;

--- a/apps/gym-tracker/tests/sw-offline-behavior.test.mjs
+++ b/apps/gym-tracker/tests/sw-offline-behavior.test.mjs
@@ -107,16 +107,32 @@ test('install populates the precache with every PRECACHE_URLS entry', async () =
     assert.ok(store.get(appJsUrl), 'js/app.js landed in the precache');
 });
 
-test('online fetch: response is served and stored in the runtime cache', async () => {
+test('online fetch of a NON-precached URL: network response served and stored in the runtime cache', async () => {
     const worker = loadWorker();
     await install(worker);
-    const url = `${ORIGIN}/apps/gym-tracker/js/views/workout-view.js`;
+    // Deliberately not in PRECACHE_URLS, so the only source online is the network.
+    const url = `${ORIGIN}/apps/gym-tracker/exercises/bench-press/index.html`;
     const { responded, response } = await driveFetch(worker, url);
     assert.equal(responded, true, 'same-origin GET is intercepted');
     assert.equal(response.body, `network:${url}`, 'network response returned');
     // The background cache.put is fire-and-forget; give the microtask a turn.
     await new Promise((r) => setImmediate(r));
     assert.ok(worker.storeFor(RUNTIME_NAME).get(url), 'response cached for next time');
+});
+
+test('online fetch of a precached URL: served instantly from the precache, refreshed into the runtime cache', async () => {
+    // Since the precache-fallback fix (TESTING-AUDIT.md #16), "cached" in the
+    // stale-while-revalidate strategy includes the app's own precache: a
+    // precached URL is served from it even online (instant load), while the
+    // background network refresh still lands in the RUNTIME cache.
+    const worker = loadWorker();
+    await install(worker);
+    const url = `${ORIGIN}/apps/gym-tracker/js/views/workout-view.js`;
+    const { responded, response } = await driveFetch(worker, url);
+    assert.equal(responded, true, 'same-origin GET is intercepted');
+    assert.match(String(response.body), /^precached:/, 'precached copy served without waiting on the network');
+    await new Promise((r) => setImmediate(r));
+    assert.ok(worker.storeFor(RUNTIME_NAME).get(url), 'background refresh stored for next time');
 });
 
 test('offline fetch: a runtime-cached URL is served from cache', async () => {
@@ -145,15 +161,13 @@ test('cross-origin requests (Firebase, fonts) are not intercepted', async () => 
     assert.equal(responded, false);
 });
 
+// Regression test for the 2026-08-15 audit defect (TESTING-AUDIT.md #16,
+// resolved): the fetch handler used to open only the RUNTIME cache, so a
+// first-visit-offline request for a precached URL got respondWith(undefined)
+// and the install-time precache was dead weight. The handler now falls back
+// to the gym precache on a runtime miss.
 test(
     'offline fetch of a PRECACHED URL that was never runtime-fetched is served from the precache',
-    {
-        todo: 'KNOWN DEFECT: sw.js fetch handler only opens the RUNTIME cache and never '
-            + 'consults the precache, so a first-visit-offline request for a precached URL '
-            + 'gets respondWith(undefined) and fails. The install work (precaching every '
-            + 'module) buys nothing until the handler falls back to caches.match / the '
-            + 'PRECACHE cache. sw.js lines ~113-121.',
-    },
     async () => {
         const worker = loadWorker();
         await install(worker);

--- a/tests/browser/suites/pwa-gym.mjs
+++ b/tests/browser/suites/pwa-gym.mjs
@@ -212,15 +212,22 @@ export async function run({ base, cdpPort }) {
       }
     })()`);
     await s.send('Network.setCacheDisabled', { cacheDisabled: false });
-    if (gap && gap.candidate && gap.fetched === false) {
-      skip('gym-pwa: offline fetch of a precached-but-never-fetched URL succeeds',
-        `KNOWN DEFECT: offline cold fetch of precached URL fails (sw fetch handler never consults the precache; sw.js opens only the RUNTIME cache) - ${gap.cold} precached URLs are cold, e.g. ${gap.candidate}: ${gap.error}`);
-    } else if (gap && gap.candidate && gap.fetched && gap.ok) {
+    // Regression check for the 2026-08-15 audit defect (TESTING-AUDIT.md
+    // #16, resolved): the fetch handler now falls back to the gym precache
+    // on a runtime-cache miss, so a precached URL the page never fetched
+    // online must be served offline.
+    if (gap && gap.candidate) {
       t('gym-pwa: offline fetch of a precached-but-never-fetched URL succeeds',
-        false,
-        `unexpected PASS for a pinned defect - investigate: ${JSON.stringify(gap)} (browser HTTP cache was disabled for this fetch)`);
+        gap.fetched === true && gap.ok === true,
+        `${gap.cold} cold precached URL(s); probed ${gap.candidate}: `
+        + (gap.fetched ? `HTTP ok=${gap.ok} status=${gap.status}` : `failed (${gap.error})`));
     } else {
-      t('gym-pwa: offline fetch of a precached-but-never-fetched URL',
+      // Zero cold URLs means every precached URL was already runtime-cached
+      // during this run, so there is nothing left to probe; that can only
+      // happen if the page fetched literally everything, which never occurs
+      // for index.html (navigations request './'). Treat it as a staging
+      // failure so the check cannot silently stop probing.
+      t('gym-pwa: offline fetch of a precached-but-never-fetched URL succeeds',
         false, `could not stage the check: ${JSON.stringify(gap)}`);
     }
 


### PR DESCRIPTION
## TL;DR

- Fixes the one HIGH defect from the testing audit (TESTING-AUDIT.md #16): the Gym Tracker service worker precached the whole app shell at install but its fetch handler only ever consulted the RUNTIME cache, so a precached URL that was never fetched online in that SW generation failed offline (`respondWith(undefined)`). In practice a cold offline start of `index.html` always failed, because navigations request `./` and never runtime-cache it.
- Smallest correct fix: on a runtime-cache miss the handler now falls back to the gym's OWN precache (never other apps' caches on this shared origin). `CACHE_VERSION` bumps 1.8.4 -> 1.9.0 (MINOR: runtime strategy change, per the file's own versioning contract), so existing installs prune the old caches on activate.
- The two audit quarantines flip into plain regression tests, exactly as the quarantine convention prescribes. Verified: unit suite 3,943 tests / 0 failures (todos 24 -> 23), full browser estate 775/775 (skips 11 -> 10), coverage floors all green.

## apps/gym-tracker/sw.js

- Fetch handler: `cached` is now runtime-cache match, falling back to a `PRECACHE` match. Resulting semantics documented in place: stale-while-revalidate serves runtime-first then precache, so precached URLs also load instantly online while the unchanged background network refresh keeps RUNTIME fresh; offline, precached-but-never-visited URLs (including `./` navigations) are served instead of failing. Only `gym-precache-*` is searched, preserving the shared-origin prefix discipline that previously prevented cross-app cache wipes.
- `CACHE_VERSION` 1.8.4 -> 1.9.0.

## apps/gym-tracker/tests/sw-offline-behavior.test.mjs

- The `{ todo: 'KNOWN DEFECT...' }` quarantine on "offline fetch of a PRECACHED URL that was never runtime-fetched" is retired; it now runs as a plain regression test referencing the resolved audit entry.
- The former "online fetch stores into the runtime cache" test encoded the old network-first-for-cold-URLs behavior; it is split into two tests matching the fixed semantics: a NON-precached URL is served from the network and stored in RUNTIME, and a precached URL is served instantly from the precache while the background refresh still lands in RUNTIME.

## tests/browser/suites/pwa-gym.mjs

- The expected-failure check ("offline fetch of a precached-but-never-fetched URL") converts to a plain passing assertion (fetch must succeed with an ok response, probed with the browser HTTP cache disabled); the zero-cold-URLs staging guard is kept so the check can never silently stop probing.

## apps/gym-tracker/FINDINGS.md

- The KNOWN DEFECT entry is replaced by the resolution record: fix date, version bump, the new cached-lookup semantics, and the regression tests that pin them. A follow-on observation is recorded: same-origin assets outside the app dir (site assets, sync-system, the two shared mario-kart CSS files) are intercepted but deliberately not precached, so a fully cold offline first visit still lacks them; widening the precache across app boundaries is a product decision, not part of this fix. The defect is also removed from the known-defects todo list.

## TESTING-AUDIT.md

- Defect 16 marked RESOLVED with the fix summary; recommended next step 1 struck through as done.
